### PR TITLE
丰富BaseAgentClient定义，提供异步版本

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "0.1.1-rc2"
+current_version = "0.1.1-rc3"
 parse = """(?x)
     (?P<major>0|[1-9]\\d*)\\.
     (?P<minor>0|[1-9]\\d*)\\.

--- a/a2c_smcp/__init__.py
+++ b/a2c_smcp/__init__.py
@@ -4,4 +4,4 @@
 # @Author  : JQQ
 # @Email   : jqq1716@gmail.com
 # @Software: PyCharm
-__version__: str = "0.1.1-rc2"
+__version__: str = "0.1.1-rc3"

--- a/a2c_smcp/agent/base.py
+++ b/a2c_smcp/agent/base.py
@@ -2,10 +2,10 @@
 * 文件名: base
 * 作者: JQQ
 * 创建日期: 2025/9/30
-* 最后修改日期: 2025/9/30
+* 最后修改日期: 2025/10/8
 * 版权: 2023 JQQ. All rights reserved.
 * 依赖: socketio, loguru
-* 描述: Agent基础客户端抽象类 / Agent base client abstract class
+* 描述: Agent基础客户端抽象类（异步和同步版本）/ Agent base client abstract classes (async and sync versions)
 """
 
 import uuid
@@ -15,7 +15,7 @@ from typing import Any
 from mcp.types import CallToolResult, TextContent
 
 from a2c_smcp.agent.auth import AgentAuthProvider
