### PR TITLE
feat(mcp-manager): host reverse-index + registration fail-fast (#12)

### DIFF
--- a/a2c_smcp/computer/mcp_clients/manager.py
+++ b/a2c_smcp/computer/mcp_clients/manager.py
@@ -14,9 +14,11 @@ from mcp.client.session import MessageHandlerFnT
 from mcp.types import CallToolResult, ReadResourceResult, Resource, Tool
 from vrl_python import VRLRuntime
 
+from a2c_smcp.computer.mcp_clients.base_client import MCPCapabilityNotSupportedError
 from a2c_smcp.computer.mcp_clients.model import A2C_TOOL_META, A2C_VRL_TRANSFORMED, MCPClientProtocol, MCPServerConfig, ToolMeta
 from a2c_smcp.computer.mcp_clients.utils import client_factory
 from a2c_smcp.types import SERVER_NAME, TOOL_NAME
+from a2c_smcp.utils import DPEURI, WindowURI, is_dpe_uri, is_window_uri
 from a2c_smcp.utils.logger import get_logger, truncate
 
 logger = get_logger("computer")
@@ -25,6 +27,27 @@ logger = get_logger("computer")
 class ToolNameDuplicatedError(Exception):
     def __init__(self, *args: Any) -> None:
         super().__init__(*args)
+
+
+class HostConflictError(Exception):
+    """
+    中文: 注册期检测到 host 跨 MCP Server 冲突；新 server 注册被拒绝。
+    英文: Host conflict across MCP Servers detected at registration time; new server registration rejected.
+
+    协议依据 / Protocol reference:
+        a2c-smcp-protocol main HEAD §4.4 — host 跨 MCP Server MUST 唯一（注册期硬约束 fail-fast）。
+        wire-level 错误码由上层 `client:get_dpe` 处理器映射为 `4014 MCP_SERVER_NOT_FOUND`（顶层 flat
+        字段 `mcp_server_name`），本异常仅是 manager 层内部信号。
+    """
+
+    def __init__(self, host: str, conflicting_servers: tuple[SERVER_NAME, SERVER_NAME], *args: Any) -> None:
+        self.host = host
+        self.conflicting_servers = conflicting_servers
+        existing, attempted = conflicting_servers
+        super().__init__(
+            f"Host '{host}' already registered by server '{existing}'; rejecting registration of '{attempted}'",
+            *args,
+        )
 
 
 class MCPServerManager:
@@ -60,10 +83,161 @@ class MCPServerManager:
         self._message_handler: MessageHandlerFnT | None = message_handler
         # 内部锁防止并发修改
         self._lock = asyncio.Lock()
+        # host 反查索引: dpe:// + window:// scheme 下的 host → 拥有该 host 的 server 集合
+        # host reverse index: host (from dpe:// + window:// scheme) → set of owning server names
+        # 协议 §4.4 注册期 fail-fast 保证同一时刻 1 host 至多对应 1 server；用 set 容器仅是为了
+        # 1 server N hosts 拓扑下统一管理（清理时按 server 移除其全部 host 占用）
+        # Protocol §4.4 fail-fast guarantees ≤1 server per host at any time; the set container exists
+        # only because a single server may declare N hosts (cleanup must remove all host slots owned by it)
+        self._host_to_servers: dict[str, set[SERVER_NAME]] = defaultdict(set)
+        # 注册期 list_resources 临时失败的 server；冲突检测延后到下一次成功 list 时（§4.4 延迟检测语义）
+        # Servers whose registration-time list_resources failed transiently; conflict detection deferred
+        # until next successful list call (§4.4 delayed-detection semantics)
+        self._host_index_pending: set[SERVER_NAME] = set()
 
     def get_server_config(self, server_name: SERVER_NAME) -> MCPServerConfig:
         """通过名称获取服务配置"""
         return self._servers_config[server_name]
+
+    def find_server_by_host(self, host: str) -> SERVER_NAME | None:
+        """
+        中文: 通过 host 反查 MCP Server 名（v0.2 `client:get_dpe` 路由依据）。
+        英文: Reverse-lookup MCP server name by host (v0.2 `client:get_dpe` routing source).
+
+        协议 §4.4 注册期 fail-fast 保证 1 host 至多对应 1 server——返回 0 或 1 个名字。
+        Protocol §4.4 fail-fast guarantees ≤1 server per host — returns 0 or 1 name.
+
+        Args:
+            host (str): 待反查的 host / Host to look up.
+
+        Returns:
+            SERVER_NAME | None: 拥有该 host 的 server 名；未注册时返回 None（上层映射 4014）/
+                Owning server name; None when unknown (upper layer maps to 4014).
+        """
+        servers = self._host_to_servers.get(host)
+        if not servers:
+            return None
+        # 注册期 fail-fast 保证至多 1 个；多对 1 是不变量违反
+        # Fail-fast guarantees ≤1; >1 indicates an invariant violation
+        return next(iter(servers))
+
+    @staticmethod
+    def _extract_hosts_from_resources(resources: Iterable[Resource]) -> set[str]:
+        """
+        中文: 从 Resource URI 列表中收集 dpe:// + window:// 的 host 集合（其他 scheme 不参与 host 索引）。
+        英文: Collect host set from Resource URIs (only `dpe://` + `window://` schemes contribute).
+        """
+        hosts: set[str] = set()
+        for res in resources:
+            uri = str(res.uri)
+            if is_dpe_uri(uri):
+                try:
+                    hosts.add(DPEURI(uri).host)
+                except Exception as e:
+                    logger.warning(f"Skip dpe URI for host extraction: {uri} ({e})")
+            elif is_window_uri(uri):
+                try:
+                    hosts.add(WindowURI(uri).mcp_id)
+                except Exception as e:
+                    logger.warning(f"Skip window URI for host extraction: {uri} ({e})")
+        return hosts
+
+    async def _acollect_hosts_for_server(self, server_name: SERVER_NAME, client: MCPClientProtocol) -> set[str]:
+        """
+        中文: 穷举 `list_resources_page` 翻页，收集 server 当前声明的 host 集合。
+        英文: Exhaust `list_resources_page` pagination to gather the host set declared by the server.
+
+        - capability 缺失（未声明 `resources`）→ 返回空集，**不**视为故障（永久状态）
+        - 网络等其他异常 → 抛出，由调用方决定是否标 pending
+        - capability missing → return empty set, NOT treated as failure (permanent state)
+        - other exceptions → propagated; caller decides whether to mark pending
+        """
+        hosts: set[str] = set()
+        cursor: str | None = None
+        try:
+            while True:
+                page, cursor = await client.list_resources_page(cursor=cursor)
+                hosts.update(self._extract_hosts_from_resources(page))
+                if cursor is None:
+                    break
+        except MCPCapabilityNotSupportedError:
+            logger.debug(f"Server {server_name} did not declare 'resources' capability — contributes no hosts")
+            return set()
+        return hosts
+
+    def _detect_host_conflict(self, server_name: SERVER_NAME, hosts: set[str]) -> tuple[str, SERVER_NAME] | None:
+        """
+        中文: 检查 hosts 与现有索引的冲突。返回 (冲突 host, 占用该 host 的另一 server) 或 None。
+        英文: Check `hosts` against existing index. Returns (conflicting_host, existing_server) or None.
+
+        排除 `server_name` 自身——重启 / 重新注册同名 server 不视为冲突（前提是清理已发生）。
+        Excludes `server_name` itself — re-registering the same name is not a conflict (assuming cleanup ran).
+        """
+        for host in hosts:
+            existing = self._host_to_servers.get(host)
+            if existing:
+                others = existing - {server_name}
+                if others:
+                    return host, next(iter(others))
+        return None
+
+    def _register_hosts(self, server_name: SERVER_NAME, hosts: set[str]) -> None:
+        """中文: 把 hosts 写入反查索引。/ English: Write `hosts` into the reverse index."""
+        for host in hosts:
+            self._host_to_servers[host].add(server_name)
+
+    def _release_hosts(self, server_name: SERVER_NAME) -> None:
+        """中文: 注销 server 时释放其占用的所有 host 槽位。/ English: Release all host slots owned by `server_name`."""
+        empty_keys: list[str] = []
+        for host, owners in self._host_to_servers.items():
+            owners.discard(server_name)
+            if not owners:
+                empty_keys.append(host)
+        for host in empty_keys:
+            del self._host_to_servers[host]
+        self._host_index_pending.discard(server_name)
+
+    async def aretry_pending_host_index(self, server_name: SERVER_NAME) -> bool:
+        """
+        中文: 对处于 `host_index_pending` 状态的 server 重新尝试 host 收集与冲突检测。
+              冲突 → 注销 server + 抛 `HostConflictError`；成功 → 写索引并清除 pending；
+              本次仍失败 → 保留 pending 返回 False。
+        英文: Retry host collection + conflict detection for a server currently in `host_index_pending`.
+              On conflict → unregister server + raise `HostConflictError`; on success → write index
+              and clear pending; on transient failure → keep pending and return False.
+
+        供 v0.2 `client:get_resources` 处理器（#14）在成功完成 list 后回调，落实 §4.4 延迟检测语义。
+        Used by the v0.2 `client:get_resources` handler (#14) after a successful list, to enforce
+        §4.4 delayed-detection semantics.
+
+        Returns:
+            bool: True 表示 pending 已解除（含本身就不在 pending 集合的快速路径）；False 表示仍 pending。
+        """
+        async with self._lock:
+            if server_name not in self._host_index_pending:
+                return True
+            client = self._active_clients.get(server_name)
+            if not client:
+                # server 已不在 active 列表，pending 标记失去意义
+                self._host_index_pending.discard(server_name)
+                return True
+            try:
+                hosts = await self._acollect_hosts_for_server(server_name, client)
+            except Exception as e:
+                logger.warning(f"Retry host index for '{server_name}' still failing: {e}")
+                return False
+            conflict = self._detect_host_conflict(server_name, hosts)
+            if conflict:
+                conflict_host, existing = conflict
+                # 冲突 → 注销该 server（同步本次 active_clients + servers_config 状态）
+                # Conflict → unregister this server (sync active_clients + servers_config state)
+                await self._astop_client(server_name)
+                self._servers_config.pop(server_name, None)
+                self._host_index_pending.discard(server_name)
+                raise HostConflictError(conflict_host, (existing, server_name))
+            self._register_hosts(server_name, hosts)
+            self._host_index_pending.discard(server_name)
+            return True
 
     def get_tool_meta(self, server_name: SERVER_NAME, tool_name: TOOL_NAME) -> ToolMeta | None:
         """
@@ -234,11 +408,33 @@ class MCPServerManager:
         client = client_factory(config, message_handler=self._message_handler)
         await client.aconnect()
         self._active_clients[server_name] = client
+
+        # host 反查索引：注册期 fail-fast（§4.4 硬约束）。list 临时失败 → 标 pending，延迟检测
+        # Host reverse index: registration-time fail-fast (§4.4 hard constraint).
+        # Transient list failure → mark pending for delayed detection.
+        try:
+            hosts = await self._acollect_hosts_for_server(server_name, client)
+        except Exception as e:
+            logger.warning(
+                f"Server '{server_name}' registered but host index pending — list_resources failed: {e}",
+            )
+            self._host_index_pending.add(server_name)
+            hosts = set()
+        else:
+            conflict = self._detect_host_conflict(server_name, hosts)
+            if conflict:
+                conflict_host, existing = conflict
+                await client.adisconnect()
+                del self._active_clients[server_name]
+                raise HostConflictError(conflict_host, (existing, server_name))
+            self._register_hosts(server_name, hosts)
+
         try:
             await self._arefresh_tool_mapping()
         except ToolNameDuplicatedError as e:
             await client.adisconnect()
             del self._active_clients[server_name]
+            self._release_hosts(server_name)
             raise e
 
     async def astop_client(self, server_name: str) -> None:
@@ -251,6 +447,9 @@ class MCPServerManager:
         client = self._active_clients.pop(server_name, None)
         if client:
             await client.adisconnect()
+            # §4.4 注销即释放 host 占用，避免后注册的同 host server 出现"假冲突"
+            # §4.4 unregister releases host slots so a later same-host registration is not a "false conflict"
+            self._release_hosts(server_name)
             await self._arefresh_tool_mapping()
 
     async def _astop_all(self) -> None:
@@ -271,6 +470,8 @@ class MCPServerManager:
         self._tool_mapping.clear()
         self._alias_mapping.clear()
         self._disabled_tools.clear()
+        self._host_to_servers.clear()
+        self._host_index_pending.clear()
 
     async def aclose(self) -> None:
         """关闭所有连接（别名）"""

--- a/a2c_smcp/computer/mcp_clients/model.py
+++ b/a2c_smcp/computer/mcp_clients/model.py
@@ -191,6 +191,10 @@ class MCPClientProtocol(Protocol):
         """列出当前MCP服务可用的窗口资源列表 / List window resources of the MCP server"""
         ...
 
+    async def list_resources_page(self, cursor: str | None = None) -> tuple[list[Resource], str | None]:
+        """单页透传 MCP `resources/list` / Single-page transparent forward of MCP `resources/list`"""
+        ...
+
     async def get_window_detail(self, resource: Resource | str) -> ReadResourceResult:
         """获取当前Window的详细内容"""
         ...

--- a/tests/unit_tests/computer/mcp_clients/test_manager_host.py
+++ b/tests/unit_tests/computer/mcp_clients/test_manager_host.py
@@ -1,0 +1,402 @@
+# -*- coding: utf-8 -*-
+# filename: test_manager_host.py
+# @Time    : 2026/4/30
+# @Author  : JQQ
+# @Email   : jqq1716@gmail.com
+# @Software: PyCharm
+"""
+中文: `MCPServerManager` host 反查索引 + 注册期 fail-fast 单元测试。
+英文: Unit tests for `MCPServerManager` host reverse-index + registration-time fail-fast.
+
+覆盖 v0.2 协议指南 §4.4 / §6.4 host 唯一性硬约束在 SDK 端的实现（Issue #12）。
+Covers v0.2 protocol §4.4 / §6.4 host uniqueness hard constraint on the SDK side (Issue #12).
+"""
+from collections.abc import AsyncGenerator
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from mcp import StdioServerParameters
+from mcp.types import AnyUrl, CallToolResult, Resource
+
+from a2c_smcp.computer.mcp_clients.base_client import MCPCapabilityNotSupportedError
+from a2c_smcp.computer.mcp_clients.manager import HostConflictError, MCPServerManager
+from a2c_smcp.computer.mcp_clients.model import StdioServerConfig
+
+
+def _make_resource(uri: str, name: str = "r") -> Resource:
+    return Resource(uri=AnyUrl(uri), name=name)
+
+
+class _MockHostClient:
+    """
+    支持 list_resources_page 翻页 + capability 模拟的最小 MCP Client mock。
+
+    pages: list[tuple[list[Resource], str | None]] — 按顺序模拟单页翻页响应。
+    raise_on_list: 异常实例，模拟 list_resources_page 抛错（含 MCPCapabilityNotSupportedError）。
+    """
+
+    def __init__(
+        self,
+        pages: list[tuple[list[Resource], str | None]] | None = None,
+        raise_on_list: Exception | None = None,
+    ) -> None:
+        self.aconnect = AsyncMock()
+        self.adisconnect = AsyncMock()
+        self.list_tools = AsyncMock(return_value=[])
+        call_ret = MagicMock(spec=CallToolResult)
+        call_ret.result = None
+        call_ret.meta = None
+        self.call_tool = AsyncMock(return_value=call_ret)
+        self.state = "connected"
+        self.message_handler = None
+        self._pages = pages or [([], None)]
+        self._page_idx = 0
+        self._raise_on_list = raise_on_list
+
+    async def list_resources_page(
+        self, cursor: str | None = None,
+    ) -> tuple[list[Resource], str | None]:
+        if self._raise_on_list is not None:
+            raise self._raise_on_list
+        # 简单实现: 按调用顺序返回 _pages 中的下一项；忽略 cursor 内容
+        if self._page_idx >= len(self._pages):
+            return [], None
+        page = self._pages[self._page_idx]
+        self._page_idx += 1
+        return page
+
+
+def _config(name: str) -> StdioServerConfig:
+    return StdioServerConfig(
+        name=name,
+        disabled=False,
+        forbidden_tools=[],
+        tool_meta={},
+        default_tool_meta=None,
+        server_parameters=MagicMock(spec=StdioServerParameters),
+    )
+
+
+@pytest.fixture
+async def manager() -> AsyncGenerator[MCPServerManager, None]:
+    m = MCPServerManager(auto_connect=True, auto_reconnect=True)
+    yield m
+    await m.aclose()
+
+
+def _patch_factory(monkeypatch, mapping: dict[str, _MockHostClient]) -> None:
+    """按 server name 把 client_factory 路由到对应 mock。"""
+    def factory(config, message_handler=None):  # noqa: ARG001
+        if config.name not in mapping:
+            return _MockHostClient()
+        client = mapping[config.name]
+        client.message_handler = message_handler
+        return client
+
+    monkeypatch.setattr("a2c_smcp.computer.mcp_clients.manager.client_factory", factory)
+
+
+@pytest.mark.asyncio
+async def test_two_servers_different_hosts_both_register(manager, monkeypatch):
+    """两个 server 声明不同 host → 都能成功注册；find_server_by_host 正确反查。"""
+    clients = {
+        "server-a": _MockHostClient(
+            pages=[([
+                _make_resource("dpe://com.example.docs/a.md"),
+                _make_resource("window://com.example.docs/main"),
+            ], None)],
+        ),
+        "server-b": _MockHostClient(
+            pages=[([_make_resource("dpe://com.example.code/file.py")], None)],
+        ),
+    }
+    _patch_factory(monkeypatch, clients)
+
+    await manager.aadd_or_aupdate_server(_config("server-a"))
+    await manager.aadd_or_aupdate_server(_config("server-b"))
+
+    assert manager.find_server_by_host("com.example.docs") == "server-a"
+    assert manager.find_server_by_host("com.example.code") == "server-b"
+    assert manager.find_server_by_host("com.example.unknown") is None
+
+
+@pytest.mark.asyncio
+async def test_one_server_multiple_hosts_allowed(manager, monkeypatch):
+    """1 server 声明 N 个 host（聚合多上游）→ 注册成功，索引含全部 host。"""
+    clients = {
+        "aggregator": _MockHostClient(
+            pages=[([
+                _make_resource("dpe://com.example.docs/a"),
+                _make_resource("dpe://com.example.code/b"),
+                _make_resource("window://com.example.editor/main"),
+            ], None)],
+        ),
+    }
+    _patch_factory(monkeypatch, clients)
+
+    await manager.aadd_or_aupdate_server(_config("aggregator"))
+
+    for host in ("com.example.docs", "com.example.code", "com.example.editor"):
+        assert manager.find_server_by_host(host) == "aggregator"
+
+
+@pytest.mark.asyncio
+async def test_host_conflict_fail_fast(manager, monkeypatch):
+    """两个 server 声明相同 host → 后注册者被拒绝（HostConflictError），先注册者保留。"""
+    shared_host_resources = [_make_resource("dpe://com.example.shared/x")]
+    clients = {
+        "first": _MockHostClient(pages=[(shared_host_resources, None)]),
+        "second": _MockHostClient(pages=[(shared_host_resources, None)]),
+    }
+    _patch_factory(monkeypatch, clients)
+
+    await manager.aadd_or_aupdate_server(_config("first"))
+
+    with pytest.raises(HostConflictError) as exc_info:
+        await manager.aadd_or_aupdate_server(_config("second"))
+
+    err = exc_info.value
+    assert err.host == "com.example.shared"
+    assert err.conflicting_servers == ("first", "second")
+
+    # 先注册者保留索引；后注册者被回滚
+    assert manager.find_server_by_host("com.example.shared") == "first"
+    assert "second" not in manager._active_clients
+    # config 也应回滚（aadd_or_aupdate_server 的 try/except 已恢复 backup_config）
+    clients["second"].adisconnect.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_aremove_server_releases_hosts_for_reuse(manager, monkeypatch):
+    """server 注销后 host 释放——同 host 可被新 server 注册（避免"假冲突"）。"""
+    clients = {
+        "owner-a": _MockHostClient(
+            pages=[([_make_resource("dpe://com.example.docs/x")], None)],
+        ),
+        "owner-b": _MockHostClient(
+            pages=[([_make_resource("dpe://com.example.docs/y")], None)],
+        ),
+    }
+    _patch_factory(monkeypatch, clients)
+
+    await manager.aadd_or_aupdate_server(_config("owner-a"))
+    assert manager.find_server_by_host("com.example.docs") == "owner-a"
+
+    await manager.aremove_server("owner-a")
+    assert manager.find_server_by_host("com.example.docs") is None
+
+    # 释放后同 host 应能被另一个 server 注册成功
+    await manager.aadd_or_aupdate_server(_config("owner-b"))
+    assert manager.find_server_by_host("com.example.docs") == "owner-b"
+
+
+@pytest.mark.asyncio
+async def test_register_time_list_failure_marks_pending(manager, monkeypatch):
+    """注册期 list_resources 临时失败（非 capability 缺失）→ 注册成功 + WARN + 标 pending。"""
+    transient_err = RuntimeError("network glitch")
+    clients = {
+        "flaky": _MockHostClient(raise_on_list=transient_err),
+    }
+    _patch_factory(monkeypatch, clients)
+
+    await manager.aadd_or_aupdate_server(_config("flaky"))
+
+    # server 已注册成功（不阻塞业务）
+    assert "flaky" in manager._active_clients
+    # 但 host 索引为空（pending）
+    assert manager._host_to_servers == {}
+    assert "flaky" in manager._host_index_pending
+
+
+@pytest.mark.asyncio
+async def test_capability_missing_no_pending_no_hosts(manager, monkeypatch):
+    """server 未声明 resources capability → 注册成功，无 host 贡献，**不**进入 pending（永久状态）。"""
+    clients = {
+        "no-resources": _MockHostClient(
+            raise_on_list=MCPCapabilityNotSupportedError("no resources"),
+        ),
+    }
+    _patch_factory(monkeypatch, clients)
+
+    await manager.aadd_or_aupdate_server(_config("no-resources"))
+
+    assert "no-resources" in manager._active_clients
+    assert manager._host_to_servers == {}
+    assert manager._host_index_pending == set()
+
+
+@pytest.mark.asyncio
+async def test_aretry_pending_host_index_success(manager, monkeypatch):
+    """pending server 在 list 恢复后调用 aretry_pending_host_index → 写入索引并清除 pending。"""
+    flaky_client = _MockHostClient(raise_on_list=RuntimeError("network glitch"))
+    clients = {"flaky": flaky_client}
+    _patch_factory(monkeypatch, clients)
+
+    await manager.aadd_or_aupdate_server(_config("flaky"))
+    assert "flaky" in manager._host_index_pending
+
+    # 模拟网络恢复：撤销 raise，让后续 list 返回真实 pages
+    flaky_client._raise_on_list = None
+    flaky_client._pages = [([_make_resource("dpe://com.example.late/x")], None)]  # type: ignore[list-item]
+    flaky_client._page_idx = 0
+
+    cleared = await manager.aretry_pending_host_index("flaky")
+    assert cleared is True
+    assert manager.find_server_by_host("com.example.late") == "flaky"
+    assert "flaky" not in manager._host_index_pending
+
+
+@pytest.mark.asyncio
+async def test_aretry_pending_host_index_conflict_unregisters(manager, monkeypatch):
+    """pending server 在 retry 时检测到与已注册 server 冲突 → 注销该 server 并抛 HostConflictError。"""
+    incumbent_client = _MockHostClient(
+        pages=[([_make_resource("dpe://com.example.shared/x")], None)],
+    )
+    flaky_client = _MockHostClient(raise_on_list=RuntimeError("network glitch"))
+    clients = {"incumbent": incumbent_client, "flaky": flaky_client}
+    _patch_factory(monkeypatch, clients)
+
+    await manager.aadd_or_aupdate_server(_config("incumbent"))
+    await manager.aadd_or_aupdate_server(_config("flaky"))
+    assert "flaky" in manager._host_index_pending
+
+    # 网络恢复后 flaky 暴露与 incumbent 共用 host
+    flaky_client._raise_on_list = None
+    flaky_client._pages = [([_make_resource("dpe://com.example.shared/y")], None)]  # type: ignore[list-item]
+    flaky_client._page_idx = 0
+
+    with pytest.raises(HostConflictError) as exc_info:
+        await manager.aretry_pending_host_index("flaky")
+
+    err = exc_info.value
+    assert err.host == "com.example.shared"
+    assert err.conflicting_servers == ("incumbent", "flaky")
+    # flaky 已被注销，incumbent 保留
+    assert "flaky" not in manager._active_clients
+    assert manager.find_server_by_host("com.example.shared") == "incumbent"
+
+
+@pytest.mark.asyncio
+async def test_aretry_pending_no_op_when_not_pending(manager, monkeypatch):
+    """retry 调用一个不在 pending 集合的 server → 直接返回 True，幂等无副作用。"""
+    clients = {
+        "happy": _MockHostClient(pages=[([_make_resource("dpe://com.example.h/a")], None)]),
+    }
+    _patch_factory(monkeypatch, clients)
+    await manager.aadd_or_aupdate_server(_config("happy"))
+
+    assert await manager.aretry_pending_host_index("happy") is True
+    assert await manager.aretry_pending_host_index("never-existed") is True
+
+
+@pytest.mark.asyncio
+async def test_clear_all_clears_host_index(manager, monkeypatch):
+    """ainitialize / aclose 路径下 _clear_all 必须把 host 索引和 pending 一并清空。"""
+    clients = {
+        "s1": _MockHostClient(pages=[([_make_resource("dpe://com.example.h1/a")], None)]),
+        "s2": _MockHostClient(raise_on_list=RuntimeError("net")),
+    }
+    _patch_factory(monkeypatch, clients)
+    await manager.aadd_or_aupdate_server(_config("s1"))
+    await manager.aadd_or_aupdate_server(_config("s2"))
+    assert manager._host_to_servers
+    assert manager._host_index_pending
+
+    await manager.ainitialize([])
+
+    assert manager._host_to_servers == {}
+    assert manager._host_index_pending == set()
+
+
+@pytest.mark.asyncio
+async def test_only_dpe_and_window_schemes_contribute_hosts(manager, monkeypatch):
+    """host 收集仅看 dpe:// 与 window:// scheme；其他 scheme 不参与索引。"""
+    clients = {
+        "mixed": _MockHostClient(
+            pages=[([
+                _make_resource("dpe://com.example.real/a"),
+                _make_resource("window://com.example.win/main"),
+                _make_resource("https://example.com/not-counted"),
+                _make_resource("file:///tmp/local"),
+                _make_resource("custom-scheme://noise/not-counted"),
+            ], None)],
+        ),
+    }
+    _patch_factory(monkeypatch, clients)
+    await manager.aadd_or_aupdate_server(_config("mixed"))
+
+    assert manager.find_server_by_host("com.example.real") == "mixed"
+    assert manager.find_server_by_host("com.example.win") == "mixed"
+    # 其他 scheme 的 host 不应进入索引
+    assert manager.find_server_by_host("example.com") is None
+    assert manager.find_server_by_host("noise") is None
+    assert "tmp" not in manager._host_to_servers
+
+
+@pytest.mark.asyncio
+async def test_pagination_exhausted(manager, monkeypatch):
+    """注册期穷举翻页：跨页 host 全部进入索引。"""
+    clients = {
+        "paginated": _MockHostClient(
+            pages=[
+                ([_make_resource("dpe://com.example.p1/a")], "cursor-2"),
+                ([_make_resource("dpe://com.example.p2/b")], "cursor-3"),
+                ([_make_resource("window://com.example.p3/main")], None),
+            ],
+        ),
+    }
+    _patch_factory(monkeypatch, clients)
+    await manager.aadd_or_aupdate_server(_config("paginated"))
+
+    for host in ("com.example.p1", "com.example.p2", "com.example.p3"):
+        assert manager.find_server_by_host(host) == "paginated"
+
+
+@pytest.mark.asyncio
+async def test_restart_same_server_not_false_conflict(manager, monkeypatch):
+    """同名 server 重启（aremove + add）不应 false-conflict 自身。"""
+    def _fresh_client() -> _MockHostClient:
+        return _MockHostClient(
+            pages=[([_make_resource("dpe://com.example.same/x")], None)],
+        )
+
+    def factory(config, message_handler=None):  # noqa: ARG001
+        # 每次工厂调用返回新实例；保持 host 资源声明一致
+        c = _fresh_client()
+        c.message_handler = message_handler
+        return c
+
+    monkeypatch.setattr("a2c_smcp.computer.mcp_clients.manager.client_factory", factory)
+
+    await manager.aadd_or_aupdate_server(_config("reborn"))
+    assert manager.find_server_by_host("com.example.same") == "reborn"
+
+    # 注销后再注册同名 server，应能成功（host 已释放）
+    await manager.aremove_server("reborn")
+    await manager.aadd_or_aupdate_server(_config("reborn"))
+    assert manager.find_server_by_host("com.example.same") == "reborn"
+
+
+@pytest.mark.asyncio
+async def test_find_server_by_host_returns_none_for_unknown(manager, monkeypatch):
+    """无匹配 host → 返回 None（上层据此映射 4014 MCP Server Not Found）。"""
+    clients = {
+        "s1": _MockHostClient(pages=[([_make_resource("dpe://com.example.real/a")], None)]),
+    }
+    _patch_factory(monkeypatch, clients)
+    await manager.aadd_or_aupdate_server(_config("s1"))
+
+    assert manager.find_server_by_host("com.example.unknown") is None
+    assert manager.find_server_by_host("") is None
+
+
+@pytest.mark.asyncio
+async def test_extract_hosts_static_helper_filters_correctly():
+    """_extract_hosts_from_resources 静态：仅 dpe:// + window:// 计入；非法 URI 跳过。"""
+    items: list[Resource] = [
+        _make_resource("dpe://com.example.a/x"),
+        _make_resource("window://com.example.b/main"),
+        _make_resource("https://example.com/skip"),
+    ]
+    hosts = MCPServerManager._extract_hosts_from_resources(items)
+    assert hosts == {"com.example.a", "com.example.b"}


### PR DESCRIPTION
## Summary

- 在 `MCPServerManager` 上落地 v0.2 协议 §4.4 host 跨 MCP Server **MUST** 唯一硬约束：注册期穷举 `list_resources_page` 收集 host 集 → 冲突即 `HostConflictError` + 回滚（fail-fast）
- 新增公开 API：
  - `find_server_by_host(host) -> SERVER_NAME | None` — `client:get_dpe` 路由依据；无匹配返 None（上层映射 `4014 MCP_SERVER_NOT_FOUND`，顶层 flat 字段 `mcp_server_name`）
  - `aretry_pending_host_index(server_name) -> bool` — `client:get_resources` 处理器（#14）在 list 成功后回调，落实 §4.4 延迟检测语义
- 新增内部状态：`_host_to_servers` 反查索引 + `_host_index_pending` 集合
- 注册期 list 临时失败 → WARN + 标 pending（保持业务可用）；capability 缺失 → 视为永久无 host 贡献，不进 pending
- 注销 / `_clear_all` 同步释放 host 占用，避免后续同 host 注册"假冲突"
- host 收集严格限定 `dpe://` + `window://` scheme；其他 scheme 不参与索引
- `MCPClientProtocol` 同步声明 #13 引入的 `list_resources_page`

## 协议依据

- [a2c-smcp-protocol main HEAD §4.4](https://github.com/A2C-SMCP/a2c-smcp-protocol/blob/main/docs/migrations/v0.2-uri-metadata-refactor.md#44-mcp-server-host-唯一性从-must-软化为-should-又收回为-must-硬约束) — host MUST 唯一 + 注册期 fail-fast
- 协议团队跨项目问询确认（2026-04-29）：MUST + fail-fast 终局；reverse domain 命名为 SHOULD（lint-style，不阻塞）；`list_changed` → host 索引刷新协议层 OPTIONAL，本 PR 不实现
- `notifications/resources/list_changed` 监听刷 host 索引明确**不在本 PR 范围**——`dpe.md` L612 \"由 SDK 在自身版本规划里着情安排\"

## 解锁

- 解除 #14（`client:get_resources` 异步实现）的代码侧依赖
- 解除 #16（`client:get_dpe` 异步实现 + 双 mimetype 解析）的 host 路由侧依赖

## Test plan

- [x] 新增 `tests/unit_tests/computer/mcp_clients/test_manager_host.py`（15 cases，全部通过）
  - [x] 不同 host 共存 + `find_server_by_host` 反查
  - [x] 1 server N hosts 合法
  - [x] 同 host 冲突 → `HostConflictError` + 后注册者完全回滚
  - [x] `aremove_server` 释放 host → 同 host 可被新 server 注册
  - [x] 注册期 list 临时失败 → 注册成功 + 标 pending
  - [x] capability 缺失 → 注册成功 + **不**标 pending（永久无 host 贡献）
  - [x] `aretry_pending_host_index` 成功路径：写入索引 + 清 pending
  - [x] `aretry_pending_host_index` 冲突路径：注销 + 抛 `HostConflictError`
  - [x] `aretry_pending_host_index` 幂等：非 pending server / 不存在 server → True 无副作用
  - [x] `_clear_all` 清空 host 索引 + pending 集合
  - [x] host 收集仅看 dpe:// + window://（其他 scheme 跳过）
  - [x] 翻页穷举：跨页 host 全部进入索引
  - [x] 同名 server 重启不 false-conflict 自身
  - [x] 无匹配 host → `find_server_by_host` 返 None（4014 上层映射依据）
  - [x] `_extract_hosts_from_resources` 静态过滤
- [x] 既有 `tests/unit_tests/computer/mcp_clients/` 全部 109 cases 通过（94 旧 + 15 新，无回归）
- [x] `uv run poe test`：631 passed, 2 skipped, 4 xfailed（无新增失败）
- [x] `uv run poe lint`（ruff + mypy）通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)