### PR TITLE
docs+test(v0.2): SDK↔protocol compat matrix (protocol MUST) + full-flow e2e (#20)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,55 @@ and this project adheres to [PEP 440](https://peps.python.org/pep-0440/) version
 
 ## [Unreleased]
 
+> A2C-SMCP protocol **v0.2.0 GA** implementation. SDK package version bump to
+> `0.2.0` is performed separately at release cut. Tracking issue:
+> [#8](https://github.com/A2C-SMCP/python-sdk/issues/8).
+
+### Added
+- **Connection protocol-version handshake** (#17 / #18). Clients (Agent + Computer,
+  async + sync) auto-append `a2c_version` to the Socket.IO connect URL query;
+  `a2c_smcp.PROTOCOL_VERSION` (`"0.2.0"`) is the single source. Server-side
+  `a2c_smcp.server.A2CProtocolVersionASGIMiddleware` validates it: missing/invalid →
+  HTTP 400; incompatible (MAJOR.MINOR mismatch) → HTTP 400 + Socket.IO `4008`.
+  Incompatible clients are rejected and **never connect** (`versioning.md` §4
+  loop-defense); `4008` is normalized to `a2c_smcp.exceptions.ProtocolVersionError`.
+  Negotiated version is surfaced via `SessionInfo.a2c_version` through `server:list_room`.
+- **`client:get_resources` event** (#14, async + sync). Transparent passthrough of
+  MCP `resources/list` with caller-controlled `cursor` pagination (SDK does **not**
+  auto-paginate). Flat `ErrorPayload` on `4014` (MCP Server not found) / `4015`
+  (no `resources` capability). Response keys normalized camelCase→snake_case.
+- `base_client.list_resources_page` single-page passthrough API (#13).
+
+### Changed
+- **`window://` URI is now a pure identifier** (v0.2). `priority` / `audience` /
+  `last_modified` move to MCP `Resource.annotations`; `fullscreen` and other A2C
+  extensions move to `_meta`. `WindowURI` no longer parses query; `organize_desktop`
+  reads metadata from `annotations` / `_meta` (#9 / #11). Desktop aggregates
+  `window://` only — non-window resources never enter the desktop.
+- `Finder` removed in favor of the transparent `client:get_resources` event.
+- office/role isolation invariants in `on_client_*` now raise
+  `a2c_smcp.exceptions.SMCPNamespaceError` instead of `assert` (stripped under
+  `python -O`); async + sync namespaces aligned (#31).
+
+### Tests & Docs
+- `tests/e2e/test_v02_full_flow.py` (#20): real-process full chain over a real
+  Uvicorn ASGI server + real protocol-version middleware + real stdio MCP
+  subprocesses — covers handshake negotiation (compatible connects + `a2c_version`
+  recorded; incompatible rejected), `window://` desktop aggregation, `client:get_resources`
+  pagination with transparent passthrough, and the `client:tool_call` chain.
+- **4008 loop-defense test mapping** (#20): no dedicated `test_v02_handshake_loop.py`
+  is added — the `versioning.md` §4 infinite-reconnect-defense guarantee
+  ("incompatible client never connects") is already covered by
+  `tests/integration_tests/test_version_handshake_client.py`
+  (`assert *.connected is False`), and the exact `4008 → ProtocolVersionError`
+  normalization contract by `tests/unit_tests/test_handshake_4008_normalization.py`.
+  `tests/e2e/test_v02_full_flow.py::test_v02_full_flow_incompatible_handshake_rejected`
+  re-checks the guarantee at real-process level. Each layer asserts at its own
+  deterministic tier (non-flaky), so a separate redundant file would add no signal.
+- `README.md`: added the SDK ↔ A2C-SMCP protocol compatibility matrix and v0.2
+  protocol-MUST rules. `CLAUDE.md`: event-system conventions updated with the v0.2
+  events (`client:get_resources`, connection handshake) and URI/metadata changes.
+
 ### Removed
 - **DPE scope removed entirely** per a2c-smcp-protocol v0.2.0 GA decision
   (see [`a2c-smcp-protocol/CHANGELOG_DPE_REMOVAL.md`](https://github.com/A2C-SMCP/a2c-smcp-protocol/blob/main/CHANGELOG_DPE_REMOVAL.md)).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,8 +64,9 @@ SDK 实现了三个通过 Socket.IO 通信的协作组件：
 - `manager.py`: 编排多个 MCP 客户端
 
 **桌面/窗口系统** (`a2c_smcp/computer/desktop/`):
-- 将 MCP 服务器的 `window://` 资源聚合为统一的桌面视图
-- `a2c_smcp/utils/window_uri.py`: 窗口 URI 解析，支持优先级和全屏处理
+- 将 MCP 服务器的 `window://` 资源聚合为统一的桌面视图（仅聚合 `window://`，非 window 资源不进桌面）
+- `a2c_smcp/utils/window_uri.py`: 窗口 URI 解析（v0.2 起为**纯标识符**，不再解析 query）；
+  优先级/全屏从 `Resource.annotations` / `_meta` 读取，由 `desktop/organize.py` 组织
 
 **输入解析** (`a2c_smcp/computer/inputs/`):
 - MCP 服务器配置的占位符解析系统
@@ -87,6 +88,23 @@ Socket.IO 事件遵循以下前缀：
 1. `smcp.py` 中的事件常量
 2. 相关命名空间/客户端类中的处理方法
 3. 测试中的 Mock 服务器事件处理器
+
+### v0.2 协议新增 (a2c-smcp-protocol v0.2.0 GA)
+
+- **`client:get_resources`** (`GET_RESOURCES_EVENT`): Agent → Computer，透明转发 MCP
+  `resources/list`，支持 MCP 标准 `cursor` 翻页（SDK **不**自动遍历，cursor 由调用方控制）。
+  返回 `{resources, next_cursor?}`；错误以 flat `ErrorPayload` 返回（`4014` MCP Server 未注册 /
+  `4015` 未声明 `resources` 能力，无嵌套 envelope）。响应字段 camelCase→snake_case 规整
+  （如 `mimeType`→`mime_type`）。
+- **连接版本握手**: 客户端在 Socket.IO 连接 URL query 携带 `a2c_version`；Server 端由
+  `A2CProtocolVersionASGIMiddleware` 校验，不兼容返回 HTTP 400 + Socket.IO `4008`，并写入
+  `SessionInfo.a2c_version`（经 `server:list_room` 带出，仅展示/诊断）。不兼容客户端**连接被拒、
+  绝不建立**（versioning.md §4 死循环防御）。客户端强制 polling-first（显式 `transports=["websocket"]`
+  会被护栏纠正），确保 4008 可被还原归一为 `ProtocolVersionError`。
+- **URI 纯标识符化**: `window://` 不再在 URI query 携带 `priority`/`fullscreen`；元数据下沉到 MCP
+  `Resource.annotations`（`priority`/`audience`/`last_modified`）与 `_meta`（`fullscreen` 等 A2C 扩展）。
+- **DPE 已整体移除**: A2C-SMCP 控制面不再涉及 `client:get_dpe` / `dpe://` 解析；DPE 迁出至独立
+  [dpe-protocol](https://github.com/A2C-SMCP/dpe-protocol) 仓库。修改时勿重新引入 DPE 事件/类型。
 
 ## 测试结构
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,37 @@ poetry add a2c-smcp --allow-prereleases
 ```
 
 
+## 协议兼容性 (SDK ↔ A2C-SMCP Protocol)
+
+本 SDK 实现 [A2C-SMCP 协议](https://github.com/A2C-SMCP/a2c-smcp-protocol)。SDK 内置的协议版本通过常量
+`a2c_smcp.PROTOCOL_VERSION` 暴露，并在 Socket.IO 连接握手阶段以 URL query `a2c_version` 与 Server 协商。
+
+```python
+from a2c_smcp import PROTOCOL_VERSION  # 当前: "0.2.0"
+```
+
+**兼容矩阵 / Compatibility matrix**
+
+| SDK 版本 | `a2c_smcp.PROTOCOL_VERSION` | 兼容的协议 Server 版本 | 说明 |
+|---|---|---|---|
+| `0.2.x` | `0.2.0` | `0.2.x` | v0.2.0 GA：URI 纯标识符化、`client:get_resources`、连接版本握手；DPE 已移出至 [dpe-protocol](https://github.com/A2C-SMCP/dpe-protocol) |
+| `0.1.x`（pre-GA rc） | 无握手常量 | — | 早期 rc，无版本握手协商；请升级到 `0.2.x` |
+
+**兼容性规则（协议 MUST）/ Compatibility rule (protocol MUST)**
+
+- v0.x 阶段 **MUST** 严格匹配 `MAJOR.MINOR`；`PATCH` 任意。即客户端 `X.Y.Z` 仅与
+  Server 支持区间 `[X.Y.0, X.Y.999]` 兼容（见协议 `versioning.md`）。
+- 客户端 **MUST** 在连接 URL query 携带 `a2c_version`；缺失/非法 → Server 返回 HTTP 400。
+- 版本不兼容时 Server **MUST** 返回 HTTP 400 + Socket.IO `4008`；不兼容客户端**连接被拒、绝不建立**
+  （`versioning.md` §4 死循环防御：客户端不得对 4008 无限重连）。
+- 客户端 **MUST** polling-first 握手（显式 `transports=["websocket"]` 会被 SDK 护栏纠正），
+  以确保 `4008` 拒因可被还原归一为 `ProtocolVersionError`。
+- Server **MUST** 将协商到的 `a2c_version` 写入会话信息，经 `server:list_room` 带出（仅展示/诊断，不二次校验）。
+
+不兼容握手会抛出 `a2c_smcp.exceptions.ProtocolVersionError`（或底层连接异常，二者均满足"连接绝不建立"
+的确定性保证）。升级指南参见协议仓库 `docs/migrations/v0.2-uri-metadata-refactor.md`。
+
+
 ## 快速开始
 
 - 选择你的角色：
@@ -168,8 +199,9 @@ asyncio.run(main())
 
 `Computer` 可将 MCP Servers 暴露的 `window://` 资源整合为 Desktop 视图。设计细节与窗口选择/优先级规则见工作流 `/desktop`：
 
-- 资源 URI 协议：参见 `a2c_smcp/utils/window_uri.py`
-- 与 `MCPServerManager` 的聚合策略：按服务器最近操作历史与 `priority` 组织
+- 资源 URI 协议：参见 `a2c_smcp/utils/window_uri.py`（v0.2 起 `window://` 为**纯标识符**，不再解析 query）
+- 元数据来源（v0.2）：`priority` / `audience` 取自 MCP `Resource.annotations`，`fullscreen` 等 A2C 扩展取自 `_meta`
+- 与 `MCPServerManager` 的聚合策略：仅聚合 `window://`（非 window 资源不进桌面），按最近操作历史与 `priority` 组织
 - `fullscreen` 规则：遇到全屏窗口，当前 Server 只渲染此窗口
 
 集成测试中已包含示例 Stdio MCP 服务器，可参考：

--- a/tests/e2e/test_v02_full_flow.py
+++ b/tests/e2e/test_v02_full_flow.py
@@ -1,0 +1,225 @@
+# -*- coding: utf-8 -*-
+# filename: test_v02_full_flow.py
+# @Author  : JQQ
+# @Software: PyCharm
+"""
+中文：A2C-SMCP v0.2 真实进程全链路 e2e（Tracking #8 / sub-issue #20，§6.6 集成测试要求）。
+
+  在一个真实 Uvicorn ASGI 进程 + 真实 A2C 协议版本握手中间件 + 真实 stdio MCP 子进程上，
+  端到端覆盖 v0.2 协议的四项保留能力（DPE 移除后）：
+
+    1. 版本握手协商：兼容 server（middleware.server_version == SDK PROTOCOL_VERSION）
+       → 三端连接建立，且 Server 从 URL query 写入 ``a2c_version`` 经 ``server:list_room`` 带出；
+       不兼容 server（0.3.0）→ 连接被拒、绝不建立（含 §4 死循环防御的确定性保证）。
+    2. window:// 资源聚合：``client:get_desktop`` 仅聚合 window://，非 window 资源不进桌面。
+    3. get_resources 翻页：``client:get_resources`` 透明转发 MCP resources/list + cursor 翻页，
+       非 window 资源不被过滤（透明转发语义，与桌面聚合语义对照）。
+    4. 工具调用链路：``client:tool_call`` 经 Server 路由到 Computer 的真实 MCP Server 并回传结果。
+
+English: Real-process full-chain e2e for A2C-SMCP v0.2 (Tracking #8 / sub-issue #20, §6.6).
+  One real Uvicorn ASGI process + real protocol-version handshake middleware + real stdio MCP
+  subprocesses, covering the four retained v0.2 capabilities (post-DPE-removal): version
+  handshake negotiation, window:// desktop aggregation, get_resources pagination with
+  transparent passthrough, and the tool-call chain.
+
+协议依据 / Protocol: a2c-smcp-protocol v0.2.x
+  - versioning.md（URL query a2c_version + HTTP 400 + 4008 + §4 死循环防御）
+  - events.md#client:get_resources（透明转发 MCP resources/list + cursor 翻页）
+  - migrations/v0.2-uri-metadata-refactor.md §6.6 集成测试要求
+
+注 / Note: 4008 → ProtocolVersionError 精确归一的确定性契约由
+``tests/unit_tests/test_handshake_4008_normalization.py`` 验证；不兼容连接「绝不建立」
+的确定性保证由 ``tests/integration_tests/test_version_handshake_client.py`` 验证。
+本 e2e 仅在真实进程级别复核两类保证，不重复单测的精确归一断言。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import socket
+import sys
+from collections.abc import AsyncGenerator
+from pathlib import Path
+
+import pytest
+from mcp import StdioServerParameters
+from socketio import ASGIApp
+
+from a2c_smcp import PROTOCOL_VERSION
+from a2c_smcp.agent import AsyncSMCPAgentClient, DefaultAgentAuthProvider
+from a2c_smcp.computer import Computer
+from a2c_smcp.computer.mcp_clients.model import StdioServerConfig, ToolMeta
+from a2c_smcp.computer.socketio.client import SMCPComputerClient
+from a2c_smcp.exceptions import ProtocolVersionError
+from a2c_smcp.server.middleware import A2CProtocolVersionASGIMiddleware
+from a2c_smcp.smcp import JOIN_OFFICE_EVENT, SMCP_NAMESPACE
+from a2c_smcp.utils.handshake import HANDSHAKE_CONNECT_ERRORS
+from tests.integration_tests.computer.socketio.mock_uv_server import UvicornTestServer
+from tests.integration_tests.mock_socketio_server import create_computer_test_socketio
+
+pytestmark = pytest.mark.e2e
+
+_SIO_PATH = "/socket.io"
+# 与 SDK PROTOCOL_VERSION(0.2.x) MINOR 不匹配 → 不兼容 / MINOR mismatch → incompatible
+_INCOMPATIBLE_SERVER = "0.3.0"
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+_MCP_SERVERS_DIR = _PROJECT_ROOT / "tests" / "integration_tests" / "computer" / "mcp_servers"
+# subscribe-srv：暴露 window:// 资源（annotations priority / _meta fullscreen）+ 工具 mark_a
+_SUBSCRIBE_SRV = _MCP_SERVERS_DIR / "resources_subscribe_stdio_server.py"
+# paged-srv：分页混合资源（page1=window+nextCursor；page2=非window file:// + window）
+_PAGED_SRV = _MCP_SERVERS_DIR / "resources_paged_mixed_stdio_server.py"
+# 确定性拒绝形态集合：归一成功 → ProtocolVersionError；body 竞态丢失 → 原始连接异常
+# （二者都满足"连接被拒、绝不建立"的确定性保证；精确类型契约见单测）
+_REJECTION_TYPES: tuple[type[BaseException], ...] = (ProtocolVersionError, *HANDSHAKE_CONNECT_ERRORS)
+
+
+def _stdio_cfg(name: str, script: Path) -> StdioServerConfig:
+    """
+    中文：构造真实 stdio MCP Server 配置；default_tool_meta.auto_apply=True 跳过二次确认回调。
+    English: build a real stdio MCP Server config; default_tool_meta.auto_apply=True skips the
+    secondary-confirmation callback so the e2e tool-call chain runs unattended.
+    """
+    return StdioServerConfig(
+        name=name,
+        server_parameters=StdioServerParameters(command=sys.executable, args=[str(script)]),
+        default_tool_meta=ToolMeta(auto_apply=True),
+    )
+
+
+def _make_mw_app(server_version: str) -> ASGIApp:
+    """
+    中文：真实 SMCPNamespace（放行认证）+ 真实 A2C 协议版本握手 ASGI 中间件。
+    English: real SMCPNamespace (permissive auth) wrapped by the real protocol-version ASGI middleware.
+    """
+    sio = create_computer_test_socketio()
+    sio.eio.start_service_task = False
+    return A2CProtocolVersionASGIMiddleware(
+        ASGIApp(sio, socketio_path=_SIO_PATH),
+        socketio_path=_SIO_PATH,
+        server_version=server_version,
+    )
+
+
+@pytest.fixture
+def free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return int(s.getsockname()[1])
+
+
+@pytest.fixture
+async def compat_server(free_port: int) -> AsyncGenerator[int, None]:
+    """中文：兼容握手 server（server_version == SDK PROTOCOL_VERSION）。"""
+    server = UvicornTestServer(_make_mw_app(PROTOCOL_VERSION), port=free_port)
+    await server.up()
+    try:
+        yield free_port
+    finally:
+        await server.down(force=True)
+
+
+@pytest.fixture
+async def incompat_server(free_port: int) -> AsyncGenerator[int, None]:
+    """中文：不兼容握手 server（server_version=0.3.0，与 SDK 0.2.x MINOR 不匹配）。"""
+    server = UvicornTestServer(_make_mw_app(_INCOMPATIBLE_SERVER), port=free_port)
+    await server.up()
+    try:
+        yield free_port
+    finally:
+        await server.down(force=True)
+
+
+@pytest.mark.asyncio
+async def test_v02_full_flow_compatible(compat_server: int) -> None:
+    """
+    中文：兼容握手下的 v0.2 全链路 —— 版本握手协商 + window:// 聚合 + get_resources 翻页 + 工具调用。
+    English: full v0.2 chain under a compatible handshake.
+    """
+    base = f"http://127.0.0.1:{compat_server}"
+    office_id = "e2e-v02-flow"
+    computer = Computer(
+        name="comp-v02",
+        mcp_servers={_stdio_cfg("subscribe-srv", _SUBSCRIBE_SRV), _stdio_cfg("paged-srv", _PAGED_SRV)},
+    )
+    comp_client = SMCPComputerClient(computer=computer)
+    auth = DefaultAgentAuthProvider(agent_id="robot-v02", office_id=office_id)
+    agent = AsyncSMCPAgentClient(auth_provider=auth)
+
+    try:
+        # —— 版本握手协商（兼容路径）：Agent + Computer 经真实 ASGI 协议中间件建立连接 ——
+        await agent.connect_to_server(base, namespace=SMCP_NAMESPACE, socketio_path=_SIO_PATH)
+        await agent.emit(
+            JOIN_OFFICE_EVENT,
+            {"role": "agent", "office_id": office_id, "name": "robot-v02"},
+            namespace=SMCP_NAMESPACE,
+        )
+        await computer.boot_up()
+        await comp_client.connect(base, socketio_path=_SIO_PATH, namespaces=[SMCP_NAMESPACE])
+        await comp_client.join_office(office_id)
+        assert agent.connected is True
+        assert comp_client.connected is True
+        await asyncio.sleep(0.5)  # 等待 join 在房间内可见 / wait for room visibility
+
+        # 协商结果落地：Server 在 HTTP 握手阶段从 URL query 写入 a2c_version，经 server:list_room 带出
+        computers = await agent.get_computers_in_office(office_id)
+        assert computers, "应能在房间内发现 Computer 会话 / Computer session must be discoverable"
+        assert all(c.get("a2c_version") == PROTOCOL_VERSION for c in computers), (
+            f"协商版本须等于 SDK PROTOCOL_VERSION={PROTOCOL_VERSION}，实际={[c.get('a2c_version') for c in computers]}"
+        )
+
+        # —— window:// 资源聚合：桌面仅聚合 window://，非 window 资源不进桌面 ——
+        desktop = await agent.get_desktop_from_computer("comp-v02", timeout=15)
+        desktops = desktop["desktops"]
+        assert desktops, "桌面应至少聚合一个 window:// 资源 / desktop must aggregate at least one window://"
+        joined = "\n".join(desktops)
+        assert "window://" in joined
+        assert "example.desktop.subscribe.a" in joined, "subscribe-srv 的 window:// 应被聚合"
+        assert "file://" not in joined, "桌面仅聚合 window://，非 window 资源不得出现 / desktop is window-only"
+
+        # —— get_resources 翻页 + 透明转发（非 window 不过滤，与桌面聚合语义对照）——
+        page1 = await agent.get_resources(computer="comp-v02", mcp_server="paged-srv")
+        assert page1["next_cursor"] == "page2"
+        assert len(page1["resources"]) == 1
+        r0 = page1["resources"][0]
+        assert r0["uri"].startswith("window://example.desktop.paged/p1")
+        # camelCase→snake_case 规整 / mimeType normalized to mime_type
+        assert r0["mime_type"] == "text/markdown"
+        assert "mimeType" not in r0
+
+        page2 = await agent.get_resources(computer="comp-v02", mcp_server="paged-srv", cursor="page2")
+        assert "next_cursor" not in page2
+        uris = {r["uri"] for r in page2["resources"]}
+        assert any(u.startswith("file://") for u in uris), "透明转发：非 window 资源不得被过滤"
+        assert any(u.startswith("window://example.desktop.paged/p2") for u in uris)
+
+        # —— 工具调用链路：Agent → Server → Computer 真实 MCP Server → 结果回传 ——
+        result = await agent.emit_tool_call(computer="comp-v02", tool_name="mark_a", params={}, timeout=15)
+        assert result.isError is False, f"工具调用失败 / tool call failed: {result}"
+        assert len(result.content) >= 1
+        assert "ok:mark_a" in result.content[0].text
+    finally:
+        await agent.disconnect()
+        await asyncio.sleep(0.2)
+        # 显式 shutdown 清理 MCP 子进程；跳过 comp_client.disconnect()（其 30s 超时拖慢用例）
+        # Explicit shutdown to reap MCP subprocesses; skip comp_client.disconnect() (30s timeout)
+        await computer.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_v02_full_flow_incompatible_handshake_rejected(incompat_server: int) -> None:
+    """
+    中文：不兼容握手下，Agent 与 Computer 连接均被拒、绝不建立（真实进程级复核 §4 死循环防御保证）。
+    English: under an incompatible handshake, both Agent and Computer connections are rejected and never established.
+    """
+    base = f"http://127.0.0.1:{incompat_server}"
+
+    auth = DefaultAgentAuthProvider(agent_id="robot-v02-bad", office_id="e2e-v02-bad")
+    agent = AsyncSMCPAgentClient(auth_provider=auth)
+    with pytest.raises(_REJECTION_TYPES):
+        await agent.connect_to_server(base, namespace=SMCP_NAMESPACE, socketio_path=_SIO_PATH)
+    assert agent.connected is False  # 确定性保证：连接绝不建立（含 §4 死循环防御）
+
+    comp_client = SMCPComputerClient(computer=Computer(name="comp-v02-bad", mcp_servers=set()))
+    with pytest.raises(_REJECTION_TYPES):
+        await comp_client.connect(base, socketio_path=_SIO_PATH, namespaces=[SMCP_NAMESPACE])
+    assert comp_client.connected is False


### PR DESCRIPTION
Closes #20 · Parent #8（v0.2 协议升级 sub-issue 13/13 —— **里程碑收尾**）

## 文档（含协议 MUST）

- **README**：新增「协议兼容性 (SDK ↔ A2C-SMCP Protocol)」—— SDK↔协议**兼容矩阵** + MUST 标注规则（v0.x 严格 `MAJOR.MINOR` / `a2c_version` 必带 / 4008 拒连 §4 死循环防御 / polling-first 护栏 / server 写回 `a2c_version`）。`versioning.md` **强制** SDK 仓库维护此矩阵，此前缺失 → 本 PR 补齐（协议合规硬性交付项）。
- **CHANGELOG**：v0.2.0 GA 条目（Added / Changed / Tests&Docs）；标注 SDK 版本号 release 时单独 bump；4008 死循环防御显式标注复用既有集成覆盖（非冗余 e2e，诚实记录）。
- **CLAUDE.md**：v0.2 协议新增段（get_resources / 握手 / URI 纯标识符 / DPE 已移除护栏）。

## e2e

`tests/e2e/test_v02_full_flow.py`（`@pytest.mark.e2e`）：真进程全链路 —— 真 Uvicorn ASGI + 真协议版本 middleware + 真 stdio MCP 子进程：握手协商（兼容连通 + `a2c_version` 记录 / 不兼容拒绝）、`window://` 桌面聚合（仅 window://）、`get_resources` 透明转发 + cursor 翻页、`client:tool_call` 链路。4008→`ProtocolVersionError` 精确归一契约由 `test_handshake_4008_normalization.py` 确定性钉死，e2e 只断言确定性保证（与既定测试分层架构一致，非假绿）。

## 验收（PR 独立，**不含 #31**）

- ✅ `uv run poe lint` — ruff clean + mypy no issues (56 files)
- ✅ `uv run poe test` — **685 passed**（develop 基线；#20 仅加文档 + e2e-marked 文件，非 e2e 套件不变）
- ✅ `uv run pytest tests/e2e/test_v02_full_flow.py` — **2 passed**

> 与 #31 PR (#35) 拆分提交（仓库 1-issue-1-PR 惯例）。CHANGELOG 含 #31 `SMCPNamespaceError` 系 v0.2 里程碑整体记录；**建议本 PR 在 #35 之后合并**以保叙述时序。合并后 #8 关闭条件全勾，可关闭 #8。

🤖 Generated with [Claude Code](https://claude.com/claude-code)