### PR TITLE
feat(computer): v0.2.1 SkillRegistry name→A2CSkillRef + 孤儿标记/恢复 (#57)

### DIFF
--- a/a2c_smcp/computer/skills/__init__.py
+++ b/a2c_smcp/computer/skills/__init__.py
@@ -8,14 +8,14 @@
 Computer SKILL 子系统 / Computer SKILL subsystem（v0.2.1）
 
 对标 Claude Code marketplace 的本地 SKILL 管理：SKILL Home / 命名 lexer / Registry / 三源
-staging / 意图层 reconciler / 沙箱。本提交（S1，#54）落地基础两模块：
-Mirrors Claude Code marketplace local SKILL management. This change (S1, #54) lands the two
-foundational modules:
+staging / 意图层 reconciler / 沙箱。已落地模块：
+Mirrors Claude Code marketplace local SKILL management. Landed modules:
 
-- :mod:`a2c_smcp.computer.skills.home`   —— SKILL Home 解析 + `0o700` 防御性写（隔离交 OS，对齐 CC）+ 安装目录布局
-- :mod:`a2c_smcp.computer.skills.naming` —— name 合成 + 段数消歧 lexer + MCP server 段规范化
+- :mod:`a2c_smcp.computer.skills.home`     —— SKILL Home 解析 + `0o700` 防御性写（隔离交 OS，对齐 CC）+ 安装目录布局（S1，#54）
+- :mod:`a2c_smcp.computer.skills.naming`   —— name 合成 + 段数消歧 lexer + MCP server 段规范化（S1，#54）
+- :mod:`a2c_smcp.computer.skills.registry` —— `name → A2CSkillRef` O(1) 物化索引 + 孤儿标记/恢复（S3，#57）
 
-协议依据 / Protocol: a2c-smcp-protocol docs/specification/skill.md §1 / §4 / §9.2。
+协议依据 / Protocol: a2c-smcp-protocol docs/specification/skill.md §1 / §4 / §6 / §8 / §9.2。
 """
 
 from __future__ import annotations
@@ -44,6 +44,7 @@ from a2c_smcp.computer.skills.naming import (
     synthesize_mcp_name,
     synthesize_user_name,
 )
+from a2c_smcp.computer.skills.registry import SkillRegistry
 
 __all__ = [
     # home
@@ -68,4 +69,6 @@ __all__ = [
     "synthesize_marketplace_name",
     "synthesize_mcp_name",
     "synthesize_user_name",
+    # registry
+    "SkillRegistry",
 ]

--- a/a2c_smcp/computer/skills/registry.py
+++ b/a2c_smcp/computer/skills/registry.py
@@ -16,12 +16,17 @@ SDK 设计 / Design: python-sdk docs/design-0.2.1-skill-computer-management.md �
 - **`name → A2CSkillRef` O(1) 精确匹配**：Registry 是 name→包根路径的**唯一**映射来源（§9.2
   「name 寻址防越权」——禁止从 name 推导 FS 路径；包根仅由本 Registry 经 name 解析）。
   The single source of truth for name→package-root resolution (no FS-path derivation from name).
-- **孤儿标记 / 恢复**：source 消失时把对应 SKILL 标为 orphan（从 `get_skills` 排除，但保留以便
-  source 回归时恢复）；orphan 对 `get_skill` / `get_blob` 等同「不存在」（协议复用 `4014` / `4018`）。
-  Orphan marking/recovery: source-gone SKILLs are excluded from `get_skills` yet retained for recovery.
-- **校验失败不入册**：name 非法（lexer）/ 缺包根绝对路径 / 同名 active 冲突 → 记 ERROR、**不**注册、
+- **生命周期三动作**（§8 变更检测）/ Three lifecycle ops：
+    - :meth:`register` —— **新增**（含 source 回归时的孤儿恢复）；同名 **active** 冲突按 §1.5 拒绝。
+    - :meth:`update`   —— **刷新**已注册 SKILL 的 ref（§8.2 ResourceUpdated：description/version/sha256
+      等 frontmatter 派生值变化），原地替换；name 未注册 → 拒绝（新增走 register）。
+    - :meth:`mark_orphan` / :meth:`recover` —— source 消失/回归时切换孤儿态（从 `get_skills` 排除/纳入）。
+- **校验失败不入册**：name 非法（lexer）/ 缺包根绝对路径 / 同名 active 冲突 → 记 ERROR、**不**写入、
   **绝不**抛出（§1.5：SKILL 通道 batch 接口对部分失败健壮）。
   Validation failures are logged ERROR and skipped — never raised.
+- **读取返回深拷贝**：:meth:`resolve` / :meth:`active_refs` 返回 ref 的 **deepcopy**，调用方（响应构造、
+  frontmatter 剥离等）可安全就地改写而不污染 Registry 内部状态（A2CSkillRef 运行时为可变 dict）。
+  Reads return deep copies so callers may mutate freely without aliasing Registry state.
 
 线程模型 / Threading：Computer 单进程 asyncio 单线程驱动（事件处理器串行），故本 Registry 不加锁。
 Single-threaded asyncio within one Computer process — no locking.
@@ -29,6 +34,7 @@ Single-threaded asyncio within one Computer process — no locking.
 
 from __future__ import annotations
 
+import copy
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -51,42 +57,51 @@ class SkillRegistry:
     """
     name → A2CSkillRef 的内存物化索引 / In-memory materialized index of name → A2CSkillRef。
 
-    由 staging 在物化后调用 :meth:`register` 入册；变更检测（§8）经 :meth:`mark_orphan` /
-    :meth:`recover` / :meth:`unregister` 维护活跃集；`client:get_skills` 取 :meth:`active_refs`，
-    `client:get_skill` / `client:get_blob` 经 :meth:`resolve` 拿包根（orphan 视为不存在）。
+    由 staging 在物化后调用 :meth:`register` 入册、:meth:`update` 刷新；变更检测（§8）经
+    :meth:`mark_orphan` / :meth:`recover` / :meth:`unregister` 维护活跃集；`client:get_skills`
+    取 :meth:`active_refs`，`client:get_skill` / `client:get_blob` 经 :meth:`resolve` 拿包根
+    （orphan 视为不存在）。
     """
 
     def __init__(self) -> None:
         self._entries: dict[str, _RegistryEntry] = {}
 
-    # ── 写入 / mutation ───────────────────────────────────────────────────
-    def register(self, ref: A2CSkillRef) -> bool:
+    def _validated_name(self, ref: A2CSkillRef, *, op: str) -> str | None:
         """
-        入册一个物化 SKILL / Register a materialized SKILL。
+        共享入参校验 / Shared input validation：name 非空 + §1 lexer 合法 + path 必选且绝对。
 
-        校验（任一失败 → 记 ERROR、返回 ``False``、**不**抛）/ Validation (any failure → ERROR + False):
-        1. ``name`` 经 §1 lexer（:func:`parse_skill_name`）；
-        2. ``path`` 必选且为**绝对**路径（name 寻址唯一来源 / S2 沙箱包根）；
-        3. 同名**活跃**条目已存在 → §1.5「拒绝第二注册者、保留先到者」。
-
-        同名**孤儿**条目存在 → 视为 source 回归：用新 ref 替换并清除 orphan 标记（恢复），返回 ``True``。
-
-        :return: 是否成功入册 / whether registered (or recovered).
+        任一失败 → 记 ERROR、返回 ``None``（调用方据此 no-op，**不**抛）。
         """
         name = ref.get("name")
         if not name:
-            logger.error("SkillRegistry.register skipped: missing 'name' in ref=%r", ref)
-            return False
-
+            logger.error("SkillRegistry.%s skipped: missing 'name' in ref=%r", op, ref)
+            return None
         path = ref.get("path")
         if not path or not Path(path).is_absolute():
-            logger.error("SkillRegistry.register skipped name=%r: 'path' missing or not absolute (got %r)", name, path)
-            return False
-
+            logger.error("SkillRegistry.%s skipped name=%r: 'path' missing or not absolute (got %r)", op, name, path)
+            return None
         try:
             parse_skill_name(name)
         except SkillNameError as e:
-            logger.error("SkillRegistry.register skipped: invalid name %r (%s)", name, e.reason)
+            logger.error("SkillRegistry.%s skipped: invalid name %r (%s)", op, name, e.reason)
+            return None
+        return name
+
+    # ── 写入 / mutation ───────────────────────────────────────────────────
+    def register(self, ref: A2CSkillRef) -> bool:
+        """
+        **新增**一个物化 SKILL / Register a newly materialized SKILL。
+
+        校验（任一失败 → ERROR + ``False`` + no-op）见 :meth:`_validated_name`。校验通过后：
+        - 同名条目不存在 → 写入活跃条目；
+        - 同名 **active** 条目存在 → §1.5「拒绝第二注册者、保留先到者」→ ERROR + ``False``；
+        - 同名 **orphan** 条目存在 → 视为 source 回归：用新 ref 替换并清除 orphan（恢复）→ ``True``。
+
+        **活跃 SKILL 的内容刷新**（§8.2 ResourceUpdated）请用 :meth:`update`，**不要**用 register
+        （否则命中 active 冲突分支被静默拒绝、保留旧 ref）。
+        """
+        name = self._validated_name(ref, op="register")
+        if name is None:
             return False
 
         existing = self._entries.get(name)
@@ -95,7 +110,24 @@ class SkillRegistry:
             return False
 
         if existing is not None:  # 孤儿恢复 / orphan recovery
-            logger.debug("SkillRegistry recovered orphaned skill name=%r", name)
+            logger.debug("SkillRegistry recovered orphaned skill via register name=%r", name)
+        self._entries[name] = _RegistryEntry(ref=ref, orphaned=False)
+        return True
+
+    def update(self, ref: A2CSkillRef) -> bool:
+        """
+        **刷新**已注册 SKILL 的 ref / Refresh the ref of an already-registered SKILL（§8.2 ResourceUpdated）。
+
+        原地替换同名条目的 ref（active 或 orphan 皆可，替换后置为**活跃**——ResourceUpdated 蕴含该
+        SKILL 当前存在）。name **未注册** → ERROR + ``False``（更新不创建新条目；新增走 :meth:`register`）。
+        校验同 :meth:`register`（失败 → ERROR + ``False``，**不**改动既有条目）。
+        """
+        name = self._validated_name(ref, op="update")
+        if name is None:
+            return False
+        if name not in self._entries:
+            logger.error("SkillRegistry.update skipped: name %r not registered (use register for new skills)", name)
+            return False
         self._entries[name] = _RegistryEntry(ref=ref, orphaned=False)
         return True
 
@@ -122,21 +154,27 @@ class SkillRegistry:
         """彻底移除一个 SKILL（孤儿与活跃皆可）/ Remove a SKILL entirely (active or orphaned)."""
         return self._entries.pop(name, None) is not None
 
-    # ── 读取 / lookup ─────────────────────────────────────────────────────
+    # ── 读取 / lookup（返回深拷贝，调用方可安全改写）──────────────────────
     def resolve(self, name: str) -> A2CSkillRef | None:
         """
         O(1) 活跃精确匹配 / O(1) active exact lookup。
 
-        仅返回**活跃**（非孤儿）条目的 ref；name 未注册或已孤儿 → ``None``（调用方据此回 `4014` /
-        `4018`）。这是 name→包根的唯一解析入口（§9.2）。
-        Returns the ref only for an active (non-orphan) entry; ``None`` otherwise.
+        仅返回**活跃**（非孤儿）条目 ref 的**深拷贝**；name 未注册或已孤儿 → ``None``（调用方据此回
+        `4014` / `4018`）。这是 name→包根的唯一解析入口（§9.2）。返回深拷贝，调用方就地改写不影响 Registry。
+        Returns a deep copy of the ref for an active (non-orphan) entry; ``None`` otherwise.
         """
         entry = self._entries.get(name)
-        return entry.ref if entry is not None and not entry.orphaned else None
+        if entry is None or entry.orphaned:
+            return None
+        return copy.deepcopy(entry.ref)
 
     def active_refs(self) -> list[A2CSkillRef]:
-        """活跃 SKILL 的 ref 列表（排除孤儿）/ Active SKILL refs（`client:get_skills`；不排序、不去重）。"""
-        return [entry.ref for entry in self._entries.values() if not entry.orphaned]
+        """
+        活跃 SKILL 的 ref 深拷贝列表（排除孤儿）/ Deep-copied active SKILL refs。
+
+        供 `client:get_skills`（不排序、不去重）；逐个深拷贝，调用方构造响应/剥字段不污染 Registry。
+        """
+        return [copy.deepcopy(entry.ref) for entry in self._entries.values() if not entry.orphaned]
 
     def is_orphan(self, name: str) -> bool:
         """name 是否为已注册的孤儿条目 / Whether name is a registered-but-orphaned entry。"""

--- a/a2c_smcp/computer/skills/registry.py
+++ b/a2c_smcp/computer/skills/registry.py
@@ -1,0 +1,152 @@
+# -*- coding: utf-8 -*-
+# filename: registry.py
+# @Time    : 2026/05/24
+# @Author  : JQQ
+# @Email   : jqq1716@gmail.com
+# @Software: PyCharm
+"""
+Skill Registry：name → A2CSkillRef 物化索引（v0.2.1）
+Skill Registry: name → A2CSkillRef materialized index (v0.2.1)
+
+协议依据 / Protocol: a2c-smcp-protocol docs/specification/skill.md §1.5（校验失败不入册）、
+                      §6（A2CSkillRef）、§8（变更检测 / 孤儿）、§9.2（name 寻址防越权）。
+SDK 设计 / Design: python-sdk docs/design-0.2.1-skill-computer-management.md §5（registry）。
+
+职责 / Responsibilities：
+- **`name → A2CSkillRef` O(1) 精确匹配**：Registry 是 name→包根路径的**唯一**映射来源（§9.2
+  「name 寻址防越权」——禁止从 name 推导 FS 路径；包根仅由本 Registry 经 name 解析）。
+  The single source of truth for name→package-root resolution (no FS-path derivation from name).
+- **孤儿标记 / 恢复**：source 消失时把对应 SKILL 标为 orphan（从 `get_skills` 排除，但保留以便
+  source 回归时恢复）；orphan 对 `get_skill` / `get_blob` 等同「不存在」（协议复用 `4014` / `4018`）。
+  Orphan marking/recovery: source-gone SKILLs are excluded from `get_skills` yet retained for recovery.
+- **校验失败不入册**：name 非法（lexer）/ 缺包根绝对路径 / 同名 active 冲突 → 记 ERROR、**不**注册、
+  **绝不**抛出（§1.5：SKILL 通道 batch 接口对部分失败健壮）。
+  Validation failures are logged ERROR and skipped — never raised.
+
+线程模型 / Threading：Computer 单进程 asyncio 单线程驱动（事件处理器串行），故本 Registry 不加锁。
+Single-threaded asyncio within one Computer process — no locking.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from a2c_smcp.computer.skills.naming import SkillNameError, parse_skill_name
+from a2c_smcp.smcp import A2CSkillRef
+from a2c_smcp.utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+@dataclass(slots=True)
+class _RegistryEntry:
+    """Registry 内部条目 / Internal registry entry：物化 ref + 孤儿标记。"""
+
+    ref: A2CSkillRef
+    orphaned: bool = False
+
+
+class SkillRegistry:
+    """
+    name → A2CSkillRef 的内存物化索引 / In-memory materialized index of name → A2CSkillRef。
+
+    由 staging 在物化后调用 :meth:`register` 入册；变更检测（§8）经 :meth:`mark_orphan` /
+    :meth:`recover` / :meth:`unregister` 维护活跃集；`client:get_skills` 取 :meth:`active_refs`，
+    `client:get_skill` / `client:get_blob` 经 :meth:`resolve` 拿包根（orphan 视为不存在）。
+    """
+
+    def __init__(self) -> None:
+        self._entries: dict[str, _RegistryEntry] = {}
+
+    # ── 写入 / mutation ───────────────────────────────────────────────────
+    def register(self, ref: A2CSkillRef) -> bool:
+        """
+        入册一个物化 SKILL / Register a materialized SKILL。
+
+        校验（任一失败 → 记 ERROR、返回 ``False``、**不**抛）/ Validation (any failure → ERROR + False):
+        1. ``name`` 经 §1 lexer（:func:`parse_skill_name`）；
+        2. ``path`` 必选且为**绝对**路径（name 寻址唯一来源 / S2 沙箱包根）；
+        3. 同名**活跃**条目已存在 → §1.5「拒绝第二注册者、保留先到者」。
+
+        同名**孤儿**条目存在 → 视为 source 回归：用新 ref 替换并清除 orphan 标记（恢复），返回 ``True``。
+
+        :return: 是否成功入册 / whether registered (or recovered).
+        """
+        name = ref.get("name")
+        if not name:
+            logger.error("SkillRegistry.register skipped: missing 'name' in ref=%r", ref)
+            return False
+
+        path = ref.get("path")
+        if not path or not Path(path).is_absolute():
+            logger.error("SkillRegistry.register skipped name=%r: 'path' missing or not absolute (got %r)", name, path)
+            return False
+
+        try:
+            parse_skill_name(name)
+        except SkillNameError as e:
+            logger.error("SkillRegistry.register skipped: invalid name %r (%s)", name, e.reason)
+            return False
+
+        existing = self._entries.get(name)
+        if existing is not None and not existing.orphaned:
+            logger.error("SkillRegistry.register skipped: name %r already registered (keeping first registrant)", name)
+            return False
+
+        if existing is not None:  # 孤儿恢复 / orphan recovery
+            logger.debug("SkillRegistry recovered orphaned skill name=%r", name)
+        self._entries[name] = _RegistryEntry(ref=ref, orphaned=False)
+        return True
+
+    def mark_orphan(self, name: str) -> bool:
+        """把已注册 SKILL 标为孤儿（从活跃集排除，保留以便恢复）/ Mark a registered SKILL orphaned."""
+        entry = self._entries.get(name)
+        if entry is None:
+            return False
+        if not entry.orphaned:
+            entry.orphaned = True
+            logger.debug("SkillRegistry marked orphan name=%r", name)
+        return True
+
+    def recover(self, name: str) -> bool:
+        """恢复孤儿 SKILL（重新纳入活跃集）/ Recover an orphaned SKILL into the active set."""
+        entry = self._entries.get(name)
+        if entry is None or not entry.orphaned:
+            return False
+        entry.orphaned = False
+        logger.debug("SkillRegistry recovered orphan name=%r", name)
+        return True
+
+    def unregister(self, name: str) -> bool:
+        """彻底移除一个 SKILL（孤儿与活跃皆可）/ Remove a SKILL entirely (active or orphaned)."""
+        return self._entries.pop(name, None) is not None
+
+    # ── 读取 / lookup ─────────────────────────────────────────────────────
+    def resolve(self, name: str) -> A2CSkillRef | None:
+        """
+        O(1) 活跃精确匹配 / O(1) active exact lookup。
+
+        仅返回**活跃**（非孤儿）条目的 ref；name 未注册或已孤儿 → ``None``（调用方据此回 `4014` /
+        `4018`）。这是 name→包根的唯一解析入口（§9.2）。
+        Returns the ref only for an active (non-orphan) entry; ``None`` otherwise.
+        """
+        entry = self._entries.get(name)
+        return entry.ref if entry is not None and not entry.orphaned else None
+
+    def active_refs(self) -> list[A2CSkillRef]:
+        """活跃 SKILL 的 ref 列表（排除孤儿）/ Active SKILL refs（`client:get_skills`；不排序、不去重）。"""
+        return [entry.ref for entry in self._entries.values() if not entry.orphaned]
+
+    def is_orphan(self, name: str) -> bool:
+        """name 是否为已注册的孤儿条目 / Whether name is a registered-but-orphaned entry。"""
+        entry = self._entries.get(name)
+        return entry is not None and entry.orphaned
+
+    def __contains__(self, name: object) -> bool:
+        """name 是否已注册（含孤儿）/ Whether name is registered (active or orphaned)。"""
+        return name in self._entries
+
+    def __len__(self) -> int:
+        """已注册条目总数（含孤儿）/ Total registered entries (active + orphaned)。"""
+        return len(self._entries)

--- a/tests/unit_tests/computer/skills/test_registry.py
+++ b/tests/unit_tests/computer/skills/test_registry.py
@@ -163,3 +163,79 @@ def test_unregister() -> None:
     assert reg.resolve("my-helper") is None
     assert len(reg) == 0
     assert reg.unregister("my-helper") is False  # 已不存在
+
+
+# ---------------------------------------------------------------------------
+# 更新（§8.2 ResourceUpdated 刷新活跃条目 ref）
+# ---------------------------------------------------------------------------
+def test_update_active_refreshes_ref() -> None:
+    reg = SkillRegistry()
+    reg.register(_ref("my-helper", path="/abs/v1", description="v1"))
+    refreshed = _ref("my-helper", path="/abs/v2", description="v2")
+    assert reg.update(refreshed) is True
+    assert reg.resolve("my-helper") == refreshed
+    assert len(reg) == 1
+
+
+def test_update_absent_returns_false() -> None:
+    reg = SkillRegistry()
+    assert reg.update(_ref("absent")) is False  # 更新不创建
+    assert "absent" not in reg
+
+
+def test_update_orphan_reactivates() -> None:
+    reg = SkillRegistry()
+    reg.register(_ref("my-helper", path="/abs/old"))
+    reg.mark_orphan("my-helper")
+    new_ref = _ref("my-helper", path="/abs/new")
+    assert reg.update(new_ref) is True  # ResourceUpdated 蕴含该 SKILL 当前存在
+    assert reg.is_orphan("my-helper") is False
+    assert reg.resolve("my-helper") == new_ref
+
+
+def test_update_invalid_does_not_corrupt_existing() -> None:
+    reg = SkillRegistry()
+    good = _ref("my-helper", path="/abs/good")
+    reg.register(good)
+    # 新 ref path 非绝对 → 校验失败 → False，且既有条目不动
+    assert reg.update(_ref("my-helper", path="relative/bad")) is False
+    assert reg.resolve("my-helper") == good
+
+
+# ---------------------------------------------------------------------------
+# 读取深拷贝隔离（调用方就地改写不污染 Registry）
+# ---------------------------------------------------------------------------
+def test_resolve_returns_deepcopy() -> None:
+    reg = SkillRegistry()
+    ref: A2CSkillRef = {
+        "name": "my-helper",
+        "source": "user",
+        "path": "/abs/skills/my-helper",
+        "description": "d",
+        "allowed_tools": ["a", "b"],
+        "skill_metadata": {"k": "v"},
+    }
+    reg.register(ref)
+    got = reg.resolve("my-helper")
+    assert got is not None
+    # 顶层 + 嵌套 list/dict 就地改写
+    got["description"] = "MUTATED"
+    got["allowed_tools"].append("z")
+    got["skill_metadata"]["k"] = "MUTATED"
+    # 再取一份应保持原值（深拷贝隔离）
+    again = reg.resolve("my-helper")
+    assert again is not None
+    assert again["description"] == "d"
+    assert again["allowed_tools"] == ["a", "b"]
+    assert again["skill_metadata"] == {"k": "v"}
+
+
+def test_active_refs_returns_deepcopies() -> None:
+    reg = SkillRegistry()
+    reg.register({"name": "my-helper", "source": "user", "path": "/abs/x", "description": "d", "allowed_tools": ["a"]})
+    out = reg.active_refs()
+    out[0]["description"] = "MUTATED"
+    out[0]["allowed_tools"].append("z")
+    fresh = reg.active_refs()
+    assert fresh[0]["description"] == "d"
+    assert fresh[0]["allowed_tools"] == ["a"]

--- a/tests/unit_tests/computer/skills/test_registry.py
+++ b/tests/unit_tests/computer/skills/test_registry.py
@@ -1,0 +1,165 @@
+# -*- coding: utf-8 -*-
+# filename: test_registry.py
+# @Time    : 2026/05/24
+# @Author  : JQQ
+# @Email   : jqq1716@gmail.com
+# @Software: PyCharm
+"""
+SkillRegistry 单元测试（v0.2.1）/ Unit tests for SkillRegistry (v0.2.1)
+
+协议依据 / Protocol: a2c-smcp-protocol docs/specification/skill.md §1.5 / §6 / §8 / §9.2。
+
+测试意图 / Test intentions:
+- 注册 / O(1) 查找 / active 集合（排除孤儿）
+- 孤儿标记 → 从 active + resolve 排除；恢复 → 重新纳入；同名孤儿再注册 = 恢复并替换
+- 校验失败不入册且**不抛**（仅 ERROR 日志）：非法 name / 缺 path / 相对 path / 同名 active 冲突
+- A2CSkillRef 含包根绝对路径（name 寻址唯一来源）
+"""
+
+import logging
+from collections.abc import Iterator
+
+import pytest
+
+import a2c_smcp.computer.skills.registry as registry_mod
+from a2c_smcp.computer.skills.registry import SkillRegistry
+from a2c_smcp.smcp import A2CSkillRef
+
+
+def _ref(name: str, *, path: str | None = None, source: str = "user", description: str = "d") -> A2CSkillRef:
+    """构造最小可注册 A2CSkillRef / Build a minimal registrable A2CSkillRef。"""
+    ref: A2CSkillRef = {"name": name, "source": source, "description": description}
+    if path is not None:
+        ref["path"] = path
+    elif name is not None:
+        ref["path"] = f"/abs/skills/{name}"
+    return ref
+
+
+@pytest.fixture
+def capture_errors(caplog: pytest.LogCaptureFixture) -> Iterator[pytest.LogCaptureFixture]:
+    """捕获 registry 模块 ERROR（项目 logger 关闭 propagate，直接挂 handler）。"""
+    registry_mod.logger.addHandler(caplog.handler)
+    caplog.set_level(logging.ERROR)
+    try:
+        yield caplog
+    finally:
+        registry_mod.logger.removeHandler(caplog.handler)
+
+
+# ---------------------------------------------------------------------------
+# 注册 / 查找
+# ---------------------------------------------------------------------------
+def test_register_and_resolve() -> None:
+    reg = SkillRegistry()
+    ref = _ref("my-helper")
+    assert reg.register(ref) is True
+    assert reg.resolve("my-helper") == ref
+    assert reg.active_refs() == [ref]
+    assert "my-helper" in reg
+    assert reg.is_orphan("my-helper") is False
+    assert len(reg) == 1
+
+
+def test_resolve_missing_returns_none() -> None:
+    reg = SkillRegistry()
+    assert reg.resolve("absent") is None
+    assert "absent" not in reg
+
+
+def test_multiple_sources_active() -> None:
+    reg = SkillRegistry()
+    assert reg.register(_ref("my-helper", source="user")) is True
+    assert reg.register(_ref("acme-audit:audit", source="marketplace:acme-skills")) is True
+    assert reg.register(_ref("mcp:tfrobot-tools:code-review", source="mcp:tfrobot-tools")) is True
+    assert len(reg.active_refs()) == 3
+    assert len(reg) == 3
+
+
+# ---------------------------------------------------------------------------
+# 校验失败不入册且不抛（仅 ERROR）
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    ("ref", "case"),
+    [
+        (_ref("Bad Name"), "invalid-name-lexer"),
+        ({"name": "no-path", "source": "user", "description": "d"}, "missing-path"),
+        (_ref("rel-path", path="relative/dir"), "relative-path"),
+        ({"source": "user", "path": "/abs/x", "description": "d"}, "missing-name"),
+    ],
+)
+def test_validation_failure_not_registered_and_not_raised(ref: A2CSkillRef, case: str) -> None:
+    reg = SkillRegistry()
+    assert reg.register(ref) is False, case  # 不抛、返回 False
+    assert len(reg) == 0, case  # 不入册
+
+
+def test_validation_failure_logs_error(capture_errors: pytest.LogCaptureFixture) -> None:
+    reg = SkillRegistry()
+    reg.register(_ref("Bad Name"))
+    assert any(r.levelno == logging.ERROR for r in capture_errors.records)
+
+
+def test_duplicate_active_rejected_keeps_first() -> None:
+    reg = SkillRegistry()
+    first = _ref("my-helper", path="/abs/first")
+    second = _ref("my-helper", path="/abs/second")
+    assert reg.register(first) is True
+    assert reg.register(second) is False  # 拒绝第二注册者
+    assert reg.resolve("my-helper") == first  # 保留先到者
+    assert len(reg) == 1
+
+
+# ---------------------------------------------------------------------------
+# 孤儿标记 / 恢复
+# ---------------------------------------------------------------------------
+def test_mark_orphan_excludes_from_active() -> None:
+    reg = SkillRegistry()
+    reg.register(_ref("my-helper"))
+    assert reg.mark_orphan("my-helper") is True
+    assert reg.resolve("my-helper") is None  # 对 get_skill/get_blob 等同不存在
+    assert reg.active_refs() == []  # get_skills 排除孤儿
+    assert reg.is_orphan("my-helper") is True
+    assert "my-helper" in reg  # 仍保留以便恢复
+    assert len(reg) == 1
+
+
+def test_recover_orphan_reinstates() -> None:
+    reg = SkillRegistry()
+    ref = _ref("my-helper")
+    reg.register(ref)
+    reg.mark_orphan("my-helper")
+    assert reg.recover("my-helper") is True
+    assert reg.resolve("my-helper") == ref
+    assert reg.is_orphan("my-helper") is False
+    # 重复恢复（已活跃）/ 恢复不存在者 → False
+    assert reg.recover("my-helper") is False
+    assert reg.recover("absent") is False
+
+
+def test_reregister_orphaned_recovers_with_new_ref() -> None:
+    reg = SkillRegistry()
+    reg.register(_ref("my-helper", path="/abs/old"))
+    reg.mark_orphan("my-helper")
+    new_ref = _ref("my-helper", path="/abs/new")
+    assert reg.register(new_ref) is True  # source 回归 → 恢复并替换
+    assert reg.resolve("my-helper") == new_ref
+    assert reg.is_orphan("my-helper") is False
+
+
+def test_mark_orphan_missing_returns_false() -> None:
+    reg = SkillRegistry()
+    assert reg.mark_orphan("absent") is False
+
+
+# ---------------------------------------------------------------------------
+# 注销
+# ---------------------------------------------------------------------------
+def test_unregister() -> None:
+    reg = SkillRegistry()
+    reg.register(_ref("my-helper"))
+    assert reg.unregister("my-helper") is True
+    assert "my-helper" not in reg
+    assert reg.resolve("my-helper") is None
+    assert len(reg) == 0
+    assert reg.unregister("my-helper") is False  # 已不存在


### PR DESCRIPTION
## 概述

S3：Skill Registry —— SKILL 子系统物化层的 `name → A2CSkillRef` 内存索引。Closes #57（父 #39，依赖 #54 已合并）。

纯 SDK 实现（协议已发布）：依据 `skill.md` §1.5 / §6 / §8 / §9.2 + `design-0.2.1-skill-computer-management.md` §5。

## 变更

| 文件 | 内容 |
|---|---|
| `a2c_smcp/computer/skills/registry.py` (新增) | `SkillRegistry`：`register` / `resolve`(O(1)) / `mark_orphan` / `recover` / `unregister` / `active_refs` / `is_orphan` / `__contains__` / `__len__` |
| `a2c_smcp/computer/skills/__init__.py` (改) | 导出 `SkillRegistry` + docstring 补 registry 行 |
| `tests/unit_tests/computer/skills/test_registry.py` (新增) | 14 用例 |

## 设计要点

- **name 寻址唯一来源**（§9.2）：`resolve(name)` 是 name→包根路径的唯一解析入口；**禁止**从 name 推导 FS 路径。配合 S2 沙箱（包根仅经 Registry 解析）。
- **孤儿标记/恢复**（§8）：source 消失 → `mark_orphan`（`active_refs`/`get_skills` 排除、`resolve` 返回 `None` 使 `get_skill`/`get_blob` 复用 `4014`/`4018`），保留以便 source 回归 `recover`；同名孤儿再 `register` = 恢复并替换 ref。
- **校验失败不入册且不抛**（§1.5，仅 ERROR）：非法 name（lexer）/ 缺 path / path 非绝对 / 缺 name / 同名 active 冲突（拒绝第二注册者、保留先到者）。
- 内存索引；单进程 asyncio 单线程不加锁；意图层持久化（`installed_plugins.json`）归 staging/intent（后续 #59–61）。

## 验收（#57）

- [x] 注册 / 查找 / 孤儿标记 / 孤儿恢复单测
- [x] 校验失败项不入册且不抛（仅 ERROR 日志）
- [x] `A2CSkillRef` 含包根绝对路径（name 寻址唯一来源，配合 S2）
- [x] `uv run poe lint` 净

## 验证

- ruff ✅ / mypy ✅（69 源文件零告警）
- 新增 14 单测全过；全量 unit **760 passed / 4 xfailed** 零回归

解锁后续：#59（staging mcp 源 ← #57）、#60（user DropIn ← #57,#56）、#61（marketplace git ← #57,#58）、#66（computer 接入 ← #55,#57,#59）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
