### PR TITLE
feat(computer): v0.2.1 ToolspoolBlobResolver lazy slice (#51)

### DIFF
--- a/a2c_smcp/computer/blob/resolver.py
+++ b/a2c_smcp/computer/blob/resolver.py
@@ -143,8 +143,12 @@ class ToolspoolBlobResolver:
         # mime 以铸造时入参为准；磁盘旁路只作诊断，不参与协议返回
         # Handle-embedded mime is authoritative; disk sidecar is diagnostic only
         _ = info.mime
-        # 闭包捕获 store + cid；handler 每次 slice 调用都触发 seek+read（O(1) memory per call）
-        # Closure captures store + cid; each slice call triggers seek+read (O(1) memory per call).
+        # 闭包仅捕获 ``store + cid``（**不**捕获 self）：让 ``ResolvedBlob`` 反向引用最小化，
+        # 避免间接钉住 ``ToolspoolBlobResolver`` 实例，便于未来 ``ResolvedBlob`` 被长时缓存
+        # 场景下的 GC。每次 slice 调用都触发独立 seek+read（O(1) memory per call）.
+        # Capture ``store + cid`` only (NOT self): keeps ``ResolvedBlob``'s back-references
+        # minimal so it doesn't pin the ``ToolspoolBlobResolver`` instance — useful for
+        # future cached scenarios. Each slice call triggers independent seek+read.
         store = self._store
 
         def _slicer(offset: int, length: int) -> bytes:

--- a/a2c_smcp/computer/blob/resolver.py
+++ b/a2c_smcp/computer/blob/resolver.py
@@ -18,28 +18,85 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from collections.abc import Callable
+from dataclasses import dataclass, field
 from typing import Any, Protocol, runtime_checkable
 
 from a2c_smcp.computer.blob.handle import BlobHandleForbiddenError
 from a2c_smcp.computer.blob.toolspool import ToolspoolBlobStore
 
+# 惰性切片闭包类型 / Lazy slice closure type: (offset, length) -> bytes
+# Resolver 在 ``resolve()`` 中构造此闭包并注入 ResolvedBlob，handler 切片时按需回读。
+# Constructed by resolver inside ``resolve()``; invoked lazily by handler at slice time.
+_BlobSlicer = Callable[[int, int], bytes]
 
-@dataclass(frozen=True)
+
+@dataclass(frozen=True, eq=False)
 class ResolvedBlob:
     """``blob_handle`` 解析后的资源描述符 / Resolved blob descriptor.
 
+    惰性切片视图（v0.2.1 #51）：``payload`` 不再驻留全量字节；``slice(offset, length)``
+    按需经 ``_slicer`` 闭包从源 seek+read。``resolve()`` 期间 O(1) 内存。
+    Lazy slice view (v0.2.1 #51): ``payload`` no longer holds full bytes; ``slice()`` reads
+    on demand via ``_slicer`` closure (seek+read). ``resolve()`` is O(1) memory.
+
     Attributes:
-        payload: 完整字节内容（解析期一次性 / 切片由 handler 完成）。Full raw bytes.
-        mime: 内容 MIME。
-        total_size: 资源总字节数（= ``len(payload)``，显式字段便于审计与单测断言）。
-        sha256: 全量 ``sha256`` 十六进制（由 resolver 自行算或回查既有 cid 值）。
+        mime: 内容 MIME（handle-authoritative，由 resolver 从句柄载荷透传）。
+            MIME from handle payload (authoritative).
+        total_size: 资源总字节数。Total resource size in bytes.
+        sha256: 全量 ``sha256`` 十六进制（kind=toolspool 即 cid）/ Full sha256 hex.
+        _slicer: closure ``(offset, length) -> bytes``；resolver 提供的惰性读闭包。
+            Resolver-supplied lazy-read closure; never None in valid construction.
+
+    Notes:
+        - ``frozen=True``：表达 "resolver 派发的不可变快照" 语义；handler MUST NOT mutate.
+        - ``eq=False``：closure 字段不参与 hash/equality（resolver 每次 resolve 创建新实例，
+          实例对比走 identity）。Closure field skipped in eq/hash; identity comparison.
     """
 
-    payload: bytes
     mime: str
     total_size: int
     sha256: str
+    _slicer: _BlobSlicer = field(repr=False)
+
+    def slice(self, offset: int, length: int) -> bytes:
+        """读取 ``[offset, offset+length)`` 字节区间，截断到 ``total_size``.
+        Read bytes in ``[offset, offset+length)``, clamped to ``total_size``.
+
+        边界语义 / Boundary semantics:
+          - ``offset == total_size`` → ``b""``（EOF probe，**非** range error）
+          - ``offset > total_size`` → ``ValueError``（调用方应先做范围校验）
+          - ``offset < 0`` or ``length < 0`` → ``ValueError``
+          - ``length == 0`` → ``b""``（无 I/O 触发）
+          - ``length`` 超出剩余 → 自动截断为 ``total_size - offset``（不 raise）
+
+        EOF probe 语义保留与 ``on_get_blob`` 严格 ``>`` 范围守卫一致，避免破坏 HTTP Range
+        风格的"探测末尾"客户端行为。
+        Preserves HTTP-Range-style probe semantics (offset == total_size returns empty,
+        offset > total_size raises) aligned with ``on_get_blob``'s strict ``>`` guard.
+        """
+        if offset < 0 or length < 0:
+            raise ValueError(f"offset/length must be non-negative: offset={offset}, length={length}")
+        if offset > self.total_size:
+            raise ValueError(f"offset {offset} > total_size {self.total_size}")
+        if length == 0 or offset == self.total_size:
+            return b""
+        actual = min(length, self.total_size - offset)
+        return self._slicer(offset, actual)
+
+    @property
+    def payload(self) -> bytes:
+        """向后兼容只读视图：等价 ``slice(0, total_size)``，**会触发一次全量读**.
+
+        新代码 SHOULD 改用 :meth:`slice` 避免内存放大；保留此属性仅为 v0.2.x 迁移期与
+        现有单测断言。计划于 v0.3 移除。
+        Back-compat shim; triggers a full read. New code SHOULD use :meth:`slice` to avoid
+        memory amplification. Retained for the v0.2.x migration window; removed in v0.3.
+
+        .. deprecated:: 0.2.1
+            Use :meth:`slice` instead.
+        """
+        return self.slice(0, self.total_size)
 
 
 @runtime_checkable
@@ -59,18 +116,19 @@ class BlobResolver(Protocol):
 
 
 class ToolspoolBlobResolver:
-    """``kind="toolspool"`` 解析器：按 ``cid`` 回查 ``.blobspool`` 暂存。
+    """``kind="toolspool"`` 解析器：按 ``cid`` 回查 ``.blobspool`` 暂存（惰性切片）.
 
     跨进程重启可解析：cid 在磁盘 → 成功；不在 → ``BlobHandleGoneError`` （协议 ``4018 gone``）。
     Survives Computer restarts: cid present on disk → success; absent → ``BlobHandleGoneError``.
 
-    TODO(v0.2.x+): ``resolve()`` 当前一次性 ``read_bytes()`` 读全量进内存，handler 再切片返回单块。
-    并行 ``concurrency=N`` 拉取大 blob 时瞬时占用 ≈ N × total_size。后续版本可引入 lazy 抽象
-    （mmap / seek+read），让 ``ResolvedBlob`` 暴露 ``slice(offset, length) → bytes`` 而不持有
-    全量字节。"无状态可重解析" 承诺不变，仅是内存峰值优化，非协议变更。
-    Future optimization (non-protocol): replace eager ``read_bytes()`` with a lazy slice view
-    (mmap / seek+read) so ``ResolvedBlob`` exposes per-chunk reads without holding the full
-    payload in memory. Stateless-reparseable contract unchanged.
+    惰性切片（v0.2.1 #51）：``resolve()`` 仅读 metadata（``stat()``），不读 payload 字节；
+    ``ResolvedBlob.slice(offset, length)`` 经 ``ToolspoolBlobStore.read_chunk`` 按需 seek+read。
+    并行 ``concurrency=N`` 拉取大 blob 时单 chunk 入内存，峰值与 ``total_size`` 解耦。
+    "无状态可重解析" 承诺不变，仅是内存峰值优化，非协议变更。
+    Lazy slice (v0.2.1 #51): ``resolve()`` reads metadata only via ``stat()``, never payload bytes;
+    ``ResolvedBlob.slice(offset, length)`` reads on demand via ``ToolspoolBlobStore.read_chunk``.
+    Concurrent fetches see per-chunk memory peak, decoupled from ``total_size``.
+    Stateless-reparseable contract unchanged.
     """
 
     def __init__(self, store: ToolspoolBlobStore) -> None:
@@ -79,15 +137,27 @@ class ToolspoolBlobResolver:
     def resolve(self, payload: dict[str, Any]) -> ResolvedBlob:
         cid = payload["cid"]
         mime_in_handle = payload["mime"]
-        # ToolspoolBlobStore.get 已做 cid 白名单 + realpath 越界防御 + GoneError 抛出
-        # store.get already validates cid + realpath + raises GoneError
-        raw, mime_on_disk = self._store.get(cid)
-        # cid 即 sha256，无需重算（store.get 已 fail-fast 路径校验）
-        # cid IS the sha256; no need to recompute (store.get already path-validated)
+        # stat 仅读元数据（size + sidecar mime）+ cid 白名单 + realpath 围栏 + GoneError/InvalidError 抛出
+        # stat reads metadata only (size + sidecar mime) + cid whitelist + realpath fence
+        info = self._store.stat(cid)
         # mime 以铸造时入参为准；磁盘旁路只作诊断，不参与协议返回
         # Handle-embedded mime is authoritative; disk sidecar is diagnostic only
-        _ = mime_on_disk
-        return ResolvedBlob(payload=raw, mime=mime_in_handle, total_size=len(raw), sha256=cid)
+        _ = info.mime
+        # 闭包捕获 store + cid；handler 每次 slice 调用都触发 seek+read（O(1) memory per call）
+        # Closure captures store + cid; each slice call triggers seek+read (O(1) memory per call).
+        store = self._store
+
+        def _slicer(offset: int, length: int) -> bytes:
+            return store.read_chunk(cid, offset, length)
+
+        # cid 即 sha256，无需重算（stat 已 fail-fast 路径校验）
+        # cid IS the sha256; no need to recompute (stat already path-validated).
+        return ResolvedBlob(
+            mime=mime_in_handle,
+            total_size=info.size,
+            sha256=cid,
+            _slicer=_slicer,
+        )
 
 
 class SkillBlobResolverPending:

--- a/a2c_smcp/computer/blob/toolspool.py
+++ b/a2c_smcp/computer/blob/toolspool.py
@@ -26,6 +26,7 @@ import logging
 import os
 import uuid
 from collections.abc import Iterator
+from dataclasses import dataclass
 from pathlib import Path
 
 from a2c_smcp.computer.blob.handle import BlobHandleGoneError, BlobHandleInvalidError
@@ -40,6 +41,24 @@ BLOBSPOOL_DIRNAME: str = ".blobspool"
 # cid validation: 64 hex chars (sha256); blocks path-traversal via cid spoofing
 _CID_LEN: int = 64
 _HEX_CHARS: frozenset[str] = frozenset("0123456789abcdef")
+
+
+@dataclass(frozen=True)
+class BlobStat:
+    """``.blobspool`` 条目元数据（不读字节）/ Entry metadata, never reads payload bytes.
+
+    v0.2.1 #51 lazy slice 接入点：``ToolspoolBlobResolver.resolve()`` 走 ``stat()`` + closure
+    ``read_chunk()``，避免一次性 ``read_bytes()`` 全量入内存。
+    v0.2.1 #51 lazy-slice entry: resolver uses ``stat() + read_chunk()`` to avoid
+    eager full-file reads.
+
+    Attributes:
+        size: 字节数（``os.stat().st_size``）。Size in bytes.
+        mime: ``.mime`` sidecar 内容（UTF-8，已 strip）。MIME from sidecar (stripped).
+    """
+
+    size: int
+    mime: str
 
 
 class ToolspoolBlobStore:
@@ -94,13 +113,12 @@ class ToolspoolBlobStore:
         return cid
 
     def get(self, cid: str) -> tuple[bytes, str]:
-        """按 ``cid`` 回查 / Look up by ``cid``.
+        """按 ``cid`` 回查（一次性全量读）/ Look up by ``cid`` (eager full read).
 
-        TODO(v0.2.x+): 当前 ``read_bytes()`` 全量入内存。后续可暴露惰性读接口
-        （如 ``open_blob(cid) -> BinaryIO`` 或 ``read_slice(cid, offset, length)``），
-        让 resolver / handler 不再持有全量 payload，降低并发拉取大 blob 时的峰值占用。
-        Future: expose lazy reads (``open_blob`` / ``read_slice``) so callers needn't hold
-        the full payload in memory; reduces peak usage when concurrent chunks pull a large blob.
+        保留为 round-trip 便利接口；新代码 SHOULD 用 :meth:`stat` + :meth:`read_chunk` 惰性读，
+        避免大 blob 的内存放大。``ToolspoolBlobResolver`` 自 v0.2.1 #51 起已迁移到惰性接口。
+        Kept as eager convenience; new code SHOULD use lazy reads via stat + read_chunk.
+        Resolver migrated to lazy interface in v0.2.1 #51.
 
         Returns:
             (payload, mime): 字节内容与 MIME。
@@ -129,6 +147,67 @@ class ToolspoolBlobStore:
         payload = blob_real.read_bytes()
         mime = mime_real.read_text(encoding="utf-8").strip()
         return payload, mime
+
+    def stat(self, cid: str) -> BlobStat:
+        """读取条目元数据：尺寸 + MIME；**不读 payload 字节**.
+
+        Read entry metadata: size + MIME; never reads payload bytes.
+
+        v0.2.1 #51: ``ToolspoolBlobResolver.resolve()`` 入口，仅 metadata + path realpath 校验.
+
+        Raises:
+            BlobHandleInvalidError: ``cid`` 格式非法 / Invalid cid format.
+            BlobHandleGoneError: ``cid`` 格式合法但文件已不在 / Valid cid, file absent.
+        """
+        _validate_cid(cid)
+        blob_path = self._blob_path(cid)
+        mime_path = self._mime_path(cid)
+        try:
+            blob_real = blob_path.resolve(strict=True)
+            mime_real = mime_path.resolve(strict=True)
+        except FileNotFoundError as e:
+            raise BlobHandleGoneError(f"toolspool entry missing: cid={cid}") from e
+        if not _is_within(blob_real, self.root) or not _is_within(mime_real, self.root):
+            raise BlobHandleInvalidError(f"resolved path escapes blobspool root: cid={cid}")
+        size = blob_real.stat().st_size  # metadata only — no payload read
+        mime = mime_real.read_text(encoding="utf-8").strip()
+        return BlobStat(size=size, mime=mime)
+
+    def read_chunk(self, cid: str, offset: int, length: int) -> bytes:
+        """从 ``cid`` 字节流 ``[offset, offset+length)`` 区间读取；越界自然返回短读 / 空.
+
+        Read ``[offset, offset+length)`` slice; over-EOF returns short / empty bytes.
+
+        v0.2.1 #51: 惰性切片底层原语，每次 ``open()`` + ``seek()`` + ``read()`` 独立 fd；
+        OS file-cache 让重复读廉价；并发 chunk 自然独立。
+        Lazy slice primitive: each call opens an independent fd; OS file-cache makes
+        repeated reads cheap; concurrent chunks naturally isolated.
+
+        边界语义 / Boundary semantics:
+          - ``length == 0`` → ``b""`` (no I/O at OS level)
+          - ``offset >= size`` → ``b""`` (mirrors Python file.read past EOF)
+          - ``length`` 超出剩余 → 自然短读（OS 截断）/ Natural short-read on over-length
+
+        Raises:
+            BlobHandleInvalidError: ``cid`` 格式非法 / Invalid cid format.
+            BlobHandleGoneError: ``cid`` 格式合法但文件已不在 / Valid cid, file absent.
+            ValueError: ``offset < 0`` 或 ``length < 0`` / Negative offset or length.
+        """
+        if offset < 0 or length < 0:
+            raise ValueError(f"offset/length must be non-negative: offset={offset}, length={length}")
+        if length == 0:
+            return b""
+        _validate_cid(cid)
+        blob_path = self._blob_path(cid)
+        try:
+            blob_real = blob_path.resolve(strict=True)
+        except FileNotFoundError as e:
+            raise BlobHandleGoneError(f"toolspool entry missing: cid={cid}") from e
+        if not _is_within(blob_real, self.root):
+            raise BlobHandleInvalidError(f"resolved path escapes blobspool root: cid={cid}")
+        with open(blob_real, "rb") as f:
+            f.seek(offset)
+            return f.read(length)
 
     def exists(self, cid: str) -> bool:
         """轻量存在性探测，不读字节 / Lightweight existence probe; never reads bytes.

--- a/a2c_smcp/computer/socketio/client.py
+++ b/a2c_smcp/computer/socketio/client.py
@@ -574,63 +574,11 @@ class SMCPComputerClient(AsyncClient):
         Returns:
             GetBlobRet | ErrorPayload: 成功为切片块（``base64`` 编码），失败为 flat ErrorPayload。
         """
-        # office/role 隔离：Server 已保证同房间路由，但 ``computer`` 标识仍需匹配
-        # office/role isolation: Server guarantees same-room routing, but ``computer`` MUST match
-        if self.computer.name != data["computer"]:
-            raise SMCPNamespaceError("计算机标识不匹配")
-
-        handle = data["blob_handle"]
-        chunk_offset = data.get("chunk_offset", 0)
-        max_chunk_bytes_req = data.get("max_chunk_bytes")
-        max_chunk_bytes = self.computer.blob_thresholds.clamp_chunk(max_chunk_bytes_req)
-
-        # 1) 解码句柄 → kind 派发 / Decode handle → kind dispatch
-        try:
-            kind, payload = decode_blob_handle(handle)
-        except BlobHandleInvalidError as e:
-            logger.warning(f"client:get_blob invalid handle: {e}")
-            return _blob_error(reason="invalid_handle")
-
-        resolver = self.computer.blob_resolvers.get(kind)
-        if resolver is None:
-            logger.warning(f"client:get_blob no resolver for kind={kind!r}")
-            return _blob_error(reason="invalid_handle")
-
-        # 2) 解析（resolver 内部重施铸造通道边界校验）/ Resolve (resolver re-applies channel auth)
-        try:
-            resolved = resolver.resolve(payload)
-        except BlobHandleError as e:
-            reason = getattr(e, "reason", "forbidden")
-            logger.warning(f"client:get_blob resolver rejected handle: kind={kind}, reason={reason}, err={e}")
-            return _blob_error(reason=reason)
-
-        # 3) 范围校验 / Range check
-        if not isinstance(chunk_offset, int) or chunk_offset < 0 or chunk_offset > resolved.total_size:
-            logger.warning(
-                f"client:get_blob range out of bounds: offset={chunk_offset}, total_size={resolved.total_size}",
-            )
-            return _blob_error(reason="range")
-
-        # 4) 切片 + base64 编码（单块 ≤ clamp 后的 max_chunk_bytes）/ Slice + base64 (chunk ≤ clamp)
-        # v0.2.1 #51: 走 lazy slice，仅单 chunk 入内存（不再触发全量 read_bytes）
-        # Lazy slice (v0.2.1 #51): only one chunk in memory; no full-file read triggered.
-        remaining = resolved.total_size - chunk_offset
-        slice_len = min(max_chunk_bytes, remaining)
-        chunk = resolved.slice(chunk_offset, slice_len)
-        # eof 公式保留 len(chunk) 形式：与原 ``end == total_size`` 等价，对 OS 短读健壮.
-        # Preserve len(chunk) form: equivalent to original ``end == total_size``, robust to short-reads.
-        eof = chunk_offset + len(chunk) == resolved.total_size
-        ret: GetBlobRet = {
-            "blob_handle": handle,
-            "mime_type": resolved.mime,
-            "total_size": resolved.total_size,
-            "sha256": resolved.sha256,
-            "chunk_offset": chunk_offset,
-            "eof": eof,
-            "blob": base64.b64encode(chunk).decode("ascii"),
-            "req_id": data["req_id"],
-        }
-        return ret
+        # 核心逻辑抽取至模块级 ``_process_get_blob``，让同步 wire 测试 mock 与本 async wrapper
+        # 复用同一份实现，避免"两份同源 handler 逻辑双份维护"的脆弱点（PR #52 fix-review）.
+        # Core logic extracted to module-level ``_process_get_blob``, shared with sync wire mock,
+        # eliminating dual-maintenance of equivalent sync/async handler bodies (PR #52 fix-review).
+        return _process_get_blob(data, self.computer)
 
 
 def _blob_error(*, reason: str) -> ErrorPayload:
@@ -642,3 +590,86 @@ def _blob_error(*, reason: str) -> ErrorPayload:
         message="Blob not accessible",
         details={"reason": reason},
     )
+
+
+def _process_get_blob(data: GetBlobReq, computer: Computer) -> GetBlobRet | ErrorPayload:
+    """通用二进制拉取的纯同步核心逻辑 / Pure synchronous core logic for ``client:get_blob``.
+
+    抽取自 :meth:`SMCPComputerClient.on_get_blob`（v0.2.1 #51 PR #52 fix-review）；让同步
+    ``socketio.Client`` wire 测试 mock 与 async ``SMCPComputerClient`` 复用同一份实现，
+    消除"两份同源 handler 逻辑双份维护"的脆弱点。``on_get_blob`` body 本是同步代码
+    （无 ``await``），抽取为纯函数零行为变更。
+    Extracted from :meth:`SMCPComputerClient.on_get_blob` so sync ``socketio.Client`` (test
+    wire mock) and async ``SMCPComputerClient`` share one implementation. The async handler's
+    body is pure-sync code (no ``await``); extraction is behavior-neutral.
+
+    完整协议依据 / 安全 / 错误语义文档保留在 :meth:`SMCPComputerClient.on_get_blob`.
+    Full protocol / security / error semantics docs are retained on the async wrapper.
+
+    Args:
+        data: ``GetBlobReq`` payload.
+        computer: 持有 ``name`` / ``blob_thresholds`` / ``blob_resolvers`` 的 ``Computer`` 实例.
+
+    Returns:
+        ``GetBlobRet`` (成功) 或 ``ErrorPayload`` (4018 invalid_handle / forbidden / gone / range).
+
+    Raises:
+        SMCPNamespaceError: ``computer.name`` 与 ``data["computer"]`` 不匹配（防御纵深，理论不可达）.
+    """
+    # office/role 隔离：Server 已保证同房间路由，但 ``computer`` 标识仍需匹配
+    # office/role isolation: Server guarantees same-room routing, but ``computer`` MUST match
+    if computer.name != data["computer"]:
+        raise SMCPNamespaceError("计算机标识不匹配")
+
+    handle = data["blob_handle"]
+    chunk_offset = data.get("chunk_offset", 0)
+    max_chunk_bytes_req = data.get("max_chunk_bytes")
+    max_chunk_bytes = computer.blob_thresholds.clamp_chunk(max_chunk_bytes_req)
+
+    # 1) 解码句柄 → kind 派发 / Decode handle → kind dispatch
+    try:
+        kind, payload = decode_blob_handle(handle)
+    except BlobHandleInvalidError as e:
+        logger.warning(f"client:get_blob invalid handle: {e}")
+        return _blob_error(reason="invalid_handle")
+
+    resolver = computer.blob_resolvers.get(kind)
+    if resolver is None:
+        logger.warning(f"client:get_blob no resolver for kind={kind!r}")
+        return _blob_error(reason="invalid_handle")
+
+    # 2) 解析（resolver 内部重施铸造通道边界校验）/ Resolve (resolver re-applies channel auth)
+    try:
+        resolved = resolver.resolve(payload)
+    except BlobHandleError as e:
+        reason = getattr(e, "reason", "forbidden")
+        logger.warning(f"client:get_blob resolver rejected handle: kind={kind}, reason={reason}, err={e}")
+        return _blob_error(reason=reason)
+
+    # 3) 范围校验 / Range check
+    if not isinstance(chunk_offset, int) or chunk_offset < 0 or chunk_offset > resolved.total_size:
+        logger.warning(
+            f"client:get_blob range out of bounds: offset={chunk_offset}, total_size={resolved.total_size}",
+        )
+        return _blob_error(reason="range")
+
+    # 4) 切片 + base64 编码（单块 ≤ clamp 后的 max_chunk_bytes）/ Slice + base64 (chunk ≤ clamp)
+    # v0.2.1 #51: 走 lazy slice，仅单 chunk 入内存（不再触发全量 read_bytes）
+    # Lazy slice (v0.2.1 #51): only one chunk in memory; no full-file read triggered.
+    remaining = resolved.total_size - chunk_offset
+    slice_len = min(max_chunk_bytes, remaining)
+    chunk = resolved.slice(chunk_offset, slice_len)
+    # eof 公式保留 len(chunk) 形式：与原 ``end == total_size`` 等价，对 OS 短读健壮.
+    # Preserve len(chunk) form: equivalent to original ``end == total_size``, robust to short-reads.
+    eof = chunk_offset + len(chunk) == resolved.total_size
+    ret: GetBlobRet = {
+        "blob_handle": handle,
+        "mime_type": resolved.mime,
+        "total_size": resolved.total_size,
+        "sha256": resolved.sha256,
+        "chunk_offset": chunk_offset,
+        "eof": eof,
+        "blob": base64.b64encode(chunk).decode("ascii"),
+        "req_id": data["req_id"],
+    }
+    return ret

--- a/a2c_smcp/computer/socketio/client.py
+++ b/a2c_smcp/computer/socketio/client.py
@@ -612,9 +612,14 @@ class SMCPComputerClient(AsyncClient):
             return _blob_error(reason="range")
 
         # 4) 切片 + base64 编码（单块 ≤ clamp 后的 max_chunk_bytes）/ Slice + base64 (chunk ≤ clamp)
-        end = min(chunk_offset + max_chunk_bytes, resolved.total_size)
-        chunk = resolved.payload[chunk_offset:end]
-        eof = end == resolved.total_size
+        # v0.2.1 #51: 走 lazy slice，仅单 chunk 入内存（不再触发全量 read_bytes）
+        # Lazy slice (v0.2.1 #51): only one chunk in memory; no full-file read triggered.
+        remaining = resolved.total_size - chunk_offset
+        slice_len = min(max_chunk_bytes, remaining)
+        chunk = resolved.slice(chunk_offset, slice_len)
+        # eof 公式保留 len(chunk) 形式：与原 ``end == total_size`` 等价，对 OS 短读健壮.
+        # Preserve len(chunk) form: equivalent to original ``end == total_size``, robust to short-reads.
+        eof = chunk_offset + len(chunk) == resolved.total_size
         ret: GetBlobRet = {
             "blob_handle": handle,
             "mime_type": resolved.mime,

--- a/tests/integration_tests/test_blob_transfer.py
+++ b/tests/integration_tests/test_blob_transfer.py
@@ -251,6 +251,77 @@ class TestInProcThresholdsAndDefense:
         assert data == payload
 
 
+class TestInProcLazyInvariant:
+    """v0.2.1 #51 lazy slice 端到端不变量：每 chunk 一次独立 ``read_chunk`` + 累计字节 ≈ ``total_size``.
+
+    End-to-end lazy invariant (v0.2.1 #51): one ``read_chunk`` per chunk request; total bytes
+    read across all chunks ≈ ``total_size`` (NOT ``N × total_size``).
+
+    防 production ``on_get_blob`` / ``_process_get_blob`` 误回退到 ``resolved.payload[...]``：
+    - 单测仍过（``.payload`` shim 工作 → ``slice(0, total_size)``）
+    - 集成字节正确性测试仍过（base64 解码后 bytes 一致）
+    - 但每次 chunk 请求都触发**全文件读**，内存峰值悄悄回归到 v0.2.1 #51 之前
+
+    PR #52 fix-review 🟡1：reviewer 原方案 ``builtins.open count == 25`` 无法捕获此回退
+    （``.payload`` shim 仍走 ``read_chunk`` → 仍 25 次 open）；本测试改监控 ``read_chunk``
+    **累计字节数** 精确区分两种实现.
+    """
+
+    @pytest.mark.asyncio
+    async def test_lazy_invariant_read_chunk_bytes_equal_total_size(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        computer_with_client: tuple[Computer, SMCPComputerClient],
+    ) -> None:
+        """drain N chunks → ``read_chunk`` 累计字节 ≈ ``total_size``，**非** ``N × total_size``.
+
+        Drain N chunks → cumulative bytes read via ``read_chunk`` ≈ ``total_size``,
+        NOT ``N × total_size`` (which would indicate ``.payload`` shim regression).
+        """
+        from a2c_smcp.computer.blob.toolspool import ToolspoolBlobStore
+
+        comp, cli = computer_with_client
+        total_size = 100 * 1024  # 100 KiB
+        chunk_size = 4096
+        expected_chunks = total_size // chunk_size  # 25
+
+        payload = bytes((i * 31 + 7) % 256 for i in range(total_size))
+        handle = comp.mint_toolspool_handle(payload=payload, mime="application/octet-stream")
+
+        # 监控 read_chunk 累计字节 + 调用次数
+        # Monitor read_chunk cumulative bytes + call count
+        real_read_chunk = ToolspoolBlobStore.read_chunk
+        cumulative_bytes = 0
+        call_count = 0
+
+        def tracking_read_chunk(self_store, cid, offset, length):  # type: ignore[no-untyped-def]
+            nonlocal cumulative_bytes, call_count
+            data = real_read_chunk(self_store, cid, offset, length)
+            cumulative_bytes += len(data)
+            call_count += 1
+            return data
+
+        monkeypatch.setattr(ToolspoolBlobStore, "read_chunk", tracking_read_chunk)
+
+        call = _make_in_proc_call(cli)
+        data, _ = await drain_blob(call, comp.name, handle, chunk_size=chunk_size)
+
+        # 字节正确性（基线 sanity，独立于 lazy 验证）
+        # Byte correctness (baseline sanity, independent of lazy verification)
+        assert data == payload
+
+        # 关键不变量：每 chunk 一次 read_chunk，累计字节恰好 == total_size
+        # Key invariant: one read_chunk per chunk request; cumulative bytes == total_size
+        assert call_count == expected_chunks, (
+            f"expected {expected_chunks} read_chunk calls (one per chunk), got {call_count}"
+        )
+        assert cumulative_bytes == total_size, (
+            f"LAZY INVARIANT VIOLATED: cumulative read_chunk bytes = {cumulative_bytes} "
+            f"(expected ≈ {total_size}). If ≈ {expected_chunks * total_size}, this indicates "
+            f"regression to .payload shim causing full-file read per chunk request."
+        )
+
+
 # ======================================================================
 # Part 2 — Real Socket.IO transport (async)
 # ======================================================================
@@ -526,29 +597,32 @@ def _run_sync_computer_process(
     handle_q: multiprocessing.Queue,
     err_q: multiprocessing.Queue,
 ) -> None:
-    """同步 mock Computer：自己暴露 client:get_blob handler（手动派发到 in-process resolver）.
+    """同步 mock Computer：复用 production ``_process_get_blob`` 核心逻辑.
 
-    Sync mock Computer: hosts ``client:get_blob`` handler in-process by dispatching to the
-    same blob infrastructure (Toolspool store + handle codec). This shows the sync wire path
-    can be exercised without depending on Computer's async-only socketio client."""
+    Sync mock Computer: reuses production ``_process_get_blob`` core; handler body is a
+    pass-through wrapper, eliminating duplicate sync/async sync mirror maintenance.
+
+    抽取自 PR #52 fix-review 🟡2：让 sync wire 测试与 async ``SMCPComputerClient.on_get_blob``
+    走同一份纯函数实现（production handler body 本是同步代码），不再手写 decode + dispatch
+    + slice 的镜像逻辑。
+    Per PR #52 fix-review 🟡2: sync wire mock and async ``SMCPComputerClient.on_get_blob``
+    now share a single pure-function implementation; the duplicated decode/dispatch/slice
+    mirror logic is eliminated.
+    """
     from pathlib import Path
 
-    from a2c_smcp.computer.blob import (
-        BlobHandleError,
-        BlobHandleInvalidError,
-        ToolspoolBlobResolver,
-        ToolspoolBlobStore,
-        decode_blob_handle,
-        encode_toolspool_handle,
-    )
+    from a2c_smcp.computer.computer import Computer
+    from a2c_smcp.computer.socketio.client import _process_get_blob
 
-    store = ToolspoolBlobStore(Path(cache_dir))
-    resolver = ToolspoolBlobResolver(store)
+    # 真 Computer 实例（自动管理 toolspool_store + blob_resolvers + blob_thresholds）
+    # Real Computer instance (auto-managed toolspool_store + blob_resolvers + blob_thresholds).
+    computer_inst = Computer(name=_SYNC_COMPUTER, blob_cache_root=Path(cache_dir))
 
     # 在进程内铸造句柄 / Mint handle within this process
     payload = b"sync mirror round trip" * 100  # ~2 KiB
-    cid = store.put(payload, "application/octet-stream")
-    handle = encode_toolspool_handle(cid=cid, mime="application/octet-stream")
+    handle = computer_inst.mint_toolspool_handle(
+        payload=payload, mime="application/octet-stream",
+    )
     expected_sha = hashlib.sha256(payload).hexdigest()
     handle_q.put({"handle": handle, "expected_sha": expected_sha, "size": len(payload)})
 
@@ -556,51 +630,9 @@ def _run_sync_computer_process(
 
     @computer.on(GET_BLOB_EVENT, namespace=SMCP_NAMESPACE)
     def _on_get_blob(data: dict) -> dict:
-        try:
-            kind, raw_payload = decode_blob_handle(data["blob_handle"])
-        except BlobHandleInvalidError:
-            return {
-                "code": int(ErrorCode.BLOB_NOT_ACCESSIBLE),
-                "message": "Blob not accessible",
-                "details": {"reason": "invalid_handle"},
-            }
-        if kind != "toolspool":
-            return {
-                "code": int(ErrorCode.BLOB_NOT_ACCESSIBLE),
-                "message": "Blob not accessible",
-                "details": {"reason": "invalid_handle"},
-            }
-        try:
-            resolved = resolver.resolve(raw_payload)
-        except BlobHandleError as e:
-            return {
-                "code": int(ErrorCode.BLOB_NOT_ACCESSIBLE),
-                "message": "Blob not accessible",
-                "details": {"reason": getattr(e, "reason", "forbidden")},
-            }
-        offset = int(data.get("chunk_offset", 0))
-        max_chunk = int(data.get("max_chunk_bytes") or 64 * 1024)
-        if offset < 0 or offset > resolved.total_size:
-            return {
-                "code": int(ErrorCode.BLOB_NOT_ACCESSIBLE),
-                "message": "Blob not accessible",
-                "details": {"reason": "range"},
-            }
-        # v0.2.1 #51: 走 lazy slice 接口（与 production on_get_blob 同款），避免 .payload shim 触发全量读
-        # Use lazy slice (mirrors production on_get_blob), preventing .payload shim from forcing full-read.
-        remaining = resolved.total_size - offset
-        slice_len = min(max_chunk, remaining)
-        chunk = resolved.slice(offset, slice_len)
-        ret: GetBlobRet = {
-            "blob_handle": data["blob_handle"],
-            "mime_type": resolved.mime,
-            "total_size": resolved.total_size,
-            "sha256": resolved.sha256,
-            "chunk_offset": offset,
-            "eof": offset + len(chunk) == resolved.total_size,
-            "blob": base64.b64encode(chunk).decode("ascii"),
-            "req_id": data["req_id"],
-        }
+        # 复用 production 同步核心；不再手写 decode + dispatch + slice 逻辑
+        # Reuse production sync core; no more duplicated decode/dispatch/slice logic.
+        ret = _process_get_blob(data, computer_inst)
         return dict(ret)
 
     try:

--- a/tests/integration_tests/test_blob_transfer.py
+++ b/tests/integration_tests/test_blob_transfer.py
@@ -586,15 +586,18 @@ def _run_sync_computer_process(
                 "message": "Blob not accessible",
                 "details": {"reason": "range"},
             }
-        end = min(offset + max_chunk, resolved.total_size)
-        chunk = resolved.payload[offset:end]
+        # v0.2.1 #51: 走 lazy slice 接口（与 production on_get_blob 同款），避免 .payload shim 触发全量读
+        # Use lazy slice (mirrors production on_get_blob), preventing .payload shim from forcing full-read.
+        remaining = resolved.total_size - offset
+        slice_len = min(max_chunk, remaining)
+        chunk = resolved.slice(offset, slice_len)
         ret: GetBlobRet = {
             "blob_handle": data["blob_handle"],
             "mime_type": resolved.mime,
             "total_size": resolved.total_size,
             "sha256": resolved.sha256,
             "chunk_offset": offset,
-            "eof": end == resolved.total_size,
+            "eof": offset + len(chunk) == resolved.total_size,
             "blob": base64.b64encode(chunk).decode("ascii"),
             "req_id": data["req_id"],
         }

--- a/tests/unit_tests/computer/blob/test_resolver.py
+++ b/tests/unit_tests/computer/blob/test_resolver.py
@@ -34,7 +34,9 @@ class TestToolspoolBlobResolver:
         resolver = ToolspoolBlobResolver(store)
         resolved = resolver.resolve({"cid": cid, "mime": "text/plain"})
         assert isinstance(resolved, ResolvedBlob)
-        assert resolved.payload == b"hello world"
+        # v0.2.1 #51: 走 lazy slice 接口断言（.payload shim 保留但 deprecated）
+        # Assert via lazy slice (the .payload shim is retained but deprecated).
+        assert resolved.slice(0, resolved.total_size) == b"hello world"
         assert resolved.mime == "text/plain"
         assert resolved.total_size == 11
         assert resolved.sha256 == hashlib.sha256(b"hello world").hexdigest()
@@ -88,3 +90,109 @@ class TestSkillBlobResolverPending:
     def test_protocol_runtime_checkable(self) -> None:
         resolver = SkillBlobResolverPending()
         assert isinstance(resolver, BlobResolver)
+
+
+class TestResolvedBlobLazySlice:
+    """``ResolvedBlob.slice()`` 边界契约（v0.2.1 #51）/ Boundary contract for ``slice()``.
+
+    覆盖：中段切片 / EOF probe / 越界 raise / length 自动截断 / 负数防御 / 兼容 shim.
+    """
+
+    @pytest.fixture
+    def resolved(self, tmp_path: Path) -> ResolvedBlob:
+        store = ToolspoolBlobStore(tmp_path)
+        cid = store.put(b"hello world", "text/plain")  # 11 bytes
+        return ToolspoolBlobResolver(store).resolve({"cid": cid, "mime": "text/plain"})
+
+    def test_mid_stream_slice(self, resolved: ResolvedBlob) -> None:
+        assert resolved.slice(2, 4) == b"llo "
+
+    def test_end_aligned_slice_at_eof(self, resolved: ResolvedBlob) -> None:
+        assert resolved.slice(5, 6) == b" world"
+
+    def test_offset_at_total_size_returns_empty(self, resolved: ResolvedBlob) -> None:
+        """EOF probe semantics: offset == total_size returns b"" (NOT a range error)."""
+        assert resolved.slice(11, 100) == b""
+
+    def test_offset_beyond_total_size_raises(self, resolved: ResolvedBlob) -> None:
+        with pytest.raises(ValueError, match="> total_size"):
+            resolved.slice(12, 1)
+
+    def test_length_zero_returns_empty(self, resolved: ResolvedBlob) -> None:
+        assert resolved.slice(3, 0) == b""
+
+    def test_length_over_remaining_auto_truncates(self, resolved: ResolvedBlob) -> None:
+        """length 超出剩余字节自动截断（不 raise）/ length over remaining auto-truncates."""
+        assert resolved.slice(8, 999) == b"rld"
+
+    def test_negative_offset_raises(self, resolved: ResolvedBlob) -> None:
+        with pytest.raises(ValueError, match="non-negative"):
+            resolved.slice(-1, 5)
+
+    def test_negative_length_raises(self, resolved: ResolvedBlob) -> None:
+        with pytest.raises(ValueError, match="non-negative"):
+            resolved.slice(0, -1)
+
+    def test_payload_shim_returns_full_bytes(self, resolved: ResolvedBlob) -> None:
+        """向后兼容 shim：.payload 等价 slice(0, total_size).
+        Back-compat shim: .payload equivalent to slice(0, total_size)."""
+        assert resolved.payload == b"hello world"
+
+
+class TestLazyMemoryFootprint:
+    """惰性切片不变量（v0.2.1 #51）：resolve() 不打开 blob body 文件.
+    Lazy invariant: ``resolve()`` reads metadata only; never opens the blob body file."""
+
+    def test_resolve_does_not_open_blob_body(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """resolve() 仅读 stat + mime sidecar；不打开 blob body 文件。
+        ``Path.read_text`` / ``Path.stat`` 走 ``os.open``，监控 ``builtins.open`` 不受干扰。
+        """
+        store = ToolspoolBlobStore(tmp_path)
+        big_payload = b"x" * (4 * 1024 * 1024)  # 4 MiB
+        cid = store.put(big_payload, "application/octet-stream")
+        resolver = ToolspoolBlobResolver(store)
+
+        real_open = open
+        opened_blob_paths: list[str] = []
+
+        def tracking_open(file, *args, **kwargs):  # type: ignore[no-untyped-def]
+            path_str = str(file)
+            # 仅记录 blob body（以 cid 结尾、非 .mime sidecar）
+            if path_str.endswith(cid) and not path_str.endswith(".mime"):
+                opened_blob_paths.append(path_str)
+            return real_open(file, *args, **kwargs)
+
+        monkeypatch.setattr("builtins.open", tracking_open)
+
+        # resolve() 只应读 stat + mime sidecar，不打开 blob body
+        resolved = resolver.resolve({"cid": cid, "mime": "application/octet-stream"})
+        assert opened_blob_paths == [], f"resolve() opened blob body unexpectedly: {opened_blob_paths}"
+
+        # slice() 必须打开 blob body（独立 fd）
+        chunk = resolved.slice(0, 1024)
+        assert len(opened_blob_paths) == 1, "slice() should open exactly once"
+        assert chunk == big_payload[:1024]
+
+    def test_multiple_slices_independent_fds(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """多次 slice 各自独立 open；每次 read 完即关闭.
+        Each slice() invocation opens an independent fd; closed via ``with``."""
+        store = ToolspoolBlobStore(tmp_path)
+        cid = store.put(b"abcdefghij" * 1024, "text/plain")  # 10 KiB
+        resolver = ToolspoolBlobResolver(store)
+
+        real_open = open
+        open_count = 0
+
+        def counting_open(file, *args, **kwargs):  # type: ignore[no-untyped-def]
+            nonlocal open_count
+            path_str = str(file)
+            if path_str.endswith(cid) and not path_str.endswith(".mime"):
+                open_count += 1
+            return real_open(file, *args, **kwargs)
+
+        monkeypatch.setattr("builtins.open", counting_open)
+        resolved = resolver.resolve({"cid": cid, "mime": "text/plain"})
+        resolved.slice(0, 1024)
+        resolved.slice(1024, 1024)
+        resolved.slice(8192, 2048)
+        assert open_count == 3

--- a/tests/unit_tests/computer/blob/test_toolspool.py
+++ b/tests/unit_tests/computer/blob/test_toolspool.py
@@ -186,3 +186,105 @@ class TestMimeValidation:
         store = ToolspoolBlobStore(tmp_path)
         with pytest.raises(ValueError, match="mime"):
             store.put(b"x", "image/png;charset=中文")
+
+
+class TestStatAndReadChunk:
+    """``ToolspoolBlobStore.stat()`` + ``read_chunk()`` 惰性原语（v0.2.1 #51）.
+    Lazy primitive tests for ``stat()`` + ``read_chunk()`` (v0.2.1 #51)."""
+
+    def test_stat_returns_size_and_mime_without_reading_payload(self, tmp_path: Path) -> None:
+        """stat 只读 metadata，不读 payload bytes / stat reads metadata only."""
+        store = ToolspoolBlobStore(tmp_path)
+        payload = b"y" * (256 * 1024)
+        cid = store.put(payload, "application/octet-stream")
+        info = store.stat(cid)
+        assert info.size == 256 * 1024
+        assert info.mime == "application/octet-stream"
+
+    def test_read_chunk_mid_stream(self, tmp_path: Path) -> None:
+        store = ToolspoolBlobStore(tmp_path)
+        payload = bytes(range(256)) * 4  # 1024 bytes, deterministic
+        cid = store.put(payload, "application/octet-stream")
+        chunk = store.read_chunk(cid, 100, 200)
+        assert chunk == payload[100:300]
+
+    def test_read_chunk_end_aligned(self, tmp_path: Path) -> None:
+        store = ToolspoolBlobStore(tmp_path)
+        payload = b"a" * 1024
+        cid = store.put(payload, "text/plain")
+        chunk = store.read_chunk(cid, 1024 - 100, 100)
+        assert chunk == payload[-100:]
+
+    def test_read_chunk_past_eof_returns_empty(self, tmp_path: Path) -> None:
+        """``offset >= total_size`` → ``b""`` (mirrors Python file.read past EOF)."""
+        store = ToolspoolBlobStore(tmp_path)
+        payload = b"abc"
+        cid = store.put(payload, "text/plain")
+        assert store.read_chunk(cid, 3, 100) == b""
+        assert store.read_chunk(cid, 10, 100) == b""
+
+    def test_read_chunk_length_over_remaining_short_read(self, tmp_path: Path) -> None:
+        """``length > remaining`` → OS 自然短读（不 raise）."""
+        store = ToolspoolBlobStore(tmp_path)
+        payload = b"abcdef"  # 6 bytes
+        cid = store.put(payload, "text/plain")
+        assert store.read_chunk(cid, 3, 999) == b"def"
+
+    def test_read_chunk_length_zero_no_io(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """``length == 0`` → ``b""`` 无 I/O 触发 / no I/O when length is 0."""
+        store = ToolspoolBlobStore(tmp_path)
+        cid = store.put(b"hello", "text/plain")
+
+        def fail_open(*args, **kwargs):  # type: ignore[no-untyped-def]
+            pytest.fail("read_chunk(length=0) must not invoke open()")
+
+        monkeypatch.setattr("builtins.open", fail_open)
+        assert store.read_chunk(cid, 0, 0) == b""
+
+    def test_read_chunk_invalid_cid_raises(self, tmp_path: Path) -> None:
+        store = ToolspoolBlobStore(tmp_path)
+        for forged in ("..", "../../etc/passwd", "not-hex" * 9, ""):
+            with pytest.raises(BlobHandleInvalidError):
+                store.read_chunk(forged, 0, 100)
+
+    def test_read_chunk_gone_cid_raises(self, tmp_path: Path) -> None:
+        store = ToolspoolBlobStore(tmp_path)
+        missing = "a" * 64  # valid hex, no file
+        with pytest.raises(BlobHandleGoneError):
+            store.read_chunk(missing, 0, 100)
+
+    def test_read_chunk_negative_offset_raises(self, tmp_path: Path) -> None:
+        store = ToolspoolBlobStore(tmp_path)
+        cid = store.put(b"hello", "text/plain")
+        with pytest.raises(ValueError, match="non-negative"):
+            store.read_chunk(cid, -1, 5)
+
+    def test_stat_invalid_cid_raises(self, tmp_path: Path) -> None:
+        store = ToolspoolBlobStore(tmp_path)
+        with pytest.raises(BlobHandleInvalidError):
+            store.stat("not-hex")
+
+    def test_stat_gone_cid_raises(self, tmp_path: Path) -> None:
+        store = ToolspoolBlobStore(tmp_path)
+        missing = "b" * 64
+        with pytest.raises(BlobHandleGoneError):
+            store.stat(missing)
+
+    def test_concurrent_read_chunks_independent(self, tmp_path: Path) -> None:
+        """并发 read_chunk 各自独立 fd，结果可靠拼接为原文.
+        Concurrent read_chunk calls use independent fds; results reassemble to original."""
+        store = ToolspoolBlobStore(tmp_path)
+        payload = b"abcdefghij" * 1024  # 10 KiB, deterministic
+        cid = store.put(payload, "text/plain")
+        chunks_per_offset: dict[int, bytes] = {}
+
+        def fetch(offset: int) -> tuple[int, bytes]:
+            return offset, store.read_chunk(cid, offset, 1024)
+
+        with ThreadPoolExecutor(max_workers=10) as pool:
+            offsets = list(range(0, len(payload), 1024))
+            for offset, chunk in pool.map(fetch, offsets):
+                chunks_per_offset[offset] = chunk
+
+        reassembled = b"".join(chunks_per_offset[off] for off in sorted(chunks_per_offset))
+        assert reassembled == payload


### PR DESCRIPTION
## Summary

v0.2.1 milestone (#42) 跨 PR 跟进项 #51 落地——把 `ToolspoolBlobResolver` 从 **一次性全文件读** 改造为 **lazy slice 视图**。每次 `client:get_blob` 内存峰值与 `total_size` 解耦，固定为单 chunk 大小（约 256 KiB），高并发拉取大 blob 不再 OOM 风险。

Closes #51 · 父追踪 #42 · base `develop-v0.2.1`

> **协议归属判定**：零协议影响。`ResolvedBlob.payload` 是 SDK 内部 API；`BlobResolver` Protocol 签名不变；`GetBlobReq` / `GetBlobRet` wire shape 不变；`PROTOCOL_VERSION` 保持 `0.2.0`。与 [a2c-smcp-protocol v0.2.2 doc patch](https://github.com/A2C-SMCP/a2c-smcp-protocol/pull/3) 完全正交。

## 架构变更

### `ResolvedBlob` 重构（`a2c_smcp/computer/blob/resolver.py`）

从 frozen dataclass 持有全字节 `payload: bytes`，改为持有 slicer 闭包：

```python
@dataclass(frozen=True, eq=False)
class ResolvedBlob:
    mime: str
    total_size: int
    sha256: str
    _slicer: _BlobSlicer = field(repr=False)  # closure: (offset, length) -> bytes

    def slice(self, offset: int, length: int) -> bytes: ...
    @property
    def payload(self) -> bytes: ...  # deprecated shim; v0.3 移除
```

**边界语义**（与 `on_get_blob` 严格 `>` 范围守卫一致）：
- `slice(offset == total_size, n)` → `b""`（HTTP Range probe semantics）
- `slice(offset > total_size, n)` → `ValueError`
- `slice(_, 0)` → `b""`（无 I/O）
- `slice(_, n > remaining)` → 自动截断
- 负数 offset/length → `ValueError`

### `ToolspoolBlobStore` 新增惰性原语（`a2c_smcp/computer/blob/toolspool.py`）

- `BlobStat(size, mime)` frozen dataclass — 元数据封装
- `stat(cid) -> BlobStat` — 仅读 metadata，**不读 payload 字节**
- `read_chunk(cid, offset, length) -> bytes` — seek+read，每次独立 fd

现有 `get()` 保留（test_toolspool.py 6 处依赖；resolver 不再使用）。

### `on_get_blob` 切片迁移（`a2c_smcp/computer/socketio/client.py:614`）

```python
# 旧：
end = min(chunk_offset + max_chunk_bytes, resolved.total_size)
chunk = resolved.payload[chunk_offset:end]  # ← 全量入内存
eof = end == resolved.total_size

# 新（v0.2.1 #51）：
remaining = resolved.total_size - chunk_offset
slice_len = min(max_chunk_bytes, remaining)
chunk = resolved.slice(chunk_offset, slice_len)  # ← 单 chunk 入内存
eof = chunk_offset + len(chunk) == resolved.total_size  # short-read resilient
```

`eof` 公式保留 `len(chunk)` 形式，与原 `end == total_size` 等价（preserve short-read 健壮性）。

### 集成测试 mock 同款迁移（`tests/integration_tests/test_blob_transfer.py:589`）

sync-mirror mock Computer 一并改用 `.slice()`，否则 `.payload` shim 会触发全量读隐式破坏 lazy 验证。

## 测试覆盖（+23 用例）

### `TestResolvedBlobLazySlice`（9 用例）
- 中段切片 / EOF probe / 越界 raise / length=0 / length 自动截断 / 负数防御 / 兼容 shim

### `TestLazyMemoryFootprint`（2 用例 — **关键不变量**）

用 `monkeypatch.setattr("builtins.open", ...)` 验证：
- `resolve()` 一个 4 MiB blob → **不打开 blob body 文件**（仅 stat + mime sidecar 走 `os.open`，不经 `builtins.open`）
- 多次 `slice()` → 各自独立 fd，每次 `with open()` close

### `TestStatAndReadChunk`（11 用例）
- `stat` 返回 size+mime / `read_chunk` 中段 / 末段 / 越 EOF / 长度短读 / length=0 无 I/O / invalid cid / gone cid / 负数 / 并发独立 fd 拼接

### 迁移
- `test_resolve_round_trip`：1 行从 `.payload` 改为 `.slice(0, total_size)`，让现有断言走 lazy 路径
- 集成测试 mock：迁移到 `.slice()`

## 数据

- **918 passed** / 2 skipped / 4 xfailed / **0 failed** / **0 regression**（v.s. PR #49 baseline 895 → +23）
- `uv run poe lint` 净（ruff + mypy strict）
- `PROTOCOL_VERSION` 保持 `0.2.0`
- **+402 / -35** 行（6 文件）

## 内存优化效果

并发 `concurrency=N` 拉 N MiB 文件：

| 文件 | 并发 | v0.2.1 PR #49 之前 | **本 PR** |
|---|---|---|---|
| 10 MiB | 4 | 40 MiB | **~1 MiB**（4 × 256 KiB） |
| 100 MiB | 4 | 400 MiB | **~1 MiB** |
| 100 MiB | 16 | ~OOM | **~4 MiB** |

`resolve()` 现在是 O(1) 内存（仅 metadata + closure）；峰值仅由 chunk 大小决定。

## 协议关系

- `data-structures.md` §`GetBlobReq` / §`GetBlobRet`（wire shape，**不变**）
- `blob-transfer.md` §5.4（句柄不可信任 — `read_chunk` 重施 cid 白名单 + realpath 围栏，契约不变）
- `error-handling.md` §4018 `gone` / `invalid_handle`（`stat` / `read_chunk` 均抛对应错误）
- 本 PR **未触及任何 wire 行为**

## v0.2.1 Milestone 进度

| Issue | 状态 |
|---|---|
| #37 协议镜像 | ✅ PR #43 |
| #38 通用二进制传输 | ✅ PR #44 |
| #41 Server 路由 + 广播 | ✅ PR #45 |
| #40 Agent 消费 + tool_call 二进制 | ✅ PR #47 |
| #48 Agent on_skills_received | ✅ PR #49 |
| **#51 Toolspool lazy slice** | 🟢 **本 PR** |
| #39 Computer SKILL 子系统 | 🟡 主线最后一块 |
| #46 Server 路由统一 + None 防御 | ⏳ 等 protocol v0.2.2 release |
| #50 A2CSkillRef Required[] | ⏳ 并入 v0.2.2 doc patch |

## Test plan

- [x] `uv run pytest tests/unit_tests/computer/blob/ -v` → 69 passed（含 +23 新用例）
- [x] `uv run pytest tests/integration_tests/test_blob_transfer.py -v` → 15 passed（含 10 MiB 并发 roundtrip）
- [x] `uv run poe test` → 918 passed / 0 failed / 0 regression
- [x] `uv run poe lint` → ruff + mypy strict 净
- [x] `PROTOCOL_VERSION` 未改动确认

## Review notes

- **关键观察点**：`TestLazyMemoryFootprint::test_resolve_does_not_open_blob_body` —— 这是 lazy 不变量的核心保证，未来若有人不慎让 `resolve()` 触发 `read_bytes()` 此测试会立即红
- `.payload` shim 文档明确 `@deprecated 0.2.1` + `Removed in v0.3` —— 防止后续在生产代码隐式回退
- mock Computer 也强制走 `.slice()`，与生产 `on_get_blob` 同源契约，防"集成测试假阳性"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
