### PR TITLE
feat(server): v0.2.1 SKILL/blob 路由 + update_skills 广播 (#41)

### DIFF
--- a/a2c_smcp/server/namespace.py
+++ b/a2c_smcp/server/namespace.py
@@ -9,7 +9,7 @@
 """
 
 import copy
-from typing import cast
+from typing import Any, cast
 
 from pydantic import TypeAdapter
 
@@ -21,23 +21,33 @@ from a2c_smcp.server.utils import aget_all_sessions_in_office
 from a2c_smcp.smcp import (
     CANCEL_TOOL_CALL_NOTIFICATION,
     ENTER_OFFICE_NOTIFICATION,
+    GET_BLOB_EVENT,
     GET_DESKTOP_EVENT,
     GET_RESOURCES_EVENT,
+    GET_SKILL_EVENT,
+    GET_SKILLS_EVENT,
     GET_TOOLS_EVENT,
     LEAVE_OFFICE_NOTIFICATION,
     SMCP_NAMESPACE,
     TOOL_CALL_EVENT,
     UPDATE_CONFIG_NOTIFICATION,
     UPDATE_DESKTOP_NOTIFICATION,
+    UPDATE_SKILLS_NOTIFICATION,
     UPDATE_TOOL_LIST_NOTIFICATION,
     AgentCallData,
     EnterOfficeNotification,
     EnterOfficeReq,
     ErrorPayload,
+    GetBlobReq,
+    GetBlobRet,
     GetDeskTopReq,
     GetDeskTopRet,
     GetResourcesReq,
     GetResourcesRet,
+    GetSkillReq,
+    GetSkillRet,
+    GetSkillsReq,
+    GetSkillsRet,
     GetToolsReq,
     GetToolsRet,
     LeaveOfficeNotification,
@@ -456,42 +466,54 @@ class SMCPNamespace(BaseNamespace):
         )
         return TypeAdapter(GetDeskTopRet).validate_python(client_response)
 
-    async def on_client_get_resources(self, sid: str, data: GetResourcesReq) -> GetResourcesRet | ErrorPayload:
-        """
-        透明转发 ``client:get_resources`` 至目标 Computer（含 cursor 翻页）。
-        Relay ``client:get_resources`` to the target Computer (with cursor pagination).
+    async def _relay_client_call(
+        self,
+        sid: str,
+        data: Any,
+        event: str,
+        ret_adapter: TypeAdapter[Any],
+    ) -> Any:
+        """通用 ``client:*`` 事件路由 / Generic ``client:*`` event router.
 
-        要求 Agent 与 Computer 在同一 office。Server 仅做路由，不解释资源语义；
-        Computer 返回的 flat ErrorPayload（4014 / 4015）原样回传，不做 GetResourcesRet 强转。
-        Requires Agent and Computer in the same office. Server only routes; a flat ErrorPayload
-        (4014 / 4015) from the Computer is passed through verbatim without GetResourcesRet coercion.
+        统一收敛 office/role 隔离校验、Computer SID 解析、flat ErrorPayload 透传，
+        让新事件 handler 缩到一行。
+        Unifies office/role isolation, Computer SID lookup, and flat-ErrorPayload pass-through,
+        so each new event handler is a one-liner.
+
+        协议依据 / Protocol: events.md 各 ``client:*`` 事件 + error-handling.md flat ErrorPayload.
 
         Args:
-            sid (str): 发起者ID，一般是Agent / Initiator ID, usually Agent
-            data (GetResourcesReq): 含 computer / mcp_server / 可选 cursor / req_id
+            sid: 发起者 SID（一般是 Agent）/ Initiator SID (usually Agent).
+            data: 请求负载，**MUST** 含 ``computer`` 字段 / payload MUST contain ``computer``.
+            event: 转发的 Socket.IO 事件名（``GET_*_EVENT`` 常量）/ Socket.IO event name to relay.
+            ret_adapter: 成功响应的 TypeAdapter（如 ``TypeAdapter(GetResourcesRet)``），用于强校验.
+                Pydantic TypeAdapter for the success-shape return.
 
         Returns:
-            GetResourcesRet | ErrorPayload: 资源页或 flat 错误负载
+            成功响应（按 ``ret_adapter`` 校验后的 TypedDict）或 flat ``ErrorPayload``。
+            Success TypedDict (validated) or flat ErrorPayload.
+
+        Raises:
+            ValueError: ``computer`` 名未找到对应 SID（4014 边界由 Computer 端铸造，Server 路由前直接拒绝）.
+            SMCPNamespaceError: ``role != "computer"`` 或跨房间访问（office_id 不一致）.
         """
         computer_name = data["computer"]
-
-        # 通过name获取computer的sid / Get computer's sid by name
         computer_sid = await self.get_sid_by_name(computer_name)
         if not computer_sid:
             raise ValueError(f"Computer with name '{computer_name}' not found")
 
         session = await self.get_session(computer_sid)
         if session["role"] != "computer":
-            raise SMCPNamespaceError("目前仅支持获取Computer资源列表")
+            raise SMCPNamespaceError(f"目前仅支持 Computer 响应 {event} / target SID is not a Computer")
 
         agent_session = await self.get_session(sid)
-        computer_office_id = session.get("office_id")
-        agent_office_id = agent_session.get("office_id")
-        if computer_office_id != agent_office_id:
-            raise SMCPNamespaceError("目前仅支持Agent获取自己房间内Computer的资源列表")
+        if session.get("office_id") != agent_session.get("office_id"):
+            raise SMCPNamespaceError(
+                f"跨房间访问被拒绝：{event} 仅限同一 office / cross-office {event} access denied",
+            )
 
         client_response = await self.call(
-            GET_RESOURCES_EVENT,
+            event,
             data,
             to=computer_sid,
             namespace=SMCP_NAMESPACE,
@@ -500,7 +522,55 @@ class SMCPNamespace(BaseNamespace):
         # Pass flat ErrorPayload through (no nested envelope; predicate shared with agent side)
         if is_protocol_error_payload(client_response):
             return TypeAdapter(ErrorPayload).validate_python(client_response)
-        return TypeAdapter(GetResourcesRet).validate_python(client_response)
+        return ret_adapter.validate_python(client_response)
+
+    async def on_client_get_resources(self, sid: str, data: GetResourcesReq) -> GetResourcesRet | ErrorPayload:
+        """
+        透明转发 ``client:get_resources`` 至目标 Computer（含 cursor 翻页）。
+        Relay ``client:get_resources`` to the target Computer (with cursor pagination).
+
+        Computer 返回的 flat ErrorPayload（4014 / 4015）原样回传，不做 GetResourcesRet 强转。
+        Flat ErrorPayload (4014 / 4015) from the Computer is passed through verbatim.
+        """
+        return cast(
+            "GetResourcesRet | ErrorPayload",
+            await self._relay_client_call(sid, data, GET_RESOURCES_EVENT, TypeAdapter(GetResourcesRet)),
+        )
+
+    async def on_client_get_skills(self, sid: str, data: GetSkillsReq) -> GetSkillsRet | ErrorPayload:
+        """透明转发 ``client:get_skills`` 至目标 Computer / Relay ``client:get_skills``.
+
+        协议依据 / Protocol: events.md §client:get_skills；data-structures.md §GetSkillsRet（轻量元数据）.
+        """
+        return cast(
+            "GetSkillsRet | ErrorPayload",
+            await self._relay_client_call(sid, data, GET_SKILLS_EVENT, TypeAdapter(GetSkillsRet)),
+        )
+
+    async def on_client_get_skill(self, sid: str, data: GetSkillReq) -> GetSkillRet | ErrorPayload:
+        """透明转发 ``client:get_skill`` 至目标 Computer / Relay ``client:get_skill``.
+
+        协议依据 / Protocol: events.md §client:get_skill；error-handling.md §4016 / §4017（``details.reason`` 透传）.
+        """
+        return cast(
+            "GetSkillRet | ErrorPayload",
+            await self._relay_client_call(sid, data, GET_SKILL_EVENT, TypeAdapter(GetSkillRet)),
+        )
+
+    async def on_client_get_blob(self, sid: str, data: GetBlobReq) -> GetBlobRet | ErrorPayload:
+        """透明转发 ``client:get_blob`` 至目标 Computer / Relay ``client:get_blob``.
+
+        Server **不**重组 blob，按 ``computer`` 逐 ack 透传；并行红利（协议 §3）由 Agent 侧 drain 例程
+        通过对不同 ``chunk_offset`` 并发调用实现。
+        Server does NOT reassemble; each ``chunk_offset`` is a separate ack. Parallel dividend
+        (protocol §3) is realized by the Agent's drain routine issuing concurrent calls per offset.
+
+        协议依据 / Protocol: events.md §client:get_blob；blob-transfer.md §3 (parallel) / §5.4 (handle untrusted).
+        """
+        return cast(
+            "GetBlobRet | ErrorPayload",
+            await self._relay_client_call(sid, data, GET_BLOB_EVENT, TypeAdapter(GetBlobRet)),
+        )
 
     async def on_server_update_desktop(self, sid: str, data: UpdateComputerConfigReq) -> None:
         """
@@ -518,6 +588,32 @@ class SMCPNamespace(BaseNamespace):
         update_req = TypeAdapter(UpdateComputerConfigReq).validate_python(data)
         await self.emit(
             UPDATE_DESKTOP_NOTIFICATION,
+            {"computer": update_req["computer"]},
+            room=session.get("office_id"),
+            skip_sid=sid,
+        )
+
+    async def on_server_update_skills(self, sid: str, data: UpdateComputerConfigReq) -> None:
+        """将 ``server:update_skills`` 广播为 ``notify:update_skills`` / Broadcast SKILL set change.
+
+        Computer 在 SKILL 集合变化（增/删/物化更新）时触发；Server 转广播给同 office 内的 Agent，
+        Agent 据此自动重拉 ``client:get_skills``（仿既有 ``notify:update_*`` 自动刷新模式）。
+        Computer emits on SKILL set change; Server broadcasts to office; Agent auto re-fetches
+        ``client:get_skills`` (same pattern as other ``notify:update_*`` events).
+
+        载荷复用 ``UpdateComputerConfigReq``（仅 ``computer`` 字段，data-structures.md §UpdateComputerConfigReq
+        三事件族共用）。
+        Payload reuses ``UpdateComputerConfigReq`` (data-structures.md shared across 3 event families).
+
+        协议依据 / Protocol: events.md §server:update_skills / §notify:update_skills.
+        """
+        session = await self.get_session(sid)
+        if session["role"] != "computer":
+            raise SMCPNamespaceError("目前仅支持 Computer 上报 SKILL 变更 / only Computers may emit update_skills")
+
+        update_req = TypeAdapter(UpdateComputerConfigReq).validate_python(data)
+        await self.emit(
+            UPDATE_SKILLS_NOTIFICATION,
             {"computer": update_req["computer"]},
             room=session.get("office_id"),
             skip_sid=sid,

--- a/a2c_smcp/server/sync_namespace.py
+++ b/a2c_smcp/server/sync_namespace.py
@@ -9,7 +9,7 @@
 """
 
 import copy
-from typing import cast
+from typing import Any, cast
 
 from pydantic import TypeAdapter
 
@@ -21,23 +21,33 @@ from a2c_smcp.server.utils import get_all_sessions_in_office
 from a2c_smcp.smcp import (
     CANCEL_TOOL_CALL_NOTIFICATION,
     ENTER_OFFICE_NOTIFICATION,
+    GET_BLOB_EVENT,
     GET_DESKTOP_EVENT,
     GET_RESOURCES_EVENT,
+    GET_SKILL_EVENT,
+    GET_SKILLS_EVENT,
     GET_TOOLS_EVENT,
     LEAVE_OFFICE_NOTIFICATION,
     SMCP_NAMESPACE,
     TOOL_CALL_EVENT,
     UPDATE_CONFIG_NOTIFICATION,
     UPDATE_DESKTOP_NOTIFICATION,
+    UPDATE_SKILLS_NOTIFICATION,
     UPDATE_TOOL_LIST_NOTIFICATION,
     AgentCallData,
     EnterOfficeNotification,
     EnterOfficeReq,
     ErrorPayload,
+    GetBlobReq,
+    GetBlobRet,
     GetDeskTopReq,
     GetDeskTopRet,
     GetResourcesReq,
     GetResourcesRet,
+    GetSkillReq,
+    GetSkillRet,
+    GetSkillsReq,
+    GetSkillsRet,
     GetToolsReq,
     GetToolsRet,
     LeaveOfficeNotification,
@@ -350,51 +360,79 @@ class SyncSMCPNamespace(SyncBaseNamespace):
 
         return TypeAdapter(GetDeskTopRet).validate_python(client_response)
 
-    def on_client_get_resources(self, sid: str, data: GetResourcesReq) -> GetResourcesRet | ErrorPayload:
-        """
-        同步：透明转发 ``client:get_resources`` 至目标 Computer（含 cursor 翻页）。
-        Sync: relay ``client:get_resources`` to the target Computer (with cursor pagination).
+    def _relay_client_call(
+        self,
+        sid: str,
+        data: Any,
+        event: str,
+        ret_adapter: TypeAdapter[Any],
+    ) -> Any:
+        """同步版通用 ``client:*`` 事件路由 / Sync mirror of ``_relay_client_call``.
 
-        要求 Agent 与 Computer 在同一 office。Server 仅做路由；Computer 返回的 flat ErrorPayload
-        （4014 / 4015）原样回传，不做 GetResourcesRet 强转。
-        Requires Agent and Computer in the same office. Server only routes; a flat ErrorPayload
-        (4014 / 4015) from the Computer is passed through verbatim without GetResourcesRet coercion.
+        统一收敛 office/role 隔离校验、Computer SID 解析、flat ErrorPayload 透传。
+        Unifies office/role isolation, Computer SID lookup, and flat-ErrorPayload pass-through.
 
-        Args:
-            sid (str): 发起者ID，一般是Agent / Initiator ID, usually Agent
-            data (GetResourcesReq): 含 computer / mcp_server / 可选 cursor / req_id
-
-        Returns:
-            GetResourcesRet | ErrorPayload: 资源页或 flat 错误负载
+        协议依据 / Protocol: events.md 各 ``client:*`` 事件 + error-handling.md flat ErrorPayload.
         """
         computer_name = data["computer"]
-
-        # 通过name获取computer的sid / Get computer's sid by name
         computer_sid = self.get_sid_by_name(computer_name)
         if not computer_sid:
             raise ValueError(f"Computer with name '{computer_name}' not found")
 
         session = self.get_session(computer_sid)
         if session["role"] != "computer":
-            raise SMCPNamespaceError("目前仅支持获取Computer资源列表")
+            raise SMCPNamespaceError(f"目前仅支持 Computer 响应 {event} / target SID is not a Computer")
 
         agent_session = self.get_session(sid)
-        computer_office_id = session.get("office_id")
-        agent_office_id = agent_session.get("office_id")
-        if computer_office_id != agent_office_id:
-            raise SMCPNamespaceError("目前仅支持Agent获取自己房间内Computer的资源列表")
+        if session.get("office_id") != agent_session.get("office_id"):
+            raise SMCPNamespaceError(
+                f"跨房间访问被拒绝：{event} 仅限同一 office / cross-office {event} access denied",
+            )
 
         client_response = self.call(
-            GET_RESOURCES_EVENT,
+            event,
             data,
             to=computer_sid,
             namespace=SMCP_NAMESPACE,
         )
-        # flat ErrorPayload 透传（无嵌套 envelope，禁止二次 unwrap；判定与 agent 侧统一）/
-        # Pass flat ErrorPayload through (no nested envelope; predicate shared with agent side)
         if is_protocol_error_payload(client_response):
             return TypeAdapter(ErrorPayload).validate_python(client_response)
-        return TypeAdapter(GetResourcesRet).validate_python(client_response)
+        return ret_adapter.validate_python(client_response)
+
+    def on_client_get_resources(self, sid: str, data: GetResourcesReq) -> GetResourcesRet | ErrorPayload:
+        """
+        同步：透明转发 ``client:get_resources`` 至目标 Computer（含 cursor 翻页）。
+        Sync: relay ``client:get_resources`` to the target Computer (with cursor pagination).
+        """
+        return cast(
+            "GetResourcesRet | ErrorPayload",
+            self._relay_client_call(sid, data, GET_RESOURCES_EVENT, TypeAdapter(GetResourcesRet)),
+        )
+
+    def on_client_get_skills(self, sid: str, data: GetSkillsReq) -> GetSkillsRet | ErrorPayload:
+        """同步：透明转发 ``client:get_skills`` / Sync relay of ``client:get_skills``."""
+        return cast(
+            "GetSkillsRet | ErrorPayload",
+            self._relay_client_call(sid, data, GET_SKILLS_EVENT, TypeAdapter(GetSkillsRet)),
+        )
+
+    def on_client_get_skill(self, sid: str, data: GetSkillReq) -> GetSkillRet | ErrorPayload:
+        """同步：透明转发 ``client:get_skill`` / Sync relay of ``client:get_skill``."""
+        return cast(
+            "GetSkillRet | ErrorPayload",
+            self._relay_client_call(sid, data, GET_SKILL_EVENT, TypeAdapter(GetSkillRet)),
+        )
+
+    def on_client_get_blob(self, sid: str, data: GetBlobReq) -> GetBlobRet | ErrorPayload:
+        """同步：透明转发 ``client:get_blob`` / Sync relay of ``client:get_blob``.
+
+        Server **不**重组 blob，按 ``computer`` 逐 ack 透传（与 async 一致）.
+        Server does NOT reassemble; each chunk is a separate ack (mirrors async).
+        """
+        return cast(
+            "GetBlobRet | ErrorPayload",
+            self._relay_client_call(sid, data, GET_BLOB_EVENT, TypeAdapter(GetBlobRet)),
+        )
 
     def on_server_update_desktop(self, sid: str, data: UpdateComputerConfigReq) -> None:
         """
@@ -412,6 +450,24 @@ class SyncSMCPNamespace(SyncBaseNamespace):
         update_req = TypeAdapter(UpdateComputerConfigReq).validate_python(data)
         self.emit(
             UPDATE_DESKTOP_NOTIFICATION,
+            {"computer": update_req["computer"]},
+            room=session.get("office_id"),
+            skip_sid=sid,
+        )
+
+    def on_server_update_skills(self, sid: str, data: UpdateComputerConfigReq) -> None:
+        """同步：``server:update_skills`` → ``notify:update_skills`` 广播.
+
+        Sync mirror of ``on_server_update_skills``; broadcasts SKILL set change to office.
+        协议依据 / Protocol: events.md §server:update_skills / §notify:update_skills.
+        """
+        session = self.get_session(sid)
+        if session["role"] != "computer":
+            raise SMCPNamespaceError("目前仅支持 Computer 上报 SKILL 变更 / only Computers may emit update_skills")
+
+        update_req = TypeAdapter(UpdateComputerConfigReq).validate_python(data)
+        self.emit(
+            UPDATE_SKILLS_NOTIFICATION,
             {"computer": update_req["computer"]},
             room=session.get("office_id"),
             skip_sid=sid,

--- a/tests/integration_tests/server/test_namespace_async.py
+++ b/tests/integration_tests/server/test_namespace_async.py
@@ -566,7 +566,9 @@ async def test_get_resources_cross_office_rejected(socketio_server, basic_server
     agent_sid = await _connect_join(agent, basic_server_port, "agent", "office-neg-A2", "robot-neg-2")
     await _connect_join(computer, basic_server_port, "computer", "office-neg-B2", "comp-neg-2")
 
-    with pytest.raises(SMCPNamespaceError, match="自己房间内Computer的资源列表"):
+    # v0.2.1 #41 起，跨房间消息由 ``_relay_client_call`` 统一收敛，错误文案改为通用 "跨房间" 模板
+    # Since v0.2.1 #41, cross-office checks are centralized in ``_relay_client_call``
+    with pytest.raises(SMCPNamespaceError, match="跨房间"):
         await socketio_server.on_client_get_resources(
             agent_sid,
             {"computer": "comp-neg-2", "agent": "robot-neg-2", "mcp_server": "any", "req_id": "neg-r2"},

--- a/tests/integration_tests/test_blob_transfer.py
+++ b/tests/integration_tests/test_blob_transfer.py
@@ -13,18 +13,17 @@
 测试分层 / Test layering:
   - Part 1 (in-process)：真实 Computer + 真实 drain_blob，跨 socketio 抽象层的 call adapter，
     覆盖跨抽象边界的串行/并行/大 payload/真实 base64+sha256 round-trip。
-  - Part 2 (real wire async)：真 Socket.IO transport + test-only Server 路由（mirror
-    on_client_get_resources，#41 正式接管前的占位）→ 跨真实 wire 端到端。
+  - Part 2 (real wire async)：真 Socket.IO transport + production Server 路由 (#41 已落地：
+    ``MockComputerServerNamespace`` 自带 ``on_client_get_blob``) → 跨真实 wire 端到端。
   - Part 3 (real wire sync mirror)：多进程 + SyncSMCPNamespace + drain_blob_sync 并行
     （ThreadPoolExecutor）+ flat ErrorPayload 透传。
 
-依赖范围说明 / Dependency scope note:
-  Server-side ``on_client_get_blob`` 路由属 #41 实现范围；本测试通过临时子类化
-  ``MockComputerServerNamespace`` 注入 test-only forwarder，确保 #38 的 wire 完整性在
-  #41 落地前即可验证；#41 接管后此 forwarder 可移除。
-  ``on_client_get_blob`` server routing belongs to #41; tests inject a test-only forwarder
-  by subclassing ``MockComputerServerNamespace`` so #38's wire integrity is verifiable
-  before #41 lands. After #41 lands, this forwarder is removable.
+#41 历史背景 / History note:
+  PR #44 (#38) 落地时 Server 还没有 ``on_client_get_blob`` 路由，测试曾通过 subclass 注入
+  test-only forwarder 验证 wire 完整性；#41 (PR ↓) 后 ``SMCPNamespace`` / ``SyncSMCPNamespace``
+  已携带 production 路由，本测试改用通用 mock 命名空间。
+  Before #41, this file injected a test-only forwarder; #41 ships production routing, so this
+  file now uses the standard mock namespaces.
 """
 
 from __future__ import annotations
@@ -253,39 +252,13 @@ class TestInProcThresholdsAndDefense:
 
 
 # ======================================================================
-# Part 2 — Real Socket.IO transport (async + test-local forwarder)
+# Part 2 — Real Socket.IO transport (async)
 # ======================================================================
-
-
-class _BlobCapableServerNamespace(MockComputerServerNamespace):
-    """注入 test-only ``on_client_get_blob`` forwarder（mirror ``on_client_get_resources``）.
-
-    Test-only ``on_client_get_blob`` forwarder; #41 ships the production version.
-    """
-
-    async def on_client_get_blob(self, sid: str, data: dict) -> dict:
-        """透明转发 client:get_blob 至目标 Computer / Transparent relay to target Computer."""
-        from a2c_smcp.smcp import is_protocol_error_payload
-
-        computer_name = data["computer"]
-        computer_sid = await self.get_sid_by_name(computer_name)
-        if not computer_sid:
-            raise ValueError(f"Computer with name {computer_name!r} not found")
-        session = await self.get_session(computer_sid)
-        agent_session = await self.get_session(sid)
-        if session.get("office_id") != agent_session.get("office_id"):
-            from a2c_smcp.exceptions import SMCPNamespaceError
-
-            raise SMCPNamespaceError("跨房间访问被拒绝 / cross-office access denied")
-        client_response = await self.call(
-            GET_BLOB_EVENT,
-            data,
-            to=computer_sid,
-            namespace=SMCP_NAMESPACE,
-        )
-        if is_protocol_error_payload(client_response):
-            return dict(client_response)
-        return dict(client_response)
+#
+# #41 落地后 SMCPNamespace 已携带 ``on_client_get_blob`` production 路由；本节直接复用
+# 通用 ``MockComputerServerNamespace``（包装 ``SMCPNamespace`` 并附带操作录制），无需 test-only forwarder.
+# After #41, ``SMCPNamespace`` carries production routing; this section reuses the standard
+# ``MockComputerServerNamespace`` (which wraps ``SMCPNamespace`` with op recording).
 
 
 def _create_blob_test_socketio() -> AsyncServer:
@@ -296,7 +269,7 @@ def _create_blob_test_socketio() -> AsyncServer:
         ping_interval=10,
         async_handlers=True,
     )
-    sio.register_namespace(_BlobCapableServerNamespace())
+    sio.register_namespace(MockComputerServerNamespace())
     return sio
 
 
@@ -480,38 +453,10 @@ _SYNC_OFFICE = "office-blob-sync"
 _SYNC_COMPUTER = "comp-blob-sync"
 
 
-class _BlobCapableSyncServerNamespace(MockComputerServerSyncNamespace):
-    """同步版 test-only ``on_client_get_blob`` forwarder.
-    Sync test-only ``on_client_get_blob`` forwarder (mirror of async test counterpart)."""
-
-    def on_client_get_blob(self, sid: str, data: dict) -> dict:
-        from a2c_smcp.smcp import is_protocol_error_payload
-
-        computer_name = data["computer"]
-        computer_sid = self.get_sid_by_name(computer_name)
-        if not computer_sid:
-            raise ValueError(f"Computer with name {computer_name!r} not found")
-        session = self.get_session(computer_sid)
-        agent_session = self.get_session(sid)
-        if session.get("office_id") != agent_session.get("office_id"):
-            from a2c_smcp.exceptions import SMCPNamespaceError
-
-            raise SMCPNamespaceError("跨房间访问被拒绝 / cross-office access denied")
-        client_response = self.call(
-            GET_BLOB_EVENT,
-            data,
-            to=computer_sid,
-            namespace=SMCP_NAMESPACE,
-        )
-        if is_protocol_error_payload(client_response):
-            return dict(client_response)
-        return dict(client_response)
-
-
 def _create_sync_blob_socketio_app():
-    """创建同步 Socket.IO + WSGI app；test-only blob forwarder.
+    """创建同步 Socket.IO + WSGI app（#41 production 路由已携带 ``on_client_get_blob``）.
 
-    Build a sync Socket.IO + WSGI app with the test-only blob forwarder.
+    Build a sync Socket.IO + WSGI app using the production ``SyncSMCPNamespace``-backed mock.
     """
     import socketio
 
@@ -519,7 +464,7 @@ def _create_sync_blob_socketio_app():
         async_mode="threading",
         cors_allowed_origins="*",
     )
-    sio.register_namespace(_BlobCapableSyncServerNamespace())
+    sio.register_namespace(MockComputerServerSyncNamespace())
     return sio, socketio.WSGIApp(sio, socketio_path="/socket.io")
 
 

--- a/tests/unit_tests/server/test_smcp_namespace.py
+++ b/tests/unit_tests/server/test_smcp_namespace.py
@@ -19,11 +19,16 @@ from a2c_smcp.server import (
     SMCPNamespace,
 )
 from a2c_smcp.smcp import (
+    GET_BLOB_EVENT,
     GET_DESKTOP_EVENT,
+    GET_SKILL_EVENT,
+    GET_SKILLS_EVENT,
     SMCP_NAMESPACE,
     UPDATE_DESKTOP_EVENT,
     UPDATE_DESKTOP_NOTIFICATION,
+    UPDATE_SKILLS_NOTIFICATION,
     EnterOfficeReq,
+    ErrorCode,
     GetDeskTopReq,
     GetDeskTopRet,
     LeaveOfficeReq,
@@ -563,3 +568,216 @@ class TestDefaultAuthenticationProvider:
         await smcp_namespace.enter_room(computer_sid, "room1")
 
         assert smcp_namespace.save_session.called
+
+
+class TestV021ClientRoutesAndUpdateSkills:
+    """v0.2.1 #41：3 ``client:*`` 路由（``get_skills`` / ``get_skill`` / ``get_blob``）+ ``server:update_skills`` 广播.
+
+    v0.2.1 #41: 3 new ``client:*`` routes + ``server:update_skills`` broadcast.
+
+    覆盖统一 ``_relay_client_call`` 助手的关键不变量：
+      - Computer SID 解析（未注册 → ValueError，对齐 4014 边界）
+      - office/role 隔离 **显式 raise SMCPNamespaceError**（非 assert，对齐 #31 `-O` 加固）
+      - flat ErrorPayload 透传（无嵌套 envelope，不二次 unwrap；与 agent 侧 predicate 一致）
+    Covers the key invariants of the unified ``_relay_client_call`` helper.
+    """
+
+    @pytest.fixture
+    def routed_ns(self, smcp_namespace, mock_server):
+        """同 office 的 agent + computer，``call`` 默认返回成功响应（按事件特化覆盖）.
+        Agent + Computer in same office; ``call`` returns happy-path responses by default."""
+        smcp_namespace.server = mock_server
+        agent_sid = "a-sid"
+        comp_name = "c1"
+        comp_sid = "c-sid"
+        sess_agent = {"role": "agent", "office_id": "room1", "name": "agent-1"}
+        sess_comp = {"role": "computer", "office_id": "room1", "name": comp_name}
+        smcp_namespace.get_session = AsyncMock(
+            side_effect=lambda sid: (sess_comp if sid == comp_sid else sess_agent),
+        )
+        smcp_namespace._name_to_sid_map = {comp_name: comp_sid, "agent-1": agent_sid}
+        smcp_namespace.call = AsyncMock()
+        return smcp_namespace, agent_sid, comp_name, comp_sid
+
+    # ── 成功路径 / Happy paths ────────────────────────────────────────
+
+    @pytest.mark.asyncio
+    async def test_on_client_get_skills_relays_and_returns_typed_ret(self, routed_ns):
+        ns, agent_sid, comp_name, comp_sid = routed_ns
+        ns.call.return_value = {"skills": [], "req_id": "r1"}
+        ret = await ns.on_client_get_skills(agent_sid, {"agent": "agent-1", "req_id": "r1", "computer": comp_name})
+        # call 携带正确事件名 + Computer 目标 SID / call must dispatch to right event + sid
+        ns.call.assert_awaited_once()
+        args, kwargs = ns.call.call_args
+        assert args[0] == GET_SKILLS_EVENT
+        assert kwargs["to"] == comp_sid
+        assert kwargs["namespace"] == SMCP_NAMESPACE
+        # 成功响应经 TypeAdapter 校验 / Success validated by TypeAdapter
+        assert "skills" in ret
+
+    @pytest.mark.asyncio
+    async def test_on_client_get_skill_relays_body_branch(self, routed_ns):
+        ns, agent_sid, comp_name, comp_sid = routed_ns
+        ns.call.return_value = {
+            "name": "user:x:y",
+            "rel_path": "SKILL.md",
+            "mime_type": "text/markdown",
+            "total_size": 5,
+            "sha256": "a" * 64,
+            "body": "# hi",
+            "req_id": "r2",
+        }
+        ret = await ns.on_client_get_skill(
+            agent_sid,
+            {"agent": "agent-1", "req_id": "r2", "computer": comp_name, "name": "user:x:y"},
+        )
+        ns.call.assert_awaited_once()
+        assert ns.call.call_args[0][0] == GET_SKILL_EVENT
+        assert ret["body"] == "# hi"
+
+    @pytest.mark.asyncio
+    async def test_on_client_get_blob_relays_chunk(self, routed_ns):
+        ns, agent_sid, comp_name, comp_sid = routed_ns
+        ns.call.return_value = {
+            "blob_handle": "h",
+            "mime_type": "image/png",
+            "total_size": 3,
+            "sha256": "b" * 64,
+            "chunk_offset": 0,
+            "eof": True,
+            "blob": "AAAA",
+            "req_id": "r3",
+        }
+        ret = await ns.on_client_get_blob(
+            agent_sid,
+            {"agent": "agent-1", "req_id": "r3", "computer": comp_name, "blob_handle": "h"},
+        )
+        ns.call.assert_awaited_once()
+        assert ns.call.call_args[0][0] == GET_BLOB_EVENT
+        assert ret["eof"] is True
+
+    # ── flat ErrorPayload 透传 / Pass-through ────────────────────────
+
+    @pytest.mark.asyncio
+    async def test_get_blob_4018_flat_error_passthrough(self, routed_ns):
+        """Computer 返回 ``4018 gone`` flat ErrorPayload → Server **原样**回传，不强转 ``GetBlobRet``.
+        Computer's flat 4018 → relayed verbatim without coercion to GetBlobRet."""
+        ns, agent_sid, comp_name, _comp_sid = routed_ns
+        err = {"code": int(ErrorCode.BLOB_NOT_ACCESSIBLE), "message": "Blob not accessible", "details": {"reason": "gone"}}
+        ns.call.return_value = err
+        ret = await ns.on_client_get_blob(
+            agent_sid,
+            {"agent": "agent-1", "req_id": "r-err", "computer": comp_name, "blob_handle": "h"},
+        )
+        assert ret["code"] == int(ErrorCode.BLOB_NOT_ACCESSIBLE)
+        assert ret["details"]["reason"] == "gone"
+
+    @pytest.mark.asyncio
+    async def test_get_skill_4017_flat_error_passthrough(self, routed_ns):
+        """Computer 返回 ``4017 traversal`` → Server 透传."""
+        ns, agent_sid, comp_name, _comp_sid = routed_ns
+        err = {
+            "code": int(ErrorCode.SKILL_RESOURCE_NOT_ACCESSIBLE),
+            "message": "Skill resource not accessible",
+            "details": {"reason": "traversal", "rel_path": "../etc"},
+        }
+        ns.call.return_value = err
+        ret = await ns.on_client_get_skill(
+            agent_sid,
+            {"agent": "agent-1", "req_id": "r-err", "computer": comp_name, "name": "user:x:y"},
+        )
+        assert ret["code"] == int(ErrorCode.SKILL_RESOURCE_NOT_ACCESSIBLE)
+        assert ret["details"]["reason"] == "traversal"
+
+    @pytest.mark.asyncio
+    async def test_get_skill_4014_name_absent_passthrough(self, routed_ns):
+        """SKILL ``name`` 格式合法但 Registry 未命中复用 4014（协议 error-handling.md §SKILL）."""
+        ns, agent_sid, comp_name, _comp_sid = routed_ns
+        err = {"code": int(ErrorCode.MCP_SERVER_NOT_FOUND), "message": "skill not found"}
+        ns.call.return_value = err
+        ret = await ns.on_client_get_skill(
+            agent_sid,
+            {"agent": "agent-1", "req_id": "r-err", "computer": comp_name, "name": "user:no-such:skill"},
+        )
+        assert ret["code"] == int(ErrorCode.MCP_SERVER_NOT_FOUND)
+
+    # ── 隔离 / Isolation ─────────────────────────────────────────────
+
+    @pytest.mark.asyncio
+    async def test_get_blob_computer_not_found_raises_value_error(self, smcp_namespace, mock_server):
+        """``computer`` 名未注册 → ``ValueError``（Server 路由前直接拒绝，4014 由 Computer 端归一）.
+        Unregistered ``computer`` → ValueError before routing (4014 minted by Computer side)."""
+        smcp_namespace.server = mock_server
+        smcp_namespace._name_to_sid_map = {}
+        smcp_namespace.get_session = AsyncMock(return_value={"role": "agent", "office_id": "room1"})
+        with pytest.raises(ValueError, match="not found"):
+            await smcp_namespace.on_client_get_blob(
+                "a-sid",
+                {"agent": "agent-1", "req_id": "r", "computer": "absent", "blob_handle": "h"},
+            )
+
+    @pytest.mark.asyncio
+    async def test_get_blob_cross_office_raises_smcp_namespace_error(self, smcp_namespace, mock_server):
+        """跨房间访问 → **显式 raise SMCPNamespaceError**（非 assert，对齐 #31 `-O` 加固）.
+        Cross-office access → explicit raise SMCPNamespaceError (not assert, per #31)."""
+        smcp_namespace.server = mock_server
+        comp_sid = "c-sid"
+        smcp_namespace._name_to_sid_map = {"c1": comp_sid, "agent-1": "a-sid"}
+        sess_comp_room1 = {"role": "computer", "office_id": "room1", "name": "c1"}
+        sess_agent_room2 = {"role": "agent", "office_id": "room2", "name": "agent-1"}
+        smcp_namespace.get_session = AsyncMock(
+            side_effect=lambda sid: sess_comp_room1 if sid == comp_sid else sess_agent_room2,
+        )
+        with pytest.raises(SMCPNamespaceError, match="跨房间"):
+            await smcp_namespace.on_client_get_blob(
+                "a-sid",
+                {"agent": "agent-1", "req_id": "r", "computer": "c1", "blob_handle": "h"},
+            )
+
+    @pytest.mark.asyncio
+    async def test_get_skills_target_role_not_computer_raises(self, smcp_namespace, mock_server):
+        """目标 SID role != computer → **显式 raise SMCPNamespaceError**.
+        Target SID with ``role != "computer"`` → explicit SMCPNamespaceError."""
+        smcp_namespace.server = mock_server
+        wrong_sid = "wrong-sid"
+        smcp_namespace._name_to_sid_map = {"agent-2": wrong_sid}
+        sess_wrong = {"role": "agent", "office_id": "room1", "name": "agent-2"}
+        smcp_namespace.get_session = AsyncMock(return_value=sess_wrong)
+        with pytest.raises(SMCPNamespaceError, match="Computer"):
+            await smcp_namespace.on_client_get_skills(
+                "a-sid",
+                {"agent": "agent-1", "req_id": "r", "computer": "agent-2"},
+            )
+
+    # ── 广播 / Broadcast ─────────────────────────────────────────────
+
+    @pytest.mark.asyncio
+    async def test_on_server_update_skills_broadcasts_notify(self, smcp_namespace, mock_server):
+        """Computer 发起 ``server:update_skills`` → Server 广播 ``notify:update_skills`` 到 office.
+        Computer-initiated ``server:update_skills`` → Server broadcasts ``notify:update_skills`` to office."""
+        smcp_namespace.server = mock_server
+        comp_sid = "c-sid"
+        comp_name = "c1"
+        sess_comp = {"role": "computer", "office_id": "room1", "name": comp_name}
+        smcp_namespace.get_session = AsyncMock(return_value=sess_comp)
+        smcp_namespace.emit = AsyncMock()
+        await smcp_namespace.on_server_update_skills(comp_sid, {"computer": comp_name})
+        smcp_namespace.emit.assert_awaited_once()
+        args, kwargs = smcp_namespace.emit.call_args
+        assert args[0] == UPDATE_SKILLS_NOTIFICATION
+        assert args[1] == {"computer": comp_name}
+        assert kwargs["room"] == "room1"
+        # 跳过发起者本人 / Skip the sender
+        assert kwargs["skip_sid"] == comp_sid
+
+    @pytest.mark.asyncio
+    async def test_on_server_update_skills_rejects_non_computer(self, smcp_namespace, mock_server):
+        """非 Computer 发起 ``server:update_skills`` → **显式 raise SMCPNamespaceError**.
+        Non-Computer ``server:update_skills`` → explicit SMCPNamespaceError."""
+        smcp_namespace.server = mock_server
+        sess_agent = {"role": "agent", "office_id": "room1", "name": "agent-1"}
+        smcp_namespace.get_session = AsyncMock(return_value=sess_agent)
+        smcp_namespace.emit = AsyncMock()
+        with pytest.raises(SMCPNamespaceError, match="Computer"):
+            await smcp_namespace.on_server_update_skills("a-sid", {"computer": "c1"})
+        smcp_namespace.emit.assert_not_awaited()

--- a/tests/unit_tests/server/test_smcp_namespace.py
+++ b/tests/unit_tests/server/test_smcp_namespace.py
@@ -604,7 +604,7 @@ class TestV021ClientRoutesAndUpdateSkills:
     @pytest.mark.asyncio
     async def test_on_client_get_skills_relays_and_returns_typed_ret(self, routed_ns):
         ns, agent_sid, comp_name, comp_sid = routed_ns
-        ns.call.return_value = {"skills": [], "req_id": "r1"}
+        ns.call.return_value = {"skills": [{"name": "user:x:y", "source": "user", "path": "/s/x/y"}], "req_id": "r1"}
         ret = await ns.on_client_get_skills(agent_sid, {"agent": "agent-1", "req_id": "r1", "computer": comp_name})
         # call 携带正确事件名 + Computer 目标 SID / call must dispatch to right event + sid
         ns.call.assert_awaited_once()
@@ -612,8 +612,10 @@ class TestV021ClientRoutesAndUpdateSkills:
         assert args[0] == GET_SKILLS_EVENT
         assert kwargs["to"] == comp_sid
         assert kwargs["namespace"] == SMCP_NAMESPACE
-        # 成功响应经 TypeAdapter 校验 / Success validated by TypeAdapter
-        assert "skills" in ret
+        # 语义级断言：内容完整透传（拒绝 "TypeAdapter 把字段吃掉" 或 "被测函数 return data" 的退化）.
+        # Semantic-level assertion: contents passed through (catches TypeAdapter swallowing fields).
+        assert ret["skills"] == [{"name": "user:x:y", "source": "user", "path": "/s/x/y"}]
+        assert ret["req_id"] == "r1"
 
     @pytest.mark.asyncio
     async def test_on_client_get_skill_relays_body_branch(self, routed_ns):

--- a/tests/unit_tests/server/test_smcp_namespace_sync.py
+++ b/tests/unit_tests/server/test_smcp_namespace_sync.py
@@ -167,14 +167,16 @@ class TestV021ClientRoutesAndUpdateSkillsSync:
 
     def test_on_client_get_skills_relays(self, routed_ns):
         ns, agent_sid, comp_name, comp_sid = routed_ns
-        ns.call.return_value = {"skills": [], "req_id": "r1"}
+        ns.call.return_value = {"skills": [{"name": "user:x:y", "source": "user", "path": "/s/x/y"}], "req_id": "r1"}
         ret = ns.on_client_get_skills(agent_sid, {"agent": "agent-1", "req_id": "r1", "computer": comp_name})
         ns.call.assert_called_once()
         args, kwargs = ns.call.call_args
         assert args[0] == GET_SKILLS_EVENT
         assert kwargs["to"] == comp_sid
         assert kwargs["namespace"] == SMCP_NAMESPACE
-        assert "skills" in ret
+        # 语义级断言：内容完整透传 / Semantic-level assertion: contents passed through
+        assert ret["skills"] == [{"name": "user:x:y", "source": "user", "path": "/s/x/y"}]
+        assert ret["req_id"] == "r1"
 
     def test_on_client_get_skill_relays(self, routed_ns):
         ns, agent_sid, comp_name, _comp_sid = routed_ns
@@ -212,6 +214,35 @@ class TestV021ClientRoutesAndUpdateSkillsSync:
         )
         assert ns.call.call_args[0][0] == GET_BLOB_EVENT
         assert ret["eof"] is True
+
+    def test_get_skill_4017_passthrough(self, routed_ns):
+        """``4017 traversal`` flat ErrorPayload 跨 sync 路由透传 / 4017 passes through sync routing.
+
+        显式镜像 async 同名用例，避免依赖 ``_relay_client_call`` 抽象等价性的间接证据。
+        Explicit sync mirror of async case; avoids relying solely on shared-helper equivalence."""
+        ns, agent_sid, comp_name, _comp_sid = routed_ns
+        ns.call.return_value = {
+            "code": int(ErrorCode.SKILL_RESOURCE_NOT_ACCESSIBLE),
+            "message": "Skill resource not accessible",
+            "details": {"reason": "traversal", "rel_path": "../etc"},
+        }
+        ret = ns.on_client_get_skill(
+            agent_sid,
+            {"agent": "agent-1", "req_id": "r-err", "computer": comp_name, "name": "user:x:y"},
+        )
+        assert ret["code"] == int(ErrorCode.SKILL_RESOURCE_NOT_ACCESSIBLE)
+        assert ret["details"]["reason"] == "traversal"
+        assert ret["details"]["rel_path"] == "../etc"
+
+    def test_get_skill_4014_name_absent_passthrough(self, routed_ns):
+        """SKILL ``name`` 格式合法但 Registry 未命中复用 4014（sync mirror of async case）."""
+        ns, agent_sid, comp_name, _comp_sid = routed_ns
+        ns.call.return_value = {"code": int(ErrorCode.MCP_SERVER_NOT_FOUND), "message": "skill not found"}
+        ret = ns.on_client_get_skill(
+            agent_sid,
+            {"agent": "agent-1", "req_id": "r-err", "computer": comp_name, "name": "user:no-such:skill"},
+        )
+        assert ret["code"] == int(ErrorCode.MCP_SERVER_NOT_FOUND)
 
     def test_get_blob_4018_passthrough(self, routed_ns):
         """``4018 gone`` flat ErrorPayload 跨 sync 路由透传 / 4018 gone passes through sync routing."""

--- a/tests/unit_tests/server/test_smcp_namespace_sync.py
+++ b/tests/unit_tests/server/test_smcp_namespace_sync.py
@@ -12,12 +12,22 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from a2c_smcp.exceptions import SMCPNamespaceError
 from a2c_smcp.server import (
     DefaultSyncAuthenticationProvider,
     SyncAuthenticationProvider,
     SyncSMCPNamespace,
 )
-from a2c_smcp.smcp import SMCP_NAMESPACE, EnterOfficeReq, LeaveOfficeReq
+from a2c_smcp.smcp import (
+    GET_BLOB_EVENT,
+    GET_SKILL_EVENT,
+    GET_SKILLS_EVENT,
+    SMCP_NAMESPACE,
+    UPDATE_SKILLS_NOTIFICATION,
+    EnterOfficeReq,
+    ErrorCode,
+    LeaveOfficeReq,
+)
 
 
 class MockSyncAuthProvider(SyncAuthenticationProvider):
@@ -134,3 +144,137 @@ class TestSyncSMCPNamespace:
         assert success is True
         assert error is None
         smcp_namespace.leave_room.assert_called_once_with("test_sid", "office_123")
+
+
+class TestV021ClientRoutesAndUpdateSkillsSync:
+    """v0.2.1 #41 sync mirror：3 ``client:*`` 路由 + ``server:update_skills`` 广播.
+
+    Sync mirror of async ``TestV021ClientRoutesAndUpdateSkills``.
+    """
+
+    @pytest.fixture
+    def routed_ns(self, smcp_namespace, mock_server):
+        smcp_namespace.server = mock_server
+        agent_sid = "a-sid"
+        comp_name = "c1"
+        comp_sid = "c-sid"
+        sess_agent = {"role": "agent", "office_id": "room1", "name": "agent-1"}
+        sess_comp = {"role": "computer", "office_id": "room1", "name": comp_name}
+        smcp_namespace.get_session = MagicMock(side_effect=lambda sid: sess_comp if sid == comp_sid else sess_agent)
+        smcp_namespace._name_to_sid_map = {comp_name: comp_sid, "agent-1": agent_sid}
+        smcp_namespace.call = MagicMock()
+        return smcp_namespace, agent_sid, comp_name, comp_sid
+
+    def test_on_client_get_skills_relays(self, routed_ns):
+        ns, agent_sid, comp_name, comp_sid = routed_ns
+        ns.call.return_value = {"skills": [], "req_id": "r1"}
+        ret = ns.on_client_get_skills(agent_sid, {"agent": "agent-1", "req_id": "r1", "computer": comp_name})
+        ns.call.assert_called_once()
+        args, kwargs = ns.call.call_args
+        assert args[0] == GET_SKILLS_EVENT
+        assert kwargs["to"] == comp_sid
+        assert kwargs["namespace"] == SMCP_NAMESPACE
+        assert "skills" in ret
+
+    def test_on_client_get_skill_relays(self, routed_ns):
+        ns, agent_sid, comp_name, _comp_sid = routed_ns
+        ns.call.return_value = {
+            "name": "user:x:y",
+            "rel_path": "SKILL.md",
+            "mime_type": "text/markdown",
+            "total_size": 5,
+            "sha256": "a" * 64,
+            "body": "# hi",
+            "req_id": "r2",
+        }
+        ret = ns.on_client_get_skill(
+            agent_sid,
+            {"agent": "agent-1", "req_id": "r2", "computer": comp_name, "name": "user:x:y"},
+        )
+        assert ns.call.call_args[0][0] == GET_SKILL_EVENT
+        assert ret["body"] == "# hi"
+
+    def test_on_client_get_blob_relays(self, routed_ns):
+        ns, agent_sid, comp_name, _comp_sid = routed_ns
+        ns.call.return_value = {
+            "blob_handle": "h",
+            "mime_type": "image/png",
+            "total_size": 3,
+            "sha256": "b" * 64,
+            "chunk_offset": 0,
+            "eof": True,
+            "blob": "AAAA",
+            "req_id": "r3",
+        }
+        ret = ns.on_client_get_blob(
+            agent_sid,
+            {"agent": "agent-1", "req_id": "r3", "computer": comp_name, "blob_handle": "h"},
+        )
+        assert ns.call.call_args[0][0] == GET_BLOB_EVENT
+        assert ret["eof"] is True
+
+    def test_get_blob_4018_passthrough(self, routed_ns):
+        """``4018 gone`` flat ErrorPayload 跨 sync 路由透传 / 4018 gone passes through sync routing."""
+        ns, agent_sid, comp_name, _comp_sid = routed_ns
+        ns.call.return_value = {
+            "code": int(ErrorCode.BLOB_NOT_ACCESSIBLE),
+            "message": "Blob not accessible",
+            "details": {"reason": "gone"},
+        }
+        ret = ns.on_client_get_blob(
+            agent_sid,
+            {"agent": "agent-1", "req_id": "r-err", "computer": comp_name, "blob_handle": "h"},
+        )
+        assert ret["code"] == int(ErrorCode.BLOB_NOT_ACCESSIBLE)
+        assert ret["details"]["reason"] == "gone"
+
+    def test_get_blob_computer_not_found_raises_value_error(self, smcp_namespace, mock_server):
+        smcp_namespace.server = mock_server
+        smcp_namespace._name_to_sid_map = {}
+        smcp_namespace.get_session = MagicMock(return_value={"role": "agent", "office_id": "room1"})
+        with pytest.raises(ValueError, match="not found"):
+            smcp_namespace.on_client_get_blob(
+                "a-sid",
+                {"agent": "agent-1", "req_id": "r", "computer": "absent", "blob_handle": "h"},
+            )
+
+    def test_get_blob_cross_office_raises_smcp_namespace_error(self, smcp_namespace, mock_server):
+        """跨房间 → 显式 raise SMCPNamespaceError（对齐 #31 `-O` 加固）.
+        Cross-office → explicit raise SMCPNamespaceError (per #31)."""
+        smcp_namespace.server = mock_server
+        comp_sid = "c-sid"
+        smcp_namespace._name_to_sid_map = {"c1": comp_sid, "agent-1": "a-sid"}
+        sess_comp = {"role": "computer", "office_id": "room1", "name": "c1"}
+        sess_agent = {"role": "agent", "office_id": "room2", "name": "agent-1"}
+        smcp_namespace.get_session = MagicMock(
+            side_effect=lambda sid: sess_comp if sid == comp_sid else sess_agent,
+        )
+        with pytest.raises(SMCPNamespaceError, match="跨房间"):
+            smcp_namespace.on_client_get_blob(
+                "a-sid",
+                {"agent": "agent-1", "req_id": "r", "computer": "c1", "blob_handle": "h"},
+            )
+
+    def test_on_server_update_skills_broadcasts(self, smcp_namespace, mock_server):
+        smcp_namespace.server = mock_server
+        comp_sid = "c-sid"
+        comp_name = "c1"
+        sess_comp = {"role": "computer", "office_id": "room1", "name": comp_name}
+        smcp_namespace.get_session = MagicMock(return_value=sess_comp)
+        smcp_namespace.emit = MagicMock()
+        smcp_namespace.on_server_update_skills(comp_sid, {"computer": comp_name})
+        smcp_namespace.emit.assert_called_once()
+        args, kwargs = smcp_namespace.emit.call_args
+        assert args[0] == UPDATE_SKILLS_NOTIFICATION
+        assert args[1] == {"computer": comp_name}
+        assert kwargs["room"] == "room1"
+        assert kwargs["skip_sid"] == comp_sid
+
+    def test_on_server_update_skills_rejects_non_computer(self, smcp_namespace, mock_server):
+        smcp_namespace.server = mock_server
+        sess_agent = {"role": "agent", "office_id": "room1", "name": "agent-1"}
+        smcp_namespace.get_session = MagicMock(return_value=sess_agent)
+        smcp_namespace.emit = MagicMock()
+        with pytest.raises(SMCPNamespaceError, match="Computer"):
+            smcp_namespace.on_server_update_skills("a-sid", {"computer": "c1"})
+        smcp_namespace.emit.assert_not_called()


### PR DESCRIPTION
## Summary

v0.2.1 milestone **#5 Server 路由 + 广播**——3 个 ``client:*`` 路由 + 1 个 ``server:*`` 广播 + 通用 ``_relay_client_call`` 抽象 + #38 留下的 test-only forwarder 清理。

Closes #41 · 父追踪 #42 · base \`develop-v0.2.1\`

## 变更范围（严格对齐 #41 验收 + #38 接管评论）

### Server 命名空间（async + sync 双镜像）

**新增 ``_relay_client_call`` 通用 forwarder**（reviewer #38 自提建议；4+4=8 处实例不再 hypothetical）：

- 统一 office/role 隔离校验
- Computer SID 解析
- flat ErrorPayload 透传（``is_protocol_error_payload`` 判定）
- 接收 ``TypeAdapter`` 注入做成功响应强校验

**3 个 ``client:*`` 路由**（每个 4 行 cast + 委托）：
- ``on_client_get_skills`` → ``GET_SKILLS_EVENT``
- ``on_client_get_skill`` → ``GET_SKILL_EVENT``
- ``on_client_get_blob`` → ``GET_BLOB_EVENT``

**``on_server_update_skills`` 广播**（仿 ``on_server_update_desktop``）：
- 载荷复用 ``UpdateComputerConfigReq``（#37 镜像层已落地）
- skip 发起者本人 + 限定目标 office room
- 协议：``server:update_skills`` → ``notify:update_skills``

**``on_client_get_resources`` 重构**：从 ~25 行内联实现缩到 ~4 行通用 forwarder 调用（**行为不变**，错误文案改为通用 ``"跨房间"`` 模板）。

### 集成测试清理（兑现 #41 评论中对 #38 的承诺）

- **删除** ``_BlobCapableServerNamespace`` / ``_BlobCapableSyncServerNamespace`` 子类（#38 落地时为绕过 Server 路由缺失而引入的 test-only forwarder）
- **删除** ``_create_blob_test_socketio`` 中的子类引用
- 改用通用 ``MockComputerServerNamespace`` / ``MockComputerServerSyncNamespace``——production 路由现已携带 ``on_client_get_blob``
- **15 个 #38 集成测试全部沿用 production 路由通过**（最强证：测试 wire 即 production wire）

## 单元测试（+19 新用例）

### async (``TestV021ClientRoutesAndUpdateSkills``，11 用例)

- 3 路由成功 + ``call`` 携带正确 event/sid/namespace
- ``4018 gone`` flat ErrorPayload 透传（``code`` 顶层 + ``details.reason``）
- ``4017 traversal`` 透传
- ``4014`` SKILL ``name`` 合法但 Registry 未命中复用（协议 §SKILL）
- ``computer`` 名未注册 → ``ValueError``（4014 由 Computer 端铸造，Server 路由前直接拒绝）
- 跨房间访问 → **显式 raise ``SMCPNamespaceError``**（非 assert，对齐 #31 ``-O`` 加固）
- 目标 SID ``role != "computer"`` → **显式 raise ``SMCPNamespaceError``**
- ``on_server_update_skills`` 广播命中 ``notify:update_skills`` + 正确 room/skip_sid
- 非 Computer 发起 ``server:update_skills`` → 显式 raise + ``emit`` 未被调用

### sync (``TestV021ClientRoutesAndUpdateSkillsSync``，8 用例，与 async 对称)

## 协议依据

- ``a2c-smcp-protocol`` ``events.md`` §``client:get_skill[s]`` / §``client:get_blob`` / §``server:update_skills`` / §``notify:update_skills``
- ``error-handling.md`` flat ErrorPayload（无嵌套 envelope）
- ``data-structures.md`` §``UpdateComputerConfigReq``（三事件族共用，#37 已落地）

## 与 #38 / #39 / #40 协作

- ✅ **解锁 #40 production 集成**：Agent SDK 真实调用 ``client:get_blob`` 现可经 production 路由跑通，不再依赖 test-local forwarder
- ✅ **接管完成 #38 评论列出的所有清理项**
- 🟢 **与 #39 不冲突**：本 PR 仅触及 ``server/`` + 测试目录；#39 触及 ``computer/skills/``

## Test plan

- [x] ``uv run poe lint``（ruff + mypy strict）净
- [x] ``uv run poe test`` **849 passed** / 2 skipped / 4 xfailed / 0 failed（v.s. develop-v0.2.1 baseline 830 → +19 新测试，零回归）
- [x] ``PROTOCOL_VERSION`` 未改动（仍 ``0.2.0``）
- [x] #38 集成测试在 production 路由下全部通过（15 用例 wire / in-process / sync 三层）

🤖 Generated with [Claude Code](https://claude.com/claude-code)