-from a2c_smcp.agent.types import AgentEventHandler
+from a2c_smcp.agent.types import AgentEventHandler, AsyncAgentEventHandler
 from a2c_smcp.smcp import (
     EnterOfficeNotification,
     GetDeskTopReq,
@@ -31,8 +31,267 @@ from a2c_smcp.utils.logger import logger
 
 class BaseAgentClient(ABC):
     """
-    Agent基础客户端抽象类，提供通用的SMCP协议处理逻辑
-    Agent base client abstract class, provides common SMCP protocol handling logic
+    Agent异步基础客户端抽象类，提供通用的SMCP协议处理逻辑（异步版本）
+    Agent async base client abstract class, provides common SMCP protocol handling logic (async version)
+    """
+
+    def __init__(
+        self,
+        auth_provider: AgentAuthProvider,
+        event_handler: AsyncAgentEventHandler | None = None,
+    ) -> None:
+        """
+        初始化异步基础Agent客户端
+        Initialize async base Agent client
+
+        Args:
+            auth_provider (AgentAuthProvider): 认证提供者 / Authentication provider
+            event_handler (AsyncAgentEventHandler | None): 异步事件处理器 / Async event handler
+        """
+        self.auth_provider = auth_provider
+        self.event_handler = event_handler
+
+    @abstractmethod
+    async def emit(self, event: str, data: Any = None, namespace: str | None = None, callback: Any = None) -> None:
+        """
+        异步发送事件的抽象方法
+        Abstract method for async sending events
+        """
+        pass
+
+    @abstractmethod
+    async def call(self, event: str, data: Any = None, namespace: str | None = None, timeout: int = 60) -> Any:
+        """
+        异步调用事件并等待响应的抽象方法
+        Abstract method for async calling events and waiting for response
+        """
+        pass
+
+    def validate_emit_event(self, event: str) -> None:
+        """
+        验证发送事件的合法性
+        Validate the legality of emitted events
+
+        Args:
+            event (str): 事件名称 / Event name
+
+        Raises:
+            ValueError: 当事件不合法时 / When event is invalid
+        """
+        if event.startswith("notify:"):
+            raise ValueError("AgentClient不允许使用notify:*事件 / AgentClient is not allowed to use notify:* events")
+        if event.startswith("agent:"):
+            raise ValueError("AgentClient不允许发起agent:*事件 / AgentClient is not allowed to initiate agent:* events")
+
+    def create_tool_call_request(self, computer: str, tool_name: str, params: dict, timeout: int) -> ToolCallReq:
+        """
+        创建工具调用请求对象
+        Create tool call request object
+
+        Args:
+            computer (str): 目标计算机ID / Target computer ID
+            tool_name (str): 工具名称 / Tool name
+            params (dict): 调用参数 / Call parameters
+            timeout (int): 超时时间 / Timeout duration
+
+        Returns:
+            ToolCallReq: 工具调用请求 / Tool call request
+        """
+        agent_config = self.auth_provider.get_agent_config()
+        return ToolCallReq(
+            computer=computer,
+            tool_name=tool_name,
+            params=params,
+            robot_id=agent_config["agent_id"],
+            req_id=uuid.uuid4().hex,
+            timeout=timeout,
+        )
+
+    def create_get_tools_request(self, computer: str) -> GetToolsReq:
+        """
+        创建获取工具请求对象
+        Create get tools request object
+
+        Args:
+            computer (str): 目标计算机ID / Target computer ID
+
+        Returns:
+            GetToolsReq: 获取工具请求 / Get tools request
+        """
+        agent_config = self.auth_provider.get_agent_config()
+        return GetToolsReq(
+            computer=computer,
+            robot_id=agent_config["agent_id"],
+            req_id=uuid.uuid4().hex,
+        )
+
+    def create_get_desktop_request(self, computer: str, *, size: int | None = None, window: str | None = None) -> GetDeskTopReq:
+        """
+        创建获取桌面请求对象
+        Create get desktop request object
+
+        Args:
+            computer (str): 目标计算机ID / Target computer ID
+            size (int | None): 桌面窗口数量上限 / Max number of windows
+            window (str | None): 指定窗口URI / Specific window URI
+
+        Returns:
+            GetDeskTopReq: 获取桌面请求 / Get desktop request
+        """
+        agent_config = self.auth_provider.get_agent_config()
+        req: GetDeskTopReq = {
+            "computer": computer,
+            "robot_id": agent_config["agent_id"],
+            "req_id": uuid.uuid4().hex,
+        }
+        if size is not None:
+            req["desktop_size"] = size
+        if window is not None:
+            req["window"] = window
+        return req
+
+    def process_desktop_response(self, response: GetDeskTopRet, computer: str) -> None:
+        """
+        处理桌面响应（默认仅记录日志；留作后续扩展回调）。
+        Process desktop response (log only by default; placeholder for future callbacks).
+        """
+        try:
+            desktops = response.get("desktops", []) if isinstance(response, dict) else []
+            logger.info(f"Received desktop from computer {computer}, windows={len(desktops)}")
+        except Exception as e:
+            logger.error(f"Error processing desktop response: {e}")
+
+    def handle_tool_call_timeout(self, req_id: str) -> CallToolResult:
+        """
+        处理工具调用超时情况
+        Handle tool call timeout situation
+
+        Args:
+            req_id (str): 请求ID / Request ID
+
+        Returns:
+            CallToolResult: 超时错误结果 / Timeout error result
+        """
+        return CallToolResult(
+            content=[TextContent(text=f"工具调用超时 / Tool call timeout, req_id={req_id}", type="text")],
+            isError=True,
+        )
+
+    def validate_office_data(self, data: EnterOfficeNotification | LeaveOfficeNotification) -> str:
+        """
+        验证办公室数据并返回计算机ID
+        Validate office data and return computer ID
+
+        Args:
+            data: 办公室通知数据 / Office notification data
+
+        Returns:
+            str: 计算机ID / Computer ID
+
+        Raises:
+            AssertionError: 当数据无效时 / When data is invalid
+        """
+        agent_config = self.auth_provider.get_agent_config()
+        assert data["office_id"] == agent_config["office_id"], "无效的办公室ID / Invalid office ID"
+        assert data.get("computer"), "无效的计算机ID / Invalid computer ID"
+        return data["computer"]
+
+    async def handle_computer_enter_office(self, data: EnterOfficeNotification) -> None:
+        """
+        异步处理Computer加入办公室事件
+        Async handle Computer enter office event
+
+        Args:
+            data: 加入办公室通知数据 / Enter office notification data
+        """
+        try:
+            computer = self.validate_office_data(data)
+            logger.info(f"Computer {computer} entered office {data['office_id']}")
+
+            # 调用异步事件处理器
+            # Call async event handler
+            if self.event_handler:
+                await self.event_handler.on_computer_enter_office(data)
+
+        except Exception as e:
+            logger.error(f"Error handling computer enter office: {e}")
+
+    async def handle_computer_leave_office(self, data: LeaveOfficeNotification) -> None:
+        """
+        异步处理Computer离开办公室事件
+        Async handle Computer leave office event
+
+        Args:
+            data: 离开办公室通知数据 / Leave office notification data
+        """
+        try:
+            computer = self.validate_office_data(data)
+            logger.info(f"Computer {computer} left office {data['office_id']}")
+
+            # 调用异步事件处理器
+            # Call async event handler
+            if self.event_handler:
+                await self.event_handler.on_computer_leave_office(data)
+
+        except Exception as e:
+            logger.error(f"Error handling computer leave office: {e}")
+
+    async def handle_computer_update_config(self, data: UpdateMCPConfigNotification) -> None:
+        """
+        异步处理Computer更新配置事件
+        Async handle Computer update config event
+
+        Args:
+            data: 配置更新通知数据 / Config update notification data
+        """
+        try:
+            computer = data["computer"]
+            logger.info(f"Computer {computer} updated config")
+
+            # 调用异步事件处理器
+            # Call async event handler
+            if self.event_handler:
+                await self.event_handler.on_computer_update_config(data)
+
+        except Exception as e:
+            logger.error(f"Error handling computer update config: {e}")
+
+    async def process_tools_response(self, response: GetToolsRet, computer: str) -> None:
+        """
+        异步处理工具响应
+        Async process tools response
+
+        Args:
+            response: 工具响应数据 / Tools response data
+            computer: 计算机ID / Computer ID
+        """
+        try:
+            if tools := response.get("tools"):
+                logger.info(f"Received {len(tools)} tools from computer {computer}")
+
+                # 调用异步事件处理器
+                # Call async event handler
+                if self.event_handler:
+                    await self.event_handler.on_tools_received(computer, tools)
+
+        except Exception as e:
+            logger.error(f"Error processing tools response: {e}")
+
+    @abstractmethod
+    def register_event_handlers(self) -> None:
+        """
+        注册事件处理器，子类需要实现具体的注册逻辑
+        Register event handlers, subclasses need to implement specific registration logic
+        """
+        # 这个方法需要在子类中实现具体的事件注册逻辑
+        # This method needs to implement specific event registration logic in subclasses
+        pass
+
+
+class BaseAgentSyncClient(ABC):
+    """
+    Agent同步基础客户端抽象类，提供通用的SMCP协议处理逻辑（同步版本）
+    Agent sync base client abstract class, provides common SMCP protocol handling logic (sync version)
     """
 
     def __init__(
@@ -41,18 +300,18 @@ class BaseAgentClient(ABC):
         event_handler: AgentEventHandler | None = None,
     ) -> None:
         """
-        初始化基础Agent客户端
-        Initialize base Agent client
+        初始化同步基础Agent客户端
+        Initialize sync base Agent client
 
         Args:
             auth_provider (AgentAuthProvider): 认证提供者 / Authentication provider
-            event_handler (AgentEventHandler | None): 事件处理器 / Event handler
+            event_handler (AgentEventHandler | None): 同步事件处理器 / Sync event handler
         """
         self.auth_provider = auth_provider
         self.event_handler = event_handler
 
     @abstractmethod
-    def emit(self, event: str, data: Any = None, namespace: str | None = None, callback: Any = None) -> Any:
+    def emit(self, event: str, data: Any = None, namespace: str | None = None, callback: Any = None) -> None:
         """
         发送事件的抽象方法
         Abstract method for sending events

--- a/a2c_smcp/agent/sync_client.py
+++ b/a2c_smcp/agent/sync_client.py
@@ -14,7 +14,7 @@ from mcp.types import CallToolResult, TextContent
 from socketio import Client  # type: ignore[import-untyped]
 
 from a2c_smcp.agent.auth import AgentAuthProvider
-from a2c_smcp.agent.base import BaseAgentClient
+from a2c_smcp.agent.base import BaseAgentSyncClient
 from a2c_smcp.agent.types import AgentEventHandler
 from a2c_smcp.smcp import (
     CANCEL_TOOL_CALL_EVENT,
@@ -36,7 +36,7 @@ from a2c_smcp.smcp import (
 from a2c_smcp.utils.logger import logger
 
 
-class SMCPAgentClient(Client, BaseAgentClient):
+class SMCPAgentClient(Client, BaseAgentSyncClient):
     """
     SMCP协议的同步Agent客户端实现
     Synchronous SMCP protocol Agent client implementation
@@ -65,7 +65,7 @@ class SMCPAgentClient(Client, BaseAgentClient):
         # 初始化基类
         # Initialize base classes
         Client.__init__(self, *args, **kwargs)
-        BaseAgentClient.__init__(self, auth_provider, event_handler)
+        BaseAgentSyncClient.__init__(self, auth_provider, event_handler)
 
         # 注册事件处理器
         # Register event handlers
@@ -226,6 +226,8 @@ class SMCPAgentClient(Client, BaseAgentClient):
         Internal method to handle Computer enter office event
         """
         try:
+            # 使用父类的处理方法
+            # Use parent class handling method
             self.handle_computer_enter_office(data)
 
             # 自动获取工具列表
@@ -242,6 +244,8 @@ class SMCPAgentClient(Client, BaseAgentClient):
         处理Computer离开办公室事件的内部方法
         Internal method to handle Computer leave office event
         """
+        # 使用父类的处理方法
+        # Use parent class handling method
         self.handle_computer_leave_office(data)
 
     def _on_computer_update_config(self, data: UpdateMCPConfigNotification) -> None:
@@ -250,6 +254,8 @@ class SMCPAgentClient(Client, BaseAgentClient):
         Internal method to handle Computer update config event
         """
         try:
+            # 使用父类的处理方法
+            # Use parent class handling method
             self.handle_computer_update_config(data)
 
             # 重新获取工具列表

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "a2c-smcp"
-version = "0.1.1-rc2"
+version = "0.1.1-rc3"
 description = "The official Python Computer Client SDK for A2C-SMCP"
 authors = [
     {name = "JQQ",email = "jqq1716@gmail.com"}

--- a/tests/integration_tests/agent/test_base.py
+++ b/tests/integration_tests/agent/test_base.py
@@ -13,12 +13,12 @@ import pytest
 from mcp.types import CallToolResult, TextContent
 
 from a2c_smcp.agent.auth import DefaultAgentAuthProvider
-from a2c_smcp.agent.base import BaseAgentClient
+from a2c_smcp.agent.base import BaseAgentSyncClient
 from a2c_smcp.agent.types import AgentEventHandler
 from a2c_smcp.smcp import EnterOfficeNotification, GetToolsRet, LeaveOfficeNotification, SMCPTool, UpdateMCPConfigNotification
 
 
-class MockAgentClient(BaseAgentClient):
+class MockAgentClient(BaseAgentSyncClient):
     """
     中文：用于测试的 Mock Agent 客户端实现。
     English: Mock Agent client implementation for testing.


### PR DESCRIPTION
原来的BaseAgentClient仅有一个同步版本的定义，在子类封装中，实现asyncio版本时封装结构有些畸形，对未来发展不利，因此直接进行一次扩展，提供了异步版本的封装。

未来Asyncio基于异步版本继承，而Sync则继承同步版本。