### PR TITLE
feat(agent): v0.2.1 on_skills_received event handler hook (#48)

### DIFF
--- a/a2c_smcp/agent/client.py
+++ b/a2c_smcp/agent/client.py
@@ -578,10 +578,11 @@ class AsyncSMCPAgentClient(AsyncClient, BaseAgentClient):
         return raw
 
     async def _on_skills_updated(self, data: dict) -> None:
-        """处理 SKILL 集合更新通知（v0.2.1）：默认自动重拉 ``client:get_skills``.
+        """处理 SKILL 集合更新通知（v0.2.1）：默认自动重拉 ``client:get_skills`` 并回调 ``on_skills_received``.
 
-        Handle ``notify:update_skills``: default behavior re-fetches ``client:get_skills`` once
-        (mirrors the existing ``notify:update_*`` auto-refresh pattern).
+        Handle ``notify:update_skills``: default behavior re-fetches ``client:get_skills`` once and
+        dispatches ``on_skills_received`` to the configured event handler (mirrors the existing
+        ``notify:update_*`` auto-refresh pattern; hook errors are isolated and never propagated).
         """
         try:
             computer = data.get("computer")
@@ -589,7 +590,18 @@ class AsyncSMCPAgentClient(AsyncClient, BaseAgentClient):
                 logger.warning("UPDATE_SKILLS_NOTIFICATION missing 'computer'")
                 return
             ret = await self.get_skills(computer)
-            logger.info(f"Skills refreshed from computer {computer}: count={len(ret.get('skills', []))}")
+            skills = ret.get("skills", [])
+            logger.info(f"Skills refreshed from computer {computer}: count={len(skills)}")
+            # v0.2.1: 派发 on_skills_received（hook 异常独立隔离，不污染拉取链路）
+            # Dispatch on_skills_received; hook errors are isolated and never propagated.
+            if self.event_handler and hasattr(self.event_handler, "on_skills_received"):
+                try:
+                    await self.event_handler.on_skills_received(computer, skills, self)
+                except Exception as hook_exc:
+                    logger.error(
+                        f"on_skills_received hook raised for computer {computer}: {hook_exc}",
+                        exc_info=True,
+                    )
         except Exception as e:
             logger.error(f"Error handling skills updated notification: {e}", exc_info=True)
 

--- a/a2c_smcp/agent/sync_client.py
+++ b/a2c_smcp/agent/sync_client.py
@@ -522,14 +522,28 @@ class SMCPAgentClient(Client, BaseAgentSyncClient):
         return raw
 
     def _on_skills_updated(self, data: dict) -> None:
-        """同步：处理 SKILL 集合更新通知（v0.2.1 sync mirror）；默认自动重拉 ``client:get_skills``."""
+        """同步：处理 SKILL 集合更新通知（v0.2.1 sync mirror）；默认自动重拉 ``client:get_skills`` 并回调 ``on_skills_received``.
+
+        Sync mirror: default auto-refresh + ``on_skills_received`` dispatch; hook errors isolated.
+        """
         try:
             computer = data.get("computer")
             if not computer:
                 logger.warning("UPDATE_SKILLS_NOTIFICATION missing 'computer'")
                 return
             ret = self.get_skills(computer)
-            logger.info(f"Skills refreshed from computer {computer}: count={len(ret.get('skills', []))}")
+            skills = ret.get("skills", [])
+            logger.info(f"Skills refreshed from computer {computer}: count={len(skills)}")
+            # v0.2.1: 派发 on_skills_received（hook 异常独立隔离，不污染拉取链路）
+            # Dispatch on_skills_received; hook errors are isolated and never propagated.
+            if self.event_handler and hasattr(self.event_handler, "on_skills_received"):
+                try:
+                    self.event_handler.on_skills_received(computer, skills, self)
+                except Exception as hook_exc:
+                    logger.error(
+                        f"on_skills_received hook raised for computer {computer}: {hook_exc}",
+                        exc_info=True,
+                    )
         except Exception as e:
             logger.error(f"Error handling skills updated notification: {e}", exc_info=True)
 

--- a/a2c_smcp/agent/types.py
+++ b/a2c_smcp/agent/types.py
@@ -16,7 +16,7 @@ from typing import TYPE_CHECKING, Protocol, TypeAlias
 from mcp.types import CallToolResult
 from typing_extensions import TypedDict
 
-from a2c_smcp.smcp import EnterOfficeNotification, LeaveOfficeNotification, SMCPTool, UpdateMCPConfigNotification
+from a2c_smcp.smcp import A2CSkillRef, EnterOfficeNotification, LeaveOfficeNotification, SMCPTool, UpdateMCPConfigNotification
 
 # 为避免运行时循环依赖，仅在类型检查时导入具体Client类型
 # To avoid runtime circular imports, import concrete Client types only during type checking
@@ -103,6 +103,26 @@ class AgentEventHandler(Protocol):
         """
         ...
 
+    def on_skills_received(self, computer: str, skills: list[A2CSkillRef], client: SMCPAgentClient) -> None:
+        """
+        接收到 SKILL 清单时的处理逻辑（v0.2.1+）
+        Handling logic when SKILL inventory is received (v0.2.1+)
+
+        触发时机 / Trigger:
+            - notify:update_skills 自动重拉 client:get_skills 成功后
+            - After auto-refresh of ``client:get_skills`` triggered by ``notify:update_skills``
+
+        向后兼容 / Backward compatibility:
+            - 旧 EventHandler 未实现此方法时，SDK 通过 hasattr 守卫静默跳过
+            - Legacy handlers missing this method are silently skipped via hasattr guard
+
+        Args:
+            computer: 计算机ID / Computer ID
+            skills: SKILL 引用列表（轻量元数据，无 SKILL.md body） / Skill refs (lightweight, no body)
+            client: 调用发生时的Socket.IO Client / Socket.IO Client where make the call
+        """
+        ...
+
 
 class AsyncAgentEventHandler(Protocol):
     """
@@ -151,6 +171,26 @@ class AsyncAgentEventHandler(Protocol):
         Args:
             computer: 计算机ID / Computer ID
             tools: 工具列表 / Tools list
+            client: 调用发生时的Socket.IO Client / Socket.IO Client where make the call
+        """
+        ...
+
+    async def on_skills_received(self, computer: str, skills: list[A2CSkillRef], client: AsyncSMCPAgentClient) -> None:
+        """
+        接收到 SKILL 清单时的异步处理逻辑（v0.2.1+）
+        Async handling logic when SKILL inventory is received (v0.2.1+)
+
+        触发时机 / Trigger:
+            - notify:update_skills 自动重拉 client:get_skills 成功后
+            - After auto-refresh of ``client:get_skills`` triggered by ``notify:update_skills``
+
+        向后兼容 / Backward compatibility:
+            - 旧 EventHandler 未实现此方法时，SDK 通过 hasattr 守卫静默跳过
+            - Legacy handlers missing this method are silently skipped via hasattr guard
+
+        Args:
+            computer: 计算机ID / Computer ID
+            skills: SKILL 引用列表（轻量元数据，无 SKILL.md body） / Skill refs (lightweight, no body)
             client: 调用发生时的Socket.IO Client / Socket.IO Client where make the call
         """
         ...

--- a/tests/unit_tests/agent/test_v021_consume.py
+++ b/tests/unit_tests/agent/test_v021_consume.py
@@ -240,6 +240,44 @@ class TestSkillsUpdatedAutoRefresh:
             await async_client._on_skills_updated({})
             mock_refresh.assert_not_awaited()
 
+    @pytest.mark.asyncio
+    async def test_async_dispatches_on_skills_received(self, async_client: AsyncSMCPAgentClient) -> None:
+        """成功重拉后回调 on_skills_received，参数透传 / Hook fires with passthrough args (v0.2.1+)."""
+        skills = [{"name": "user:x:y", "source": "user", "path": "/s/x/y"}]
+        hook = AsyncMock()
+        async_client.event_handler = hook  # type: ignore[assignment]
+        with patch.object(async_client, "get_skills", new=AsyncMock(return_value={"skills": skills, "req_id": "r"})):
+            await async_client._on_skills_updated({"computer": "comp-1"})
+            hook.on_skills_received.assert_awaited_once_with("comp-1", skills, async_client)
+
+    @pytest.mark.asyncio
+    async def test_async_skips_hook_when_event_handler_is_none(self, async_client: AsyncSMCPAgentClient) -> None:
+        """event_handler is None：不抛 / silent skip when event_handler absent."""
+        async_client.event_handler = None  # type: ignore[assignment]
+        with patch.object(async_client, "get_skills", new=AsyncMock(return_value={"skills": [], "req_id": "r"})):
+            await async_client._on_skills_updated({"computer": "comp-1"})  # must not raise
+
+    @pytest.mark.asyncio
+    async def test_async_skips_hook_when_handler_missing_method(self, async_client: AsyncSMCPAgentClient) -> None:
+        """向后兼容：旧 handler 未实现 on_skills_received → hasattr 守卫静默跳过.
+        Backward-compat: legacy handler missing the method → hasattr guard skips silently."""
+        class _LegacyEH:
+            async def on_tools_received(self, *a: Any, **k: Any) -> None: ...
+
+        async_client.event_handler = _LegacyEH()  # type: ignore[assignment]
+        with patch.object(async_client, "get_skills", new=AsyncMock(return_value={"skills": [], "req_id": "r"})):
+            await async_client._on_skills_updated({"computer": "comp-1"})  # must not raise
+
+    @pytest.mark.asyncio
+    async def test_async_hook_exception_does_not_propagate(self, async_client: AsyncSMCPAgentClient) -> None:
+        """hook 抛错被独立 try 捕获，不向上传播 / Hook errors isolated, not propagated."""
+        hook = AsyncMock()
+        hook.on_skills_received.side_effect = RuntimeError("hook boom")
+        async_client.event_handler = hook  # type: ignore[assignment]
+        with patch.object(async_client, "get_skills", new=AsyncMock(return_value={"skills": [], "req_id": "r"})):
+            await async_client._on_skills_updated({"computer": "comp-1"})  # must not raise
+            hook.on_skills_received.assert_awaited_once()
+
 
 # ── tool_call binary post-process ───────────────────────────────────
 
@@ -394,3 +432,37 @@ class TestSyncMirror:
         with patch.object(sync_client, "get_skills", new=MagicMock(return_value={"skills": [], "req_id": "r"})) as mock_refresh:
             sync_client._on_skills_updated({"computer": "comp-1"})
             mock_refresh.assert_called_once_with("comp-1")
+
+    def test_sync_dispatches_on_skills_received(self, sync_client: SMCPAgentClient) -> None:
+        """sync 镜像：成功重拉后回调 on_skills_received（v0.2.1+）.
+        Sync mirror: hook fires with passthrough args (v0.2.1+)."""
+        skills = [{"name": "user:x:y", "source": "user", "path": "/s/x/y"}]
+        hook = MagicMock()
+        sync_client.event_handler = hook  # type: ignore[assignment]
+        with patch.object(sync_client, "get_skills", new=MagicMock(return_value={"skills": skills, "req_id": "r"})):
+            sync_client._on_skills_updated({"computer": "comp-1"})
+            hook.on_skills_received.assert_called_once_with("comp-1", skills, sync_client)
+
+    def test_sync_skips_hook_when_event_handler_is_none(self, sync_client: SMCPAgentClient) -> None:
+        """sync 镜像：event_handler is None → 静默跳过."""
+        sync_client.event_handler = None  # type: ignore[assignment]
+        with patch.object(sync_client, "get_skills", new=MagicMock(return_value={"skills": [], "req_id": "r"})):
+            sync_client._on_skills_updated({"computer": "comp-1"})  # must not raise
+
+    def test_sync_skips_hook_when_handler_missing_method(self, sync_client: SMCPAgentClient) -> None:
+        """sync 镜像：向后兼容旧 handler 缺方法时 hasattr 守卫静默跳过."""
+        class _LegacyEH:
+            def on_tools_received(self, *a: Any, **k: Any) -> None: ...
+
+        sync_client.event_handler = _LegacyEH()  # type: ignore[assignment]
+        with patch.object(sync_client, "get_skills", new=MagicMock(return_value={"skills": [], "req_id": "r"})):
+            sync_client._on_skills_updated({"computer": "comp-1"})  # must not raise
+
+    def test_sync_hook_exception_does_not_propagate(self, sync_client: SMCPAgentClient) -> None:
+        """sync 镜像：hook 抛错独立隔离不向上传播."""
+        hook = MagicMock()
+        hook.on_skills_received.side_effect = RuntimeError("hook boom")
+        sync_client.event_handler = hook  # type: ignore[assignment]
+        with patch.object(sync_client, "get_skills", new=MagicMock(return_value={"skills": [], "req_id": "r"})):
+            sync_client._on_skills_updated({"computer": "comp-1"})  # must not raise
+            hook.on_skills_received.assert_called_once()


### PR DESCRIPTION
## Summary

v0.2.1 milestone (#42) 跨 PR 跟进项 #48 落地——给 `AgentEventHandler` / `AsyncAgentEventHandler` 加 `on_skills_received(computer, skills, client)` 业务回调钩子，配合 PR #47 已落地的 `_on_skills_updated` 自动重拉链路把 SKILL 集合刷新结果交付业务层。

Closes #48 · 父追踪 #42 · base `develop-v0.2.1`

> **协议归属判定结论**：`AgentEventHandler` 是 SDK 内部回调 Protocol，与协议层 wire 行为完全正交。本 PR **不涉及协议变更**，与 [a2c-smcp-protocol v0.2.2 doc patch](https://github.com/A2C-SMCP/a2c-smcp-protocol/compare/main...docs/v0.2.2-clarify-ack-flat-error-and-inflight-disconnect)（澄清 ack flat ErrorPayload + in-flight disconnect）正交，可独立推进。详情见 Issue #48 评论。

## 变更范围

### Agent 侧 Protocol 扩展（`agent/types.py`）

新增 `A2CSkillRef` 导入，给两个 Protocol 各加 1 个方法（带英汉双语 docstring）：

```python
# sync
def on_skills_received(self, computer: str, skills: list[A2CSkillRef], client: SMCPAgentClient) -> None: ...
# async
async def on_skills_received(self, computer: str, skills: list[A2CSkillRef], client: AsyncSMCPAgentClient) -> None: ...
```

签名严格对齐 `on_tools_received` 范式（参数顺序 / client 类型 / Protocol `...` 风格）。

### Agent 侧 `_on_skills_updated` 改造（`agent/client.py` + `sync_client.py`）

在 `get_skills` 拉取成功后追加 hook 派发，**分层异常隔离**：

```python
ret = await self.get_skills(computer)
skills = ret.get("skills", [])
logger.info(f"Skills refreshed from computer {computer}: count={len(skills)}")
if self.event_handler and hasattr(self.event_handler, "on_skills_received"):
    try:
        await self.event_handler.on_skills_received(computer, skills, self)
    except Exception as hook_exc:
        logger.error(f"on_skills_received hook raised for computer {computer}: {hook_exc}", exc_info=True)
```

**架构决策**：
- 嵌套 `try` 区分"拉取链路失败"和"业务回调失败"——排障归属不同，日志通道独立
- `hasattr` 守卫保证向后兼容：旧 `EventHandler` 实现未定义 `on_skills_received` 时静默跳过，零破坏
- 空列表也派发 hook：`skills == []`（如全部卸载）是合法状态语义，业务方需感知

## 测试覆盖（+8 新用例）

| 类 | async | sync |
|---|:-:|:-:|
| `test_*_dispatches_on_skills_received` — hook 被调用 + 参数透传 | ✅ | ✅ |
| `test_*_skips_hook_when_event_handler_is_none` — None 守卫 | ✅ | ✅ |
| `test_*_skips_hook_when_handler_missing_method` — `hasattr` 守卫向后兼容 | ✅ | ✅ |
| `test_*_hook_exception_does_not_propagate` — hook 抛错独立隔离 | ✅ | ✅ |

测试归位现有类（async → `TestSkillsUpdatedAutoRefresh`，sync → `TestSyncMirror`），mock 注入用 `AsyncMock` / `MagicMock` 直接赋值 `event_handler` 字段（`... | None` 类型合法），不改 fixture。

## 数据

- **895 passed** / 2 skipped / 4 xfailed / **0 failed** / **0 regression**（v.s. PR #47 baseline 885 → +10）
- `uv run poe lint` 净（ruff + mypy strict）
- `PROTOCOL_VERSION` 保持 `0.2.0`
- **+145 / -7** 行（4 文件）

## 协议关系

- `data-structures.md` §`A2CSkillRef` / §`GetSkillsRet`（只读引用，类型来源）
- `events.md` §`notify:update_skills` / §`client:get_skills`（wire 路径已由 PR #41/#45/#47 实现，本 PR 仅扩展 SDK 业务层 API）
- 本 PR **未触及任何 wire 行为**

## 与 v0.2.1 Milestone 进度

| Issue | 状态 |
|---|---|
| #37 协议镜像 | ✅ PR #43 |
| #38 通用二进制传输 | ✅ PR #44 |
| #41 Server 路由 + 广播 | ✅ PR #45 |
| #40 Agent 消费 + tool_call 二进制一致性 | ✅ PR #47 |
| **#48 Agent on_skills_received 钩子** | 🟢 **本 PR** |
| #39 Computer SKILL 子系统 | 🟡 milestone 主线最后一块 |
| #46 Server 路由统一 + None 防御 | ⏳ 等 protocol v0.2.2 release |

## Test plan

- [x] `uv run pytest tests/unit_tests/agent/test_v021_consume.py -v -k "on_skills_received or dispatches or skips_hook or hook_exception"` → 8 新用例全过
- [x] `uv run pytest tests/unit_tests/agent/` → 104 passed（含原 96 + 新 8）
- [x] `uv run poe test` → 895 passed / 0 failed / 0 regression
- [x] `uv run poe lint` → ruff + mypy strict 净
- [x] PROTOCOL_VERSION 未改动确认

🤖 Generated with [Claude Code](https://claude.com/claude-code)
