### PR TITLE
feat(window-uri): align parser with v0.2 protocol (#9)

### DIFF
--- a/a2c_smcp/computer/desktop/organize.py
+++ b/a2c_smcp/computer/desktop/organize.py
@@ -76,6 +76,7 @@ async def organize_desktop(
             continue
         try:
             wuri = WindowURI(str(res.uri))
+            # TODO(#11): v0.2 起 priority / fullscreen 改读 res.annotations.priority / res._meta.fullscreen
             prio = wuri.priority if wuri.priority is not None else 0
             fullscreen = bool(wuri.fullscreen) if wuri.fullscreen is not None else False
         except Exception:

--- a/a2c_smcp/computer/mcp_clients/base_client.py
+++ b/a2c_smcp/computer/mcp_clients/base_client.py
@@ -392,6 +392,7 @@ class BaseMCPClient(ABC, Generic[ParamsT]):
                 if not is_window_uri(res.uri):
                     continue
                 # 解析优先级（缺省为0）
+                # TODO(#11): v0.2 起 priority 不再来自 URI query，改读 res.annotations.priority (float [0,1])
                 uri = WindowURI(str(res.uri))
                 prio = uri.priority if uri.priority is not None else 0
                 filtered.append((res, prio))

--- a/a2c_smcp/utils/window_uri.py
+++ b/a2c_smcp/utils/window_uri.py
@@ -5,22 +5,27 @@
 # @Email   : jqq1716@gmail.com
 # @Software: PyCharm
 """
-窗口协议 WindowURI 封装
-WindowURI encapsulation for MCP window:// resources
+窗口协议 WindowURI 封装（v0.2 协议）
+WindowURI encapsulation for MCP window:// resources (v0.2 protocol)
 
-协议说明 / Protocol:
-- scheme 固定为 window -> 形如 window://host/path1/path2?.../pathN?priority=..&fullscreen=..
-  Scheme is fixed to 'window' -> e.g., window://host/path1/.../pathN?priority=..&fullscreen=..
-- host 为 MCP 的唯一标识（建议域名），由 MCP 自定义，需避免与其他 MCP 冲突
-  host is MCP unique id (domain-like recommended), defined by MCP, must not collide with others
-- path 可以有 0..N 个段，一个 MCP 可暴露多个 window，是否渲染由桌面系统决定
-  path can have 0..N segments; desktop decides actual rendering
-- 查询参数 / Query params：
-  - priority: 0-100 的整数，仅在同一 MCP 内部窗口间比较时生效，影响布局排序（越大越靠上）
-              integer 0-100, only intra-MCP comparison; affects layout ordering (higher -> higher)
-  - fullscreen: 布尔值；若为 true，Agent 调用该 MCP 工具后，Desktop 将尽量完整渲染该 window。
-                多个 fullscreen 仅第一个生效。
-                boolean; if true, desktop attempts full rendering; only the first fullscreen window takes effect.
+协议说明 / Protocol (v0.2):
+- scheme 固定为 window，URI 形如 window://host/path1/path2/.../pathN —— 纯标识符
+  Scheme is fixed to 'window'; URI is a pure identifier: window://host/path1/.../pathN
+- host 为 MCP 的唯一标识（建议反向域名风格），跨 MCP Server MUST 唯一
+  host is the MCP unique id (reverse-DNS style recommended); MUST be unique across MCP Servers
+- path 可以有 0..N 个段，由 MCP 决定其窗口拓扑
+  path can have 0..N segments; topology decided by the MCP
+- v0.2 起 priority / fullscreen 等元数据不再放在 URI query，而下沉到 MCP Resource
+  的 annotations / _meta（详见协议指南 v0.2-uri-metadata-refactor.md §4.1）
+  Since v0.2, priority / fullscreen metadata are no longer carried in URI query —
+  they live on Resource.annotations / Resource._meta (see protocol guide §4.1)
+
+URI query 处理分层（协议 §F4 Postel's law）：
+URI query handling layers (Postel's law):
+- Computer 解析层（本类）：解析时若含 query → WARN 日志后丢弃，不抛异常
+  Computer parser layer (this class): on query → WARN + drop, no exception
+- Agent SDK 构造层（build_uri）：不接受 priority / fullscreen 参数
+  Agent SDK builder layer (build_uri): does not accept priority / fullscreen params
 
 Pydantic v2 兼容：支持字符串 <-> WindowURI 的校验与序列化
 Pydantic v2 compatibility: supports string <-> WindowURI validation and serialization
@@ -37,26 +42,36 @@ from pydantic.json_schema import JsonSchemaValue
 from pydantic_core import CoreSchema
 from yarl import URL as YURL
 
+from a2c_smcp.utils.logger import get_logger
+
+logger = get_logger("utils.window_uri")
+
 
 class WindowURI:
     """
-    WindowURI 用于解析与构建 window:// 协议的 URI。
-    WindowURI is for parsing and building window:// protocol URIs.
+    WindowURI 用于解析与构建 window:// 协议的 URI（v0.2 纯标识符形态）。
+    WindowURI parses and builds window:// URIs (v0.2 pure-identifier form).
     """
 
     def __init__(self, uri: str) -> None:
         """
         使用 yarl.URL 解析并缓存 URL 组件，避免第三方在 Py3.12 的兼容性问题。
         Parse and cache URL components via yarl.URL to avoid compat issues on Py3.12.
+
+        v0.2 协议层容错：含 query 的 URI 仍可解析成功，但 query 部分会被丢弃并记录 WARN。
+        v0.2 tolerance: URIs with query still parse, but the query is dropped with a WARN log.
         """
         self._url = YURL(uri)
         if self._url.scheme != "window":
             raise ValueError(f"Invalid URI scheme: {self._url.scheme}, uri={uri}")
         if not self._url.host:
             raise IndexError(f"Missing host (MCP id) in URI: {uri}")
-        # 校验查询参数合法性 / validate query params
-        _ = self.priority  # will raise if invalid
-        _ = self.fullscreen  # normalize
+        if self._url.query_string:
+            logger.warning(
+                "WindowURI v0.2 不再支持 query 元数据，已丢弃 query 部分。"
+                "WindowURI v0.2 no longer supports query metadata; query has been dropped. "
+                f"uri={uri}",
+            )
 
     # -------------------------
     # 基础属性 / Basic properties
@@ -91,41 +106,33 @@ class WindowURI:
         return [unquote(seg) for seg in raw.split("/")]
 
     # -------------------------
-    # 查询参数 / Query parameters
+    # 已废弃属性（v0.2 起 query 不再承载元数据）/ Deprecated attrs
     # -------------------------
+    # TODO(#11): 移除 priority / fullscreen 属性，调用方改读 Resource.annotations.priority / _meta.fullscreen
     @cached_property
     def priority(self) -> int | None:
         """
-        获取 priority（0-100），不存在则返回 None；非法值抛出异常
-        Get priority (0-100); None if absent; raise on invalid
+        v0.2 起 priority 不再来自 URI query，统一返回 None。
+        Since v0.2, priority is no longer carried in the URI query; always returns None.
+
+        元数据真实来源：MCP Resource.annotations.priority（float [0,1]）。调用方应改读
+        Resource.annotations，本属性仅为旧调用点向后兼容（由 sub-issue #4 移除）。
+        Real source: MCP Resource.annotations.priority (float [0,1]). Callers should
+        switch to Resource.annotations; this attribute exists only for legacy back-compat
+        (to be removed by sub-issue #4).
         """
-        val = self._url.query.get("priority")
-        if val is None:
-            return None
-        raw = val
-        try:
-            int_val = int(raw)
-        except Exception as e:
-            raise ValueError(f"Invalid priority value: {raw}") from e
-        if not (0 <= int_val <= 100):
-            raise ValueError(f"priority must be in [0, 100], got: {val}")
-        return int_val
+        return None
 
     @cached_property
     def fullscreen(self) -> bool | None:
         """
-        获取 fullscreen 布尔值；不存在则返回 None
-        Get fullscreen boolean; None if absent
+        v0.2 起 fullscreen 不再来自 URI query，统一返回 None。
+        Since v0.2, fullscreen is no longer carried in the URI query; always returns None.
+
+        元数据真实来源：MCP Resource._meta.fullscreen（bool）。
+        Real source: MCP Resource._meta.fullscreen (bool).
         """
-        val = self._url.query.get("fullscreen")
-        if val is None:
-            return None
-        raw = val.strip().lower()
-        if raw in {"1", "true", "yes", "on"}:
-            return True
-        if raw in {"0", "false", "no", "off"}:
-            return False
-        raise ValueError(f"Invalid fullscreen value: {raw}")
+        return None
 
     # -------------------------
     # 构造函数 / Builder
@@ -136,16 +143,20 @@ class WindowURI:
         *,
         host: str,
         windows: Iterable[str] | None = None,
-        priority: int | None = None,
-        fullscreen: bool | None = None,
     ) -> Self:
         """
-        通过 host、windows（0..N 段路径）、可选 priority 与 fullscreen 构建 WindowURI。
-        Build WindowURI from host, windows (0..N path segments), optional priority and fullscreen.
-        所有路径段进行 URL 编码；仅在提供时添加查询参数。
-        All path segments are URL-encoded; query params only included when provided.
+        通过 host 与 windows（0..N 段路径）构建 WindowURI（v0.2 纯标识符）。
+        Build a v0.2 pure-identifier WindowURI from host and windows (0..N path segments).
+
+        所有路径段进行 URL 编码（如 "c/d" -> "c%2Fd"，保持为单段）。
+        All path segments are URL-encoded (e.g., "c/d" -> "c%2Fd", kept as a single segment).
+
+        v0.2 起不再接受 priority / fullscreen 参数 —— 元数据由 MCP Server 在
+        Resource.annotations / _meta 中声明，详见 v0.2 协议指南 §4.1。
+        Since v0.2, priority / fullscreen are not accepted here — metadata is declared by the
+        MCP Server on Resource.annotations / _meta (see protocol guide §4.1).
         """
-        from urllib.parse import quote, urlencode
+        from urllib.parse import quote
 
         if not host:
             raise ValueError("host (MCP id) is required")
@@ -153,20 +164,7 @@ class WindowURI:
         # 对每个段进行编码，确保如 "c/d" -> "c%2Fd" 保持为单段
         segs = [quote(p, safe="") for p in (list(windows) if windows else [])]
         path = "/" + "/".join(segs) if segs else ""
-
-        query_items: dict[str, str] = {}
-        if priority is not None:
-            if not isinstance(priority, int) or not (0 <= priority <= 100):
-                raise ValueError(f"priority must be int in [0, 100], got: {priority}")
-            query_items["priority"] = str(priority)
-        if fullscreen is not None:
-            query_items["fullscreen"] = "true" if fullscreen else "false"
-
-        query_str = urlencode(query_items) if query_items else ""
-        s = f"window://{host}{path}"
-        if query_str:
-            s += f"?{query_str}"
-        return cls(s)
+        return cls(f"window://{host}{path}")
 
     # -------------------------
     # Pydantic v2 支持 / Pydantic v2 support
@@ -216,10 +214,10 @@ def is_window_uri(value: str | AnyUrl | object) -> bool:
     判断给定字符串是否为合法的 WindowURI（window:// 协议）
     Check whether the given string is a valid WindowURI (window:// scheme)
 
-    规则 / Rules:
+    规则 / Rules (v0.2):
     - 必须为 window scheme
     - 必须包含 host（MCP 唯一标识）
-    - 查询参数若存在则需可被解析（如 priority 范围/类型、fullscreen 布尔）
+    - URI 含 query 不会判定为非法（仅在解析时记录 WARN 并丢弃）
     """
     try:
         s = str(value)

--- a/tests/e2e/computer/test_cli_desktop_e2e.py
+++ b/tests/e2e/computer/test_cli_desktop_e2e.py
@@ -45,6 +45,10 @@ def _server_cfg_for_script(name: str, script_rel_path: str) -> dict[str, Any]:
 
 
 @pytest.mark.e2e
+@pytest.mark.xfail(
+    reason="v0.2 WindowURI parser drops query; priority/fullscreen migration to annotations/_meta lands in #11",
+    strict=False,
+)
 def test_desktop_order_respects_recent_tool_calls(cli_proc: pexpect.spawn, tmp_path: Path) -> None:
     """
     场景：

--- a/tests/integration_tests/computer/mcp_clients/test_base_client_windows.py
+++ b/tests/integration_tests/computer/mcp_clients/test_base_client_windows.py
@@ -50,6 +50,13 @@ async def test_list_windows_without_subscribe_returns_resources() -> None:
     await client._async_session_closed_event.wait()
 
 
+@pytest.mark.skip(
+    reason=(
+        "待 sub-issue #11 (organize_desktop 改读 annotations / _meta) 重写："
+        "v0.2 起 priority 不再来自 URI query，base_client.list_windows() 的 priority 排序"
+        "需迁移到读取 Resource.annotations.priority；mock server 也需相应升级。"
+    ),
+)
 @pytest.mark.asyncio
 async def test_list_windows_with_subscribe_returns_sorted_and_subscribed() -> None:
     """

--- a/tests/unit_tests/computer/desktop/test_organize.py
+++ b/tests/unit_tests/computer/desktop/test_organize.py
@@ -20,6 +20,9 @@ from mcp.types import ReadResourceResult, TextResourceContents
 from a2c_smcp.computer.desktop.organize import organize_desktop
 
 
+@pytest.mark.skip(
+    reason="待 sub-issue #11 (organize_desktop 改读 annotations / _meta) 重写：v0.2 起 priority 不再来自 URI query",
+)
 @pytest.mark.asyncio
 async def test_priority_within_server_and_size_cap():
     """
@@ -42,6 +45,9 @@ async def test_priority_within_server_and_size_cap():
     assert ret[1].startswith("window://srv/w1?priority=10") and "w1-text" in ret[1]
 
 
+@pytest.mark.skip(
+    reason="待 sub-issue #11 (organize_desktop 改读 annotations / _meta) 重写：v0.2 起 fullscreen 不再来自 URI query",
+)
 @pytest.mark.asyncio
 async def test_fullscreen_one_per_server_then_next_server():
     """

--- a/tests/unit_tests/utils/test_window_uri.py
+++ b/tests/unit_tests/utils/test_window_uri.py
@@ -5,28 +5,68 @@
 # @Email   : jqq1716@gmail.com
 # @Software: PyCharm
 """
-WindowURI 单元测试 / Unit tests for WindowURI
+WindowURI 单元测试（v0.2 协议）/ Unit tests for WindowURI (v0.2 protocol)
 
 测试意图 / Test intentions:
-- 解析 window:// 协议的基本能力（host、路径段、查询参数）
-- priority 的取值范围与类型校验（0-100）
-- fullscreen 的布尔解析（多种等价表示）
-- 构造函数 build_uri 的编码与可选参数拼装
-- 异常分支：非法 scheme、缺失 host、非法 priority / fullscreen
+- v0.2 纯标识符形态：解析 host、路径段、URL 编码 / 解码
+- v0.2 容错层：URI 含 query 时不抛异常，仅记录 WARN 并丢弃 query
+- 兼容旧调用点：priority / fullscreen 属性永远返回 None
+- 构造层（Agent SDK）：build_uri 不再接受 priority / fullscreen 参数
+- 异常分支：非法 scheme、缺失 host
 - Pydantic v2 集成校验与序列化
+- is_window_uri 行为：含 query 仍判定为 valid
 """
+
+import logging
+from collections.abc import Iterator
 
 import pytest
 from pydantic import BaseModel
 
-from a2c_smcp.utils import WindowURI
+import a2c_smcp.utils.window_uri as window_uri_mod
+from a2c_smcp.utils import WindowURI, is_window_uri
+
+
+@pytest.fixture(autouse=True)
+def attach_project_logger_to_caplog(caplog: pytest.LogCaptureFixture) -> Iterator[None]:
+    """
+    捕获 window_uri 模块的 WARN 输出。
+    Capture WARN output from the window_uri module.
+
+    背景 / Background：项目 logger "a2c_smcp" 关闭了 propagate；
+    且 tests/unit_tests/computer/utils/test_logger.py 的 reset 钩子会
+    `logging.Logger.manager.loggerDict.clear()`，可能让 window_uri 里
+    模块级 logger 变量与 getLogger("a2c_smcp.utils.window_uri") 指向不同对象。
+    所以这里直接把 caplog.handler 挂到源模块当前持有的 logger 引用上。
+
+    "a2c_smcp" disables propagation; and another test's reset hook calls
+    loggerDict.clear(), which can detach window_uri's module-level logger.
+    Attach caplog.handler directly to the source module's current logger reference.
+    """
+    src_logger = window_uri_mod.logger
+    prev_level = src_logger.level
+    prev_propagate = src_logger.propagate
+
+    src_logger.setLevel(logging.DEBUG)
+    src_logger.addHandler(caplog.handler)
+
+    try:
+        yield
+    finally:
+        try:
+            src_logger.removeHandler(caplog.handler)
+        except Exception:
+            pass
+        src_logger.setLevel(prev_level)
+        src_logger.propagate = prev_propagate
+
 
 # ------------------------------
 # 解析相关 / Parsing tests
 # ------------------------------
 
 
-def test_parse_minimal():
+def test_parse_minimal() -> None:
     """最小 URI：仅 host，无路径与参数 / Minimal URI with only host"""
     u = WindowURI("window://com.example.mcp")
     assert u.mcp_id == "com.example.mcp"
@@ -35,65 +75,83 @@ def test_parse_minimal():
     assert u.fullscreen is None
 
 
-def test_parse_with_paths():
-    """带多个路径段 / With multiple path segments"""
+def test_parse_with_paths() -> None:
+    """带多个路径段 / Multiple path segments"""
     u = WindowURI("window://com.example.mcp/dashboard/main")
     assert u.mcp_id == "com.example.mcp"
     assert u.windows == ["dashboard", "main"]
 
 
-def test_parse_with_query_params():
-    """带查询参数 priority 与 fullscreen / With priority and fullscreen query params"""
-    u = WindowURI("window://com.example.mcp/page?priority=90&fullscreen=true")
+def test_parse_path_segment_url_decoding() -> None:
+    """单段 URL 编码保持为一段 / URL-encoded slash within a segment stays one part"""
+    u = WindowURI("window://h/a%2Fb")
+    assert u.windows == ["a/b"]
+
+
+# ------------------------------
+# v0.2 容错：URI 含 query 时丢弃 + WARN
+# ------------------------------
+
+
+def test_parse_with_query_drops_query_and_warns(caplog: pytest.LogCaptureFixture) -> None:
+    """含 query 的 URI 解析成功；query 部分被丢弃；priority/fullscreen 返回 None；记录 WARN
+
+    URIs carrying query parse successfully; query is dropped; priority/fullscreen return None;
+    a WARN log is emitted (Computer parser layer tolerance, protocol guide §4.1).
+    """
+    with caplog.at_level(logging.WARNING, logger="a2c_smcp"):
+        u = WindowURI("window://com.example.mcp/page?priority=90&fullscreen=true")
+
+    assert u.mcp_id == "com.example.mcp"
     assert u.windows == ["page"]
-    assert u.priority == 90
-    assert u.fullscreen is True
+    # v0.2：旧字段统一返回 None
+    assert u.priority is None
+    assert u.fullscreen is None
+
+    # 至少一条 WARN 提到 query 被丢弃
+    warn_msgs = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
+    assert any("query" in msg.lower() for msg in warn_msgs)
+
+
+def test_parse_with_query_no_warn_on_empty(caplog: pytest.LogCaptureFixture) -> None:
+    """无 query 的 URI 解析时不产生 WARN，避免日志风暴 / No WARN when query is absent"""
+    with caplog.at_level(logging.WARNING, logger="a2c_smcp"):
+        WindowURI("window://com.example.mcp/page")
+
+    warn_msgs = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
+    assert not any("query" in msg.lower() for msg in warn_msgs)
+
+
+def test_parse_with_invalid_query_value_does_not_raise() -> None:
+    """v0.2：含非法 priority/fullscreen 值的 URI 不再抛异常 / v0.2 no longer raises on invalid query values"""
+    # v0.1 时这些会抛 ValueError；v0.2 改为容错丢弃
+    WindowURI("window://x?priority=-1")
+    WindowURI("window://x?priority=999")
+    WindowURI("window://x?priority=abc")
+    WindowURI("window://x?fullscreen=maybe")
 
 
 # ------------------------------
-# priority 解析 / Priority tests
+# 旧字段向后兼容 / Legacy attribute back-compat
 # ------------------------------
 
 
-def test_priority_bounds_and_types():
-    """priority 合法边界 0 与 100 / Legal bounds 0 and 100"""
-    assert WindowURI("window://x?a=1&priority=0").priority == 0
-    assert WindowURI("window://x?priority=100").priority == 100
+def test_priority_and_fullscreen_always_none() -> None:
+    """priority / fullscreen 属性永远返回 None（兼容旧调用点；由 sub-issue #4 移除）
 
-    with pytest.raises(ValueError):
-        WindowURI("window://x?priority=-1")
-    with pytest.raises(ValueError):
-        WindowURI("window://x?priority=101")
-    with pytest.raises(ValueError):
-        WindowURI("window://x?priority=abc")
-
-
-# ------------------------------
-# fullscreen 解析 / Fullscreen tests
-# ------------------------------
-@pytest.mark.parametrize(
-    "val,expected",
-    [
-        ("true", True),
-        ("1", True),
-        ("yes", True),
-        ("on", True),
-        ("false", False),
-        ("0", False),
-        ("no", False),
-        ("off", False),
-    ],
-)
-def test_fullscreen_variants(val, expected):
-    """多种布尔等价值解析 / Multiple boolean equivalent values"""
-    u = WindowURI(f"window://x?fullscreen={val}")
-    assert u.fullscreen is expected
-
-
-def test_fullscreen_invalid():
-    """非法 fullscreen 值抛出异常 / Invalid fullscreen value raises"""
-    with pytest.raises(ValueError):
-        WindowURI("window://x?fullscreen=maybe")
+    Attributes always return None for legacy callers (removed by sub-issue #4).
+    """
+    cases = [
+        "window://h",
+        "window://h/p",
+        "window://h/p?priority=80",
+        "window://h/p?priority=0&fullscreen=true",
+        "window://h/p?fullscreen=false",
+    ]
+    for uri in cases:
+        u = WindowURI(uri)
+        assert u.priority is None
+        assert u.fullscreen is None
 
 
 # ------------------------------
@@ -101,36 +159,48 @@ def test_fullscreen_invalid():
 # ------------------------------
 
 
-def test_build_uri_basic_and_roundtrip():
-    """构造基本 URI 并可解析回属性 / Build basic URI and roundtrip parse"""
-    u = WindowURI.build_uri(host="com.example.mcp", windows=["dashboard", "main"], priority=80, fullscreen=False)
+def test_build_uri_basic_and_roundtrip() -> None:
+    """构造基本 URI 并可解析回属性 / Build and roundtrip parse"""
+    u = WindowURI.build_uri(host="com.example.mcp", windows=["dashboard", "main"])
     s = str(u)
-    assert s.startswith("window://com.example.mcp/dashboard/main")
-    assert "priority=80" in s and "fullscreen=false" in s
+    assert s == "window://com.example.mcp/dashboard/main"
 
-    # 反向解析 / reverse parse
     u2 = WindowURI(s)
     assert u2.mcp_id == "com.example.mcp"
     assert u2.windows == ["dashboard", "main"]
-    assert u2.priority == 80
-    assert u2.fullscreen is False
 
 
-def test_build_uri_encoding():
-    """路径段自动 URL 编码，但解析后的 parts 为原始值 / Path segments are URL-encoded, parts are decoded"""
+def test_build_uri_encoding() -> None:
+    """路径段自动 URL 编码，但解析后的 parts 为原始值 / Encoded on build, decoded on parse"""
     u = WindowURI.build_uri(host="h", windows=["A B", "c/d"])
     s = str(u)
-    # 编码形式 / encoded in string form
     assert "A%20B" in s and "c%2Fd" in s
-    # 解析形式 / decoded in parts
     u2 = WindowURI(s)
     assert u2.windows == ["A B", "c/d"]
 
 
-def test_build_uri_optional_params():
-    """未提供可选参数时不拼接查询串 / Without optional params, no query string"""
+def test_build_uri_no_path() -> None:
+    """无 windows 时仅生成 host 形式 / Host-only when windows is empty"""
     u = WindowURI.build_uri(host="h", windows=[])
     assert str(u) == "window://h"
+
+
+def test_build_uri_empty_host_rejected() -> None:
+    """空 host 抛 ValueError / Empty host raises"""
+    with pytest.raises(ValueError):
+        WindowURI.build_uri(host="", windows=["p"])
+
+
+def test_build_uri_rejects_legacy_priority_kwarg() -> None:
+    """v0.2：build_uri 不再接受 priority / fullscreen 参数
+
+    v0.2: build_uri no longer accepts priority / fullscreen kwargs (Agent SDK
+    builder layer is strict — protocol guide §F4).
+    """
+    with pytest.raises(TypeError):
+        WindowURI.build_uri(host="h", windows=["p"], priority=80)  # type: ignore[call-arg]
+    with pytest.raises(TypeError):
+        WindowURI.build_uri(host="h", windows=["p"], fullscreen=True)  # type: ignore[call-arg]
 
 
 # ------------------------------
@@ -138,12 +208,36 @@ def test_build_uri_optional_params():
 # ------------------------------
 
 
-def test_invalid_scheme_and_missing_host():
-    """非法 scheme 与缺失 host 抛出异常 / Invalid scheme and missing host raise"""
+def test_invalid_scheme_raises() -> None:
+    """非法 scheme 抛 ValueError / Non-window scheme raises ValueError"""
     with pytest.raises(ValueError):
         WindowURI("http://x")
+
+
+def test_missing_host_raises() -> None:
+    """缺失 host 抛 IndexError / Missing host raises IndexError"""
     with pytest.raises(IndexError):
         WindowURI("window://")
+
+
+# ------------------------------
+# is_window_uri 行为 / is_window_uri behavior
+# ------------------------------
+
+
+def test_is_window_uri_true_cases() -> None:
+    """合法 URI 返回 True；含 query 也算合法（仅记录 WARN） / Valid cases incl. query"""
+    assert is_window_uri("window://h") is True
+    assert is_window_uri("window://h/p1/p2") is True
+    # v0.2：含 query 不再判定为非法
+    assert is_window_uri("window://h?priority=80") is True
+
+
+def test_is_window_uri_false_cases() -> None:
+    """非法 URI 返回 False / Invalid cases"""
+    assert is_window_uri("http://h") is False
+    assert is_window_uri("window://") is False
+    assert is_window_uri("not a uri") is False
 
 
 # ------------------------------
@@ -151,20 +245,32 @@ def test_invalid_scheme_and_missing_host():
 # ------------------------------
 
 
-def test_pydantic_integration_validate_and_serialize():
+def test_pydantic_integration_validate_and_serialize() -> None:
     """Pydantic 字段类型为 WindowURI，验证字符串输入与序列化输出 / Pydantic field of WindowURI"""
 
     class M(BaseModel):
         uri: WindowURI
 
-    m = M(uri="window://com.example/p1/p2?priority=20&fullscreen=1")
+    m = M.model_validate({"uri": "window://com.example/p1/p2"})
     assert isinstance(m.uri, WindowURI)
     assert m.uri.mcp_id == "com.example"
     assert m.uri.windows == ["p1", "p2"]
-    assert m.uri.priority == 20
-    assert m.uri.fullscreen is True
 
-    # 序列化 / serialization
     data = m.model_dump()
     assert isinstance(data["uri"], str)
-    assert data["uri"].startswith("window://com.example/p1/p2")
+    assert data["uri"] == "window://com.example/p1/p2"
+
+
+def test_pydantic_integration_tolerates_query_with_warn(caplog: pytest.LogCaptureFixture) -> None:
+    """Pydantic 校验同样走 v0.2 容错：含 query 不抛错，仅 WARN / Pydantic shares v0.2 tolerance"""
+
+    class M(BaseModel):
+        uri: WindowURI
+
+    with caplog.at_level(logging.WARNING, logger="a2c_smcp"):
+        m = M.model_validate({"uri": "window://com.example/p?priority=20"})
+
+    assert m.uri.mcp_id == "com.example"
+    assert m.uri.priority is None
+    warn_msgs = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
+    assert any("query" in msg.lower() for msg in warn_msgs)


### PR DESCRIPTION
## Summary
- Drop `priority`/`fullscreen` query parsing — `window://` URI is now a pure identifier per v0.2 protocol §4.1
- Computer parser layer tolerates legacy query (WARN + drop, no exception); Agent SDK builder layer is strict (`build_uri()` rejects `priority`/`fullscreen` kwargs)
- Keep `priority`/`fullscreen` attrs returning `None` for back-compat; tagged `TODO(#11)` along with the two remaining call sites (`organize_desktop`, `base_client.list_windows`)
- 3 tests skipped pending sub-issue #11 — explicit `reason=` strings reference the future migration

## Test plan
- [x] `uv run pytest tests/unit_tests/utils/test_window_uri.py -v` — 18 new tests covering protocol guide §6.1 Window column
- [x] `uv run poe test` — 574 passed, 4 skipped (3 ours + 1 pre-existing), 4 xfailed
- [x] `uv run poe lint` — ruff + mypy clean

## Scope note
Issue #9 body lists `organize_desktop` as the only call site of `WindowURI.priority`/`.fullscreen`, but `a2c_smcp/computer/mcp_clients/base_client.py:list_windows` is a second site. Both are tagged `TODO(#11)` and pinned with `pytest.mark.skip` in the test layer. Sub-issue #11 should cover both.

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)