### PR TITLE
test(sync-mirror): fill sync↔async v0.2 test parity gaps (#19)

### DIFF
--- a/tests/integration_tests/server/test_namespace_sync.py
+++ b/tests/integration_tests/server/test_namespace_sync.py
@@ -23,12 +23,16 @@ import pytest
 from socketio import Client, Namespace, SimpleClient
 from werkzeug.serving import make_server
 
+from a2c_smcp import PROTOCOL_VERSION
+from a2c_smcp.agent.auth import DefaultAgentAuthProvider
+from a2c_smcp.agent.sync_client import SMCPAgentClient
 from a2c_smcp.smcp import (
     ENTER_OFFICE_NOTIFICATION,
     GET_TOOLS_EVENT,
     JOIN_OFFICE_EVENT,
     LEAVE_OFFICE_EVENT,
     LEAVE_OFFICE_NOTIFICATION,
+    LIST_ROOM_EVENT,
     SMCP_NAMESPACE,
     TOOL_CALL_EVENT,
     UPDATE_CONFIG_EVENT,
@@ -536,3 +540,37 @@ def test_computer_switch_room_with_same_name_allowed(startup_and_shutdown_local_
 
     finally:
         computer.disconnect()
+
+
+def test_list_room_session_info_contains_a2c_version_sync(
+    startup_and_shutdown_local_sync_server,
+    sync_server_port: int,
+) -> None:
+    """
+    中文：同步镜像 test_version_handshake_server::test_list_room_session_info_contains_a2c_version。
+    真实 SMCPAgentClient 连接时由 SDK 自动拼 ``a2c_version`` query → SyncSMCPNamespace.on_connect
+    经 sync_base._extract_a2c_version 记录到 session → server:list_room 的 SessionInfo 带出。
+    English: Sync mirror of the async handshake list_room test. The real sync SDK client
+    auto-appends ``a2c_version``; SyncSMCPNamespace records it at connect and emits it back
+    in the ``server:list_room`` SessionInfo.
+    """
+    office_id = "office-sync-handshake-ver"
+    auth = DefaultAgentAuthProvider(agent_id="robot-ver-sync", office_id=office_id)
+    agent = SMCPAgentClient(auth_provider=auth)
+    agent.connect_to_server(
+        f"http://localhost:{sync_server_port}",
+        namespace=SMCP_NAMESPACE,
+        socketio_path="/socket.io",
+    )
+    try:
+        agent.join_office(office_id=office_id, agent_name="robot-ver-sync", namespace=SMCP_NAMESPACE)
+        result = agent.call(
+            LIST_ROOM_EVENT,
+            {"agent": "robot-ver-sync", "req_id": "lr-sync-1", "office_id": office_id},
+            namespace=SMCP_NAMESPACE,
+        )
+        agents = [s for s in result["sessions"] if s["role"] == "agent"]
+        assert agents, "房间内应有 agent 会话 / room must contain the agent session"
+        assert all(s.get("a2c_version") == PROTOCOL_VERSION for s in agents)
+    finally:
+        agent.disconnect()

--- a/tests/integration_tests/test_get_resources.py
+++ b/tests/integration_tests/test_get_resources.py
@@ -280,6 +280,14 @@ def _run_mock_computer_process(port: int, ready_q: multiprocessing.Queue, err_q:
     @computer.on(GET_RESOURCES_EVENT, namespace=SMCP_NAMESPACE)
     def _on_get_resources(data: dict) -> dict:  # noqa: ANN001
         mcp_server = data["mcp_server"]
+        if mcp_server == "does-not-exist":
+            # 镜像 async test_get_resources_unregistered_server_raises_4014：
+            # 未注册 server → flat 4014 ErrorPayload（无 capability 字段）
+            return {
+                "code": 4014,
+                "message": "MCP Server not found",
+                "mcp_server_name": "does-not-exist",
+            }
         if mcp_server == "no-res":
             return {
                 "code": 4015,
@@ -329,6 +337,16 @@ def _run_sync_agent_process(port: int, result_q: multiprocessing.Queue, err_q: m
             err_code = e.code
             capability = e.capability
 
+        # 镜像 async test_get_resources_unregistered_server_raises_4014：
+        # 未注册 server → flat 4014 ErrorPayload 经 SyncSMCPNamespace 透传 → SMCPProtocolError
+        err4014_code: int | None = None
+        err4014_server: str | None = None
+        try:
+            agent.get_resources(computer=_SYNC_COMPUTER, mcp_server="does-not-exist")
+        except SMCPProtocolError as e:
+            err4014_code = e.code
+            err4014_server = e.mcp_server_name
+
         result_q.put(
             {
                 "page1_next": page1.get("next_cursor"),
@@ -337,6 +355,8 @@ def _run_sync_agent_process(port: int, result_q: multiprocessing.Queue, err_q: m
                 "page2_uri": page2["resources"][0]["uri"],
                 "err_code": err_code,
                 "capability": capability,
+                "err4014_code": err4014_code,
+                "err4014_server": err4014_server,
             },
         )
         agent.disconnect()
@@ -378,6 +398,9 @@ def test_get_resources_sync_pagination_and_error_passthrough(sync_smcp_server: i
             # flat ErrorPayload（4015）经 SyncSMCPNamespace 原样透传 → SMCPProtocolError
             assert res["err_code"] == 4015
             assert res["capability"] == "resources"
+            # flat ErrorPayload（4014 未注册 server）同样透传 → SMCPProtocolError，含 mcp_server_name
+            assert res["err4014_code"] == 4014
+            assert res["err4014_server"] == "does-not-exist"
         finally:
             if agent_proc.is_alive():
                 agent_proc.terminate()

--- a/tests/unit_tests/agent/test_handshake_config.py
+++ b/tests/unit_tests/agent/test_handshake_config.py
@@ -86,6 +86,16 @@ def test_async_agent_client_custom_namespace_registers_all_handlers() -> None:
     assert set(client.handlers[custom_ns].keys()) == EXPECTED_NOTIFY_EVENTS
 
 
+def test_sync_agent_client_default_namespace() -> None:
+    """Sync Agent 客户端默认 namespace 为 ``/smcp`` / sync agent default namespace is ``/smcp``"""
+    provider = DefaultAgentAuthProvider(agent_id="a", office_id="o")
+    client = SMCPAgentClient(auth_provider=provider)
+
+    assert client.namespace == SMCP_NAMESPACE
+    assert SMCP_NAMESPACE in client.handlers
+    assert set(client.handlers[SMCP_NAMESPACE].keys()) == EXPECTED_NOTIFY_EVENTS
+
+
 def test_sync_agent_client_custom_namespace_registers_all_handlers() -> None:
     """Sync Agent 客户端自定义 namespace 同样贯穿事件处理器注册"""
     custom_ns = "/tf-smcp"

--- a/tests/unit_tests/server/test_middleware.py
+++ b/tests/unit_tests/server/test_middleware.py
@@ -330,6 +330,32 @@ class TestWSGIMiddleware:
         body = b"".join(mw({"PATH_INFO": "/health", "QUERY_STRING": ""}, sr))
         assert body == b"DOWNSTREAM"
 
+    def test_missing_version_no_4008_header(self) -> None:
+        # 镜像 ASGI test_missing_version_no_4008_header：缺失 a2c_version → 400，
+        # 但 400≠4008，rejection builder 不得附带 x-a2c-error-code 诊断 header。
+        def app(environ, start_response):  # pragma: no cover - 不应被调用
+            start_response("200 OK", [])
+            return [b"DOWNSTREAM"]
+
+        mw = A2CProtocolVersionWSGIMiddleware(app, socketio_path="/socket.io")
+        sr, cap = self._start_response_collector()
+        body = b"".join(mw({"PATH_INFO": "/socket.io/", "QUERY_STRING": ""}, sr))
+        assert cap["status"].startswith("400")
+        assert not any(k == "x-a2c-error-code" for k, _ in cap["headers"])
+        assert json.loads(body) == {"code": 400, "message": "Missing a2c_version query parameter"}
+
+    def test_prefix_pollution_not_matched(self) -> None:
+        # 镜像 ASGI test_prefix_pollution_not_matched：/socket.iofoo 不得被误判为
+        # socketio 前缀（PATH_INFO 精确前缀匹配），即使缺 a2c_version 也透传下游。
+        def app(environ, start_response):
+            start_response("200 OK", [])
+            return [b"DOWNSTREAM"]
+
+        mw = A2CProtocolVersionWSGIMiddleware(app, socketio_path="/socket.io")
+        sr, _ = self._start_response_collector()
+        body = b"".join(mw({"PATH_INFO": "/socket.iofoo", "QUERY_STRING": ""}, sr))
+        assert body == b"DOWNSTREAM"
+
     def test_ws_upgrade_incompatible_still_rejected(self) -> None:
         # WSGI 实测（勿假设）：WS-only over WSGI 起始即普通 HTTP GET（带 Upgrade 头）；
         # 中间件对 Upgrade 无关、仅看 PATH_INFO+QUERY_STRING → 仍走同一 400/4008，天然覆盖。


### PR DESCRIPTION
## 背景

Closes #19 · Parent #8（v0.2 协议升级 sub-issue 12/13）

经 `/add-feature` 流程门控审视，#19 原 body 已过时（引用已取消的 DPE/`get_dpe`/#10、已合并的 #13）。按父 #8 北极星，**源码同步镜像已随 #14/PR #29（`get_resources` sync）与 #17/#18/PR #33（协议握手 sync）交付**。本 PR 收口 #19 的真实剩余范围：**sync↔async 测试奇偶校验审计 + 补缺口**。

- Step 0 判定：A2C 线、**非协议变更**（v0.2.0 已 GA）→ 直进实现，无协议门控。
- 变更性质：**test-only，+97 行 / 4 文件，0 源码改动**（吻合 #19 估算「非测试 ~0 行 / 测试 ~50–100 行」）。

## 奇偶校验矩阵结论

审计 4 个 sync/async 敏感面，识别并修复 5 处缺口，均为异步路径的**严格 1:1 镜像，零新行为**：

| Gap | 缺口 | 修复 |
|---|---|---|
| A1 | sync agent 默认 namespace 无测试 | `test_handshake_config.py::test_sync_agent_client_default_namespace` |
| B1 | sync `get_resources` 缺 4014 未注册 server flat-ErrorPayload 透传 | `test_get_resources.py` 扩展 mock computer + 4014 断言 |
| C1 | WSGI 中间件缺「400≠4008 无诊断 header」 | `TestWSGIMiddleware::test_missing_version_no_4008_header` |
| C2 | WSGI 中间件缺前缀污染路径精确匹配 | `TestWSGIMiddleware::test_prefix_pollution_not_matched` |
| **D1** | **sync `_extract_a2c_version` → `server:list_room` a2c_version 全链路零 sync 覆盖** | `test_namespace_sync.py::test_list_room_session_info_contains_a2c_version_sync`（真实 `SMCPAgentClient` 自动拼 `a2c_version`） |

**Parity-by-design（无需 WSGI 镜像）**：ASGI 的 WS-scope / lifespan / denial-response 6 项 —— WSGI 无对应 scope，已由 `test_build_rejection_single_source_of_truth`（body 字节一致 SSOT）+ `test_ws_upgrade_incompatible_still_rejected` 覆盖，测试注释已说明。

**Shared / transport-agnostic（单一测试集即正确）**：`utils/test_handshake.py`、`test_smcp.py` —— sync+async client 共用，无需镜像。

## 验收

- ✅ `uv run poe lint` — ruff clean + mypy `no issues found in 56 source files`
- ✅ `uv run poe test` — **685 passed**, 2 skipped, 4 xfailed, **0 failed**（含 5 个新镜像）
- ✅ CLAUDE.md「同步/异步一致性」约定未违反
- ⚠️ Pre-existing 非阻塞警告：`test_sync_client_desktop.py`（**本 PR 未改动**）后台线程 teardown `PytestUnhandledThreadExceptionWarning`，与 #19 无关，如实记录

## 影响

- 解除对 **#20**（集成测试 + e2e + 文档）的阻塞。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
