### PR TITLE
fix(server): office/role isolation assert→explicit raise — survive python -O (#31)

### DIFF
--- a/a2c_smcp/computer/socketio/client.py
+++ b/a2c_smcp/computer/socketio/client.py
@@ -12,6 +12,7 @@ from socketio import AsyncClient
 from a2c_smcp import PROTOCOL_VERSION
 from a2c_smcp.computer.computer import Computer
 from a2c_smcp.computer.mcp_clients.base_client import MCPCapabilityNotSupportedError, MCPServerNotFoundError
+from a2c_smcp.exceptions import SMCPNamespaceError
 from a2c_smcp.smcp import (
     GET_CONFIG_EVENT,
     GET_DESKTOP_EVENT,
@@ -305,7 +306,8 @@ class SMCPComputerClient(AsyncClient):
         """
         # Server 通过 session 保证请求来自同一 office，无需在此验证 agent 与 office_id 的关系
         # Server guarantees request is from same office via session, no need to validate agent vs office_id here
-        assert self.computer.name == data["computer"], "计算机标识不匹配"
+        if self.computer.name != data["computer"]:
+            raise SMCPNamespaceError("计算机标识不匹配")
         try:
             ret = await self.computer.aexecute_tool(
                 req_id=data["req_id"],
@@ -328,7 +330,8 @@ class SMCPComputerClient(AsyncClient):
         """
         # Server 通过 session 保证请求来自同一 office，无需在此验证 agent 与 office_id 的关系
         # Server guarantees request is from same office via session, no need to validate agent vs office_id here
-        assert self.computer.name == data["computer"], "计算机标识不匹配"
+        if self.computer.name != data["computer"]:
+            raise SMCPNamespaceError("计算机标识不匹配")
 
         mcp_tools = await self.computer.aget_available_tools()
 
@@ -347,7 +350,8 @@ class SMCPComputerClient(AsyncClient):
         """
         # Server 通过 session 保证请求来自同一 office，无需在此验证 agent 与 office_id 的关系
         # Server guarantees request is from same office via session, no need to validate agent vs office_id here
-        assert self.computer.name == data["computer"], "计算机标识不匹配"
+        if self.computer.name != data["computer"]:
+            raise SMCPNamespaceError("计算机标识不匹配")
         size = data.get("desktop_size")
         window_uri = data.get("window")
         desktops = await self.computer.get_desktop(size=size, window_uri=window_uri)
@@ -370,7 +374,8 @@ class SMCPComputerClient(AsyncClient):
         """
         # Server 通过 session 保证请求来自同一 office，无需在此验证 agent 与 office_id 的关系
         # Server guarantees request is from same office via session, no need to validate agent vs office_id here
-        assert self.computer.name == data["computer"], "计算机标识不匹配"
+        if self.computer.name != data["computer"]:
+            raise SMCPNamespaceError("计算机标识不匹配")
 
         servers: dict[str, dict] = {}
         # 从 Computer 中获取初始化时传入的配置集合（不可变元组）
@@ -412,7 +417,8 @@ class SMCPComputerClient(AsyncClient):
         """
         # Server 通过 session 保证请求来自同一 office，无需在此验证 agent 与 office_id 的关系
         # Server guarantees request is from same office via session, no need to validate agent vs office_id here
-        assert self.computer.name == data["computer"], "计算机标识不匹配"
+        if self.computer.name != data["computer"]:
+            raise SMCPNamespaceError("计算机标识不匹配")
         mcp_server = data["mcp_server"]
         cursor = data.get("cursor")
         try:

--- a/a2c_smcp/exceptions.py
+++ b/a2c_smcp/exceptions.py
@@ -62,3 +62,34 @@ class ProtocolVersionError(Exception):
             f"(client_version={self.client_version}, server_version={self.server_version}, "
             f"min_supported={self.min_supported}, max_supported={self.max_supported})"
         )
+
+
+class SMCPNamespaceError(Exception):
+    """
+    SMCP 命名空间路由/隔离校验失败（role / office(Room) / session 不匹配）。
+    SMCP namespace routing/isolation check failure (role / office(Room) / session mismatch).
+
+    适用范围 / Scope：Server 端 ``on_client_*`` / ``on_server_*`` 处理器，以及 Computer 端
+    socketio handler 的隔离校验——跨房间访问、错误角色发起、computer/agent 标识不匹配等。
+    Server-side ``on_client_*`` / ``on_server_*`` handlers and the Computer-side socketio
+    handler isolation checks — cross-room access, wrong-role initiation, computer/agent
+    identity mismatch, etc.
+
+    取代原先的 ``assert``：``assert`` 在 ``python -O`` / ``PYTHONOPTIMIZE`` 下被字节码整体
+    剥离，会令隔离校验被静默关闭（协议将房间隔离列为**不可违反约束**）。显式 ``raise``
+    保证校验在任何运行模式下均生效；属 sid/session 路由层拒绝，**非** 4014/4015 业务错误，
+    故沿用与同处理器既有路由失败一致的"抛异常"形态，不回 flat ErrorPayload。
+    Replaces the former ``assert``: ``assert`` is stripped wholesale under ``python -O`` /
+    ``PYTHONOPTIMIZE``, silently disabling the isolation check (the protocol lists room
+    isolation as an **inviolable constraint**). An explicit ``raise`` guarantees the check
+    holds in every run mode. This is a sid/session routing-layer rejection, **not** a
+    4014/4015 business error, so it keeps the same "raise" shape as the pre-existing
+    routing failures in the same handlers and does NOT return a flat ErrorPayload.
+
+    放置于顶层包：Server 与 Computer 客户端共用，避免 Computer 反向依赖 ``a2c_smcp.server``。
+    Placed at the top-level package: shared by both Server and Computer client, avoiding a
+    reverse dependency from the Computer client onto ``a2c_smcp.server``.
+
+    协议依据 / Protocol: docs/specification/error-handling.md（§通用错误码 403 / §4104 Cross Room Access）
+                          docs/specification/security.md（§房间隔离）
+    """

--- a/a2c_smcp/server/namespace.py
+++ b/a2c_smcp/server/namespace.py
@@ -13,6 +13,7 @@ from typing import cast
 
 from pydantic import TypeAdapter
 
+from a2c_smcp.exceptions import SMCPNamespaceError
 from a2c_smcp.server.auth import AuthenticationProvider
 from a2c_smcp.server.base import BaseNamespace
 from a2c_smcp.server.types import OFFICE_ID, SID
@@ -280,10 +281,12 @@ class SMCPNamespace(BaseNamespace):
             data (AgentCallData): Agent调用数据 / Agent call data
         """
         session = await self.get_session(sid)
-        assert session["role"] == "agent", "目前仅支持Agent调用取消ToolCall的操作"
+        if session["role"] != "agent":
+            raise SMCPNamespaceError("目前仅支持Agent调用取消ToolCall的操作")
 
         agent_call = TypeAdapter(AgentCallData).validate_python(data)
-        assert session.get("name") == agent_call["agent"], "取消工具调用的广播仅可以由对应Agent发出"
+        if session.get("name") != agent_call["agent"]:
+            raise SMCPNamespaceError("取消工具调用的广播仅可以由对应Agent发出")
 
         # 广播到 office 房间，而不是 Agent 的私有房间 / Broadcast to office room, not Agent's private room
         office_id = session.get("office_id")
@@ -304,7 +307,8 @@ class SMCPNamespace(BaseNamespace):
             data (UpdateComputerConfigReq): 更新配置请求数据 / Update config request data
         """
         session = await self.get_session(sid)
-        assert session["role"] == "computer", "目前仅支持Computer调用更新MCP配置的操作"
+        if session["role"] != "computer":
+            raise SMCPNamespaceError("目前仅支持Computer调用更新MCP配置的操作")
 
         update_config = TypeAdapter(UpdateComputerConfigReq).validate_python(data)
 
@@ -325,7 +329,8 @@ class SMCPNamespace(BaseNamespace):
             data (UpdateComputerConfigReq): 载荷复用 UpdateConfigReq，仅需 computer 标识 / Reuse UpdateConfigReq for payload
         """
         session = await self.get_session(sid)
-        assert session["role"] == "computer", "目前仅支持Computer上报工具列表变更"
+        if session["role"] != "computer":
+            raise SMCPNamespaceError("目前仅支持Computer上报工具列表变更")
 
         update_req = TypeAdapter(UpdateComputerConfigReq).validate_python(data)
 
@@ -354,7 +359,8 @@ class SMCPNamespace(BaseNamespace):
             dict: 工具调用结果 / Tool call result
         """
         session = await self.get_session(sid)
-        assert session["role"] == "agent", "目前仅支持Agent调用工具"
+        if session["role"] != "agent":
+            raise SMCPNamespaceError("目前仅支持Agent调用工具")
 
         tool_call = TypeAdapter(ToolCallReq).validate_python(data)
 
@@ -396,7 +402,8 @@ class SMCPNamespace(BaseNamespace):
             raise ValueError(f"Computer with name '{computer_name}' not found")
 
         session = await self.get_session(computer_sid)
-        assert session["role"] == "computer", "目前仅支持Computer获取工具列表"
+        if session["role"] != "computer":
+            raise SMCPNamespaceError("目前仅支持Computer获取工具列表")
 
         # 验证Agent是否有权限获取该Computer的工具列表
         # Verify if Agent has permission to get this Computer's tool list
@@ -404,7 +411,8 @@ class SMCPNamespace(BaseNamespace):
         computer_office_id = session.get("office_id")
         agent_office_id = agent_session.get("office_id")
 
-        assert computer_office_id == agent_office_id, "目前仅支持Agent获取自己房间内Computer的工具列表"
+        if computer_office_id != agent_office_id:
+            raise SMCPNamespaceError("目前仅支持Agent获取自己房间内Computer的工具列表")
 
         client_response = await self.call(
             GET_TOOLS_EVENT,
@@ -431,12 +439,14 @@ class SMCPNamespace(BaseNamespace):
             raise ValueError(f"Computer with name '{computer_name}' not found")
 
         session = await self.get_session(computer_sid)
-        assert session["role"] == "computer", "目前仅支持获取Computer桌面"
+        if session["role"] != "computer":
+            raise SMCPNamespaceError("目前仅支持获取Computer桌面")
 
         agent_session = await self.get_session(sid)
         computer_office_id = session.get("office_id")
         agent_office_id = agent_session.get("office_id")
-        assert computer_office_id == agent_office_id, "目前仅支持Agent获取自己房间内Computer的桌面"
+        if computer_office_id != agent_office_id:
+            raise SMCPNamespaceError("目前仅支持Agent获取自己房间内Computer的桌面")
 
         client_response = await self.call(
             GET_DESKTOP_EVENT,
@@ -471,12 +481,14 @@ class SMCPNamespace(BaseNamespace):
             raise ValueError(f"Computer with name '{computer_name}' not found")
 
         session = await self.get_session(computer_sid)
-        assert session["role"] == "computer", "目前仅支持获取Computer资源列表"
+        if session["role"] != "computer":
+            raise SMCPNamespaceError("目前仅支持获取Computer资源列表")
 
         agent_session = await self.get_session(sid)
         computer_office_id = session.get("office_id")
         agent_office_id = agent_session.get("office_id")
-        assert computer_office_id == agent_office_id, "目前仅支持Agent获取自己房间内Computer的资源列表"
+        if computer_office_id != agent_office_id:
+            raise SMCPNamespaceError("目前仅支持Agent获取自己房间内Computer的资源列表")
 
         client_response = await self.call(
             GET_RESOURCES_EVENT,
@@ -500,7 +512,8 @@ class SMCPNamespace(BaseNamespace):
             data (UpdateComputerConfigReq): 载荷复用 UpdateConfigReq，仅需 computer 标识
         """
         session = await self.get_session(sid)
-        assert session["role"] == "computer", "目前仅支持Computer上报桌面刷新"
+        if session["role"] != "computer":
+            raise SMCPNamespaceError("目前仅支持Computer上报桌面刷新")
 
         update_req = TypeAdapter(UpdateComputerConfigReq).validate_python(data)
         await self.emit(
@@ -531,7 +544,8 @@ class SMCPNamespace(BaseNamespace):
         agent_session = await self.get_session(sid)
         agent_office_id = agent_session.get("office_id")
 
-        assert agent_office_id == office_id, f"Agent只能查询自己所在房间的会话信息。Agent office: {agent_office_id}, requested: {office_id}"
+        if agent_office_id != office_id:
+            raise SMCPNamespaceError(f"Agent只能查询自己所在房间的会话信息。Agent office: {agent_office_id}, requested: {office_id}")
 
         # 使用工具函数获取房间内所有会话信息 / Use utility function to get all session info in the room
         all_sessions = await aget_all_sessions_in_office(office_id, self.server)

--- a/a2c_smcp/server/sync_namespace.py
+++ b/a2c_smcp/server/sync_namespace.py
@@ -13,6 +13,7 @@ from typing import cast
 
 from pydantic import TypeAdapter
 
+from a2c_smcp.exceptions import SMCPNamespaceError
 from a2c_smcp.server.sync_auth import SyncAuthenticationProvider
 from a2c_smcp.server.sync_base import SyncBaseNamespace
 from a2c_smcp.server.types import OFFICE_ID, SID
@@ -203,10 +204,12 @@ class SyncSMCPNamespace(SyncBaseNamespace):
         Sync: broadcast tool call cancellation to other members in the room
         """
         session = self.get_session(sid)
-        assert session["role"] == "agent", "目前仅支持Agent调用取消ToolCall的操作"
+        if session["role"] != "agent":
+            raise SMCPNamespaceError("目前仅支持Agent调用取消ToolCall的操作")
 
         agent_call = TypeAdapter(AgentCallData).validate_python(data)
-        assert session.get("name") == agent_call["agent"], "取消工具调用的广播仅可以由对应Agent发出"
+        if session.get("name") != agent_call["agent"]:
+            raise SMCPNamespaceError("取消工具调用的广播仅可以由对应Agent发出")
 
         # 广播到 office 房间，而不是 Agent 的私有房间 / Broadcast to office room, not Agent's private room
         office_id = session.get("office_id")
@@ -223,7 +226,8 @@ class SyncSMCPNamespace(SyncBaseNamespace):
         Sync: broadcast MCP config update
         """
         session = self.get_session(sid)
-        assert session["role"] == "computer", "目前仅支持Computer调用更新MCP配置的操作"
+        if session["role"] != "computer":
+            raise SMCPNamespaceError("目前仅支持Computer调用更新MCP配置的操作")
 
         update_config = TypeAdapter(UpdateComputerConfigReq).validate_python(data)
         self.emit(
@@ -239,7 +243,8 @@ class SyncSMCPNamespace(SyncBaseNamespace):
         Sync: broadcast tool list update
         """
         session = self.get_session(sid)
-        assert session["role"] == "computer", "目前仅支持Computer上报工具列表变更"
+        if session["role"] != "computer":
+            raise SMCPNamespaceError("目前仅支持Computer上报工具列表变更")
 
         update_req = TypeAdapter(UpdateComputerConfigReq).validate_python(data)
 
@@ -256,7 +261,8 @@ class SyncSMCPNamespace(SyncBaseNamespace):
         Sync: respond to tool call, use call method to wait for Computer response
         """
         session = self.get_session(sid)
-        assert session["role"] == "agent", "目前仅支持Agent调用工具"
+        if session["role"] != "agent":
+            raise SMCPNamespaceError("目前仅支持Agent调用工具")
 
         tool_call = TypeAdapter(dict).validate_python(data)
 
@@ -292,12 +298,14 @@ class SyncSMCPNamespace(SyncBaseNamespace):
             raise ValueError(f"Computer with name '{computer_name}' not found")
 
         session = self.get_session(computer_sid)
-        assert session["role"] == "computer", "目前仅支持Computer获取工具列表"
+        if session["role"] != "computer":
+            raise SMCPNamespaceError("目前仅支持Computer获取工具列表")
 
         agent_session = self.get_session(sid)
         computer_office_id = session.get("office_id")
         agent_office_id = agent_session.get("office_id")
-        assert computer_office_id == agent_office_id, "目前仅支持Agent获取自己房间内Computer的工具列表"
+        if computer_office_id != agent_office_id:
+            raise SMCPNamespaceError("目前仅支持Agent获取自己房间内Computer的工具列表")
 
         client_response = self.call(
             GET_TOOLS_EVENT,
@@ -324,12 +332,14 @@ class SyncSMCPNamespace(SyncBaseNamespace):
             raise ValueError(f"Computer with name '{computer_name}' not found")
 
         session = self.get_session(computer_sid)
-        assert session["role"] == "computer", "目前仅支持Computer获取桌面"
+        if session["role"] != "computer":
+            raise SMCPNamespaceError("目前仅支持Computer获取桌面")
 
         agent_session = self.get_session(sid)
         computer_office_id = session.get("office_id")
         agent_office_id = agent_session.get("office_id")
-        assert computer_office_id == agent_office_id, "目前仅支持Agent获取自己房间内Computer的桌面"
+        if computer_office_id != agent_office_id:
+            raise SMCPNamespaceError("目前仅支持Agent获取自己房间内Computer的桌面")
 
         client_response = self.call(
             GET_DESKTOP_EVENT,
@@ -365,12 +375,14 @@ class SyncSMCPNamespace(SyncBaseNamespace):
             raise ValueError(f"Computer with name '{computer_name}' not found")
 
         session = self.get_session(computer_sid)
-        assert session["role"] == "computer", "目前仅支持获取Computer资源列表"
+        if session["role"] != "computer":
+            raise SMCPNamespaceError("目前仅支持获取Computer资源列表")
 
         agent_session = self.get_session(sid)
         computer_office_id = session.get("office_id")
         agent_office_id = agent_session.get("office_id")
-        assert computer_office_id == agent_office_id, "目前仅支持Agent获取自己房间内Computer的资源列表"
+        if computer_office_id != agent_office_id:
+            raise SMCPNamespaceError("目前仅支持Agent获取自己房间内Computer的资源列表")
 
         client_response = self.call(
             GET_RESOURCES_EVENT,
@@ -394,7 +406,8 @@ class SyncSMCPNamespace(SyncBaseNamespace):
             data (UpdateComputerConfigReq): 载荷复用 UpdateConfigReq，仅需 computer 标识
         """
         session = self.get_session(sid)
-        assert session["role"] == "computer", "目前仅支持Computer上报桌面刷新"
+        if session["role"] != "computer":
+            raise SMCPNamespaceError("目前仅支持Computer上报桌面刷新")
 
         update_req = TypeAdapter(UpdateComputerConfigReq).validate_python(data)
         self.emit(
@@ -425,7 +438,8 @@ class SyncSMCPNamespace(SyncBaseNamespace):
         agent_session = self.get_session(sid)
         agent_office_id = agent_session.get("office_id")
 
-        assert agent_office_id == office_id, f"Agent只能查询自己所在房间的会话信息。Agent office: {agent_office_id}, requested: {office_id}"
+        if agent_office_id != office_id:
+            raise SMCPNamespaceError(f"Agent只能查询自己所在房间的会话信息。Agent office: {agent_office_id}, requested: {office_id}")
 
         # 使用工具函数获取房间内所有会话信息 / Use utility function to get all session info in the room
         all_sessions = get_all_sessions_in_office(office_id, self.server)

--- a/tests/integration_tests/server/test_isolation_hardening.py
+++ b/tests/integration_tests/server/test_isolation_hardening.py
@@ -1,0 +1,108 @@
+# -*- coding: utf-8 -*-
+"""
+* 文件名: test_isolation_hardening
+* 描述: GitHub #31 —— on_client_* / on_server_* 的 office/role 隔离在 ``-O``
+        （断言被字节码剥离）下必须依旧生效。
+        Hardening regression: office/role isolation MUST still hold when Python runs
+        with ``-O`` (assert statements stripped at compile time).
+
+设计说明 / Design note:
+  本用例不依赖具体异常类型——只验证"设计无关的安全不变量"：在断言被剥离时，
+  跨房间访问 **不得** 静默放行并泄露另一房间的会话数据。
+  This case is exception-type agnostic. It only asserts the design-agnostic security
+  invariant: with assertions stripped, a cross-room request MUST NOT silently pass
+  and leak the other room's session data.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+
+# 子进程脚本：构造 namespace，mock 跨房间会话，调用 on_server_list_room。
+# Subprocess script: build namespace, mock cross-room sessions, call on_server_list_room.
+# Agent 在 office_A，却请求 office_B —— 隔离生效应拒绝；失效则会泄露 office_B 数据。
+# Agent in office_A requests office_B — isolation must reject; if broken it leaks office_B data.
+_ASYNC_SCRIPT = textwrap.dedent(
+    """
+    import asyncio
+    from unittest.mock import AsyncMock, MagicMock
+    import a2c_smcp.server.namespace as ns_mod
+    from a2c_smcp.server import SMCPNamespace, AuthenticationProvider
+
+    async def main():
+        ns = SMCPNamespace(MagicMock(spec=AuthenticationProvider))
+        ns.server = MagicMock()
+        ns.get_session = AsyncMock(
+            return_value={"sid": "a_sid", "name": "a", "role": "agent", "office_id": "office_A"}
+        )
+        leaked = [
+            {"sid": "spy", "name": "spy", "role": "agent", "office_id": "office_B"},
+            {"sid": "c_b", "name": "c_b", "role": "computer", "office_id": "office_B"},
+        ]
+        ns_mod.aget_all_sessions_in_office = AsyncMock(return_value=leaked)
+        try:
+            ret = await ns.on_server_list_room(
+                "a_sid", {"agent": "a_sid", "req_id": "r", "office_id": "office_B"}
+            )
+        except Exception:
+            print("REJECTED")
+            return
+        # 未抛异常 = 隔离被剥离，office_B 数据被泄露
+        print("LEAK:" + ",".join(s["sid"] for s in ret.get("sessions", [])))
+
+    asyncio.run(main())
+    """
+)
+
+_SYNC_SCRIPT = textwrap.dedent(
+    """
+    from unittest.mock import MagicMock
+    import a2c_smcp.server.sync_namespace as ns_mod
+    from a2c_smcp.server import SyncSMCPNamespace, SyncAuthenticationProvider
+
+    ns = SyncSMCPNamespace(MagicMock(spec=SyncAuthenticationProvider))
+    ns.server = MagicMock()
+    ns.get_session = MagicMock(
+        return_value={"sid": "a_sid", "name": "a", "role": "agent", "office_id": "office_A"}
+    )
+    leaked = [
+        {"sid": "spy", "name": "spy", "role": "agent", "office_id": "office_B"},
+        {"sid": "c_b", "name": "c_b", "role": "computer", "office_id": "office_B"},
+    ]
+    ns_mod.get_all_sessions_in_office = MagicMock(return_value=leaked)
+    try:
+        ret = ns.on_server_list_room(
+            "a_sid", {"agent": "a_sid", "req_id": "r", "office_id": "office_B"}
+        )
+    except Exception:
+        print("REJECTED")
+    else:
+        print("LEAK:" + ",".join(s["sid"] for s in ret.get("sessions", [])))
+    """
+)
+
+
+def _run_optimized(script: str) -> str:
+    """以 ``python -O`` 执行脚本（断言被剥离），返回 stdout 末行。"""
+    proc = subprocess.run(
+        [sys.executable, "-O", "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert proc.returncode == 0, f"subprocess failed: {proc.stderr}"
+    return proc.stdout.strip().splitlines()[-1]
+
+
+def test_async_list_room_isolation_holds_under_O() -> None:
+    """``-O`` 下异步 on_server_list_room 的跨房间隔离必须依旧拒绝。"""
+    result = _run_optimized(_ASYNC_SCRIPT)
+    assert result == "REJECTED", f"跨房间隔离在 -O 下被剥离，泄露了 office_B 数据: {result}"
+
+
+def test_sync_list_room_isolation_holds_under_O() -> None:
+    """``-O`` 下同步 on_server_list_room 的跨房间隔离必须依旧拒绝。"""
+    result = _run_optimized(_SYNC_SCRIPT)
+    assert result == "REJECTED", f"跨房间隔离在 -O 下被剥离，泄露了 office_B 数据: {result}"

--- a/tests/integration_tests/server/test_namespace_async.py
+++ b/tests/integration_tests/server/test_namespace_async.py
@@ -20,6 +20,7 @@ import pytest
 from mcp.types import CallToolResult, TextContent
 from socketio import AsyncClient
 
+from a2c_smcp.exceptions import SMCPNamespaceError
 from a2c_smcp.smcp import (
     ENTER_OFFICE_NOTIFICATION,
     GET_TOOLS_EVENT,
@@ -515,4 +516,98 @@ async def test_computer_switch_room_with_same_name_allowed(socketio_server, basi
     assert ok, f"Computer切换房间应该成功 / Computer switching rooms should succeed, error: {err}"
     assert err is None, "不应该有错误信息 / Should not have error message"
 
+
+# ======================================================================
+# GitHub #31：office/role 隔离负路径（显式 raise，-O 下亦生效）
+# GitHub #31: office/role isolation negative paths (explicit raise, holds under -O)
+#
+# 服务端与 UvicornTestServer 同进程，可直接以真实会话调用真实处理器，
+# 精确断言抛出 SMCPNamespaceError（而非依赖 ACK 超时的弱断言）。
+# Server runs in-process with UvicornTestServer, so the real handler can be
+# invoked with real sessions and precisely asserted to raise SMCPNamespaceError
+# (instead of a weak ACK-timeout assertion).
+# ======================================================================
+
+
+async def _connect_join(client: AsyncClient, port: int, role: Literal["computer", "agent"], office_id: str, name: str) -> str:
+    """连接 + 加入 office，返回服务端可见的 sid。/ Connect + join office, return server-side sid."""
+    await client.connect(
+        f"http://localhost:{port}",
+        namespaces=[SMCP_NAMESPACE],
+        socketio_path="/socket.io",
+    )
+    await _join_office(client, role=role, office_id=office_id, name=name)
+    return client.get_sid(namespace=SMCP_NAMESPACE)
+
+
+@pytest.mark.asyncio
+async def test_get_tools_cross_office_rejected(socketio_server, basic_server_port: int):
+    """跨房间 client:get_tools：Agent(office_A) 取 Computer(office_B) 工具 → SMCPNamespaceError。"""
+    agent = AsyncClient()
+    computer = AsyncClient()
+    agent_sid = await _connect_join(agent, basic_server_port, "agent", "office-neg-A", "robot-neg-1")
+    await _connect_join(computer, basic_server_port, "computer", "office-neg-B", "comp-neg-1")
+
+    with pytest.raises(SMCPNamespaceError, match="自己房间内Computer的工具列表"):
+        await socketio_server.on_client_get_tools(
+            agent_sid,
+            {"computer": "comp-neg-1", "agent": "robot-neg-1", "req_id": "neg-r1"},
+        )
+
+    await agent.disconnect()
     await computer.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_get_resources_cross_office_rejected(socketio_server, basic_server_port: int):
+    """跨房间 client:get_resources（PR #29 来源场景）→ SMCPNamespaceError，不路由到 Computer。"""
+    agent = AsyncClient()
+    computer = AsyncClient()
+    agent_sid = await _connect_join(agent, basic_server_port, "agent", "office-neg-A2", "robot-neg-2")
+    await _connect_join(computer, basic_server_port, "computer", "office-neg-B2", "comp-neg-2")
+
+    with pytest.raises(SMCPNamespaceError, match="自己房间内Computer的资源列表"):
+        await socketio_server.on_client_get_resources(
+            agent_sid,
+            {"computer": "comp-neg-2", "agent": "robot-neg-2", "mcp_server": "any", "req_id": "neg-r2"},
+        )
+
+    await agent.disconnect()
+    await computer.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_tool_call_wrong_role_rejected(socketio_server, basic_server_port: int):
+    """错角色 client:tool_call：由 Computer 发起工具调用 → SMCPNamespaceError。"""
+    computer = AsyncClient()
+    comp_sid = await _connect_join(computer, basic_server_port, "computer", "office-neg-C", "comp-neg-3")
+
+    with pytest.raises(SMCPNamespaceError, match="目前仅支持Agent调用工具"):
+        await socketio_server.on_client_tool_call(
+            comp_sid,
+            {
+                "agent": "comp-neg-3",
+                "computer": "comp-neg-3",
+                "req_id": "neg-r3",
+                "tool_name": "t",
+                "params": {},
+                "timeout": 5,
+            },
+        )
+
+    await computer.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_list_room_cross_office_rejected(socketio_server, basic_server_port: int):
+    """跨房间 server:list_room：Agent(office_A) 查询 office_B → SMCPNamespaceError，不泄露他房会话。"""
+    agent = AsyncClient()
+    agent_sid = await _connect_join(agent, basic_server_port, "agent", "office-neg-D", "robot-neg-4")
+
+    with pytest.raises(SMCPNamespaceError, match="Agent只能查询自己所在房间的会话信息"):
+        await socketio_server.on_server_list_room(
+            agent_sid,
+            {"agent": "robot-neg-4", "req_id": "neg-r4", "office_id": "office-neg-OTHER"},
+        )
+
+    await agent.disconnect()

--- a/tests/integration_tests/server/test_namespace_sync.py
+++ b/tests/integration_tests/server/test_namespace_sync.py
@@ -21,6 +21,7 @@ from typing import Any
 
 import pytest
 from socketio import Client, Namespace, SimpleClient
+from socketio.exceptions import TimeoutError as SioTimeoutError
 from werkzeug.serving import make_server
 
 from a2c_smcp import PROTOCOL_VERSION
@@ -574,3 +575,72 @@ def test_list_room_session_info_contains_a2c_version_sync(
         assert all(s.get("a2c_version") == PROTOCOL_VERSION for s in agents)
     finally:
         agent.disconnect()
+
+
+# ======================================================================
+# GitHub #31：office/role 隔离负路径（同步镜像，黑盒）
+# GitHub #31: office/role isolation negative paths (sync mirror, black-box)
+#
+# 同步服务器运行于独立进程，只能黑盒验证：处理器显式 raise SMCPNamespaceError
+# → 不回 ACK → 客户端 .call() 超时（socketio TimeoutError）。跨房间用例额外
+# 断言 Computer 的事件处理器从未被调用，证明在 Server 路由前即被拒绝（非误判超时）。
+# The sync server runs in a separate process, so this is black-box: the handler
+# raises SMCPNamespaceError → no ACK → the client .call() times out. The
+# cross-room case additionally asserts the Computer handler was never invoked,
+# proving rejection happened at the Server before routing (not a spurious timeout).
+# ======================================================================
+
+
+def test_get_tools_cross_office_rejected_sync(startup_and_shutdown_local_sync_server, sync_server_port: int) -> None:
+    """跨房间 client:get_tools（同步）：office 不一致 → 拒绝且不路由到 Computer。"""
+    agent = Client()
+    computer = Client()
+    computer_invoked = threading.Event()
+
+    @computer.on(GET_TOOLS_EVENT, namespace=SMCP_NAMESPACE)
+    def _on_get_tools(data: dict) -> dict:  # pragma: no cover - 不应被调用 / must not be called
+        computer_invoked.set()
+        return {"tools": [], "req_id": data.get("req_id", "")}
+
+    agent.connect(f"http://localhost:{sync_server_port}", namespaces=[SMCP_NAMESPACE], socketio_path="/socket.io")
+    computer.connect(f"http://localhost:{sync_server_port}", namespaces=[SMCP_NAMESPACE], socketio_path="/socket.io")
+    try:
+        _join_office(agent, role="agent", office_id="office-sync-neg-A", name="robot-sneg-1")
+        _join_office(computer, role="computer", office_id="office-sync-neg-B", name="comp-sneg-1")
+
+        with pytest.raises(SioTimeoutError):
+            agent.call(
+                GET_TOOLS_EVENT,
+                {"computer": "comp-sneg-1", "agent": "robot-sneg-1", "req_id": "sneg-r1"},
+                namespace=SMCP_NAMESPACE,
+                timeout=3,
+            )
+        assert not computer_invoked.is_set(), "跨房间请求不得路由到 Computer / cross-room request must not reach Computer"
+    finally:
+        agent.disconnect()
+        computer.disconnect()
+
+
+def test_tool_call_wrong_role_rejected_sync(startup_and_shutdown_local_sync_server, sync_server_port: int) -> None:
+    """错角色 client:tool_call（同步）：Computer 发起工具调用 → 被拒绝（超时，无 ACK）。"""
+    computer = Client()
+    computer.connect(f"http://localhost:{sync_server_port}", namespaces=[SMCP_NAMESPACE], socketio_path="/socket.io")
+    try:
+        _join_office(computer, role="computer", office_id="office-sync-neg-C", name="comp-sneg-2")
+
+        with pytest.raises(SioTimeoutError):
+            computer.call(
+                TOOL_CALL_EVENT,
+                {
+                    "agent": "comp-sneg-2",
+                    "computer": "comp-sneg-2",
+                    "req_id": "sneg-r2",
+                    "tool_name": "t",
+                    "params": {},
+                    "timeout": 5,
+                },
+                namespace=SMCP_NAMESPACE,
+                timeout=3,
+            )
+    finally:
+        computer.disconnect()

--- a/tests/unit_tests/server/test_smcp_namespace.py
+++ b/tests/unit_tests/server/test_smcp_namespace.py
@@ -12,6 +12,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from a2c_smcp.exceptions import SMCPNamespaceError
 from a2c_smcp.server import (
     AuthenticationProvider,
     DefaultAuthenticationProvider,
@@ -371,8 +372,9 @@ class TestSMCPNamespace:
 
         smcp_namespace.get_session = AsyncMock(return_value=agent_session)
 
-        # 执行测试，应该抛出 AssertionError / Execute test, should raise AssertionError
-        with pytest.raises(AssertionError, match="Agent只能查询自己所在房间的会话信息"):
+        # 执行测试，应该抛出 SMCPNamespaceError（隔离校验在 -O 下亦生效）
+        # Execute test, should raise SMCPNamespaceError (isolation holds even under -O)
+        with pytest.raises(SMCPNamespaceError, match="Agent只能查询自己所在房间的会话信息"):
             await smcp_namespace.on_server_list_room(
                 agent_sid,
                 {"agent": agent_sid, "req_id": "req_456", "office_id": "office_B"},

--- a/tests/unit_tests/server/test_sync_smcp_namespace.py
+++ b/tests/unit_tests/server/test_sync_smcp_namespace.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from a2c_smcp.exceptions import SMCPNamespaceError
 from a2c_smcp.server.sync_namespace import SyncSMCPNamespace
 from a2c_smcp.smcp import (
     CANCEL_TOOL_CALL_NOTIFICATION,
@@ -276,10 +277,9 @@ def test_on_server_list_room_permission_denied():
 
     ns.get_session = MagicMock(return_value=agent_session)
 
-    # 执行测试，应该抛出 AssertionError / Execute test, should raise AssertionError
-    import pytest
-
-    with pytest.raises(AssertionError, match="Agent只能查询自己所在房间的会话信息"):
+    # 执行测试，应该抛出 SMCPNamespaceError（隔离校验在 -O 下亦生效）
+    # Execute test, should raise SMCPNamespaceError (isolation holds even under -O)
+    with pytest.raises(SMCPNamespaceError, match="Agent只能查询自己所在房间的会话信息"):
         ns.on_server_list_room(
             agent_sid,
             {"agent": agent_sid, "req_id": "req_456", "office_id": "office_B"},


### PR DESCRIPTION
Closes #31 · Parent #8（v0.2 协议升级）

## 根因

所有 `on_client_*` / `on_server_*` 处理器及 Computer 侧 socketio handler 用 `assert` 做 role / office(Room) 隔离。`python -O` / `PYTHONOPTIMIZE` 下 `assert` 被字节码整体剥离 → **跨房间 / 错角色校验被静默关闭**（协议将房间隔离列为不可违反约束）。来源：PR #29 code-review 🟡4。

## 修复（根因，非补丁）

- 新增 `a2c_smcp.exceptions.SMCPNamespaceError`：顶层共用（Server+Computer，避免 Computer 反向依赖 server）；属 sid/session 路由层拒绝，**非** 4014/4015 业务错误 → 保持同处理器既有 raise 形态，**不回 flat ErrorPayload**（符合 #31 约束）。
- `server/namespace.py` + `server/sync_namespace.py`：**13↔13 完全对称**，`assert X,"m"` → `if not X: raise SMCPNamespaceError("m")`，条件取反、消息不变、**正路径不变**。
- `computer/socketio/client.py`：5 处「计算机标识不匹配」`assert` → `if/raise`。
- 全局一致：tool_call_cancel / update_config / update_tool_list / tool_call / get_tools / get_desktop / get_resources / update_desktop / list_room，async + sync 镜像（CLAUDE.md 同步一致性）。

## 测试（负路径，先红后绿）

- **`test_isolation_hardening.py`**（新建）：真实 `python -O` 子进程（断言字节码剥离）下，跨房间 `on_server_list_room` 必须 `REJECTED`、不泄露另一 office 会话；**async + sync 双侧**；设计为异常类型无关（验证安全不变量本身，而非实现细节）。
- `test_namespace_async.py` / `test_namespace_sync.py`：跨房间 `get_tools`/`get_resources`、错角色 `tool_call` 负路径（async 精确断言 `SMCPNamespaceError`；sync 黑盒：超时 + 断言未路由到 Computer）。
- `test_smcp_namespace.py` / `test_sync_smcp_namespace.py`：`list_room` 跨房间期望更新为 `SMCPNamespaceError`。

## 验收

- ✅ `uv run poe lint` — ruff clean + mypy no issues (56 files)
- ✅ `uv run poe test` — **693 passed**, 2 skipped, 4 xfailed, 0 failed
- ✅ async/sync 转换数量对称（各 13）；正路径行为不变

> 注：本 PR 与 #20（集成/文档/e2e）拆分提交（仓库 1-issue-1-PR 惯例）。建议先合本 PR，#20 PR 的 CHANGELOG 即可准确描述已合入的 #31。

🤖 Generated with [Claude Code](https://claude.com/claude-code)