### PR TITLE
feat(dpe-uri): add v0.2 DPE URI parser (#10)

### DIFF
--- a/a2c_smcp/utils/__init__.py
+++ b/a2c_smcp/utils/__init__.py
@@ -10,9 +10,12 @@
 Export utilities
 """
 
+from .dpe_uri import DPEURI, is_dpe_uri
 from .window_uri import WindowURI, is_window_uri
 
 __all__ = [
+    "DPEURI",
     "WindowURI",
+    "is_dpe_uri",
     "is_window_uri",
 ]

--- a/a2c_smcp/utils/dpe_uri.py
+++ b/a2c_smcp/utils/dpe_uri.py
@@ -1,0 +1,254 @@
+# -*- coding: utf-8 -*-
+# filename: dpe_uri.py
+# @Time    : 2026/04/28 14:00
+# @Author  : JQQ
+# @Email   : jqq1716@gmail.com
+# @Software: PyCharm
+"""
+DPE URI 解析器 / DPEURI parser (v0.2 协议)
+
+协议说明 / Protocol (v0.2 §4.2):
+- scheme 固定为 dpe，URI 形如 dpe://host/doc-ref —— 纯文档标识符
+  Scheme is fixed to 'dpe'; URI is a pure document identifier: dpe://host/doc-ref
+- host 为 MCP 的唯一标识（建议反向域名风格 SHOULD），跨 MCP Server MUST 唯一
+  host is the MCP unique id (reverse-DNS style recommended SHOULD); MUST be unique across MCP Servers
+- doc-ref 为 host 之后第一个 '/' 起到 URI 末尾的整段路径，整体作为文档唯一标识；
+  **不再有 sub-path（pages/N、elements/ID）概念** —— Page / Element 在 DPE JSON 内部表达
+  doc-ref is the full path from the first '/' after host to URI end, used as the whole document identifier;
+  **no more sub-path concepts** — Page / Element live inside the DPE JSON body
+- 拒绝 `dpe://host` 形式（无 doc-ref）；解析失败对应错误码 4012
+  Reject `dpe://host` form (no doc-ref); parse failure maps to error code 4012
+
+URI query / fragment 处理分层（协议 §F4 Postel's law）：
+URI query / fragment handling layers (Postel's law):
+- Computer 解析层（本类）：解析时若含 query / fragment → WARN 日志后丢弃，不抛异常
+  Computer parser layer (this class): on query/fragment → WARN + drop, no exception
+- Agent SDK 构造层（build）：不接受 query / fragment 参数，纯标识符
+  Agent SDK builder layer (build): does not accept query/fragment params
+
+Pydantic v2 兼容：支持字符串 <-> DPEURI 的校验与序列化
+Pydantic v2 compatibility: supports string <-> DPEURI validation and serialization
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable
+from functools import cached_property
+from typing import Any, Self, cast
+from urllib.parse import quote, unquote
+
+from pydantic import AnyUrl, GetCoreSchemaHandler, GetJsonSchemaHandler
+from pydantic.json_schema import JsonSchemaValue
+from pydantic_core import CoreSchema
+from yarl import URL as YURL
+
+from a2c_smcp.utils.logger import get_logger
+
+logger = get_logger("utils.dpe_uri")
+
+# 反向域名风格 lint 模式（SHOULD）：至少 3 段小写字母数字 + 连字符，点分隔
+# Reverse-DNS lint pattern (SHOULD): at least 3 lowercase alphanumeric+hyphen segments, dot-separated
+# 例如 / e.g.: com.example.docs ✅ / docs ⚠️ / DOCS.EXAMPLE.COM ⚠️ / docs_server ⚠️
+_REVERSE_DOMAIN_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*(?:\.[a-z0-9]+(?:-[a-z0-9]+)*){2,}$")
+
+
+class DPEURI:
+    """
+    DPEURI 用于解析与构建 dpe:// 协议的 URI（v0.2 纯文档标识符形态）。
+    DPEURI parses and builds dpe:// URIs (v0.2 pure-document-identifier form).
+    """
+
+    def __init__(self, uri: str) -> None:
+        """
+        使用 yarl.URL 解析并缓存 URL 组件。
+        Parse and cache URL components via yarl.URL.
+
+        v0.2 协议层容错：含 query / fragment 的 URI 仍可解析成功，但 query / fragment
+        部分会被丢弃并记录 WARN（Computer 解析层 §F4 Postel's law）。
+        v0.2 tolerance: URIs with query/fragment still parse, but query/fragment are
+        dropped with a WARN log (Computer parser layer §F4 Postel's law).
+
+        Raises:
+            ValueError: scheme 非 dpe / scheme is not 'dpe'
+            ValueError: doc-ref 为空（对应错误码 4012）/ empty doc-ref (maps to 4012)
+            IndexError: host 缺失 / missing host
+        """
+        self._url = YURL(uri)
+        if self._url.scheme != "dpe":
+            raise ValueError(f"Invalid URI scheme: {self._url.scheme}, uri={uri}")
+        if not self._url.host:
+            raise IndexError(f"Missing host (MCP id) in URI: {uri}")
+
+        # doc-ref 必须非空（拒绝 dpe://host 与 dpe://host/ 两种形式）
+        # doc-ref MUST be non-empty (reject both `dpe://host` and `dpe://host/`)
+        raw_path = self._url.raw_path.lstrip("/")
+        if not raw_path:
+            raise ValueError(f"Missing doc-ref in DPE URI (maps to 4012): {uri}")
+
+        if self._url.query_string:
+            logger.warning(
+                "DPEURI v0.2 不再支持 query 元数据，已丢弃 query 部分。"
+                "DPEURI v0.2 no longer supports query metadata; query has been dropped. "
+                f"uri={uri}",
+            )
+        if self._url.fragment:
+            logger.warning(
+                "DPEURI v0.2 不支持 fragment，已丢弃 fragment 部分。"
+                "DPEURI v0.2 does not support fragments; fragment has been dropped. "
+                f"uri={uri}",
+            )
+
+        # host 反向域名风格 SHOULD lint（不阻塞解析，仅 WARN）
+        # Reverse-DNS host style SHOULD lint (no block, WARN only)
+        host = str(self._url.host)
+        if not _REVERSE_DOMAIN_RE.match(host):
+            logger.warning(
+                "DPEURI host 不符合反向域名规范 (SHOULD)：建议 <tld>.<organization>.<service>[.<sub>]* 风格。"
+                "DPEURI host does not match reverse-DNS lint (SHOULD). "
+                f"host={host}, uri={uri}",
+            )
+
+    # -------------------------
+    # 基础属性 / Basic properties
+    # -------------------------
+    @cached_property
+    def host(self) -> str:
+        """
+        获取 MCP 唯一标识（host）
+        Get MCP unique identifier (host)
+        """
+        return str(self._url.host)
+
+    @cached_property
+    def doc_ref(self) -> str:
+        """
+        文档唯一标识：host 之后整段 path，已逐段解码。
+        Document identifier: full path after host, segment-wise decoded.
+
+        例如 / e.g.:
+            dpe://h/reports/2026/annual -> "reports/2026/annual"
+            dpe://h/a%2Fb              -> "a/b"  (单段，URL 编码 / single segment)
+        """
+        return "/".join(self.doc_ref_parts)
+
+    @cached_property
+    def doc_ref_parts(self) -> list[str]:
+        """
+        doc-ref 分段列表：基于原始编码 path 分段后逐段解码，
+        保证如 "c%2Fd" -> "c/d" 保持为单段。
+        doc-ref segments: split raw-encoded path then decode each segment,
+        keeping "c%2Fd" as one "c/d" part.
+        """
+        raw = self._url.raw_path.lstrip("/")
+        if not raw:
+            return []
+        return [unquote(seg) for seg in raw.split("/")]
+
+    # -------------------------
+    # 构造函数 / Builder
+    # -------------------------
+    @classmethod
+    def build(
+        cls,
+        *,
+        host: str,
+        doc_ref: str | Iterable[str],
+    ) -> Self:
+        """
+        通过 host 与 doc-ref 构建 DPEURI（v0.2 纯文档标识符）。
+        Build a v0.2 pure-document-identifier DPEURI from host and doc-ref.
+
+        - `doc_ref: str` —— 视为整体路径，自动按 '/' 分段并对每段做 URL 编码
+        - `doc_ref: Iterable[str]` —— 视为已分段路径，每段独立 URL 编码
+          （如此 "c/d" 段保持为单段 "c%2Fd"）
+
+        所有 query / fragment 在构造层不被接受 —— Agent SDK 构造层 MUST 严格（§F4）。
+
+        Args:
+            host: MCP 唯一标识，必须非空
+            doc_ref: 文档标识，str 自动分段；Iterable[str] 视为已分段
+
+        Returns:
+            DPEURI 实例
+
+        Raises:
+            ValueError: host 为空 / doc_ref 为空
+        """
+        if not host:
+            raise ValueError("host (MCP id) is required")
+
+        if isinstance(doc_ref, str):
+            segs_raw: list[str] = [s for s in doc_ref.split("/") if s != ""]
+        else:
+            segs_raw = list(doc_ref)
+
+        if not segs_raw:
+            raise ValueError("doc_ref is required (empty doc_ref maps to error code 4012)")
+
+        segs = [quote(p, safe="") for p in segs_raw]
+        return cls(f"dpe://{host}/" + "/".join(segs))
+
+    # -------------------------
+    # Pydantic v2 支持 / Pydantic v2 support
+    # -------------------------
+    @classmethod
+    def __get_pydantic_core_schema__(cls, source_type: Any, handler: GetCoreSchemaHandler) -> Any:
+        """
+        定义 Pydantic 校验与序列化行为：
+        1. 校验：允许字符串或 DPEURI 实例 -> 返回 DPEURI 实例
+        2. 序列化：DPEURI 实例 -> 字符串
+        Define Pydantic validation and serialization:
+        1. Validation: allow str or DPEURI -> return DPEURI
+        2. Serialization: DPEURI -> str
+        """
+        from pydantic_core import core_schema
+
+        def validate(value: str | DPEURI) -> DPEURI:
+            if isinstance(value, cls):
+                return value
+            try:
+                return cls(cast(str, value))
+            except Exception as e:
+                raise ValueError(f"Invalid DPEURI: {value}") from e
+
+        def serialize(value: DPEURI) -> str:
+            return str(value)
+
+        return core_schema.no_info_plain_validator_function(
+            function=validate,
+            serialization=core_schema.plain_serializer_function_ser_schema(function=serialize),
+        )
+
+    @classmethod
+    def __get_pydantic_json_schema__(cls, core_schema: CoreSchema, handler: GetJsonSchemaHandler) -> JsonSchemaValue:
+        return {"type": "string", "format": "uri"}
+
+    # -------------------------
+    # 基础访问 / Basic delegates
+    # -------------------------
+    def __str__(self) -> str:  # noqa: D401
+        """返回标准字符串形式 / Return canonical string form"""
+        return str(self._url)
+
+
+def is_dpe_uri(value: str | AnyUrl | object) -> bool:
+    """
+    判断给定字符串是否为合法的 DPEURI（dpe:// 协议）
+    Check whether the given string is a valid DPEURI (dpe:// scheme)
+
+    规则 / Rules (v0.2):
+    - 必须为 dpe scheme
+    - 必须包含 host（MCP 唯一标识）
+    - 必须包含非空 doc-ref（拒绝 dpe://host 形式）
+    - URI 含 query / fragment 不会判定为非法（仅在解析时记录 WARN 并丢弃）
+    """
+    try:
+        s = str(value)
+    except Exception:
+        return False
+    try:
+        _ = DPEURI(s)
+        return True
+    except Exception:
+        return False

--- a/tests/unit_tests/utils/test_dpe_uri.py
+++ b/tests/unit_tests/utils/test_dpe_uri.py
@@ -1,0 +1,354 @@
+# -*- coding: utf-8 -*-
+# filename: test_dpe_uri.py
+# @Time    : 2026/04/28 14:00
+# @Author  : JQQ
+# @Email   : jqq1716@gmail.com
+# @Software: PyCharm
+"""
+DPEURI 单元测试（v0.2 协议）/ Unit tests for DPEURI (v0.2 protocol)
+
+测试意图 / Test intentions（覆盖协议指南 §6.1 测试矩阵）：
+- 解析：host、doc-ref（单段 / 分段路径）、URL 编码 / 解码
+- 拒绝：dpe://host（无 doc-ref，对应 4012）、非 dpe scheme、缺 host
+- 容错：URI 含 query / fragment 时 WARN + 丢弃，不抛异常
+- 反向域名 SHOULD lint：不规范 host 仅 WARN，不阻塞
+- 构造层（Agent SDK）：build 严格，拒绝空 host / 空 doc_ref
+- Pydantic v2 集成：字符串校验与序列化
+- is_dpe_uri：含 query 仍判定为 valid
+"""
+
+import logging
+from collections.abc import Iterator
+
+import pytest
+from pydantic import BaseModel
+
+import a2c_smcp.utils.dpe_uri as dpe_uri_mod
+from a2c_smcp.utils import DPEURI, is_dpe_uri
+
+
+@pytest.fixture(autouse=True)
+def attach_project_logger_to_caplog(caplog: pytest.LogCaptureFixture) -> Iterator[None]:
+    """
+    捕获 dpe_uri 模块的 WARN 输出。
+    Capture WARN output from the dpe_uri module.
+
+    背景 / Background：项目 logger "a2c_smcp" 关闭了 propagate；
+    且 tests/unit_tests/computer/utils/test_logger.py 的 reset 钩子会
+    `logging.Logger.manager.loggerDict.clear()`，可能让 dpe_uri 里
+    模块级 logger 变量与 getLogger("a2c_smcp.utils.dpe_uri") 指向不同对象。
+    所以这里直接把 caplog.handler 挂到源模块当前持有的 logger 引用上。
+
+    "a2c_smcp" disables propagation; another test's reset hook calls
+    loggerDict.clear(), which can detach dpe_uri's module-level logger.
+    Attach caplog.handler directly to the source module's current logger reference.
+    """
+    src_logger = dpe_uri_mod.logger
+    prev_level = src_logger.level
+    prev_propagate = src_logger.propagate
+
+    src_logger.setLevel(logging.DEBUG)
+    src_logger.addHandler(caplog.handler)
+
+    try:
+        yield
+    finally:
+        try:
+            src_logger.removeHandler(caplog.handler)
+        except Exception:
+            pass
+        src_logger.setLevel(prev_level)
+        src_logger.propagate = prev_propagate
+
+
+# ------------------------------
+# 解析相关 / Parsing tests
+# ------------------------------
+
+
+def test_parse_minimal_doc_ref() -> None:
+    """单段 doc-ref / Single-segment doc-ref"""
+    u = DPEURI("dpe://com.example.docs/rpt-2026")
+    assert u.host == "com.example.docs"
+    assert u.doc_ref == "rpt-2026"
+    assert u.doc_ref_parts == ["rpt-2026"]
+
+
+def test_parse_multi_segment_doc_ref() -> None:
+    """多段 doc-ref / Multi-segment doc-ref (协议 §6.1)"""
+    u = DPEURI("dpe://com.example.docs/reports/2026/annual")
+    assert u.host == "com.example.docs"
+    assert u.doc_ref == "reports/2026/annual"
+    assert u.doc_ref_parts == ["reports", "2026", "annual"]
+
+
+def test_parse_doc_ref_with_extension() -> None:
+    """含扩展名 / With file extension (协议 §4.2)"""
+    u = DPEURI("dpe://com.example.code/src/main/java/Foo.java")
+    assert u.host == "com.example.code"
+    assert u.doc_ref == "src/main/java/Foo.java"
+
+
+def test_parse_url_encoded_segment_kept_single_part() -> None:
+    """单段 URL 编码保持为一段 / URL-encoded slash within a segment stays one part (§6.1)"""
+    u = DPEURI("dpe://com.example.docs/a%2Fb")
+    assert u.doc_ref_parts == ["a/b"]
+    # doc_ref 重组后包含解码后的斜杠（单段中的斜杠）
+    assert u.doc_ref == "a/b"
+
+
+def test_str_roundtrip_canonical() -> None:
+    """str(uri) 返回标准字符串形式 / Canonical string form"""
+    u = DPEURI("dpe://com.example.docs/reports/2026/annual")
+    assert str(u) == "dpe://com.example.docs/reports/2026/annual"
+
+
+# ------------------------------
+# v0.2 容错：URI 含 query / fragment
+# ------------------------------
+
+
+def test_parse_with_query_drops_and_warns(caplog: pytest.LogCaptureFixture) -> None:
+    """含 query 的 URI 解析成功；query 被丢弃；记录 WARN（协议 §6.1 / §F4）
+
+    URIs carrying query parse successfully; query is dropped; a WARN log is emitted.
+    """
+    with caplog.at_level(logging.WARNING, logger="a2c_smcp"):
+        u = DPEURI("dpe://com.example.docs/doc?format=md")
+
+    assert u.host == "com.example.docs"
+    assert u.doc_ref == "doc"
+
+    warn_msgs = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
+    assert any("query" in msg.lower() for msg in warn_msgs)
+
+
+def test_parse_with_fragment_drops_and_warns(caplog: pytest.LogCaptureFixture) -> None:
+    """含 fragment 的 URI 解析成功；fragment 被丢弃；记录 WARN
+
+    URIs carrying fragment parse successfully; fragment is dropped; a WARN log is emitted.
+    """
+    with caplog.at_level(logging.WARNING, logger="a2c_smcp"):
+        u = DPEURI("dpe://com.example.docs/doc#section-1")
+
+    assert u.host == "com.example.docs"
+    assert u.doc_ref == "doc"
+
+    warn_msgs = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
+    assert any("fragment" in msg.lower() for msg in warn_msgs)
+
+
+def test_parse_no_warn_on_clean_uri(caplog: pytest.LogCaptureFixture) -> None:
+    """无 query / fragment 的标准 URI 不产生 WARN / No WARN on clean URI"""
+    with caplog.at_level(logging.WARNING, logger="a2c_smcp"):
+        DPEURI("dpe://com.example.docs/doc")
+
+    warn_msgs = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
+    # 不应有 query/fragment 相关的 WARN
+    assert not any("query" in msg.lower() or "fragment" in msg.lower() for msg in warn_msgs)
+
+
+# ------------------------------
+# host 反向域名 SHOULD lint / Reverse-DNS host lint
+# ------------------------------
+
+
+def test_reverse_domain_compliant_host_no_warn(caplog: pytest.LogCaptureFixture) -> None:
+    """合规反向域名 host 不产生 lint WARN / Compliant reverse-DNS host emits no lint WARN"""
+    with caplog.at_level(logging.WARNING, logger="a2c_smcp"):
+        DPEURI("dpe://com.example.docs/doc")
+
+    warn_msgs = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
+    assert not any("反向域名" in msg or "reverse-DNS" in msg for msg in warn_msgs)
+
+
+def test_non_reverse_domain_host_warns_but_parses(caplog: pytest.LogCaptureFixture) -> None:
+    """单段 host 不阻塞解析，仅产生 SHOULD WARN / Single-segment host parses with SHOULD WARN"""
+    with caplog.at_level(logging.WARNING, logger="a2c_smcp"):
+        u = DPEURI("dpe://docs/some-doc")
+
+    assert u.host == "docs"
+    assert u.doc_ref == "some-doc"
+    warn_msgs = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
+    assert any("反向域名" in msg or "reverse-DNS" in msg for msg in warn_msgs)
+
+
+def test_uppercase_host_warns(caplog: pytest.LogCaptureFixture) -> None:
+    """大写 host 不规范，产生 WARN（注意 yarl 可能将 host 标准化为小写）/ Uppercase host warns"""
+    # 用 underscore 代替 uppercase 触发 lint WARN（yarl 会自动小写化 host，因此用 _ 测试）
+    with caplog.at_level(logging.WARNING, logger="a2c_smcp"):
+        DPEURI("dpe://docs_server/doc")
+
+    warn_msgs = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
+    assert any("反向域名" in msg or "reverse-DNS" in msg for msg in warn_msgs)
+
+
+# ------------------------------
+# 异常分支 / Error cases (协议 §6.1)
+# ------------------------------
+
+
+def test_invalid_scheme_raises() -> None:
+    """非 dpe scheme 抛 ValueError / Non-dpe scheme raises"""
+    with pytest.raises(ValueError):
+        DPEURI("http://com.example.docs/doc")
+    with pytest.raises(ValueError):
+        DPEURI("window://com.example.docs/doc")
+
+
+def test_missing_host_raises() -> None:
+    """缺 host 抛 IndexError / Missing host raises (§6.1 dpe:///doc-ref)"""
+    with pytest.raises(IndexError):
+        DPEURI("dpe:///doc-ref")
+
+
+def test_missing_doc_ref_raises_for_4012() -> None:
+    """无 doc-ref（dpe://host）抛 ValueError，对应错误码 4012（§6.1）
+
+    Empty doc-ref raises ValueError mapping to error code 4012.
+    """
+    with pytest.raises(ValueError, match="4012"):
+        DPEURI("dpe://com.example.docs")
+
+
+def test_empty_doc_ref_with_trailing_slash_raises() -> None:
+    """带尾部斜杠但无 doc-ref（dpe://host/）也应被拒绝 / Trailing slash without doc-ref also rejected"""
+    with pytest.raises(ValueError, match="4012"):
+        DPEURI("dpe://com.example.docs/")
+
+
+# ------------------------------
+# 构造函数 / build() tests
+# ------------------------------
+
+
+def test_build_with_str_doc_ref_basic() -> None:
+    """str doc-ref 构造 / build with str doc_ref"""
+    u = DPEURI.build(host="com.example.docs", doc_ref="rpt-2026")
+    assert str(u) == "dpe://com.example.docs/rpt-2026"
+    assert u.doc_ref == "rpt-2026"
+
+
+def test_build_with_str_doc_ref_multi_segment() -> None:
+    """str doc-ref 自动按 '/' 分段 / Slash-split str doc_ref"""
+    u = DPEURI.build(host="com.example.docs", doc_ref="reports/2026/annual")
+    assert str(u) == "dpe://com.example.docs/reports/2026/annual"
+    assert u.doc_ref_parts == ["reports", "2026", "annual"]
+
+
+def test_build_with_iterable_doc_ref_keeps_segment_with_slash() -> None:
+    """Iterable doc-ref 保持段内斜杠为编码（"c/d" -> "c%2Fd" 单段）
+
+    Iterable doc_ref keeps in-segment slash encoded (single segment).
+    """
+    u = DPEURI.build(host="com.example.docs", doc_ref=["a", "c/d"])
+    s = str(u)
+    assert "c%2Fd" in s
+    u2 = DPEURI(s)
+    assert u2.doc_ref_parts == ["a", "c/d"]
+
+
+def test_build_with_special_chars_url_encoded() -> None:
+    """构造时特殊字符自动 URL 编码 / Special chars auto URL-encoded"""
+    u = DPEURI.build(host="com.example.docs", doc_ref="A B")
+    s = str(u)
+    assert "A%20B" in s
+    u2 = DPEURI(s)
+    assert u2.doc_ref == "A B"
+
+
+def test_build_empty_host_rejected() -> None:
+    """空 host 抛 ValueError / Empty host raises"""
+    with pytest.raises(ValueError):
+        DPEURI.build(host="", doc_ref="doc")
+
+
+def test_build_empty_doc_ref_rejected() -> None:
+    """空 doc_ref 抛 ValueError（构造层严格 §F4）/ Empty doc_ref rejected (Agent SDK strict)"""
+    with pytest.raises(ValueError):
+        DPEURI.build(host="com.example.docs", doc_ref="")
+    with pytest.raises(ValueError):
+        DPEURI.build(host="com.example.docs", doc_ref=[])
+    # 仅含斜杠也视为空
+    with pytest.raises(ValueError):
+        DPEURI.build(host="com.example.docs", doc_ref="/")
+
+
+def test_build_roundtrip() -> None:
+    """构造后再解析，属性一致 / Build then parse roundtrip"""
+    built = DPEURI.build(host="com.example.docs", doc_ref="reports/2026/annual")
+    parsed = DPEURI(str(built))
+    assert parsed.host == "com.example.docs"
+    assert parsed.doc_ref_parts == ["reports", "2026", "annual"]
+
+
+# ------------------------------
+# is_dpe_uri 行为 / is_dpe_uri behavior
+# ------------------------------
+
+
+def test_is_dpe_uri_true_cases() -> None:
+    """合法 URI 返回 True；含 query 也算合法 / Valid cases incl. query"""
+    assert is_dpe_uri("dpe://com.example.docs/doc") is True
+    assert is_dpe_uri("dpe://com.example.docs/reports/2026/annual") is True
+    # v0.2：含 query 不再判定为非法
+    assert is_dpe_uri("dpe://com.example.docs/doc?format=md") is True
+
+
+def test_is_dpe_uri_false_cases() -> None:
+    """非法 URI 返回 False / Invalid cases"""
+    assert is_dpe_uri("http://com.example.docs/doc") is False
+    assert is_dpe_uri("dpe:///doc") is False
+    assert is_dpe_uri("dpe://com.example.docs") is False  # 无 doc-ref
+    assert is_dpe_uri("dpe://com.example.docs/") is False  # 空 doc-ref
+    assert is_dpe_uri("not a uri") is False
+
+
+# ------------------------------
+# Pydantic v2 集成 / Pydantic integration
+# ------------------------------
+
+
+def test_pydantic_integration_validate_and_serialize() -> None:
+    """Pydantic 字段类型为 DPEURI / Pydantic field of DPEURI"""
+
+    class M(BaseModel):
+        uri: DPEURI
+
+    m = M.model_validate({"uri": "dpe://com.example.docs/reports/2026"})
+    assert isinstance(m.uri, DPEURI)
+    assert m.uri.host == "com.example.docs"
+    assert m.uri.doc_ref_parts == ["reports", "2026"]
+
+    data = m.model_dump()
+    assert isinstance(data["uri"], str)
+    assert data["uri"] == "dpe://com.example.docs/reports/2026"
+
+
+def test_pydantic_integration_rejects_invalid() -> None:
+    """非法字符串 Pydantic 校验失败 / Invalid string fails Pydantic validation"""
+
+    class M(BaseModel):
+        uri: DPEURI
+
+    with pytest.raises(ValueError):
+        M.model_validate({"uri": "dpe://com.example.docs"})  # 无 doc-ref
+    with pytest.raises(ValueError):
+        M.model_validate({"uri": "http://com.example.docs/doc"})  # 错 scheme
+
+
+def test_pydantic_integration_tolerates_query_with_warn(caplog: pytest.LogCaptureFixture) -> None:
+    """Pydantic 校验同样走 v0.2 容错：含 query 不抛错，仅 WARN
+
+    Pydantic shares v0.2 tolerance (query dropped + WARN, no exception).
+    """
+
+    class M(BaseModel):
+        uri: DPEURI
+
+    with caplog.at_level(logging.WARNING, logger="a2c_smcp"):
+        m = M.model_validate({"uri": "dpe://com.example.docs/doc?format=md"})
+
+    assert m.uri.doc_ref == "doc"
+    warn_msgs = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
+    assert any("query" in msg.lower() for msg in warn_msgs)


### PR DESCRIPTION
## Summary

Closes #10 — v0.2 协议升级 sub-issue 3/13（DPE URI 解析器）。

Greenfield 实现，v0.1 没有 DPE URI；按协议指南 [§4.2](https://github.com/A2C-SMCP/a2c-smcp-protocol/blob/main/docs/migrations/v0.2-uri-metadata-refactor.md#42-dpe-uri-重构) / §6.1 / §F4 落地：

- **DPEURI 类**：`__init__` / `host` / `doc_ref` / `doc_ref_parts` / `build()` / `__str__`
- **解析层（Computer，容错 §F4）**：query / fragment 检测后 **WARN + 丢弃**，不抛异常
- **构造层（Agent SDK，严格 §F4）**：`build()` 拒绝空 host / 空 doc_ref
- **拒绝 `dpe://host` 与 `dpe://host/`**（无 doc-ref → `ValueError`，映射协议错误码 **4012**）
- **host 反向域名 SHOULD lint**：不规范 host 仅 WARN，不阻塞解析（§4.4 lint-style）
- **doc-ref 整体语义**：协议指南要求 doc-ref 整体作为文档唯一标识，不再有 sub-path（pages/N、elements/ID）
- **Iterable[str] 形式 build**：段内斜杠保持单段（`["a", "c/d"]` → `dpe://h/a/c%2Fd`）
- **Pydantic v2 schema**：字符串 <-> DPEURI 校验 + 序列化
- **is_dpe_uri() helper**

## 测试覆盖（协议 §6.1 测试矩阵）

27 个新增用例：

| 维度 | 用例 |
|---|---|
| 解析 | 单段 / 多段 / 含扩展名 / URL 编码段 / `__str__` 标准化 |
| v0.2 容错 | 含 query → WARN+丢弃；含 fragment → WARN+丢弃；干净 URI 不产生 WARN |
| host SHOULD lint | 合规反向域名 host 静默；单段 host WARN；underscore host WARN |
| 异常分支 | 错 scheme / 缺 host / `dpe://host` / `dpe://host/` → 抛错并含 \"4012\" 标识 |
| build 构造 | str/Iterable doc_ref / 空值拒绝 / URL 编码 / roundtrip |
| is_dpe_uri | 合法 / 非法分支 |
| Pydantic | 校验 + 序列化 + 拒绝非法 + query 容错 |

测试侧防御：autouse fixture 直挂 `caplog.handler` 到源模块 `logger` 引用，规避 `test_logger.py` 的 `loggerDict.clear()` 钩子让 logger 引用错位（沿用 #9 修复模式）。

## 依赖与阻塞

- 依赖 #21（错误码 4012 已落地于 `c57fa56`）✅
- 阻塞 #15（DPE Resolver 抽象 + DefaultPassthroughResolver） — 解除阻塞

## Test plan

- [x] `uv run poe lint`（ruff + mypy strict）
- [x] `uv run pytest tests/unit_tests/utils/test_dpe_uri.py`：27/27 通过
- [x] `uv run poe test`：604 passed（无回归；基线 577 + 27 = 604 ✓）

🤖 Generated with [Claude Code](https://claude.com/claude-code)