### PR TITLE
feat(smcp): v0.2.1 协议镜像（events + TypedDict + ErrorCode）(#37)

### DIFF
--- a/a2c_smcp/smcp.py
+++ b/a2c_smcp/smcp.py
@@ -23,6 +23,12 @@ GET_TOOLS_EVENT = "client:get_tools"
 GET_DESKTOP_EVENT = "client:get_desktop"
 # v0.2 新增：资源发现事件 / v0.2 added: resource discovery event
 GET_RESOURCES_EVENT = "client:get_resources"
+# v0.2.1 新增：SKILL 通道发现 / 渐进式披露 + 通用二进制传输
+# 协议依据 / Protocol: events.md §client:get_skill[s] / §client:get_blob
+# v0.2.1 added: SKILL channel discovery / progressive disclosure + generic blob transfer
+GET_SKILLS_EVENT = "client:get_skills"
+GET_SKILL_EVENT = "client:get_skill"
+GET_BLOB_EVENT = "client:get_blob"
 # 服务端事件 由server:开头的事件服务端执行
 JOIN_OFFICE_EVENT = "server:join_office"
 LEAVE_OFFICE_EVENT = "server:leave_office"
@@ -31,6 +37,10 @@ UPDATE_TOOL_LIST_EVENT = "server:update_tool_list"
 # 桌面刷新事件：当资源列表或资源内容变化时，由Computer端通知Server广播。
 # 中文: 当需要让Agent刷新桌面时，由Computer触发此事件。英文: Computer emits this when Agent should refresh desktop.
 UPDATE_DESKTOP_EVENT = "server:update_desktop"
+# v0.2.1 新增：SKILL 集合变化（增/删/物化更新）由 Computer 触发，Server 向房间广播 notify:update_skills
+# 协议依据 / Protocol: events.md §server:update_skills；data-structures.md §UpdateComputerConfigReq（复用，不新建结构）
+# v0.2.1 added: SKILL set change (add/remove/restage) emitted by Computer, broadcast by Server as notify:update_skills
+UPDATE_SKILLS_EVENT = "server:update_skills"
 CANCEL_TOOL_CALL_EVENT = "server:tool_call_cancel"
 # 列出房间内所有会话事件：Agent可以通过此事件查询指定房间内的所有会话信息。
 # List all sessions in room event: Agent can query all session info in a specific room via this event.
@@ -46,6 +56,10 @@ UPDATE_CONFIG_NOTIFICATION = "notify:update_config"  # AgentClient必须实现 �
 UPDATE_TOOL_LIST_NOTIFICATION = "notify:update_tool_list"  # AgentClient必须实现，通过 client:get_tools 实现更新工具配置
 # 桌面刷新通知：Server接收 server:update_desktop 后广播。Agent据此拉取最新桌面。
 UPDATE_DESKTOP_NOTIFICATION = "notify:update_desktop"
+# v0.2.1 新增：SKILL 集合变化广播。Agent 据此自动重拉 client:get_skills（与既有 notify:update_* 自动刷新模式一致）
+# 协议依据 / Protocol: events.md §notify:update_skills
+# v0.2.1 added: SKILL set change broadcast. Agent re-fetches client:get_skills (same pattern as other notify:update_*)
+UPDATE_SKILLS_NOTIFICATION = "notify:update_skills"
 
 
 class AgentCallData(TypedDict):
@@ -90,6 +104,14 @@ class LeaveOfficeReq(TypedDict):
 
 
 class UpdateComputerConfigReq(TypedDict):
+    """
+    复用 / Reused by:
+      - server:update_config / notify:update_config（v0.1+）
+      - server:update_desktop / notify:update_desktop（v0.2）
+      - server:update_skills / notify:update_skills（v0.2.1）
+    协议依据 / Protocol: data-structures.md §UpdateComputerConfigReq（明示三事件族共用同一结构，不新建）。
+    """
+
     computer: str  # 机器人计算机自定义名称
 
 
@@ -352,8 +374,23 @@ class ListRoomRet(TypedDict):
 
 class ErrorCode(IntEnum):
     """
-    A2C-SMCP 协议错误码（v0.2.0）。
-    A2C-SMCP protocol error codes (v0.2.0).
+    A2C-SMCP 协议错误码（v0.2.0 起，v0.2.1 加性追加 4016/4017/4018）。
+    A2C-SMCP protocol error codes (v0.2.0+, v0.2.1 additively adds 4016/4017/4018).
+
+    4014 复用语义 / 4014 reuse (v0.2.1, error-handling.md §SKILL):
+      SKILL ``name`` **格式合法但不存在**（未注册 / 已卸载 / 已孤儿）复用 ``MCP_SERVER_NOT_FOUND`` 语义；
+      ``name`` 格式非法 → 4016；``name`` 有效但 ``rel_path`` 不可达 → 4017。
+      SKILL ``name`` legal-but-absent (unregistered / uninstalled / orphan) reuses ``MCP_SERVER_NOT_FOUND``;
+      malformed name → 4016; name OK but rel_path unreachable → 4017.
+
+    SKILL 通道**不使用** 4015 —— 未声明 ``resources`` capability 的 server 在物化阶段即被排除，不上送 Agent.
+    SKILL channel does **not** use 4015 — servers lacking the ``resources`` capability are filtered out at
+    staging time and never surface to the Agent.
+
+    4017 / 4018 ``details.reason`` 为开放枚举 / open enum: 解析方 **MUST** 容忍未知值并兜底
+    （默认「不重试 + 诊断」），未来可非破坏新增 reason.
+    ``details.reason`` is an open enum: parsers **MUST** tolerate unknown values with a default of
+    "do not retry + diagnose"; new reasons may be added non-breakingly.
     """
 
     # MCP 上游授权 / MCP upstream authorization
@@ -362,8 +399,15 @@ class ErrorCode(IntEnum):
     # 协议版本握手 / Protocol version handshake
     PROTOCOL_VERSION_MISMATCH = 4008
     # MCP Server 路由 / MCP Server routing
-    MCP_SERVER_NOT_FOUND = 4014
+    MCP_SERVER_NOT_FOUND = 4014  # v0.2.1 复用：SKILL name 合法但 Registry 未命中（含孤儿/卸载）
     MCP_CAPABILITY_NOT_SUPPORTED = 4015
+    # v0.2.1 新增：SKILL 通道 / SKILL channel
+    # 协议依据 / Protocol: error-handling.md §4016 / §4017
+    SKILL_NAME_INVALID = 4016  # client:get_skill 入参 name 违反 SKILL name lexer 规则（格式硬错）
+    SKILL_RESOURCE_NOT_ACCESSIBLE = 4017  # rel_path 穿越 / .skillenv forbidden / not_found / too_large
+    # v0.2.1 新增：通用二进制传输 / Generic binary transfer
+    # 协议依据 / Protocol: error-handling.md §4018
+    BLOB_NOT_ACCESSIBLE = 4018  # client:get_blob 拉取期：invalid_handle / forbidden / gone / range
 
 
 # WebSocket close code（RFC 6455 私有段 4000-4999），用于 WS-only 直连握手按版本不匹配拒绝
@@ -446,6 +490,13 @@ class ErrorPayload(TypedDict, total=False):
       - 4014: mcp_server_name
       - 4015: mcp_server_name / capability
 
+    v0.2.1 起，4016 / 4017 / 4018 的 code-specific 字段下沉到 ``details`` 子对象（无顶层平铺新字段）：
+    From v0.2.1, code-specific fields for 4016 / 4017 / 4018 live under ``details`` (no new top-level fields):
+      - 4016: details.name
+      - 4017: details.reason (traversal/forbidden/not_found/too_large) / details.rel_path / details.total_size
+      - 4018: details.reason (invalid_handle/forbidden/gone/range)
+    协议依据 / Protocol: error-handling.md §各错误码标准字段总表 / §4016 / §4017 / §4018.
+
     details 是诊断容器；Agent MUST NOT 透传给最终用户（防泄露）。
     details is a diagnostic container; Agent MUST NOT propagate to end users.
     """
@@ -464,6 +515,190 @@ class ErrorPayload(TypedDict, total=False):
     capability: str
     # 诊断容器 / Diagnostic container
     details: dict[str, Any]
+
+
+# =====================================================================
+# v0.2.1 协议新增 / v0.2.1 protocol additions
+# 协议来源 / Protocol source: A2C-SMCP/a2c-smcp-protocol v0.2.1
+#   - docs/migrations/v0.2.1-skill-and-blob-transfer.md（先读总纲）
+#   - docs/specification/data-structures.md §SKILL / §BlobHandle / §GetBlob*
+#   - docs/specification/error-handling.md §4016 / §4017 / §4018（4014 复用）
+#   - docs/specification/events.md §client:get_skill[s] / §client:get_blob / §server:update_skills
+#   - docs/specification/skill.md / docs/specification/blob-transfer.md
+# 加性升级 / Additive: PROTOCOL_VERSION 未改动；所有新结构均为 total=False 开放 TypedDict，
+# 允许未来非破坏追加字段。
+# =====================================================================
+
+
+class A2CSkillRef(TypedDict, total=False):
+    """
+    SKILL 引用对象，``client:get_skills`` 返回列表元素。
+    Skill reference object — element of ``client:get_skills`` return list.
+
+    协议依据 / Protocol: data-structures.md §A2CSkillRef；skill.md §2 命名 / §3 ref 字段。
+
+    关键约束 / Key invariants:
+      - ``name`` 是协议主键（含 source prefix 的合成全局唯一名），Agent **MUST** 当作不透明可比较字符串
+        ``name`` is the protocol primary key (synthesized globally-unique name including source prefix);
+        Agent **MUST** treat as opaque comparable string.
+      - ``path`` 必选（staging 落盘是所有 source 的统一第一步，故进入 Registry 的 SKILL 必有可读本地目录）
+        ``path`` is required (staging is the unified first step for all sources; any SKILL in Registry
+        has a readable local directory).
+      - **无 ``mcp_server`` 字段** —— Agent 侧协议表面与 source 无关；来源追溯由 ``source`` 与（仅 MCP）
+        ``uri`` 承担（skill.md §2）
+        **No ``mcp_server`` field** — Agent-facing protocol surface is source-agnostic; provenance is
+        carried by ``source`` and (MCP only) ``uri``.
+    """
+
+    # 主键 / Primary key
+    name: str  # 合成全局唯一名，含 source prefix；如 mcp:tfrobot-tools:code-review
+    # 来源元数据 / Provenance
+    source: str  # source prefix；如 mcp:tfrobot-tools / marketplace:acme-skills / user
+    uri: str  # 仅 MCP 来源：skill://host/skill-name；Agent 非权威（skill.md §2）
+    # 物化输出 / Materialization output
+    path: str  # 必选：Computer 本地绝对目录路径，面向 Agent SDK（脚本执行/文件访问），LLM 永不可见
+    # SKILL.md frontmatter 派生 / Derived from SKILL.md frontmatter
+    description: str  # marketplace SKILL v1 §3.1
+    license: str
+    compatibility: str
+    allowed_tools: list[str]  # frontmatter "allowed-tools" 规范化为 list
+    version: str
+    skill_metadata: dict[str, Any]  # frontmatter.metadata 透传；A2C 不解释 / passthrough, A2C does not interpret
+
+
+class GetSkillsReq(AgentCallData, total=True):
+    """
+    获取 SKILL 清单请求。协议依据 / Protocol: events.md §client:get_skills；data-structures.md §GetSkillsReq.
+    Get SKILL inventory request.
+    """
+
+    computer: str
+
+
+class GetSkillsRet(TypedDict, total=False):
+    """
+    获取 SKILL 清单响应——轻量元数据，**不含** SKILL.md body（body 由 ``client:get_skill`` 拉取）。
+    Skill inventory response — lightweight metadata, **without** SKILL.md body (body via ``client:get_skill``).
+
+    协议依据 / Protocol: data-structures.md §GetSkillsRet；skill.md §6 排除孤儿 / 不排序 / 不去重.
+    """
+
+    skills: list[A2CSkillRef]  # 当前已安装且可用 SKILL（排除孤儿；不排序、不去重）
+    req_id: str
+
+
+class GetSkillReq(AgentCallData, total=True):
+    """
+    获取 SKILL 包内单个资源请求。SKILL 本质是文件夹：``rel_path`` 缺省取包根 ``SKILL.md``（入口），
+    携带 ``rel_path`` 取包内其它资源（渐进式披露）。
+    Get a single resource inside a SKILL package. SKILL is essentially a folder: ``rel_path`` defaults
+    to package-root ``SKILL.md`` (entry); pass ``rel_path`` to fetch other in-package resources
+    (progressive disclosure).
+
+    协议依据 / Protocol: events.md §client:get_skill；data-structures.md §GetSkillReq；
+    skill.md §9 安全模型（``rel_path`` MUST 相对、无 ``..``、无绝对路径，沙箱在 Computer 解析时强制）.
+    """
+
+    computer: str
+    name: str  # 必选：来自某 A2CSkillRef.name
+    rel_path: NotRequired[str]  # 可选：SKILL 包根 POSIX 相对路径；缺省 = "SKILL.md"
+
+
+class GetSkillRet(TypedDict, total=False):
+    """
+    获取 SKILL 包内单个资源响应。文本且可内联 → ``body`` 直接给出；二进制或过大文本 → ``blob_handle``
+    转 ``client:get_blob`` 拉取——``body`` 与 ``blob_handle`` **恰一存在**（exactly one）。
+    Get-skill response. Inlineable text → ``body``; binary or oversize text → ``blob_handle`` (fetched
+    via ``client:get_blob``). Exactly one of ``body`` / ``blob_handle`` is present.
+
+    协议依据 / Protocol: data-structures.md §GetSkillRet；blob-transfer.md §5 生产者通道接入契约；
+    skill.md §9 安全 / too_large 不铸句柄.
+
+    完整性 / Integrity:
+      - ``total_size`` / ``sha256`` 基于 **Agent 最终消费的资源字节**（SKILL.md → frontmatter 剥离后 body；
+        其它 → 原始字节；占位符 ``$TFROBOT_*`` **不展开**，由 Agent SDK 渲染层处理）
+        ``total_size`` / ``sha256`` are based on the **bytes the Agent will ultimately consume**
+        (SKILL.md → body with frontmatter stripped; others → raw bytes; ``$TFROBOT_*`` placeholders
+        **NOT expanded**, handled by Agent SDK prompt rendering).
+      - Agent **SHOULD** 用 ``sha256`` 校验内联 ``body``；handle 路径于 ``eof`` 后全量校验
+        Agent **SHOULD** verify ``body`` against ``sha256`` inline; for handle path verify after ``eof``.
+    """
+
+    name: str  # 回显请求 name
+    rel_path: str  # 回显请求 rel_path；缺省请求时回显 "SKILL.md"
+    mime_type: str  # 资源 MIME，如 text/markdown / image/png
+    total_size: int  # 资源总字节数（基于最终消费字节）
+    sha256: str  # 全量资源 sha256 十六进制（完整性 + 变更检测）
+    body: str  # 文本且 ≤ 内联预算：直接内容（与 blob_handle 恰一）
+    blob_handle: str  # 否则：转 client:get_blob 的不透明句柄（与 body 恰一）
+    req_id: str
+
+
+# ── 通用二进制传输 / Generic binary transfer ──────────────────────────────
+# 协议依据 / Protocol: blob-transfer.md（句柄契约 / 生产者-消费者模型 / 安全模型）
+
+
+BlobHandle: TypeAlias = str
+"""
+不透明、Computer 铸造、无状态可重解析的 blob 句柄。
+Opaque, Computer-minted, stateless-reparseable blob handle.
+
+Agent 行为约束 / Agent behavior constraints (blob-transfer.md §1):
+  - MUST 视为不透明字符串；MUST NOT 解析 / 拼接 / 伪造 / 跨 Computer 复用
+  - MUST treat as opaque string; MUST NOT parse / concatenate / forge / reuse across Computers
+
+载体随响应结构而异 / Carrier varies by response shape:
+  - ``GetSkillRet.blob_handle``（A2C 可变结构 / A2C mutable）
+  - MCP ``CallToolResult`` content item ``_meta.a2c_blob_handle``（MCP 不可变结构旁路 / MCP immutable sideband）
+"""
+
+
+class GetBlobReq(AgentCallData, total=True):
+    """
+    通用二进制拉取请求。Computer 无服务端状态、幂等可并行（``chunk_offset`` 为资源字节绝对偏移）。
+    Generic binary pull request. Stateless on Computer, idempotent, parallelizable
+    (``chunk_offset`` is absolute byte offset within the resource).
+
+    协议依据 / Protocol: events.md §client:get_blob；data-structures.md §GetBlobReq；
+    blob-transfer.md §2 (handle) / §3 (chunking) / §4 (errors).
+    """
+
+    computer: str
+    blob_handle: str  # 必选：来自某通道响应的不透明句柄
+    chunk_offset: NotRequired[int]  # 可选：资源字节绝对偏移；缺省 0；无状态幂等 → 可续传 / 重试 / 并行
+    max_chunk_bytes: NotRequired[int]  # 可选：客户建议单块上限；Computer clamp（恒保证不超 Server buffer）
+
+
+class GetBlobRet(TypedDict, total=False):
+    """
+    通用二进制拉取响应。
+    Generic binary pull response.
+
+    协议依据 / Protocol: data-structures.md §GetBlobRet；blob-transfer.md §3 完整性 / §4 错误 / §5 演进缝隙.
+
+    完整性与一致性铁律 / Integrity & consistency invariants:
+      - ``eof`` ⟺ ``chunk_offset + len(decode(blob)) == total_size``
+      - ``eof`` 后 Agent **SHOULD** 校验重组 ``sha256`` == 响应 ``sha256``，不符即损坏、重读
+        After ``eof`` Agent **SHOULD** verify reassembled ``sha256`` == response ``sha256``;
+        on mismatch the data is corrupt — reread.
+      - 一次逻辑读取内 ``sha256`` / ``total_size`` **MUST** 稳定；跨块变化 ⇒ 源被改写，
+        Agent **MUST** 从 offset 0 重读
+        Within one logical read ``sha256`` / ``total_size`` **MUST** be stable; on change ⇒ source rewritten,
+        Agent **MUST** restart from offset 0.
+
+    演进缝隙 / Evolution slack (open TypedDict): 未来可非破坏追加 ``content_encoding`` (gzip 等，缺省 identity)
+    / ``etag``；offset / total_size / sha256 基于**解码后**资源字节，加压缩不致歧义。
+    Future fields may be added non-breakingly; offset / total_size / sha256 are on **decoded** bytes.
+    """
+
+    blob_handle: str  # 回显
+    mime_type: str
+    total_size: int  # 首块即知；一次读取内恒定
+    sha256: str  # 全量资源 sha256；跨块恒定
+    chunk_offset: int  # 本块起始字节偏移
+    eof: bool  # ⟺ chunk_offset + 本块字节数 == total_size
+    blob: str  # base64，本块字节
+    req_id: str
 
 
 # 协议错误码取值集合（flat ErrorPayload 顶层 code）/ Protocol error-code value set (flat ErrorPayload top-level code)

--- a/docs/design-0.2.1-skill-computer-management.md
+++ b/docs/design-0.2.1-skill-computer-management.md
@@ -1,0 +1,307 @@
+# 设计文档：0.2.1 — SKILL Computer 管理 + A2C 发现与传递
+
+> **性质**：python-sdk 实现设计（**不是协议规范**）。协议为唯一权威；本文档只规定协议明确判给 SDK 自决的部分、SDK 模块落点、既有约定对齐、WBS 与验收。
+> **配套**：开发工单 [`docs/upgrade-0.2.1-skill-blob-transfer.md`](upgrade-0.2.1-skill-blob-transfer.md)（范围/约束/PR 拆分）；本文档是其设计补全。
+> **范本**：Claude Code Marketplace/Plugin 操作生命周期（`MARKETPLACE_PLUGIN_OPERATIONS.md`，外部参考）——SKILL Computer 本地管理侧的设计蓝本。
+> **追踪**：GitHub Milestone「v0.2.1 SKILL 通道 + 通用二进制传输」+ parent tracking issue。
+> **前置门控**：✅ 协议 0.2.1 已在 `a2c-smcp-protocol` 评审/合并/发布（`main`）。`PROTOCOL_VERSION` 常量**不改**（0.2.x 加性）。
+
+---
+
+## 0. 协议权威（只读引用，禁止 SDK 侧二次规范）
+
+字段/事件/错误码/边界一律以协议为准，实现与之偏离即 bug：
+
+| 主题 | 权威文档（`a2c-smcp-protocol`） |
+|---|---|
+| 跨语言适配总纲（先读） | `docs/migrations/v0.2.1-skill-and-blob-transfer.md` |
+| SKILL 通道（命名 lexer / 多 source / 沙箱 / 变更检测 / 生命周期） | `docs/specification/skill.md` |
+| 通用二进制传输（句柄契约 / 分块背压完整性 / 4018） | `docs/specification/blob-transfer.md` |
+| 事件请求响应 + Computer 处理流程 | `docs/specification/events.md` |
+| TypedDict 字段 | `docs/specification/data-structures.md` |
+| 错误码 4016/4017/4018，4014 复用 | `docs/specification/error-handling.md` |
+
+本文档**只**补协议没有、也不该有的内容。
+
+---
+
+## 1. 范围
+
+**在范围**
+
+1. **A2C 发现与传递（协议侧）**：`client:get_skills` / `client:get_skill` / `client:get_blob`、`server:update_skills` / `notify:update_skills`；`client:tool_call` 二进制一致性（`_meta.a2c_blob_handle` 旁路）。镜像既有 `get_resources` v0.2 全链路范式。
+2. **SKILL Computer 本地管理（SDK 自决侧）**：SKILL Home / 三源 staging（`mcp:` / `marketplace:` / `user`）/ Skill Registry / 命名 lexer / 变更检测 / 安全沙箱。
+
+**不在范围**（解耦，勿在本工单触碰）
+
+- 协议版本握手 / WS-only 收口 —— 归 PR #33（已合并）。本工单不碰 `server/middleware.py`、`utils/handshake.py`、`version.py`。
+- 后台定时对账守护进程 —— 显式后置为 backlog（见 §3.2）。
+
+---
+
+## 2. 三项 SDK-自决关键决策（已评审锁定）
+
+协议 `skill.md §4` 把「本地安装位置 / 管理 UX / 探测机制」判给 SDK。以下三项为本设计的架构基线：
+
+### 2.1 决策 ① SKILL 源「意图层」落点 → **混合**
+
+「意图层」= 用户声明「想要哪些 SKILL 源」的配置；「物化层」= 磁盘实际 staging 产物 + Registry；二者由 reconciler 对账（概念源自 Claude Code `MARKETPLACE_PLUGIN_OPERATIONS.md §1`）。
+
+| Source | 意图层落点 | 物化层 | 变更检测 |
+|---|---|---|---|
+| `mcp:` | **复用现有 MCP Server 配置**（`MCPServerConfig`，经 `client:get_config`）。无独立意图层——协议 `skill.md §5`「MCP Server 连接动作本身即视为 SKILL 安装授权」 | SKILL Home `mcp/<server>/<skill>/` | 复用现有 MCP `ResourceListChanged/Updated` 经 `computer.py:_on_manager_change`（与 `window://` 并行） |
+| `marketplace:` | **SKILL Home 下独立 registry**（git 源清单，对标 Claude Code `known_marketplaces.json`） | SKILL Home `marketplace/<repo>/<...>/<skill>/` | 启动对账 + 显式 refresh（§2.2） |
+| `user` | **SKILL Home 下独立 registry**（DropIn 目录清单） | SKILL Home `user/<skill>/` | 启动扫描 + 显式 refresh / SDK 管理 UX 动作 |
+
+**依据**：
+- `mcp:` 已有可用意图（MCP 配置）+ 可用物化/变更线路（`manager` + `_on_manager_change`）。工单 §3.1/§3.2 明确规定 `mcp:` 复用 `mcp_clients/manager.py` 枚举 `skill://`、扩展 `_on_manager_change`。强行另起独立 registry = 重复造源管理。
+- `marketplace:` / `user` 为净新增、无现有配置宿主，概念上正是 Claude Code marketplace 两层模型。把 git 源生命周期（clone/pull/孤儿/GC/autoUpdate）塞进 `MCPServerConfig`（传输/工具配置）= 范畴错误，且会把 SKILL 源意图泄进 `client:get_config`（违背协议理念 #2「对 Agent 暴露表面与 source 无关」）。
+- 混合方案使「三源各按本性管理、对 Agent 表面统一」，正合 `skill.md §8`「表面与 source 无关，机制细节按源不同（§5）」。
+
+### 2.2 决策 ② marketplace git 源刷新/对账 → **Claude Code 对标（无 TTL）**
+
+- **eager add**：用户配置 git 源即时 `git clone --depth 1`（SSH→HTTPS 回退；`GIT_TERMINAL_PROMPT=0`、`GIT_ASKPASS=''`；超时可配，默认 120s）。不走 `gh`。
+- **显式 refresh**：原地 `git pull`（失败则全量重 clone）→ 与缓存 SKILL 集合对账。
+- **启动对账（reconcile）**：Computer 启动时按意图同步物化（缺的 clone、变的重拉、删的清理）；尊重 per-source `auto_update` 标志（对标 Claude Code「autoUpdate 启动时触发」，非 TTL）。
+- **无 TTL 自动刷新**。后台定时对账守护进程**显式后置**为 backlog（协议 `skill.md §8.3` 只要求「定时 / 用户触发」其一；启动对账 + 显式 refresh 已满足；可日后非破坏加性引入）。
+- **失败降级铁律**（工单 §8）：网络/clone/对账失败记 ERROR，不阻断其余 source，不向 Agent 硬报错，不入协议错误码（物化失败的 SKILL 不进 Registry，对 Agent 不可见）。
+
+**依据**：范本 `MARKETPLACE_PLUGIN_OPERATIONS.md §0/§5` 明确「eager add，非懒加载」「无 TTL，要么显式要么 autoUpdate 启动」。纯懒加载相悖且把网络延迟塞进 Agent 朝向的轻量 `get_skills`；后台定时器是真·加性，范围/测试面膨胀，后置。
+
+### 2.3 决策 ③ SKILL Home 路径 → **可配置，默认 `$XDG_DATA_HOME/a2c/skills`（回退 `~/.a2c/skills`）**
+
+- 解析顺序：显式配置/环境变量覆盖 → `$XDG_DATA_HOME/a2c/skills` → `~/.a2c/skills`。
+- env 覆盖键：`A2C_SKILL_HOME`（镜像 Claude Code `CLAUDE_CODE_PLUGIN_CACHE_DIR` 的「默认在用户 home + 可覆盖」范式）。
+- 布局：`<skill_home>/<source>/<...>/<skill>/`（协议 `skill.md §4` 推荐三级分组）。
+- 隔离铁律（协议 `skill.md §9.2`）：**MUST NOT 跨用户共享**，不放系统目录；多用户每用户独立 home；覆盖路径仍 MUST 非系统共享目录（启动时校验，违反 fail-fast）。
+
+**依据**：Claude Code 范本本就是「默认用户 home + env 覆盖」；工单 §8 点名容器/多实例必须有覆盖旋钮，否则同镜像多实例撞目录。XDG-first 为跨平台惯例。
+
+---
+
+## 3. 架构总览
+
+```
+        Agent SDK                    Server                       Computer SDK
+  ┌───────────────────┐      ┌──────────────────┐      ┌──────────────────────────────┐
+  │ get_skills         │─────▶│ 路由 client:*     │─────▶│  ┌─ 协议发现传递侧 ───────────┐ │
+  │ get_skill ─┐       │      │ (按 computer)     │      │  │ on_get_skills/skill/blob   │ │
+  │ get_blob ◀─┘drain  │◀─────│ 广播 notify:*     │◀─────│  │ tool_call 二进制旁路        │ │
+  │ utils/blob.drain   │      └──────────────────┘      │  │ emit_update_skills         │ │
+  │ notify:update_skills│                                │  └────────────┬───────────────┘ │
+  └───────────────────┘                                 │      Skill Registry (name→ref)  │
+                                                          │  ┌─ SKILL Computer 本地管理 ──┐ │
+                                                          │  │ SKILL Home staging          │ │
+                                                          │  │ mcp: / marketplace: / user  │ │
+                                                          │  │ 意图层↔物化层↔reconciler    │ │
+                                                          │  │ naming lexer / 沙箱         │ │
+                                                          │  └─────────────────────────────┘ │
+                                                          └──────────────────────────────┘
+```
+
+两大块解耦：**协议发现传递侧**镜像 `get_resources` v0.2 范式（无 SDK 设计自由度，照协议）；**SKILL Computer 本地管理侧**按 §2 三决策落地（SDK 自决，对标 Claude Code）。Skill Registry 是二者唯一接缝（`name → A2CSkillRef`，含包根绝对路径）。
+
+---
+
+## 4. 协议发现传递侧设计（镜像 `get_resources` v0.2 范式）
+
+### 4.1 协议镜像层 `a2c_smcp/smcp.py`
+
+范本：现有 `GetResourcesReq/Ret`（`smcp.py:413-432`）、`ErrorPayload`（`:435-466`）、`is_protocol_error_payload`（`:473-483`）。
+
+新增（字段严格对齐 `data-structures.md`，注释标注协议出处，沿用既有 `*_EVENT` 命名/注释风格）：
+
+- 事件常量：`GET_SKILLS_EVENT="client:get_skills"`、`GET_SKILL_EVENT="client:get_skill"`、`GET_BLOB_EVENT="client:get_blob"`、`UPDATE_SKILLS_EVENT="server:update_skills"`、`UPDATE_SKILLS_NOTIFICATION="notify:update_skills"`。
+- TypedDict：`A2CSkillRef`（**无 `mcp_server` 字段**；`path` 必选）、`GetSkillsReq/Ret`、`GetSkillReq/Ret`（`body` 与 `blob_handle` 恰一）、`GetBlobReq/Ret`；类型别名 `BlobHandle: TypeAlias = str`。
+- `ErrorCode` 增 `SKILL_NAME_INVALID=4016`、`SKILL_RESOURCE_NOT_ACCESSIBLE=4017`、`BLOB_NOT_ACCESSIBLE=4018`（沿用 `IntEnum` 风格 + 注释）；`4014` 复用语义 docstring 标注；`4017/4018.details.reason` 为开放枚举，解析方 MUST 容忍未知值兜底（默认「不重试 + 诊断」）。
+- `server:update_skills` / `notify:update_skills` **复用** `UpdateComputerConfigReq`（`smcp.py:92`），不新建结构。
+
+### 4.2 Computer 生产侧 `a2c_smcp/computer/socketio/client.py`
+
+范本：`on_get_resources`（`socketio/client.py:398-447`）的注册（`:143`）+ flat `ErrorPayload` 返回模式。
+
+- `__init__` 注册三事件 handler（仿 `:143`）。
+- `on_get_skills`：从 Registry 读可用项，排除孤儿，不读 body，按发现序返回。
+- `on_get_skill`：name lexer 失败 → `4016`；name 不在 Registry → `4014`；`rel_path` `safe_join`+`realpath` 越界/命中 `.skillenv`/不存在 → `4017`（reason）；`total_size` 超上限 → `4017 too_large`（不铸句柄）；仅 SKILL.md 剥 frontmatter；文本 ≤ 内联预算 → `body`，否则铸 `blob_handle`。
+- `on_get_blob`：解析句柄 → **重施 §6 沙箱** → 切片；`4018`(`invalid_handle`/`forbidden`/`gone`/`range`)；单块序列化 ≤ Server `maxHttpBufferSize`。
+- `emit_update_skills`：仿 `emit_update_tool_list`（`:281-287`），复用 `UpdateComputerConfigReq`，`office_id` 守卫。
+- `on_tool_call`（`:297-322`）返回前：遍历 `CallToolResult.content`，对超内联预算二进制 item 清空内联 `data`/`blob`、写 item `_meta.a2c_blob_handle`(+`a2c_total_size`/`a2c_sha256`，MIME 复用 item `mimeType`)；小图原样内联；工具失败仍走 MCP `isError`（既有不变量）。
+
+错误以 flat `ErrorPayload` 经 Socket.IO ack 第一参回传（无嵌套 envelope），与 `on_get_resources` 完全一致。
+
+### 4.3 blob_handle 无状态编码方案（SDK 自决，协议 `blob-transfer.md §1/§5` 约束）
+
+句柄是**逻辑源描述符**，不是文件系统路径。两类生产者两种 kind，统一**单层**编码（无签名层）：
+
+```
+blob_handle = base64url( msgpack({
+    "v": 1,
+    "kind": "skill" | "toolspool",
+    # kind=skill:     {"name": <A2CSkillRef.name>, "rel_path": <POSIX rel>}
+    # kind=toolspool: {"cid": <content-addressed id = sha256>, "mime": <mime>}
+}) )
+```
+
+- **不透明性**：协议 §1 的「不透明」是**Agent 行为 MUST**（Agent MUST NOT 解析/拼接/伪造/跨 Computer 复用），不可由 Computer 加密强制对端。SDK 满足契约即 Agent SDK 始终把句柄当字符串透传、不解码；这与协议要求一致。
+- **不签名 / 不 MAC**：协议 §1/§5.4 把句柄安全边界定在「**Computer 解析时 MUST 重跑本通道边界校验，不信任句柄内容**」——这是唯一真安全根。MAC 是冗余防御层，不增加任何真正安全（伪造句柄仍要过 Registry + 沙箱），却带来 per-process secret 管理/轮转/测试 fixture 维护负担，**故不采用**。业界对照：SFTP / OCI registry / gRPC / OpenAI Realtime 均不签内部传输 token。
+- **无状态可重解析**：无 session/游标/TTL/per-process secret。每次 `get_blob` 独立确定性回源、幂等、可并行（§4.5）：
+  - `kind=skill`：**忽略句柄内任何路径**，用 `name` 经 Skill Registry O(1) 解析包根 → 对 `rel_path` **重跑 §6 沙箱**（不信任句柄内容，协议 §5.4）。Registry 未命中/孤儿 → `4018 gone`；沙箱失败 → `4018 forbidden`；msgpack 格式不识别 / `v` 未知 → `4018 invalid_handle`。
+  - `kind=toolspool`:tool_call 二进制不可由工具重跑确定性重得，故铸造时溢写到**内容寻址 blob 暂存区**（SKILL Home 同级 `<skill_home>/.blobspool/<cid>`，`cid=sha256`）。`get_blob` 按 `cid` 回查并校验 sha256。暂存被 GC/淘汰 → `4018 gone`（协议许可「源消失 → gone → Agent 回生产者重取句柄」）。**句柄跨 Computer 重启可解析**（cid 在磁盘 / Registry 启动重建），无 HMAC 后此红利兑现。
+- **句柄有效期语义**（协议 §5.3 要求文档化）：本 SDK 不设 TTL；句柄「有效」≡「源仍被铸造通道授权且可解析」。源变更由 `sha256`/`total_size` 检测，源消失由 `4018 gone` 表达。
+
+### 4.4 阈值默认值（SDK 可配，协议要求「保证单条 ack 不超 Server buffer」）
+
+| 项 | 默认 | 配置键 | 说明 |
+|---|---|---|---|
+| 内联预算 inline budget | 32 KiB | `A2C_SKILL_INLINE_BUDGET` | 文本资源 ≤ 此 → `body`；否则铸句柄。二进制 MIME 一律铸句柄 |
+| 绝对上限 too_large cap | 100 MiB | `A2C_SKILL_MAX_SIZE` | `total_size` 超此 → `4017 too_large`，不铸句柄、零字节传输（DoS 防御） |
+| 单块默认 max_chunk_bytes | 256 KiB（原始字节）| `A2C_BLOB_CHUNK_BYTES` | Computer 对客户建议值 clamp；恒保证 base64(+33%)+envelope ≤ Server `maxHttpBufferSize`（默认 1 MB），故 ~342 KiB base64 远低于 1 MB |
+
+「资源字节」基准三处一致（协议 `blob-transfer.md`）：SKILL.md → frontmatter 剥离后 body；其它 → 原始字节；占位符 `$TFROBOT_*` **不展开**（Agent prompt 渲染层职责，非协议层）。
+
+### 4.5 Agent 消费侧
+
+- **统一拉取例程** `a2c_smcp/utils/blob.py`（与 `utils/handshake.py` 同层）：
+
+  ```python
+  async def drain_blob(
+      call, computer: str, blob_handle: str, *,
+      concurrency: int = 1,              # 默认串行（协议 reference impl 语义）；>1 启用并行
+      chunk_size: int | None = None,     # 客户建议 max_chunk_bytes；缺省由 Computer clamp
+  ) -> tuple[bytes, str]: ...
+  ```
+
+  共享行为：`eof` 后校验全量 `sha256`；跨块 `sha256`/`total_size` 变化 → 从 0 重读；`4018` 分支（`invalid_handle`/`forbidden` 不重试，`gone` 回生产者重取句柄，`range` 修偏移）。**get_skill 与 tool_call 两处共用此一函数。** 行为契约见协议 `blob-transfer.md §5.1` reference impl。
+
+- **并行红利（协议 §3 明文）**：`chunk_offset` 为资源字节绝对偏移、Computer 无服务端状态 → 「天然幂等、可并行不同 offset」。`drain_blob` 实现两种模式：
+  - `concurrency=1`：串行循环（协议 reference impl，最小可证），保守默认。
+  - `concurrency>1`：
+    1. 首块（offset=0，串行）获知 `total_size`/`sha256`/`mime_type`；
+    2. 计算剩余 chunk 起点集合，经 `asyncio.Semaphore(concurrency)`（sync 镜像走 `ThreadPoolExecutor`）并发 `client:get_blob`；
+    3. **错误协调**：任一块 `4018 invalid_handle`/`forbidden` → 取消所有在飞 + raise；`gone` → 取消 + raise（上层回生产者）；`range` → 取消 + 串行 fallback；任一块的 `sha256`/`total_size` 与首块不一致 → 取消所有在飞 + 从 0 串行重读（不在并发态拼接错配字节）；
+    4. 按 offset 重组 → 全量 `sha256` 自证。
+
+  docstring **必须** 明示「并行安全」与上述错误协调矩阵——这是和 SFTP（有状态句柄需多 handle）拉开差距的红利，丢失即等同自我贬值。
+- **请求构造** `a2c_smcp/agent/_request_builders.py`（#30 纯函数范式，范本 `build_get_resources_request`）：增 `build_get_skills_request` / `build_get_skill_request` / `build_get_blob_request`。
+- **Base 客户端** `a2c_smcp/agent/base.py`：`BaseAgentClient` / `BaseAgentSyncClient` 各增 `create_get_skills/skill/blob_request`（范本 `create_get_resources_request:119`）。
+- **async/sync 双镜像** `agent/client.py` ↔ `agent/sync_client.py`（范本 `get_resources`，`client.py:357` / `sync_client.py:390`）：`get_skills` / `get_skill` / `get_blob`；`raise_for_error_payload`（`errors.py:44`）复用判错；`get_skill` 响应分支 `body` 直接用 / `blob_handle` → `drain_blob`；`tool_call` 消费遍历 `CallToolResult.content` 命中 `_meta.a2c_blob_handle` → `drain_blob` 还原后交付上层（**不实现 = 大二进制工具结果静默变空**，破坏性关键点）；`notify:update_skills` → 自动重拉 `client:get_skills`（仿既有 `notify:update_*` 自动刷新）。
+
+### 4.6 Server 路由 `a2c_smcp/server/namespace.py` ↔ `sync_namespace.py`
+
+范本：`on_client_get_resources`（`namespace.py:459` / `sync_namespace.py:459`）+ office/role 隔离校验（**显式 raise `SMCPNamespaceError`**，非 assert——对齐 #31/`-O` 安全加固）。
+
+- 路由 `client:get_skills`/`client:get_skill`/`client:get_blob`（确认 `client:*` 转发是否已泛化；白名单则加三事件）。
+- 收 `server:update_skills` → 向房间广播 `notify:update_skills`（复用既有 update 广播路径，范本 `on_server_update_tool_list:322`）。
+- Server **不**重组 blob，按 `computer` 逐 ack 透传；flat `ErrorPayload` 原样透传（禁止二次 unwrap）。
+
+---
+
+## 5. SKILL Computer 本地管理侧设计（SDK 自决，对标 Claude Code）
+
+新建包 `a2c_smcp/computer/skills/`：
+
+| 模块 | 职责 | Claude Code 范本对照 |
+|---|---|---|
+| `home.py` | SKILL Home 路径解析（§2.3）+ 隔离 fail-fast 校验 + `<source>/<...>/<skill>/` 布局 | `getMarketplacesCacheDir()` / `CLAUDE_CODE_PLUGIN_CACHE_DIR` |
+| `naming.py` | name 合成 + lexer + MCP server 段规范化（`[^a-zA-Z0-9_-]→_`，**不实现** `claude.ai ` 特例）；非法 → `4016` | `normalizeNameForMCP()`（去特例） |
+| `registry.py` | Skill Registry：`name → A2CSkillRef`；O(1) 精确匹配；孤儿标记/恢复；校验失败不入册（记 ERROR，不硬报错） | `installed_plugins.json` 物化注册表 |
+| `staging.py` | 多 source 物化到统一本地安装目录（marketplace SKILL v1 §2 包结构）：`mcp:` 经 `manager` 枚举 `skill://` 按 `_meta.source∈{mounted,archive,resources}` 物化；`marketplace:` git clone/pull+对账；`user` DropIn 扫描 | `loadAndCacheMarketplace()` / `cacheMarketplaceFromGit()` |
+| `intent.py` | marketplace/user 独立 registry（意图层持久化）+ reconciler（启动/显式 refresh 对账意图↔物化）；`mcp:` 不经此（复用 MCP 配置） | `known_marketplaces.json` + `reconciler.ts` |
+| `sandbox.py` | `safe_join`+`realpath` 包根内校验；`.skillenv` 等敏感文件任何 `rel_path` 下 `4017 forbidden`（不泄漏存在性）；name 寻址防越权（包根仅由 Registry 经 name 解析，禁从 name/rel_path 推导 FS 路径） | — |
+
+### 5.1 接入点 `a2c_smcp/computer/computer.py`
+
+- 持有 `SkillRegistry`（仿持有 `mcp_manager`，`computer.py:98`）。
+- 扩展 `_on_manager_change`（`computer.py:187-257`，现仅 `window://`）：**并行**新增 `skill://` 分支——`ResourceListChanged` 重枚举 `skill://` 集合、`ResourceUpdated(skill://)` 重物化该 SKILL → 增量物化 → `emit_update_skills`。仿 `_acollect_window_uris`（`:259-271`）新增 `_acollect_skill_refs` 缓存对比（集合相同跳过，仅 DEBUG）。
+- 新增 marketplace/user 源本地探测（启动 reconcile + 显式 refresh 入口；机制 SDK 自决，与 `window://` 探测同构）。
+- 委托方法 `get_skills` / `get_skill` / `get_blob`（仿 `get_resources` 委托 `manager`，但委托 `SkillRegistry`/`staging`/`sandbox`）。
+
+### 5.2 mcp: 源枚举 `a2c_smcp/computer/mcp_clients/manager.py`
+
+范本：`list_resources`（`manager.py:455-480`，单页 cursor 透传）、`list_windows`（按 scheme 过滤 `window://`，`:519-544`）、`get_windows_details`（`resources/read`，`:546-571`）。
+
+- 新增 `list_skill_resources`：按 `skill://` scheme 过滤 + server 归属，**完整消费 cursor 翻页直至末尾**（协议 `skill.md §12`：Computer 完整消费翻页，区别于 `get_resources` 的 Agent 控制翻页）。
+- `archive`/`resources` 模式经现有 `read_resource` 入口逐子资源物化。
+
+### 5.3 安全模型落地（协议 `skill.md §9` 回归化为反例测试）
+
+每条配「红→绿」反例测试（工单 §4）：
+
+- 沙箱穿越：`..` / 绝对路径 / symlink 逃逸 → `4017 traversal`。
+- `.skillenv` forbidden：任何 `rel_path` 命中 → `4017 forbidden`，存在/不存在**同 reason**（不泄漏存在性）。
+- `too_large` 不铸句柄：超上限 → `4017 too_large`，零字节。
+- 句柄不信任：`get_blob` 重施沙箱；伪造/篡改句柄不提权。
+- staging 隔离：SKILL Home 非系统共享目录（启动 fail-fast）。
+- name 寻址：包根仅 Registry 经 name 解析，不从 name 推导 FS 路径。
+
+---
+
+## 6. 强制工程约束（对齐工单 §4 + 既有约定）
+
+- **sync 镜像 parity**：每个 async 改动同 PR 内补 sync 镜像（`agent/client.py↔sync_client.py`、`server/namespace.py↔sync_namespace.py`、`base.py` 内 `BaseAgentClient↔BaseAgentSyncClient`），否则视为未完成。Computer `socketio/client.py` 仅 async（Computer 总异步运行，无 sync 镜像，沿用现状）。
+- **请求构造走 `_request_builders`**：新请求 MUST 复用纯函数模式（#30），不在 client 内联拼 dict。
+- **隔离不变量显式 raise**：office/role 校验用 `SMCPNamespaceError`，禁 `assert`（#31，`-O` 下被剥离）。
+- **协议保真 > Issue 字面**：偏离协议即 bug；确有库行为差异在 docstring 标注权威路径。
+- **协议镜像缺口即补**：`smcp.py` 缺字段即补，注释标注「对齐 <协议文档> §x」。
+- **lint/type 净**：`uv run poe lint`（ruff + mypy）零告警；`uv run poe test` 零回归。门为 mypy（非 Pyright）。
+
+---
+
+## 7. WBS / Milestone 拆解
+
+GitHub Milestone「v0.2.1 SKILL 通道 + 通用二进制传输」+ parent tracking issue（镜像已关闭 Milestone #1「v0.2 协议升级」issue #8 范式）。按工单 §7 五条工作流拆 5 子 issue：
+
+```
+              [① smcp 协议镜像]  (无行为，先合，解锁其余)
+                     │
+        ┌────────────┼───────────────┐
+        ▼            ▼               ▼
+  [② blob 传输]  [③ skill 子系统]  [⑤ server 路由+广播]
+        │            │
+        └─────┬──────┘
+              ▼
+  [④ agent 消费 + tool_call 二进制一致性]  (依赖 ①②)
+```
+
+| # | 子 issue | 范围 | 主要文件 | 依赖 | label |
+|---|---|---|---|---|---|
+| ① | smcp 0.2.1 协议镜像 | 5 事件常量 + 7 TypedDict + `BlobHandle` + `ErrorCode 4016/4017/4018` | `smcp.py` | — | type/feature, priority/high, area/protocol |
+| ② | 通用二进制传输 | Computer 句柄铸造/解析（§4.3，无 MAC 单层 msgpack）+ `utils/blob.drain_blob` 单一例程（串行 + `concurrency>1` 并行，§4.5）| `socketio/client.py`, `utils/blob.py` | ① | type/feature, priority/high, area/blob-transfer |
+| ③ | Computer SKILL 子系统 | `computer/skills/`（home/naming/registry/staging/intent/sandbox 三源含 marketplace）+ `computer.py` `_on_manager_change` 扩展 + `manager.py` `skill://` 枚举 | `computer/skills/*`, `computer.py`, `mcp_clients/manager.py` | ① | type/feature, priority/high, area/skill, area/marketplace |
+| ④ | Agent 消费 + tool_call 二进制一致性 | `_request_builders` 三 builder + base/client/sync_client 消费分支 + tool_call content 扫描 + notify:update_skills 重拉 | `agent/_request_builders.py`, `agent/base.py`, `agent/client.py`, `agent/sync_client.py`, `socketio/client.py`(tool_call 铸造) | ①② | type/feature, priority/high, area/skill, area/sync-mirror |
+| ⑤ | Server 路由 + 广播 | 三 `client:*` 路由 + `server:update_skills`→`notify:update_skills` 广播（async+sync） | `server/namespace.py`, `server/sync_namespace.py` | ① | type/feature, priority/medium, area/protocol, area/sync-mirror |
+
+②③ 可并行（均依赖 ①）；④ 依赖 ①②；⑤ 依赖 ①。每子 PR 自带 async+sync 镜像与对应测试。
+
+---
+
+## 8. 验收清单（对齐工单 §6）
+
+- [ ] `smcp.py`：5 事件常量 + 7 TypedDict + `BlobHandle` + `ErrorCode 4016/4017/4018`，注释标注协议出处
+- [ ] `computer/skills/`：home + naming + registry + staging + intent + sandbox（mcp / **marketplace git** / user 三源）
+- [ ] `computer.py` `_on_manager_change` 扩展 `skill://` + 非 MCP 源探测 → `server:update_skills`
+- [ ] `socketio/client.py`：get_skills/get_skill/get_blob 处理 + tool_call 二进制旁路 + emit_update_skills
+- [ ] `utils/blob.py` `drain_blob` 单一例程（默认串行 + `concurrency>1` 并行 + 错误协调矩阵），get_skill 与 tool_call 共用；docstring 明示「并行安全」
+- [ ] `agent/_request_builders.py` 三 builder；`agent/{base,client,sync_client}.py` 消费分支 + tool_call 扫描 + notify:update_skills 重拉
+- [ ] `server/{namespace,sync_namespace}.py` 路由 + 广播（显式 raise 隔离）
+- [ ] 安全反例测试全部红→绿（沙箱/`.skillenv`/句柄不信任/`too_large`/staging 隔离/name 寻址）
+- [ ] `uv run poe lint` 净；`uv run poe test` 零回归；`PROTOCOL_VERSION` 未改动
+
+---
+
+## 9. 风险与依赖（对齐工单 §8）
+
+- **marketplace git 源**：网络拉取/缓存/对账失败降级（记 ERROR、不阻断其余 source、不向 Agent 硬报错）；首拉成本与对账策略见 §2.2（无 TTL，后台定时后置 backlog）。
+- **staging 目录隔离**：MUST NOT 跨用户共享；多用户每用户独立 home；覆盖路径仍校验非系统目录（§2.3）。
+- **底层 mcp 包**：沿用 0.2 锚定（`mcp >= 1.15.0`），`Resource._meta`/`annotations` 须可用（启动自检 fail-fast）。
+- **与 PR #33 无代码冲突**：本工单不碰 `server/middleware.py`/`utils/handshake.py`/`version.py`；无强依赖。
+
+---
+
+## 参考
+
+- 协议：`a2c-smcp-protocol` `docs/specification/{skill,blob-transfer,events,data-structures,error-handling}.md`、`docs/migrations/v0.2.1-skill-and-blob-transfer.md`
+- 工单：[`docs/upgrade-0.2.1-skill-blob-transfer.md`](upgrade-0.2.1-skill-blob-transfer.md)
+- 本地管理范本：Claude Code `MARKETPLACE_PLUGIN_OPERATIONS.md`（外部参考，意图/物化两层 + reconciler + eager add + 无 TTL）
+- 实现范本（v0.2 `get_resources` 全链路）：`smcp.py:413` / `socketio/client.py:398` / `mcp_clients/manager.py:455` / `server/namespace.py:459` / `agent/client.py:357` / `agent/base.py:119` / `agent/errors.py:44`
+- 追踪范式：已关闭 Milestone #1「v0.2 协议升级」+ parent tracking issue #8

--- a/docs/upgrade-0.2.1-skill-blob-transfer.md
+++ b/docs/upgrade-0.2.1-skill-blob-transfer.md
@@ -1,0 +1,169 @@
+# python-sdk 升级工单：0.2.1 — SKILL 通道 + 通用二进制传输 + MCP Marketplace Plugin
+
+> **性质**：开发工单（不是规范）。协议为唯一权威，本文件只规定 **python-sdk 如何落地**。
+> **目标读者**：python-sdk 实现工程师
+> **前置门控**：✅ 已通过——协议 0.2.1 已在 `a2c-smcp-protocol` 评审、合并、发布（`main`）。代码仓库可跟进实现。
+> **基线**：python-sdk 已完成 0.2.0 适配；协议版本握手在 PR #33（`feature/v0.2-version-handshake`，base `develop`）在途。
+> **包/协议版本**：本次为 **0.2.x 加性能力**（协议侧已定为缺陷澄清级，不 MINOR bump）。`PROTOCOL_VERSION` 常量**不变**；包 PATCH 自由。
+
+---
+
+## 0. 范围
+
+**在范围**（0.2.1 能力跟进）：
+
+1. **SKILL 通道** —— `client:get_skills` / `client:get_skill`，`server:update_skills` / `notify:update_skills`；多 source：`mcp:` / **`marketplace:`（git plugin skills）** / `user`（DropIn）。
+2. **通用二进制传输** —— `client:get_blob` + 无状态不透明 `blob_handle` 生产者-消费者模型。
+3. **`client:tool_call` 二进制一致性** —— 超内联预算的二进制 content item 经 `_meta.a2c_blob_handle` 旁路（唯一触及既有事件的破坏性点）。
+
+**不在范围**（勿在本工单内做，避免与他人冲突）：
+
+- 协议版本握手 / WS-only §5 收口 —— 由 **PR #33** 承载，已在该 PR 评论给出 `websocket` scope 改动点。本工单与 PR #33 **解耦**，base 同样指向 `develop`，合并顺序无强依赖。
+
+---
+
+## 1. 协议权威（只读引用，禁止在 SDK 侧二次规范）
+
+字段/事件/错误码/边界**一律以协议文档为准**，实现与之偏离即为 bug：
+
+| 主题 | 权威文档 |
+|---|---|
+| SKILL 通道（命名 lexer、多 source、沙箱、变更检测、生命周期） | `a2c-smcp-protocol` `docs/specification/skill.md` |
+| 通用二进制传输（句柄契约、分块/背压/完整性、4018） | `docs/specification/blob-transfer.md` |
+| 事件请求/响应 + Computer 处理流程 | `docs/specification/events.md`（`client:get_skill[s]` / `client:get_blob` / `tool_call`） |
+| TypedDict 字段 | `docs/specification/data-structures.md` |
+| 错误码 4016/4017/4018、4014 复用 | `docs/specification/error-handling.md` |
+| **跨语言适配总纲（先读这份）** | `docs/migrations/v0.2.1-skill-and-blob-transfer.md` |
+
+本工单只补充协议文档没有、也不该有的内容：**python-sdk 的模块落点、既有约定对齐、测试与验收**。
+
+---
+
+## 2. python-sdk 基线与必须对齐的既有约定
+
+| 约定 | 要求 |
+|---|---|
+| **async + sync 双镜像** | 凡 `client.py` 的改动必须等价镜像到 `sync_client.py`；`server/namespace.py`↔`sync_namespace.py`、`server/base.py`↔`sync_base.py` 同理。**禁止只做 async**（参考 PR #33 同步镜像边界处理） |
+| **请求构造走 `_request_builders`** | Agent 侧新请求（get_skills/get_skill/get_blob）**MUST** 复用 `a2c_smcp/agent/_request_builders.py` 的 `create_*_request` 纯函数模式（#30 重构产物），不在 client 内联拼 dict |
+| **协议保真 > Issue 字面** | 与 PR #33 同样原则：库实测行为/协议权威优先，偏离 Issue 字面处在代码 docstring 写明理由 |
+| **lint/type 净** | `uv run poe lint`（ruff + mypy）零告警；`uv run poe test` 零回归 |
+| **协议镜像缺口即补** | `smcp.py` 是协议结构在 SDK 的镜像层，缺字段即补，注释标注"对齐 <协议文档> §x" |
+
+---
+
+## 3. 工作分解（WBS，按模块 + 真实文件路径）
+
+### 3.1 协议镜像层 — `a2c_smcp/smcp.py`
+
+- **事件常量**新增：`GET_SKILLS_EVENT="client:get_skills"`、`GET_SKILL_EVENT="client:get_skill"`、`GET_BLOB_EVENT="client:get_blob"`、`UPDATE_SKILLS_EVENT="server:update_skills"`、`UPDATE_SKILLS_NOTIFICATION="notify:update_skills"`（与既有 `*_EVENT` 命名/注释风格一致）。
+- **TypedDict** 新增（字段严格对齐 `data-structures.md`）：`A2CSkillRef`（**无 `mcp_server` 字段**；`path` 必选）、`GetSkillsReq/Ret`、`GetSkillReq/Ret`（`body` 与 `blob_handle` 恰一）、`GetBlobReq/Ret`；类型别名 `BlobHandle = str`。
+- **`server:update_skills`/`notify:update_skills` 复用** `UpdateComputerConfigReq`（已存在），不新建结构。
+- **`ErrorCode`** 增 `4016`/`4017`/`4018`（沿用既有 enum 风格 + 注释）；`4014` 复用语义在 docstring 标注；`4018.details.reason` 与 `4017.details.reason` 为开放枚举，解析方 MUST 容忍未知值兜底。
+
+### 3.2 Computer — SKILL 子系统（**本次最大工作量**）
+
+新建包 `a2c_smcp/computer/skills/`：
+
+- `registry.py` —— Skill Registry：`name → A2CSkillRef`；O(1) 精确匹配；孤儿标记/恢复；校验失败不入册（记 ERROR，不向 Agent 硬报错）。
+- `naming.py` —— name 合成 + lexer + MCP server 段规范化（= Claude Code 通用规则 `[^a-zA-Z0-9_-]→_`，**不实现** `claude.ai ` 特例）；非法 → `4016`。
+- `staging.py` —— 多 source 物化到统一本地安装目录（marketplace SKILL v1 §2 包结构）：
+  - `mcp:` —— 复用 `computer/mcp_clients/manager.py` 枚举 `skill://` 资源，按 `_meta.source ∈ {mounted, archive, resources}` 物化。
+  - **`marketplace:` —— 用户配置 git 源：clone/pull + 对账（这是 "MCP marketplace Plugin" 能力的落点）**。
+  - `user` —— 本地 DropIn 目录扫描。
+- 安全铁律：包根绝对路径**只**由 Registry 经 name 解析；`safe_join`+`realpath` 必在包根内；`.skillenv` 等敏感文件任何 `rel_path` 下不可读出（→ `4017 forbidden`，不泄漏存在性）。
+
+接入点：
+
+- `a2c_smcp/computer/computer.py` —— 持有 registry；扩展 `_on_manager_change`（现仅处理 `window://`）**并行**处理 `skill://` 集合/内容变化 → 触发 `server:update_skills`；新增 marketplace/user 源的本地探测（机制 SDK 自决，与 `window://` 探测同构）。
+- `a2c_smcp/computer/socketio/client.py`（`SMCPComputerClient`）——
+  - 处理入站 `client:get_skills`（排除孤儿，不读 body）、`client:get_skill`（`4016`/`4014`/`4017`；仅 SKILL.md 剥 frontmatter；文本≤预算→`body`，否则铸 `blob_handle`、`total_size` 超上限→`4017 too_large` 不铸句柄）、`client:get_blob`（解析句柄→**重施 §9 沙箱**→切片→`4018`；单块≤Server `maxHttpBufferSize`）。
+  - emit `server:update_skills`（复用 `UpdateComputerConfigReq`）。
+  - **`tool_call` 返回前后处理**：遍历 `CallToolResult.content`，超内联预算的二进制 item 清空内联 `data`/`blob`、写 item `_meta.a2c_blob_handle`(+`a2c_total_size`/`a2c_sha256`，MIME 复用 item `mimeType`)；小图原样内联。工具失败仍走 MCP `isError`。
+
+### 3.3 通用 blob-transfer
+
+- Computer 端句柄铸造/解析与 §3.2 复用同一沙箱（句柄不透明、无状态、可重解析；解析时重跑边界校验，不信任句柄内容）。
+- Agent 端**统一拉取例程** —— 新建 `a2c_smcp/utils/blob.py`（与 `utils/handshake.py` 同层）：`drain_blob(call, computer, blob_handle) -> (bytes, mime)`：`chunk_offset` 循环至 `eof`；`eof` 后校验 `sha256`；跨块 `sha256`/`total_size` 变化→从 0 重读；`4018` 分支（`invalid_handle`/`forbidden` 不重试，`gone` 回生产者重取，`range` 修偏移）。**get_skill 与 tool_call 两处共用此一函数。**
+
+### 3.4 Agent 消费 — `a2c_smcp/agent/{client,sync_client,base}.py` + `_request_builders.py`
+
+- `_request_builders.py` 增 `create_get_skills_request` / `create_get_skill_request` / `create_get_blob_request`。
+- 处理 `notify:update_skills` → 自动重拉 `client:get_skills`（与既有 `notify:update_*` 自动刷新模式一致）。
+- `get_skill` 响应**分支**：`body` 直接用；`blob_handle` → `utils/blob.drain_blob`。
+- **`tool_call` 消费**：遍历 `CallToolResult.content`，命中 `_meta.a2c_blob_handle` → `drain_blob` 还原后再交付上层（**不实现 = 大二进制工具结果静默变空**，破坏性关键点）。
+- async + sync 双实现。
+
+### 3.5 Server 路由 — `a2c_smcp/server/{namespace,sync_namespace}.py`
+
+- 路由 `client:get_skills`/`client:get_skill`/`client:get_blob`（确认现有 `client:*` 转发是否泛化；若白名单则加）。
+- 收 `server:update_skills` → 向房间广播 `notify:update_skills`（复用既有 update 广播路径）。
+- Server **不**重组 blob，按 `computer` 逐 ack 透传。
+
+---
+
+## 4. 强制工程约束
+
+- **sync 镜像 parity**：每个 async 改动同 PR 内补 sync 镜像，否则视为未完成。
+- **安全不变量回归化**：沙箱穿越 / `.skillenv` forbidden（不泄漏存在性）/ handle 不信任 / `4017 too_large` 不铸句柄——每条都要有**对应的红→绿反例测试**。
+- **协议保真**：偏离任何协议文档即 bug；确有库行为差异在 docstring 标注权威路径（同 PR #33 §4008 提取的处理范式）。
+- **占位符不展开**：`$TFROBOT_*` 由 Agent SDK 在 prompt 渲染层处理，Computer 协议层只送原始字节。
+
+---
+
+## 5. 测试要求（按现有 `tests/{unit_tests,integration_tests,e2e}/{agent,computer,server,utils}` 分层）
+
+| 层 | 必覆盖 |
+|---|---|
+| `unit_tests/utils` | `drain_blob`：多块重组 / `eof` / sha256 校验失败重读 / `total_size` 跨块变更重读 / `4018` 各 reason |
+| `unit_tests/computer` | name lexer（合法/非法→4016）；沙箱（`..`/绝对路径/symlink 逃逸→4017 traversal）；`.skillenv`→4017 forbidden（存在/不存在同 reason）；`too_large` 不铸句柄；inline-vs-handle 阈值；marketplace 源 clone/对账；孤儿标记/恢复 |
+| `unit_tests/agent` | get_skill 分支 body/handle；**tool_call content `_meta.a2c_blob_handle` 还原**；notify:update_skills→重拉 |
+| `unit_tests/server` | 三个新 `client:*` 路由；`server:update_skills`→`notify:update_skills` 广播 |
+| `integration_tests` | get_skills→get_skill→get_blob 全链路（含二进制 round-trip sha256 一致）；marketplace plugin 源端到端纳管 |
+| `e2e` | Agent 渐进式披露：读 SKILL.md→按 rel_path 取引用资源（文本内联 + 二进制经 blob）|
+
+零回归（对齐 PR #33 的"基线 → 零回归"验收口径）。
+
+---
+
+## 6. 验收清单
+
+- [ ] `smcp.py`：5 事件常量 + 7 TypedDict + `BlobHandle` + `ErrorCode 4016/4017/4018`，注释标注协议出处
+- [ ] `computer/skills/`：registry + naming + staging（mcp / **marketplace git** / user 三源）
+- [ ] `computer.py` `_on_manager_change` 扩展 `skill://` + 非 MCP 源探测 → `server:update_skills`
+- [ ] `computer/socketio/client.py`：get_skills/get_skill/get_blob 处理 + tool_call 二进制旁路（async+sync）
+- [ ] `utils/blob.py` `drain_blob` 单一例程，get_skill 与 tool_call 共用
+- [ ] `agent/_request_builders.py` 三 builder；`agent/client.py`+`sync_client.py` 消费分支 + tool_call 扫描
+- [ ] `server/namespace.py`+`sync_namespace.py` 路由 + 广播
+- [ ] 安全反例测试全部红→绿；`uv run poe lint` 净；`uv run poe test` 零回归
+- [ ] `PROTOCOL_VERSION` 未改动（本次 0.2.x 加性）
+
+---
+
+## 7. 建议 PR 拆分（与 PR #33 解耦，base 均 `develop`）
+
+建一个 parent tracking issue，子 PR 串行/并行：
+
+1. `feat(smcp): 0.2.1 协议镜像（events/TypedDict/ErrorCode）` —— 无行为，先合，解锁其余
+2. `feat(blob): 通用二进制传输（Computer 句柄 + utils/blob.drain_blob）`
+3. `feat(skill): Computer SKILL 子系统（registry/naming/staging 三源含 marketplace）`
+4. `feat(skill/tool_call): Agent 消费 + tool_call 二进制一致性`
+5. `feat(server): SKILL/blob 事件路由 + update_skills 广播`
+
+每个子 PR 自带 async+sync 镜像与对应测试；2/3 可并行，4 依赖 1/2，5 依赖 1。
+
+---
+
+## 8. 风险与依赖
+
+- **marketplace git 源**：网络拉取/缓存/对账失败要降级（记 ERROR、不阻断其余 source、不向 Agent 硬报错）；首拉成本与定时对账策略 SDK 自决。
+- **staging 目录隔离**：MUST NOT 跨用户共享（勿放系统目录）；多用户每用户独立 home。
+- **底层 mcp 包**：沿用 0.2 锚定（`mcp >= 1.15.0`），`Resource._meta` / `annotations` 须可用（启动自检 fail-fast，沿用 versioning.md §校验建议）。
+- **与 PR #33 无代码冲突**：本工单不碰 `server/middleware.py` / `utils/handshake.py` / `version.py`；如需先合 PR #33 仅为减少 rebase，无强依赖。
+
+---
+
+## 参考
+
+- 协议：`a2c-smcp-protocol` `docs/specification/{skill,blob-transfer,events,data-structures,error-handling}.md`
+- 跨语言适配总纲：`docs/migrations/v0.2.1-skill-and-blob-transfer.md`
+- 同期协议侧改动：versioning.md §5（WS-only 收口，归 PR #33，不在本工单）

--- a/tests/unit_tests/test_smcp.py
+++ b/tests/unit_tests/test_smcp.py
@@ -13,13 +13,28 @@ Acceptance tests for issue #21: protocol constants + data types + error code enu
 """
 from __future__ import annotations
 
+import base64
+import hashlib
 from enum import IntEnum
 
 import a2c_smcp
 from a2c_smcp import PROTOCOL_VERSION
 from a2c_smcp.smcp import (
+    GET_BLOB_EVENT,
     GET_RESOURCES_EVENT,
+    GET_SKILL_EVENT,
+    GET_SKILLS_EVENT,
+    UPDATE_SKILLS_EVENT,
+    UPDATE_SKILLS_NOTIFICATION,
+    A2CSkillRef,
+    BlobHandle,
     ErrorCode,
+    GetBlobReq,
+    GetBlobRet,
+    GetSkillReq,
+    GetSkillRet,
+    GetSkillsReq,
+    GetSkillsRet,
     is_protocol_error_payload,
 )
 
@@ -71,6 +86,218 @@ class TestEventConstants:
 
     def test_get_resources_event_string(self) -> None:
         assert GET_RESOURCES_EVENT == "client:get_resources"
+
+
+class TestEventConstantsV021:
+    """v0.2.1 新增事件常量字符串 / v0.2.1 added event constant strings.
+
+    协议依据 / Protocol: a2c-smcp-protocol docs/specification/events.md
+      §client:get_skills / §client:get_skill / §client:get_blob /
+      §server:update_skills / §notify:update_skills
+    """
+
+    def test_get_skills_event_string(self) -> None:
+        assert GET_SKILLS_EVENT == "client:get_skills"
+
+    def test_get_skill_event_string(self) -> None:
+        assert GET_SKILL_EVENT == "client:get_skill"
+
+    def test_get_blob_event_string(self) -> None:
+        assert GET_BLOB_EVENT == "client:get_blob"
+
+    def test_update_skills_event_string(self) -> None:
+        assert UPDATE_SKILLS_EVENT == "server:update_skills"
+
+    def test_update_skills_notification_string(self) -> None:
+        assert UPDATE_SKILLS_NOTIFICATION == "notify:update_skills"
+
+
+class TestErrorCodeV021:
+    """ErrorCode v0.2.1 加性扩展（4016/4017/4018）+ is_protocol_error_payload 一致性。
+    v0.2.1 additive ErrorCode extension and predicate consistency."""
+
+    def test_skill_name_invalid_code(self) -> None:
+        assert ErrorCode.SKILL_NAME_INVALID == 4016
+
+    def test_skill_resource_not_accessible_code(self) -> None:
+        assert ErrorCode.SKILL_RESOURCE_NOT_ACCESSIBLE == 4017
+
+    def test_blob_not_accessible_code(self) -> None:
+        assert ErrorCode.BLOB_NOT_ACCESSIBLE == 4018
+
+    def test_is_protocol_error_payload_recognizes_new_codes(self) -> None:
+        """新错误码自动并入 _ERROR_CODE_VALUES 集合 → is_protocol_error_payload 直接识别（无需 server/agent 二次维护）。
+        New codes automatically join _ERROR_CODE_VALUES → recognized by predicate without extra wiring."""
+        # 4016 — details.name
+        assert is_protocol_error_payload({"code": 4016, "message": "x", "details": {"name": "bad!"}})
+        # 4017 — details.reason / details.rel_path / details.total_size
+        assert is_protocol_error_payload(
+            {"code": 4017, "message": "x", "details": {"reason": "traversal", "rel_path": "../etc"}},
+        )
+        # 4018 — details.reason
+        assert is_protocol_error_payload({"code": 4018, "message": "x", "details": {"reason": "gone"}})
+
+    def test_4014_reuse_for_skill_name_absent_still_recognized(self) -> None:
+        """SKILL name 合法但 Registry 未命中 → 4014 复用语义；predicate 仍识别为协议错误。
+        SKILL name legal-but-absent reuses 4014; predicate still recognizes it as a protocol error."""
+        assert is_protocol_error_payload({"code": 4014, "message": "skill not found"})
+
+
+class TestTypedDictsV021:
+    """v0.2.1 TypedDict 镜像层可构造性烟雾测试（字段对齐 data-structures.md）。
+    Smoke tests confirming v0.2.1 TypedDict mirror layer is constructable per data-structures.md."""
+
+    def test_a2c_skill_ref_minimal_required_fields(self) -> None:
+        """name / source / path 是协议主键 + 必选物化输出；total=False 允许仅设这三个。
+        name / source / path are required core fields; total=False permits a minimal ref."""
+        ref: A2CSkillRef = {
+            "name": "mcp:tfrobot-tools:code-review",
+            "source": "mcp:tfrobot-tools",
+            "path": "/tmp/skills/mcp/tfrobot-tools/code-review",
+        }
+        assert ref["name"] == "mcp:tfrobot-tools:code-review"
+        assert ref["source"].startswith("mcp:")
+        assert ref["path"].startswith("/")
+
+    def test_a2c_skill_ref_full_with_frontmatter_fields(self) -> None:
+        """完整 ref 含 SKILL.md frontmatter 派生字段 / Full ref includes frontmatter-derived fields."""
+        ref: A2CSkillRef = {
+            "name": "user:dev-tools:reviewer",
+            "source": "user",
+            "path": "/home/u/.a2c/skills/user/dev-tools/reviewer",
+            "description": "Code reviewer skill",
+            "license": "MIT",
+            "compatibility": ">=0.2.1",
+            "allowed_tools": ["read", "grep"],
+            "version": "1.0.0",
+            "skill_metadata": {"author": "alice"},
+        }
+        assert ref["allowed_tools"] == ["read", "grep"]
+        assert ref["skill_metadata"]["author"] == "alice"
+
+    def test_a2c_skill_ref_uri_only_for_mcp_source(self) -> None:
+        """uri 仅 MCP 来源；其他来源不应携带（结构允许，语义由 Computer 端 staging 决定）。
+        ``uri`` is MCP-only by semantics; structure permits, semantics enforced by Computer staging."""
+        ref: A2CSkillRef = {
+            "name": "mcp:tfrobot-tools:code-review",
+            "source": "mcp:tfrobot-tools",
+            "path": "/tmp/skills/mcp/tfrobot-tools/code-review",
+            "uri": "skill://tfrobot-tools/code-review",
+        }
+        assert ref["uri"].startswith("skill://")
+
+    def test_get_skills_req_required_fields(self) -> None:
+        """GetSkillsReq total=True：agent / req_id / computer 都是必选。
+        total=True: agent / req_id / computer all required."""
+        req: GetSkillsReq = {"agent": "ag1", "req_id": "r1", "computer": "c1"}
+        assert req["computer"] == "c1"
+
+    def test_get_skills_ret_skills_list(self) -> None:
+        """GetSkillsRet 携带 skills 列表与 req_id；空清单（无任何 SKILL）亦合法。
+        Holds skills list and req_id; empty list (no SKILLs) is valid."""
+        ret: GetSkillsRet = {"skills": [], "req_id": "r1"}
+        assert ret["skills"] == []
+
+    def test_get_skill_req_default_rel_path_omitted(self) -> None:
+        """rel_path 可省，缺省语义在 Computer 端解析为 SKILL.md。
+        rel_path may be omitted; defaults to SKILL.md (server-side resolution)."""
+        req: GetSkillReq = {"agent": "ag1", "req_id": "r1", "computer": "c1", "name": "user:x:y"}
+        assert "rel_path" not in req
+
+    def test_get_skill_req_with_rel_path(self) -> None:
+        req: GetSkillReq = {
+            "agent": "ag1",
+            "req_id": "r1",
+            "computer": "c1",
+            "name": "user:x:y",
+            "rel_path": "docs/intro.md",
+        }
+        assert req["rel_path"] == "docs/intro.md"
+
+    def test_get_skill_ret_body_branch(self) -> None:
+        """body 与 blob_handle 恰一存在 —— body 分支（文本且可内联）。
+        Exactly one of body / blob_handle — body branch (inlineable text)."""
+        ret: GetSkillRet = {
+            "name": "user:x:y",
+            "rel_path": "SKILL.md",
+            "mime_type": "text/markdown",
+            "total_size": 42,
+            "sha256": "a" * 64,
+            "body": "# hello",
+            "req_id": "r1",
+        }
+        assert "blob_handle" not in ret
+        assert ret["body"].startswith("#")
+
+    def test_get_skill_ret_blob_handle_branch(self) -> None:
+        """body 与 blob_handle 恰一存在 —— blob_handle 分支（二进制或过大文本）。
+        blob_handle branch (binary or oversize text)."""
+        ret: GetSkillRet = {
+            "name": "user:x:y",
+            "rel_path": "diagram.png",
+            "mime_type": "image/png",
+            "total_size": 100_000,
+            "sha256": "b" * 64,
+            "blob_handle": "opaque-handle-xyz",
+            "req_id": "r1",
+        }
+        assert "body" not in ret
+        assert ret["blob_handle"] == "opaque-handle-xyz"
+
+    def test_get_blob_req_minimal(self) -> None:
+        """chunk_offset / max_chunk_bytes 可省；缺省语义在 Computer 解析（offset=0, clamp）。
+        chunk_offset / max_chunk_bytes optional; defaults resolved by Computer."""
+        req: GetBlobReq = {
+            "agent": "ag1",
+            "req_id": "r1",
+            "computer": "c1",
+            "blob_handle": "opaque",
+        }
+        assert "chunk_offset" not in req
+        assert "max_chunk_bytes" not in req
+
+    def test_get_blob_req_with_offset(self) -> None:
+        req: GetBlobReq = {
+            "agent": "ag1",
+            "req_id": "r1",
+            "computer": "c1",
+            "blob_handle": "opaque",
+            "chunk_offset": 65536,
+            "max_chunk_bytes": 262144,
+        }
+        assert req["chunk_offset"] == 65536
+
+    def test_get_blob_ret_chunk_with_eof(self) -> None:
+        """eof=True 时本块结束；spec 不变式 / spec invariant (blob-transfer.md §3):
+            eof ⟺ chunk_offset + len(decode(blob)) == total_size
+        且 / and: 重组 sha256 == 响应 sha256（Agent SHOULD 校验 / Agent SHOULD verify）.
+
+        基于真实 round-trip 字节构造（base64 编码、长度等式、sha256 一致性同时成立）。
+        Built from a real round-trip: base64 encoding, length equation, and sha256 consistency
+        all hold simultaneously."""
+        raw_bytes = b"hello, blob"
+        ret: GetBlobRet = {
+            "blob_handle": "opaque",
+            "mime_type": "application/octet-stream",
+            "total_size": len(raw_bytes),
+            "sha256": hashlib.sha256(raw_bytes).hexdigest(),
+            "chunk_offset": 0,
+            "eof": True,
+            "blob": base64.b64encode(raw_bytes).decode("ascii"),
+            "req_id": "r1",
+        }
+        # eof 不变式 / eof invariant: chunk_offset + 本块解码字节数 == total_size
+        decoded = base64.b64decode(ret["blob"])
+        assert ret["eof"] is True
+        assert ret["chunk_offset"] + len(decoded) == ret["total_size"]
+        # 完整性校验 / Integrity check: 重组 sha256 == 响应 sha256
+        assert hashlib.sha256(decoded).hexdigest() == ret["sha256"]
+
+    def test_blob_handle_is_str_alias(self) -> None:
+        """BlobHandle: TypeAlias = str —— 在结构上等同于 str。
+        BlobHandle: TypeAlias = str — structurally equivalent to str."""
+        h: BlobHandle = "any-opaque-string"
+        assert isinstance(h, str)
 
 
 class TestIsProtocolErrorPayload:


### PR DESCRIPTION
## Summary

v0.2.1 milestone **#1 协议镜像层**——无行为加性升级，先合解锁余下 4 子 PR (#38/#39/#40/#41)。`PROTOCOL_VERSION` 未改动。

Closes #37 · 父追踪 #42 · base `develop-v0.2.1` (milestone 集成分支)

## 变更范围（严格对齐 #37 验收）

- **5 事件常量**: `GET_SKILLS_EVENT` / `GET_SKILL_EVENT` / `GET_BLOB_EVENT` / `UPDATE_SKILLS_EVENT` / `UPDATE_SKILLS_NOTIFICATION`
- **7 TypedDict** (字段严格对齐 `data-structures.md`):
  - `A2CSkillRef` (无 `mcp_server` 字段；`path` 必选)
  - `GetSkillsReq` / `GetSkillsRet`
  - `GetSkillReq` (`rel_path: NotRequired`) / `GetSkillRet` (`body` 与 `blob_handle` 恰一)
  - `GetBlobReq` (`chunk_offset` / `max_chunk_bytes: NotRequired`) / `GetBlobRet`
- **`BlobHandle: TypeAlias = str`** — docstring 标注不透明性与 Agent 行为约束
- **`ErrorCode` 加性扩展**: `SKILL_NAME_INVALID=4016` / `SKILL_RESOURCE_NOT_ACCESSIBLE=4017` / `BLOB_NOT_ACCESSIBLE=4018`
  - 4014 复用语义 / 4015 SKILL 通道不使用 / 4017 & 4018 `details.reason` 开放枚举兜底 — 全部在类 docstring 标注
- **既有结构 docstring 补注**:
  - `UpdateComputerConfigReq` — 标注 v0.2.1 `update_skills` 复用 (不新建结构)
  - `ErrorPayload` — 标注 4016/4017/4018 经 `details` 下沉（非顶层平铺）
- **单元测试** (`tests/unit_tests/test_smcp.py` +227):
  - `TestEventConstantsV021` / `TestErrorCodeV021` / `TestTypedDictsV021`
  - `is_protocol_error_payload` 自动并入新错误码验证
  - `GetBlobRet` 真实 round-trip：`base64.b64decode` 长度等式 + `sha256` 完整性双断言（替换原永真 sanity 断言）

## v0.2.1 milestone 设计基线（同 PR 落地）

随首个子 PR 引入两份共享基线文档，供后续 #38-#41 引用：

- `docs/design-0.2.1-skill-computer-management.md` — SDK 实现设计（三项 SDK-自决决策 / blob_handle 无状态 msgpack 编码 / 模块落点 / WBS / 验收）
- `docs/upgrade-0.2.1-skill-blob-transfer.md` — 开发工单（范围 / 既有约定 / 5 工作流拆分 / 强制工程约束 / 验收清单）

二者均为只读引用——**协议为唯一权威**（`a2c-smcp-protocol` `main`，已通过 v0.2.1 评审/合并/发布门控；commit `ace6b04` migration + `7c2760f` versioning）。

## 协议依据 (a2c-smcp-protocol)

- `docs/migrations/v0.2.1-skill-and-blob-transfer.md`（总纲）
- `docs/specification/data-structures.md` §SKILL / §通用二进制传输
- `docs/specification/error-handling.md` §4016 / §4017 / §4018
- `docs/specification/events.md` §`client:get_skill[s]` / §`client:get_blob` / §`server:update_skills`
- `docs/specification/skill.md` / `docs/specification/blob-transfer.md`

## Test plan

- [x] `uv run poe lint`（ruff + mypy strict）净
- [x] `uv run poe test` 730 passed / 2 skipped / 4 xfailed / 0 failed（零回归）
- [x] `uv run pytest tests/unit_tests/test_smcp.py` 36 passed
- [x] `PROTOCOL_VERSION` 未改动 (仍为 `0.2.0`)

## 已 deferred 的代码审查建议（reviewer 自身建议跟进）

- 🟡 `A2CSkillRef` 用 `Required[]` 编码必选字段 → 跨 spec+SDK 对齐项，需先在协议仓走 `/add-feature` 流程，**不在本镜像 PR 单方面引入**
- 🟡 `GetSkillRet` body/blob_handle XOR 类型层约束 → 归属未来 Computer-handler PR (#39/#40) 的 Pydantic model 层

🤖 Generated with [Claude Code](https://claude.com/claude-code)