### PR TITLE
feat(computer): v0.2.1 staging mcp 源 + manager.list_skill_resources (#59)

### DIFF
--- a/a2c_smcp/computer/mcp_clients/manager.py
+++ b/a2c_smcp/computer/mcp_clients/manager.py
@@ -22,6 +22,10 @@ from a2c_smcp.utils.logger import get_logger, truncate
 
 logger = get_logger("computer")
 
+# SKILL 资源枚举翻页安全上界：防御恒非空 cursor（server bug / 恶意）导致的无限循环挂死物化。
+# Pagination safety bound for SKILL enumeration: guard against a never-terminating cursor hanging staging.
+_MAX_SKILL_LIST_PAGES = 1000
+
 
 class ToolNameDuplicatedError(Exception):
     def __init__(self, *args: Any) -> None:
@@ -570,10 +574,18 @@ class MCPServerManager:
                 continue
             try:
                 cursor: str | None = None
+                pages = 0
                 while True:
                     page, cursor = await client.list_resources_page(cursor)
                     results.extend((sname, res) for res in page if str(res.uri).startswith("skill://"))
+                    pages += 1
                     if not cursor:
+                        break
+                    if pages >= _MAX_SKILL_LIST_PAGES:
+                        logger.error(
+                            f"list_skill_resources: server {sname} exceeded {_MAX_SKILL_LIST_PAGES} pages "
+                            f"(non-terminating cursor?); aborting enumeration for this server",
+                        )
                         break
             except Exception as e:
                 # 未声明 resources 能力 / 连接异常 / 翻页失败 → 跳过该 server，不阻断其余

--- a/a2c_smcp/computer/mcp_clients/manager.py
+++ b/a2c_smcp/computer/mcp_clients/manager.py
@@ -543,6 +543,62 @@ class MCPServerManager:
                 results.append((server_name, res))
         return results
 
+    async def list_skill_resources(self, server_name: SERVER_NAME | None = None) -> list[tuple[SERVER_NAME, Resource]]:
+        """
+        中文: 枚举活跃 MCP Server 的 ``skill://`` 资源（附 server 归属），**完整消费 cursor 翻页直至末尾**。
+        英文: Enumerate ``skill://`` resources from active MCP servers (with owning server), exhausting cursor pages.
+
+        与 :meth:`list_resources`（单页、Agent 控制翻页）不同：SKILL 物化由 Computer 主导，须拿到**全量**
+        ``skill://`` 集合，故在此完整消费翻页（协议 skill.md §12）。未声明 ``resources`` 能力或枚举出错的
+        server **跳过**（记 ERROR、不中断其余），对齐「SKILL 通道不使用 4015——无 resources 能力的 server
+        在物化阶段即被排除」（error-handling.md / skill.md §1.5）。
+        Unlike :meth:`list_resources` (single-page, Agent-driven): Computer-driven SKILL materialization needs
+        the full ``skill://`` set, so pages are exhausted here. Servers lacking ``resources`` capability or
+        erroring are skipped (logged ERROR, others continue).
+
+        Args:
+            server_name (SERVER_NAME | None): 若提供仅枚举该 server（用于 ResourceListChanged 单 server 重枚举）；
+                否则枚举全部活跃 server / restrict to one server, else enumerate all active servers.
+
+        Returns:
+            list[tuple[SERVER_NAME, Resource]]: [(server_name, skill_resource), ...]
+        """
+        results: list[tuple[SERVER_NAME, Resource]] = []
+        active_snapshot = list(self._active_clients.items())
+        for sname, client in active_snapshot:
+            if server_name is not None and sname != server_name:
+                continue
+            try:
+                cursor: str | None = None
+                while True:
+                    page, cursor = await client.list_resources_page(cursor)
+                    results.extend((sname, res) for res in page if str(res.uri).startswith("skill://"))
+                    if not cursor:
+                        break
+            except Exception as e:
+                # 未声明 resources 能力 / 连接异常 / 翻页失败 → 跳过该 server，不阻断其余
+                logger.error(f"Error listing skill resources for {sname}: {e}", exc_info=True)
+                continue
+        return results
+
+    async def read_resource(self, server_name: SERVER_NAME, uri: str) -> ReadResourceResult:
+        """
+        中文: 读取指定 MCP Server 的单个资源内容（通用 ``resources/read`` 入口，供 SKILL ``resources`` 模式
+              逐子资源物化与子文件渐进式披露复用）。
+        英文: Read a single resource's contents from a server (generic ``resources/read`` entry; reused by
+              SKILL ``resources``-mode per-sub-resource materialization).
+
+        复用既有 ``client.get_window_detail``——其实现为通用 ``read_resource``（命名沿用历史，非仅 window）。
+        Reuses ``client.get_window_detail`` whose impl is a generic ``read_resource`` (name is historical).
+
+        Raises:
+            MCPServerNotFoundError: server_name 未注册 / server_name not registered.
+        """
+        client = self._active_clients.get(server_name)
+        if client is None:
+            raise MCPServerNotFoundError(f"MCP Server '{server_name}' is not registered")
+        return await client.get_window_detail(uri)
+
     async def get_windows_details(self, window_uri: str | None = None) -> list[tuple[SERVER_NAME, Resource, ReadResourceResult]]:
         """
         中文: 读取所有活动 MCP 服务器的窗口资源详情。由于 MCP 协议中的 Resource 仅为标识，需要通过 read_resource 获取内容。

--- a/a2c_smcp/computer/skills/__init__.py
+++ b/a2c_smcp/computer/skills/__init__.py
@@ -45,6 +45,7 @@ from a2c_smcp.computer.skills.naming import (
     synthesize_user_name,
 )
 from a2c_smcp.computer.skills.registry import SkillRegistry
+from a2c_smcp.computer.skills.staging import SkillStagingError, parse_skill_frontmatter, stage_mcp_skills
 
 __all__ = [
     # home
@@ -71,4 +72,8 @@ __all__ = [
     "synthesize_user_name",
     # registry
     "SkillRegistry",
+    # staging
+    "SkillStagingError",
+    "parse_skill_frontmatter",
+    "stage_mcp_skills",
 ]

--- a/a2c_smcp/computer/skills/staging.py
+++ b/a2c_smcp/computer/skills/staging.py
@@ -20,7 +20,8 @@ This module implements **mcp-source** materialization only (#59).
 2. 其中带 ``_meta.source∈{mounted,archive,resources}`` 者为 **SKILL 根**，按模式物化到
    ``<home>/mcp/<normalized-server>/<skill>/``（marketplace SKILL v1 §2 包结构）：
    - **mounted**：``_meta.mount_dir`` 本地目录 → 复制进 staging（自包含，避免符号链接绕过沙箱）；
-   - **archive**：HTTP 拉 ``_meta.archive_uri`` → 校验 ``archive_sha256``（若有）→ 安全解包（防穿越/拒符号链接）；
+   - **archive**：HTTP 拉 ``_meta.archive_uri`` → 校验 ``archive_sha256``（若有）+ 大小/解压/成员数上限（防 tar·zip bomb）
+     → 安全解包（防穿越/拒符号链接）；
    - **resources**：枚举 ``skill://<root>/**`` 子资源，逐个 ``resources/read``，按相对路径安全写入 staging。
 3. 读 staged ``SKILL.md`` 的 YAML frontmatter 作为元数据权威源（§3：不镜像进 ``_meta``）；
    包根目录名校正为 ``frontmatter.name``（§4）；
@@ -59,6 +60,12 @@ SKILL_MD = "SKILL.md"
 SKILL_URI_PREFIX = "skill://"
 _MCP_SOURCE_MODES = frozenset({"mounted", "archive", "resources"})
 
+# 归档安全上界（防 tar/zip bomb OOM；可信源模型下为安全网，默认宽松，后续可配置化）。
+# Archive safety bounds (bomb guard): generous defaults under the trusted-source model.
+MAX_ARCHIVE_DOWNLOAD_BYTES = 64 * 1024 * 1024  # 压缩态下载上限 / compressed download cap (64 MiB)
+MAX_EXTRACTED_BYTES = 256 * 1024 * 1024  # 解压累计字节上限 / cumulative uncompressed cap (256 MiB)
+MAX_ARCHIVE_MEMBERS = 10_000  # 成员数上限（防海量小文件 bomb）/ member-count cap
+
 # 物化所需的最小 manager 协议（便于测试注入 fake）/ Minimal manager protocol for materialization (mockable).
 ArchiveFetcher = Callable[[str], Awaitable[bytes]]
 
@@ -94,17 +101,41 @@ def parse_skill_frontmatter(skill_md_text: str) -> dict[str, Any]:
 
 # ── 安全解包 / safe extraction ──────────────────────────────────────────────
 def _resolved_member_target(dest: Path, member_name: str) -> Path:
-    """归一化并校验归档成员落点仍在 ``dest`` 内（防 ``..`` / 绝对路径穿越）/ Anti-traversal member target。"""
+    """
+    归一化并校验归档成员落点仍在 ``dest`` 内（防 ``..`` / 绝对路径穿越）/ Anti-traversal member target。
+
+    函数内对 ``dest`` 也 ``resolve()``，使不变量自洽——不依赖调用方传入已规范化路径（含 symlink 的 home 不误拒）。
+    Resolves ``dest`` too so the invariant is self-contained (no reliance on a pre-canonicalized dest).
+    """
+    dest = dest.resolve()
     target = (dest / member_name).resolve()
     if target != dest and dest not in target.parents:
         raise SkillStagingError(f"archive member escapes staging dir: {member_name!r}")
     return target
 
 
+def _copy_capped(src: Any, out: Any, already: int) -> int:
+    """分块复制并累计校验解压上限（防 bomb）/ Chunked copy enforcing the cumulative extraction cap。"""
+    total = already
+    while True:
+        chunk = src.read(1 << 16)
+        if not chunk:
+            break
+        total += len(chunk)
+        if total > MAX_EXTRACTED_BYTES:
+            raise SkillStagingError(f"archive exceeds extracted size limit ({MAX_EXTRACTED_BYTES} bytes)")
+        out.write(chunk)
+    return total
+
+
 def _extract_tar_gz(data: bytes, dest: Path) -> None:
-    """安全解 ``tar.gz``：拒符号/硬链接，逐成员校验落点 / Safe tar.gz extraction (reject links, guard paths)。"""
+    """安全解 ``tar.gz``：拒符号/硬链接、成员数上限、解压累计上限、逐成员校验落点 / Safe tar.gz extraction。"""
     with tarfile.open(fileobj=io.BytesIO(data), mode="r:gz") as tar:
-        for member in tar.getmembers():
+        members = tar.getmembers()
+        if len(members) > MAX_ARCHIVE_MEMBERS:
+            raise SkillStagingError(f"archive has too many members ({len(members)} > {MAX_ARCHIVE_MEMBERS})")
+        extracted_bytes = 0
+        for member in members:
             if member.issym() or member.islnk():
                 raise SkillStagingError(f"archive contains link member (rejected): {member.name!r}")
             target = _resolved_member_target(dest, member.name)
@@ -112,25 +143,34 @@ def _extract_tar_gz(data: bytes, dest: Path) -> None:
                 target.mkdir(parents=True, exist_ok=True)
             elif member.isfile():
                 target.parent.mkdir(parents=True, exist_ok=True)
-                extracted = tar.extractfile(member)
-                if extracted is None:
+                fobj = tar.extractfile(member)
+                if fobj is None:
                     continue
-                with extracted as src, target.open("wb") as out:
-                    shutil.copyfileobj(src, out)
+                with fobj as src, target.open("wb") as out:
+                    extracted_bytes = _copy_capped(src, out, extracted_bytes)
             # 其它类型（设备/FIFO 等）一律忽略 / ignore device/fifo etc.
 
 
 def _extract_zip(data: bytes, dest: Path) -> None:
-    """安全解 ``zip``：逐成员校验落点 / Safe zip extraction (guard paths)。"""
+    """
+    安全解 ``zip``：成员数上限、解压累计上限、逐成员校验落点 / Safe zip extraction。
+
+    注：Python ``zipfile`` **不**还原 zip 内的符号链接（写为普通文件），故无需 tar 那样的链接拒绝分支；
+    落点校验已防穿越。Python zipfile does not restore in-zip symlinks, so no link-rejection branch is needed.
+    """
     with zipfile.ZipFile(io.BytesIO(data)) as zf:
-        for name in zf.namelist():
+        names = zf.namelist()
+        if len(names) > MAX_ARCHIVE_MEMBERS:
+            raise SkillStagingError(f"archive has too many members ({len(names)} > {MAX_ARCHIVE_MEMBERS})")
+        extracted_bytes = 0
+        for name in names:
             target = _resolved_member_target(dest, name)
             if name.endswith("/"):
                 target.mkdir(parents=True, exist_ok=True)
             else:
                 target.parent.mkdir(parents=True, exist_ok=True)
                 with zf.open(name) as src, target.open("wb") as out:
-                    shutil.copyfileobj(src, out)
+                    extracted_bytes = _copy_capped(src, out, extracted_bytes)
 
 
 def _reset_dir(dest: Path) -> None:
@@ -142,12 +182,19 @@ def _reset_dir(dest: Path) -> None:
 
 # ── 三种 source 模式物化 / three materialization modes ──────────────────────
 async def _default_archive_fetch(url: str) -> bytes:
-    """默认归档拉取（aiohttp GET）/ Default archive fetch via aiohttp。测试可注入替身。"""
+    """默认归档拉取（aiohttp GET，流式累计上限防 OOM）/ Default archive fetch via aiohttp (size-capped stream)。"""
     import aiohttp
 
+    chunks: list[bytes] = []
+    total = 0
     async with aiohttp.ClientSession() as session, session.get(url) as resp:
         resp.raise_for_status()
-        return await resp.read()
+        async for chunk in resp.content.iter_chunked(1 << 16):
+            total += len(chunk)
+            if total > MAX_ARCHIVE_DOWNLOAD_BYTES:
+                raise SkillStagingError(f"archive exceeds download size limit ({MAX_ARCHIVE_DOWNLOAD_BYTES} bytes)")
+            chunks.append(chunk)
+    return b"".join(chunks)
 
 
 def _materialize_mounted(meta: dict[str, Any], dest: Path) -> None:
@@ -172,6 +219,8 @@ async def _materialize_archive(meta: dict[str, Any], dest: Path, fetch: ArchiveF
     if fmt not in ("tar.gz", "zip"):
         raise SkillStagingError(f"unsupported archive_format: {fmt!r} (expect 'tar.gz' | 'zip')")
     data = await fetch(uri)
+    if len(data) > MAX_ARCHIVE_DOWNLOAD_BYTES:
+        raise SkillStagingError(f"archive exceeds download size limit ({len(data)} > {MAX_ARCHIVE_DOWNLOAD_BYTES} bytes)")
     expected_sha = meta.get("archive_sha256")
     if expected_sha:
         actual = hashlib.sha256(data).hexdigest()
@@ -234,16 +283,16 @@ def _uri_leaf(uri: str) -> str:
 
 # ── A2CSkillRef 合成 / ref construction ─────────────────────────────────────
 def _build_ref(
-    server_name: str,
+    name: str,
     normalized_server: str,
     frontmatter: dict[str, Any],
     meta: dict[str, Any],
     path: Path,
     uri: str,
 ) -> A2CSkillRef:
-    """从 frontmatter + ``_meta`` 合成 A2CSkillRef（name 经 :func:`synthesize_mcp_name`，可能抛 SkillNameError）。"""
+    """从已合成 ``name`` + frontmatter + ``_meta`` 组装 A2CSkillRef / Assemble A2CSkillRef from precomputed name + frontmatter。"""
     ref: A2CSkillRef = {
-        "name": synthesize_mcp_name(server_name, str(frontmatter["name"])),
+        "name": name,
         "source": f"mcp:{normalized_server}",
         "uri": uri,
         "path": str(path),
@@ -291,6 +340,7 @@ async def stage_mcp_skills(
         by_server[sname].append(res)
 
     registered: list[str] = []
+    seen_this_run: set[str] = set()  # 本 run 已处理的合成 name，用于真冲突检测（§1.5 保留先到者）
     for sname, resources in by_server.items():
         normalized_server = normalize_mcp_server_segment(sname)
         for res in resources:
@@ -319,7 +369,7 @@ async def stage_mcp_skills(
                 shutil.rmtree(staged, ignore_errors=True)
                 continue
 
-            name = _finalize_and_register(sname, normalized_server, meta, staged, root_uri, home, registry)
+            name = _finalize_and_register(sname, normalized_server, meta, staged, root_uri, home, registry, seen_this_run)
             if name is not None:
                 registered.append(name)
     return registered
@@ -333,8 +383,9 @@ def _finalize_and_register(
     root_uri: str,
     home: Path,
     registry: SkillRegistry,
+    seen_this_run: set[str],
 ) -> str | None:
-    """读 frontmatter → 校正包根目录名为 frontmatter.name → 合成 ref → register/update。失败返回 None。"""
+    """读 frontmatter → 真冲突拒绝（落盘前）→ 校正包根目录名 → register/update。失败返回 None。"""
     skill_md = staged / SKILL_MD
     if not skill_md.is_file():
         logger.error("staged SKILL missing %s, skipped: %s", SKILL_MD, root_uri)
@@ -347,6 +398,21 @@ def _finalize_and_register(
         shutil.rmtree(staged, ignore_errors=True)
         return None
 
+    try:
+        name = synthesize_mcp_name(server_name, str(frontmatter["name"]))
+    except SkillNameError as e:
+        logger.error("skill name synthesis failed, skipped: %s (%s)", root_uri, e.reason)
+        shutil.rmtree(staged, ignore_errors=True)
+        return None
+
+    # 真冲突（本 run 内两个不同 SKILL 合成同 name）必须在 rename 落盘前拒绝——否则会覆盖先到者的磁盘文件。
+    # §1.5「拒绝第二注册者、保留先到者」；区别于 register/update 分流：跨 run 既存同一 SKILL 才走 update（刷新/孤儿恢复）。
+    if name in seen_this_run:
+        logger.error("duplicate synthesized SKILL name within staging run (collision), keeping first: %s (%s)", name, root_uri)
+        shutil.rmtree(staged, ignore_errors=True)
+        return None
+    seen_this_run.add(name)
+
     # 包根目录名校正为 frontmatter.name（skill.md §4）
     final = mcp_skill_dir(home, normalized_server, str(frontmatter["name"]))
     if final != staged:
@@ -355,13 +421,7 @@ def _finalize_and_register(
         final.parent.mkdir(parents=True, exist_ok=True)
         staged.rename(final)
 
-    try:
-        ref = _build_ref(server_name, normalized_server, frontmatter, meta, final, root_uri)
-    except SkillNameError as e:
-        logger.error("skill name synthesis failed, skipped: %s (%s)", root_uri, e.reason)
-        shutil.rmtree(final, ignore_errors=True)
-        return None
-
-    name = ref["name"]
+    ref = _build_ref(name, normalized_server, frontmatter, meta, final, root_uri)
+    # 本 run 已 seen 去重；此处 name in registry 必为跨 run 既存的同一 SKILL → update（刷新/孤儿恢复）
     ok = registry.update(ref) if name in registry else registry.register(ref)
     return name if ok else None

--- a/a2c_smcp/computer/skills/staging.py
+++ b/a2c_smcp/computer/skills/staging.py
@@ -1,0 +1,367 @@
+# -*- coding: utf-8 -*-
+# filename: staging.py
+# @Time    : 2026/05/24
+# @Author  : JQQ
+# @Email   : jqq1716@gmail.com
+# @Software: PyCharm
+"""
+SKILL staging：mcp 源物化（v0.2.1）
+SKILL staging: mcp-source materialization (v0.2.1)
+
+协议依据 / Protocol: a2c-smcp-protocol docs/specification/skill.md §3（MCP source 模式 mounted/archive/
+                      resources）、§4（包根目录名 = frontmatter.name）、§12（Computer 完整消费 cursor）。
+SDK 设计 / Design: python-sdk docs/design-0.2.1-skill-computer-management.md §5.2。
+
+本模块只实现 **mcp 源** 物化（#59）；marketplace git（#61）/ user DropIn（#60）另见对应模块。
+This module implements **mcp-source** materialization only (#59).
+
+流程 / Flow：
+1. 经 ``manager.list_skill_resources`` 完整消费 cursor 拿到 server 全量 ``skill://`` 资源；
+2. 其中带 ``_meta.source∈{mounted,archive,resources}`` 者为 **SKILL 根**，按模式物化到
+   ``<home>/mcp/<normalized-server>/<skill>/``（marketplace SKILL v1 §2 包结构）：
+   - **mounted**：``_meta.mount_dir`` 本地目录 → 复制进 staging（自包含，避免符号链接绕过沙箱）；
+   - **archive**：HTTP 拉 ``_meta.archive_uri`` → 校验 ``archive_sha256``（若有）→ 安全解包（防穿越/拒符号链接）；
+   - **resources**：枚举 ``skill://<root>/**`` 子资源，逐个 ``resources/read``，按相对路径安全写入 staging。
+3. 读 staged ``SKILL.md`` 的 YAML frontmatter 作为元数据权威源（§3：不镜像进 ``_meta``）；
+   包根目录名校正为 ``frontmatter.name``（§4）；
+4. 合成 ``A2CSkillRef``（name = ``mcp:<normalized-server>:<frontmatter.name>``）→ 注册进 :class:`SkillRegistry`。
+
+失败降级 / Failure isolation：任一 SKILL 物化/解析失败 → 记 ERROR、清理半成品、跳过该 SKILL，
+**不**阻断其余、**不**抛给上层（skill.md §1.5：batch 接口对部分失败健壮）。
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import io
+import shutil
+import tarfile
+import zipfile
+from collections import defaultdict
+from collections.abc import Awaitable, Callable, Sequence
+from functools import partial
+from pathlib import Path
+from typing import Any
+
+import yaml
+from mcp.types import BlobResourceContents, ReadResourceResult, Resource, TextResourceContents
+
+from a2c_smcp.computer.skills.home import mcp_skill_dir
+from a2c_smcp.computer.skills.naming import SkillNameError, normalize_mcp_server_segment, synthesize_mcp_name
+from a2c_smcp.computer.skills.registry import SkillRegistry
+from a2c_smcp.smcp import A2CSkillRef
+from a2c_smcp.utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+SKILL_MD = "SKILL.md"
+SKILL_URI_PREFIX = "skill://"
+_MCP_SOURCE_MODES = frozenset({"mounted", "archive", "resources"})
+
+# 物化所需的最小 manager 协议（便于测试注入 fake）/ Minimal manager protocol for materialization (mockable).
+ArchiveFetcher = Callable[[str], Awaitable[bytes]]
+
+
+class SkillStagingError(Exception):
+    """staging 物化失败（穿越/校验/格式等）/ Materialization failure (traversal / checksum / format)。"""
+
+
+# ── frontmatter ───────────────────────────────────────────────────────────
+def parse_skill_frontmatter(skill_md_text: str) -> dict[str, Any]:
+    """
+    解析 SKILL.md 头部 YAML frontmatter（``---`` 包裹）/ Parse the leading YAML frontmatter of SKILL.md。
+
+    无 frontmatter 或解析失败 → 返回 ``{}``（调用方据缺字段判废）。
+    """
+    if not skill_md_text.startswith("---"):
+        return {}
+    # 以行级定位首尾 --- 之间的 YAML 块
+    lines = skill_md_text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return {}
+    for i in range(1, len(lines)):
+        if lines[i].strip() == "---":
+            block = "\n".join(lines[1:i])
+            try:
+                data = yaml.safe_load(block)
+            except yaml.YAMLError as e:
+                logger.error("SKILL.md frontmatter YAML parse failed: %s", e)
+                return {}
+            return data if isinstance(data, dict) else {}
+    return {}
+
+
+# ── 安全解包 / safe extraction ──────────────────────────────────────────────
+def _resolved_member_target(dest: Path, member_name: str) -> Path:
+    """归一化并校验归档成员落点仍在 ``dest`` 内（防 ``..`` / 绝对路径穿越）/ Anti-traversal member target。"""
+    target = (dest / member_name).resolve()
+    if target != dest and dest not in target.parents:
+        raise SkillStagingError(f"archive member escapes staging dir: {member_name!r}")
+    return target
+
+
+def _extract_tar_gz(data: bytes, dest: Path) -> None:
+    """安全解 ``tar.gz``：拒符号/硬链接，逐成员校验落点 / Safe tar.gz extraction (reject links, guard paths)。"""
+    with tarfile.open(fileobj=io.BytesIO(data), mode="r:gz") as tar:
+        for member in tar.getmembers():
+            if member.issym() or member.islnk():
+                raise SkillStagingError(f"archive contains link member (rejected): {member.name!r}")
+            target = _resolved_member_target(dest, member.name)
+            if member.isdir():
+                target.mkdir(parents=True, exist_ok=True)
+            elif member.isfile():
+                target.parent.mkdir(parents=True, exist_ok=True)
+                extracted = tar.extractfile(member)
+                if extracted is None:
+                    continue
+                with extracted as src, target.open("wb") as out:
+                    shutil.copyfileobj(src, out)
+            # 其它类型（设备/FIFO 等）一律忽略 / ignore device/fifo etc.
+
+
+def _extract_zip(data: bytes, dest: Path) -> None:
+    """安全解 ``zip``：逐成员校验落点 / Safe zip extraction (guard paths)。"""
+    with zipfile.ZipFile(io.BytesIO(data)) as zf:
+        for name in zf.namelist():
+            target = _resolved_member_target(dest, name)
+            if name.endswith("/"):
+                target.mkdir(parents=True, exist_ok=True)
+            else:
+                target.parent.mkdir(parents=True, exist_ok=True)
+                with zf.open(name) as src, target.open("wb") as out:
+                    shutil.copyfileobj(src, out)
+
+
+def _reset_dir(dest: Path) -> None:
+    """清空并新建目标目录（重物化幂等）/ Clear and recreate the dest dir (idempotent re-materialization)。"""
+    if dest.exists() or dest.is_symlink():
+        shutil.rmtree(dest, ignore_errors=True)
+    dest.mkdir(parents=True, exist_ok=True)
+
+
+# ── 三种 source 模式物化 / three materialization modes ──────────────────────
+async def _default_archive_fetch(url: str) -> bytes:
+    """默认归档拉取（aiohttp GET）/ Default archive fetch via aiohttp。测试可注入替身。"""
+    import aiohttp
+
+    async with aiohttp.ClientSession() as session, session.get(url) as resp:
+        resp.raise_for_status()
+        return await resp.read()
+
+
+def _materialize_mounted(meta: dict[str, Any], dest: Path) -> None:
+    """mounted：复制 ``_meta.mount_dir`` 本地目录树进 staging（自包含，不留符号链接）。"""
+    mount_dir = meta.get("mount_dir")
+    if not mount_dir or not isinstance(mount_dir, str):
+        raise SkillStagingError("mounted source missing 'mount_dir'")
+    src = Path(mount_dir)
+    if not src.is_dir():
+        raise SkillStagingError(f"mounted source dir not found: {mount_dir!r}")
+    _reset_dir(dest)
+    # symlinks=False：复制内容而非符号链接，确保 staging 自包含、沙箱 realpath 不外逃
+    shutil.copytree(src, dest, dirs_exist_ok=True, symlinks=False)
+
+
+async def _materialize_archive(meta: dict[str, Any], dest: Path, fetch: ArchiveFetcher) -> None:
+    """archive：拉取 → 校验 sha256（若声明）→ 按格式安全解包。"""
+    uri = meta.get("archive_uri")
+    fmt = meta.get("archive_format")
+    if not uri or not isinstance(uri, str):
+        raise SkillStagingError("archive source missing 'archive_uri'")
+    if fmt not in ("tar.gz", "zip"):
+        raise SkillStagingError(f"unsupported archive_format: {fmt!r} (expect 'tar.gz' | 'zip')")
+    data = await fetch(uri)
+    expected_sha = meta.get("archive_sha256")
+    if expected_sha:
+        actual = hashlib.sha256(data).hexdigest()
+        if actual.lower() != str(expected_sha).lower():
+            raise SkillStagingError(f"archive sha256 mismatch: expected {expected_sha}, got {actual}")
+    _reset_dir(dest)
+    if fmt == "tar.gz":
+        _extract_tar_gz(data, dest)
+    else:
+        _extract_zip(data, dest)
+
+
+def _content_bytes(content: TextResourceContents | BlobResourceContents) -> bytes:
+    """把单个资源内容块还原为字节 / Decode a resource content item to bytes。"""
+    if isinstance(content, TextResourceContents):
+        return content.text.encode("utf-8")
+    # BlobResourceContents.blob 为 base64 字符串
+    return base64.b64decode(content.blob)
+
+
+async def _materialize_resources(
+    read_resource: Callable[[str], Awaitable[ReadResourceResult]],
+    root_uri: str,
+    sub_resources: Sequence[Resource],
+    dest: Path,
+) -> None:
+    """resources：逐个 ``resources/read`` 子资源，按相对路径安全写入 staging。"""
+    _reset_dir(dest)
+    root_path = _uri_path(root_uri)
+    wrote_any = False
+    for res in sub_resources:
+        sub_uri = str(res.uri)
+        rel = _uri_path(sub_uri)[len(root_path) + 1 :]  # 去掉 "<root_path>/" 前缀
+        if not rel:
+            continue
+        target = _resolved_member_target(dest, rel)
+        result = await read_resource(sub_uri)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        with target.open("wb") as out:
+            for content in result.contents:
+                out.write(_content_bytes(content))
+        wrote_any = True
+    if not wrote_any:
+        raise SkillStagingError(f"resources-mode SKILL has no sub-resources under {root_uri!r}")
+
+
+# ── URI 辅助 / uri helpers ──────────────────────────────────────────────────
+def _uri_path(uri: str) -> str:
+    """``skill://host/a/b`` → ``a/b``（host 之后的路径，无前导 ``/``）。"""
+    rest = uri[len(SKILL_URI_PREFIX) :] if uri.startswith(SKILL_URI_PREFIX) else uri
+    _, _, path = rest.partition("/")
+    return path
+
+
+def _uri_leaf(uri: str) -> str:
+    """SKILL 根 URI 的首路径段（provisional staging 目录名）/ first path segment of a SKILL root URI。"""
+    path = _uri_path(uri)
+    return path.split("/", 1)[0] if path else ""
+
+
+# ── A2CSkillRef 合成 / ref construction ─────────────────────────────────────
+def _build_ref(
+    server_name: str,
+    normalized_server: str,
+    frontmatter: dict[str, Any],
+    meta: dict[str, Any],
+    path: Path,
+    uri: str,
+) -> A2CSkillRef:
+    """从 frontmatter + ``_meta`` 合成 A2CSkillRef（name 经 :func:`synthesize_mcp_name`，可能抛 SkillNameError）。"""
+    ref: A2CSkillRef = {
+        "name": synthesize_mcp_name(server_name, str(frontmatter["name"])),
+        "source": f"mcp:{normalized_server}",
+        "uri": uri,
+        "path": str(path),
+        "description": str(frontmatter["description"]),
+    }
+    if frontmatter.get("license") is not None:
+        ref["license"] = str(frontmatter["license"])
+    if frontmatter.get("compatibility") is not None:
+        ref["compatibility"] = str(frontmatter["compatibility"])
+    allowed = frontmatter.get("allowed-tools", frontmatter.get("allowed_tools"))
+    if allowed is not None:
+        ref["allowed_tools"] = [str(t) for t in allowed] if isinstance(allowed, (list, tuple)) else [str(allowed)]
+    if isinstance(frontmatter.get("metadata"), dict):
+        ref["skill_metadata"] = frontmatter["metadata"]
+    version = meta.get("version")
+    if version is not None:
+        ref["version"] = str(version)
+    return ref
+
+
+# ── 编排 / orchestration ────────────────────────────────────────────────────
+async def stage_mcp_skills(
+    manager: Any,
+    registry: SkillRegistry,
+    home: Path,
+    *,
+    server_name: str | None = None,
+    archive_fetch: ArchiveFetcher | None = None,
+) -> list[str]:
+    """
+    枚举并物化 mcp 源 SKILL，注册进 Registry / Enumerate, materialize and register mcp-source SKILLs。
+
+    :param manager: 提供 ``list_skill_resources(server_name)`` 与 ``read_resource(server, uri)`` 的 MCP 管理器。
+    :param registry: 目标 :class:`SkillRegistry`。
+    :param home: SKILL Home 绝对根（见 :mod:`~a2c_smcp.computer.skills.home`）。
+    :param server_name: 若提供仅物化该 server（ResourceListChanged 单 server 重物化）；否则全部活跃 server。
+    :param archive_fetch: 归档拉取替身（默认 aiohttp）；便于测试注入。
+    :return: 成功注册（或刷新）的 SKILL name 列表 / names successfully registered (or refreshed).
+    """
+    fetch = archive_fetch or _default_archive_fetch
+    pairs: list[tuple[str, Resource]] = await manager.list_skill_resources(server_name)
+
+    by_server: dict[str, list[Resource]] = defaultdict(list)
+    for sname, res in pairs:
+        by_server[sname].append(res)
+
+    registered: list[str] = []
+    for sname, resources in by_server.items():
+        normalized_server = normalize_mcp_server_segment(sname)
+        for res in resources:
+            meta = dict(getattr(res, "meta", None) or {})
+            mode = meta.get("source")
+            if mode not in _MCP_SOURCE_MODES:
+                continue  # 非 SKILL 根（子资源 / 未声明 source）→ 跳过
+
+            root_uri = str(res.uri)
+            leaf = _uri_leaf(root_uri)
+            if not leaf:
+                logger.error("skill root URI has no path segment, skipped: %s", root_uri)
+                continue
+
+            staged = mcp_skill_dir(home, normalized_server, leaf)
+            try:
+                if mode == "mounted":
+                    _materialize_mounted(meta, staged)
+                elif mode == "archive":
+                    await _materialize_archive(meta, staged, fetch)
+                else:  # resources
+                    subs = [r for r in resources if str(r.uri).startswith(root_uri + "/")]
+                    await _materialize_resources(partial(manager.read_resource, sname), root_uri, subs, staged)
+            except Exception as e:
+                logger.error("materialize failed for %s (mode=%s): %s", root_uri, mode, e, exc_info=True)
+                shutil.rmtree(staged, ignore_errors=True)
+                continue
+
+            name = _finalize_and_register(sname, normalized_server, meta, staged, root_uri, home, registry)
+            if name is not None:
+                registered.append(name)
+    return registered
+
+
+def _finalize_and_register(
+    server_name: str,
+    normalized_server: str,
+    meta: dict[str, Any],
+    staged: Path,
+    root_uri: str,
+    home: Path,
+    registry: SkillRegistry,
+) -> str | None:
+    """读 frontmatter → 校正包根目录名为 frontmatter.name → 合成 ref → register/update。失败返回 None。"""
+    skill_md = staged / SKILL_MD
+    if not skill_md.is_file():
+        logger.error("staged SKILL missing %s, skipped: %s", SKILL_MD, root_uri)
+        shutil.rmtree(staged, ignore_errors=True)
+        return None
+
+    frontmatter = parse_skill_frontmatter(skill_md.read_text(encoding="utf-8"))
+    if not frontmatter.get("name") or not frontmatter.get("description"):
+        logger.error("SKILL.md frontmatter missing required 'name'/'description', skipped: %s", root_uri)
+        shutil.rmtree(staged, ignore_errors=True)
+        return None
+
+    # 包根目录名校正为 frontmatter.name（skill.md §4）
+    final = mcp_skill_dir(home, normalized_server, str(frontmatter["name"]))
+    if final != staged:
+        if final.exists():
+            shutil.rmtree(final, ignore_errors=True)
+        final.parent.mkdir(parents=True, exist_ok=True)
+        staged.rename(final)
+
+    try:
+        ref = _build_ref(server_name, normalized_server, frontmatter, meta, final, root_uri)
+    except SkillNameError as e:
+        logger.error("skill name synthesis failed, skipped: %s (%s)", root_uri, e.reason)
+        shutil.rmtree(final, ignore_errors=True)
+        return None
+
+    name = ref["name"]
+    ok = registry.update(ref) if name in registry else registry.register(ref)
+    return name if ok else None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,6 +97,8 @@ module = [
     "pexpect.*",
     "msgpack",
     "msgpack.*",
+    "yaml",
+    "yaml.*",
 ]
 ignore_missing_imports = true
 

--- a/tests/unit_tests/computer/mcp_clients/test_manager_skill_resources.py
+++ b/tests/unit_tests/computer/mcp_clients/test_manager_skill_resources.py
@@ -1,0 +1,100 @@
+# -*- coding: utf-8 -*-
+# filename: test_manager_skill_resources.py
+# @Time    : 2026/05/24
+# @Author  : JQQ
+# @Email   : jqq1716@gmail.com
+# @Software: PyCharm
+"""
+MCPServerManager.list_skill_resources / read_resource 单元测试（v0.2.1 #59）
+
+测试意图 / Test intentions:
+- list_skill_resources：完整消费 cursor 翻页（多页）；仅返回 skill:// + 附 server 归属；非 skill:// 排除
+- 某 server 枚举抛错（如未声明 resources 能力）→ 跳过该 server、不阻断其余
+- read_resource：委托 client 通用读取；未注册 server → MCPServerNotFoundError
+"""
+
+import pytest
+from mcp.types import ReadResourceResult, Resource, TextResourceContents
+
+from a2c_smcp.computer.mcp_clients.base_client import MCPServerNotFoundError
+from a2c_smcp.computer.mcp_clients.manager import MCPServerManager
+
+
+class _PagedClient:
+    """按 cursor 返回多页 resources/list 的假客户端 / fake client paging resources/list by cursor。"""
+
+    def __init__(self, pages: list[tuple[list[Resource], str | None]]) -> None:
+        self._pages = pages
+        self.cursors_seen: list[str | None] = []
+
+    async def list_resources_page(self, cursor: str | None = None) -> tuple[list[Resource], str | None]:
+        self.cursors_seen.append(cursor)
+        idx = 0 if cursor is None else int(cursor)
+        return self._pages[idx]
+
+
+class _RaisingClient:
+    async def list_resources_page(self, cursor: str | None = None) -> tuple[list[Resource], str | None]:
+        raise RuntimeError("no resources capability")
+
+
+class _ReadClient:
+    def __init__(self, result: ReadResourceResult) -> None:
+        self._result = result
+        self.read_uris: list[str] = []
+
+    async def get_window_detail(self, uri: str) -> ReadResourceResult:
+        self.read_uris.append(str(uri))
+        return self._result
+
+
+def _res(uri: str) -> Resource:
+    return Resource(uri=uri, name=uri.rsplit("/", 1)[-1])
+
+
+async def test_list_skill_resources_exhausts_cursor_and_filters() -> None:
+    page0 = ([_res("skill://h/a"), _res("http://h/not-skill"), _res("skill://h/b")], "1")
+    page1 = ([_res("skill://h/c")], None)
+    client = _PagedClient([page0, page1])
+    mgr = MCPServerManager()
+    mgr._active_clients = {"srv": client}  # type: ignore[assignment]
+
+    out = await mgr.list_skill_resources()
+    names = [str(r.uri) for _, r in out]
+    assert names == ["skill://h/a", "skill://h/b", "skill://h/c"]  # 跨页、滤掉 http://
+    assert all(s == "srv" for s, _ in out)  # server 归属
+    assert client.cursors_seen == [None, "1"]  # 完整消费翻页直至末页
+
+
+async def test_list_skill_resources_skips_erroring_server() -> None:
+    good = _PagedClient([([_res("skill://h/a")], None)])
+    bad = _RaisingClient()
+    mgr = MCPServerManager()
+    mgr._active_clients = {"good": good, "bad": bad}  # type: ignore[assignment]
+
+    out = await mgr.list_skill_resources()
+    assert [(s, str(r.uri)) for s, r in out] == [("good", "skill://h/a")]  # bad 被跳过、good 不受影响
+
+
+async def test_list_skill_resources_server_filter() -> None:
+    c1 = _PagedClient([([_res("skill://h/a")], None)])
+    c2 = _PagedClient([([_res("skill://h/b")], None)])
+    mgr = MCPServerManager()
+    mgr._active_clients = {"s1": c1, "s2": c2}  # type: ignore[assignment]
+
+    out = await mgr.list_skill_resources(server_name="s2")
+    assert [(s, str(r.uri)) for s, r in out] == [("s2", "skill://h/b")]
+
+
+async def test_read_resource_delegates_and_unknown_server_raises() -> None:
+    result = ReadResourceResult(contents=[TextResourceContents(uri="skill://h/a/SKILL.md", text="hi")])
+    client = _ReadClient(result)
+    mgr = MCPServerManager()
+    mgr._active_clients = {"srv": client}  # type: ignore[assignment]
+
+    got = await mgr.read_resource("srv", "skill://h/a/SKILL.md")
+    assert got is result
+    assert client.read_uris == ["skill://h/a/SKILL.md"]
+
+    with pytest.raises(MCPServerNotFoundError):
+        await mgr.read_resource("absent", "skill://h/a/SKILL.md")

--- a/tests/unit_tests/computer/skills/test_staging.py
+++ b/tests/unit_tests/computer/skills/test_staging.py
@@ -1,0 +1,222 @@
+# -*- coding: utf-8 -*-
+# filename: test_staging.py
+# @Time    : 2026/05/24
+# @Author  : JQQ
+# @Email   : jqq1716@gmail.com
+# @Software: PyCharm
+"""
+SKILL staging（mcp 源）单元测试（v0.2.1 #59）
+
+协议依据 / Protocol: a2c-smcp-protocol docs/specification/skill.md §3（mounted/archive/resources）/ §4。
+
+测试意图 / Test intentions:
+- mounted / archive(tar.gz, zip) / resources 三模式各物化正确（文件落盘 + 注册 A2CSkillRef）
+- archive sha256 不符 / 归档穿越成员 → 物化失败不入册、不抛、不逃逸
+- 包根目录名校正为 frontmatter.name（§4）；缺 SKILL.md / 缺 frontmatter 必填 → 跳过
+- resources 模式文本 + 二进制（blob）子资源还原正确
+"""
+
+import base64
+import hashlib
+import io
+import tarfile
+import zipfile
+from pathlib import Path
+
+from mcp.types import BlobResourceContents, ReadResourceResult, Resource, TextResourceContents
+
+from a2c_smcp.computer.skills.registry import SkillRegistry
+from a2c_smcp.computer.skills.staging import stage_mcp_skills
+
+
+# ── 测试替身 / doubles ───────────────────────────────────────────────────────
+class FakeManager:
+    def __init__(self, pairs: list[tuple[str, Resource]], reads: dict[str, ReadResourceResult] | None = None) -> None:
+        self._pairs = pairs
+        self._reads = reads or {}
+
+    async def list_skill_resources(self, server_name: str | None = None) -> list[tuple[str, Resource]]:
+        return [(s, r) for s, r in self._pairs if server_name is None or s == server_name]
+
+    async def read_resource(self, server: str, uri: str) -> ReadResourceResult:
+        return self._reads[str(uri)]
+
+
+def _skill_md(name: str = "my-skill", description: str = "聚合 CSV") -> str:
+    return f"---\nname: {name}\ndescription: {description}\nlicense: MIT\nallowed-tools:\n  - read\n  - write\n---\n# {name}\nbody\n"
+
+
+def _root(uri: str, meta: dict) -> Resource:
+    return Resource(uri=uri, name=uri.rsplit("/", 1)[-1], _meta=meta)
+
+
+def _make_targz(files: dict[str, bytes]) -> bytes:
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        for name, data in files.items():
+            info = tarfile.TarInfo(name)
+            info.size = len(data)
+            tar.addfile(info, io.BytesIO(data))
+    return buf.getvalue()
+
+
+def _make_zip(files: dict[str, bytes]) -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        for name, data in files.items():
+            zf.writestr(name, data)
+    return buf.getvalue()
+
+
+def _fetch_returning(data: bytes):
+    async def _fetch(url: str) -> bytes:
+        return data
+
+    return _fetch
+
+
+# ── mounted ──────────────────────────────────────────────────────────────────
+async def test_stage_mounted(tmp_path: Path) -> None:
+    mount = tmp_path / "mount" / "my-skill"
+    (mount / "scripts").mkdir(parents=True)
+    (mount / "SKILL.md").write_text(_skill_md(), encoding="utf-8")
+    (mount / "scripts" / "run.py").write_text("print(1)", encoding="utf-8")
+
+    res = _root("skill://h/my-skill", {"source": "mounted", "mount_dir": str(mount), "version": "1.2.0"})
+    reg = SkillRegistry()
+    home = tmp_path / "home"
+
+    names = await stage_mcp_skills(FakeManager([("tfrobot-tools", res)]), reg, home)
+
+    assert names == ["mcp:tfrobot-tools:my-skill"]
+    ref = reg.resolve("mcp:tfrobot-tools:my-skill")
+    assert ref is not None
+    assert ref["path"] == str(home / "mcp" / "tfrobot-tools" / "my-skill")
+    assert (Path(ref["path"]) / "SKILL.md").is_file()
+    assert (Path(ref["path"]) / "scripts" / "run.py").is_file()
+    assert ref["source"] == "mcp:tfrobot-tools"
+    assert ref["version"] == "1.2.0"
+    assert ref["license"] == "MIT"
+    assert ref["allowed_tools"] == ["read", "write"]
+    assert ref["description"] == "聚合 CSV"
+
+
+# ── archive ────────────────────────────────────────────────────────────────────
+async def test_stage_archive_targz(tmp_path: Path) -> None:
+    data = _make_targz({"SKILL.md": _skill_md().encode(), "scripts/run.py": b"print(1)"})
+    sha = hashlib.sha256(data).hexdigest()
+    res = _root(
+        "skill://h/my-skill",
+        {"source": "archive", "archive_uri": "https://x/s.tgz", "archive_format": "tar.gz", "archive_sha256": sha},
+    )
+    reg = SkillRegistry()
+    home = tmp_path / "home"
+
+    names = await stage_mcp_skills(FakeManager([("srv", res)]), reg, home, archive_fetch=_fetch_returning(data))
+
+    assert names == ["mcp:srv:my-skill"]
+    ref = reg.resolve("mcp:srv:my-skill")
+    assert ref is not None
+    assert (Path(ref["path"]) / "SKILL.md").is_file()
+    assert (Path(ref["path"]) / "scripts" / "run.py").read_text() == "print(1)"
+
+
+async def test_stage_archive_zip(tmp_path: Path) -> None:
+    data = _make_zip({"SKILL.md": _skill_md(name="zskill").encode(), "ref.txt": b"x"})
+    res = _root("skill://h/zskill", {"source": "archive", "archive_uri": "https://x/s.zip", "archive_format": "zip"})
+    reg = SkillRegistry()
+    home = tmp_path / "home"
+
+    names = await stage_mcp_skills(FakeManager([("srv", res)]), reg, home, archive_fetch=_fetch_returning(data))
+
+    assert names == ["mcp:srv:zskill"]
+    assert (Path(reg.resolve("mcp:srv:zskill")["path"]) / "ref.txt").read_text() == "x"  # type: ignore[index]
+
+
+async def test_stage_archive_sha256_mismatch_not_registered(tmp_path: Path) -> None:
+    data = _make_targz({"SKILL.md": _skill_md().encode()})
+    res = _root(
+        "skill://h/my-skill",
+        {"source": "archive", "archive_uri": "https://x/s.tgz", "archive_format": "tar.gz", "archive_sha256": "deadbeef"},
+    )
+    reg = SkillRegistry()
+    home = tmp_path / "home"
+
+    names = await stage_mcp_skills(FakeManager([("srv", res)]), reg, home, archive_fetch=_fetch_returning(data))
+
+    assert names == []  # 校验失败 → 不入册、不抛
+    assert len(reg) == 0
+
+
+async def test_stage_archive_path_traversal_rejected(tmp_path: Path) -> None:
+    # 含 ../evil 的恶意归档 → 安全解包拒绝 → 不入册、不逃逸
+    data = _make_targz({"SKILL.md": _skill_md().encode(), "../evil.txt": b"pwned"})
+    res = _root("skill://h/my-skill", {"source": "archive", "archive_uri": "https://x/s.tgz", "archive_format": "tar.gz"})
+    reg = SkillRegistry()
+    home = tmp_path / "home"
+
+    names = await stage_mcp_skills(FakeManager([("srv", res)]), reg, home, archive_fetch=_fetch_returning(data))
+
+    assert names == []
+    assert not (tmp_path / "evil.txt").exists()  # 未逃逸到 staging 之外
+
+
+# ── resources ──────────────────────────────────────────────────────────────────
+async def test_stage_resources_text_and_blob(tmp_path: Path) -> None:
+    root_uri = "skill://h/my-skill"
+    md_uri = "skill://h/my-skill/SKILL.md"
+    bin_uri = "skill://h/my-skill/assets/logo.bin"
+    root = _root(root_uri, {"source": "resources"})
+    sub_md = Resource(uri=md_uri, name="SKILL.md")
+    sub_bin = Resource(uri=bin_uri, name="logo.bin")
+    reads = {
+        md_uri: ReadResourceResult(contents=[TextResourceContents(uri=md_uri, text=_skill_md())]),
+        bin_uri: ReadResourceResult(contents=[BlobResourceContents(uri=bin_uri, blob=base64.b64encode(b"\x00\x01\x02").decode())]),
+    }
+    mgr = FakeManager([("srv", root), ("srv", sub_md), ("srv", sub_bin)], reads=reads)
+    reg = SkillRegistry()
+    home = tmp_path / "home"
+
+    names = await stage_mcp_skills(mgr, reg, home)
+
+    assert names == ["mcp:srv:my-skill"]
+    path = Path(reg.resolve("mcp:srv:my-skill")["path"])  # type: ignore[index]
+    assert (path / "SKILL.md").is_file()
+    assert (path / "assets" / "logo.bin").read_bytes() == b"\x00\x01\x02"
+
+
+# ── 元数据 / 边界 ──────────────────────────────────────────────────────────────
+async def test_frontmatter_name_canonicalizes_dir(tmp_path: Path) -> None:
+    # URI 叶 old-leaf 与 frontmatter.name real-name 不一致 → 包根目录名校正为 real-name（§4）
+    mount = tmp_path / "mount" / "whatever"
+    mount.mkdir(parents=True)
+    (mount / "SKILL.md").write_text(_skill_md(name="real-name"), encoding="utf-8")
+    res = _root("skill://h/old-leaf", {"source": "mounted", "mount_dir": str(mount)})
+    reg = SkillRegistry()
+    home = tmp_path / "home"
+
+    names = await stage_mcp_skills(FakeManager([("srv", res)]), reg, home)
+
+    assert names == ["mcp:srv:real-name"]
+    assert reg.resolve("mcp:srv:real-name")["path"] == str(home / "mcp" / "srv" / "real-name")  # type: ignore[index]
+    assert not (home / "mcp" / "srv" / "old-leaf").exists()
+
+
+async def test_missing_skill_md_not_registered(tmp_path: Path) -> None:
+    mount = tmp_path / "mount" / "my-skill"
+    mount.mkdir(parents=True)
+    (mount / "README.md").write_text("no skill md", encoding="utf-8")
+    res = _root("skill://h/my-skill", {"source": "mounted", "mount_dir": str(mount)})
+    reg = SkillRegistry()
+    names = await stage_mcp_skills(FakeManager([("srv", res)]), reg, tmp_path / "home")
+    assert names == []
+    assert len(reg) == 0
+
+
+async def test_resource_without_source_meta_skipped(tmp_path: Path) -> None:
+    # 无 _meta.source 的 skill:// 资源（子资源 / 未声明）→ 非 SKILL 根 → 跳过
+    plain = Resource(uri="skill://h/not-a-root", name="not-a-root")
+    reg = SkillRegistry()
+    names = await stage_mcp_skills(FakeManager([("srv", plain)]), reg, tmp_path / "home")
+    assert names == []
+    assert len(reg) == 0

--- a/tests/unit_tests/computer/skills/test_staging.py
+++ b/tests/unit_tests/computer/skills/test_staging.py
@@ -25,6 +25,7 @@ from pathlib import Path
 
 from mcp.types import BlobResourceContents, ReadResourceResult, Resource, TextResourceContents
 
+import a2c_smcp.computer.skills.staging as staging_mod
 from a2c_smcp.computer.skills.registry import SkillRegistry
 from a2c_smcp.computer.skills.staging import stage_mcp_skills
 
@@ -161,6 +162,56 @@ async def test_stage_archive_path_traversal_rejected(tmp_path: Path) -> None:
     assert not (tmp_path / "evil.txt").exists()  # 未逃逸到 staging 之外
 
 
+async def test_stage_archive_symlink_member_rejected(tmp_path: Path) -> None:
+    # 恶意 tar：含 symlink 成员（指向 /etc/passwd）→ 拒绝 → 不入册（PR 主打安全特性的回归用例）
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        md = _skill_md().encode()
+        info = tarfile.TarInfo("SKILL.md")
+        info.size = len(md)
+        tar.addfile(info, io.BytesIO(md))
+        link = tarfile.TarInfo("evil-link")
+        link.type = tarfile.SYMTYPE
+        link.linkname = "/etc/passwd"
+        tar.addfile(link)
+    res = _root("skill://h/my-skill", {"source": "archive", "archive_uri": "https://x/s.tgz", "archive_format": "tar.gz"})
+    reg = SkillRegistry()
+
+    names = await stage_mcp_skills(FakeManager([("srv", res)]), reg, tmp_path / "home", archive_fetch=_fetch_returning(buf.getvalue()))
+
+    assert names == []
+    assert len(reg) == 0
+
+
+async def test_stage_archive_extracted_size_cap(tmp_path: Path, monkeypatch) -> None:  # noqa: ANN001
+    # 解压累计超上限 → 中止 → 不入册（炸弹防护）。临时把上限调到极小以触发。
+    monkeypatch.setattr(staging_mod, "MAX_EXTRACTED_BYTES", 8)
+    data = _make_targz({"SKILL.md": _skill_md().encode()})  # 远超 8 字节
+    res = _root("skill://h/my-skill", {"source": "archive", "archive_uri": "https://x/s.tgz", "archive_format": "tar.gz"})
+    reg = SkillRegistry()
+    names = await stage_mcp_skills(FakeManager([("srv", res)]), reg, tmp_path / "home", archive_fetch=_fetch_returning(data))
+    assert names == []
+    assert len(reg) == 0
+
+
+async def test_stage_archive_download_size_cap(tmp_path: Path, monkeypatch) -> None:  # noqa: ANN001
+    monkeypatch.setattr(staging_mod, "MAX_ARCHIVE_DOWNLOAD_BYTES", 4)
+    data = _make_targz({"SKILL.md": _skill_md().encode()})
+    res = _root("skill://h/my-skill", {"source": "archive", "archive_uri": "https://x/s.tgz", "archive_format": "tar.gz"})
+    reg = SkillRegistry()
+    names = await stage_mcp_skills(FakeManager([("srv", res)]), reg, tmp_path / "home", archive_fetch=_fetch_returning(data))
+    assert names == []
+
+
+async def test_stage_archive_member_count_cap(tmp_path: Path, monkeypatch) -> None:  # noqa: ANN001
+    monkeypatch.setattr(staging_mod, "MAX_ARCHIVE_MEMBERS", 1)
+    data = _make_targz({"SKILL.md": _skill_md().encode(), "a.txt": b"x"})  # 2 成员 > 1
+    res = _root("skill://h/my-skill", {"source": "archive", "archive_uri": "https://x/s.tgz", "archive_format": "tar.gz"})
+    reg = SkillRegistry()
+    names = await stage_mcp_skills(FakeManager([("srv", res)]), reg, tmp_path / "home", archive_fetch=_fetch_returning(data))
+    assert names == []
+
+
 # ── resources ──────────────────────────────────────────────────────────────────
 async def test_stage_resources_text_and_blob(tmp_path: Path) -> None:
     root_uri = "skill://h/my-skill"
@@ -211,6 +262,35 @@ async def test_missing_skill_md_not_registered(tmp_path: Path) -> None:
     names = await stage_mcp_skills(FakeManager([("srv", res)]), reg, tmp_path / "home")
     assert names == []
     assert len(reg) == 0
+
+
+async def test_in_run_name_collision_keeps_first(tmp_path: Path) -> None:
+    # 同一 run 内两个不同 SKILL 合成同 name（frontmatter.name 撞）→ 第二个按 §1.5 拒绝、保留先到者，
+    # 且不覆盖先到者磁盘文件（真冲突在 rename 落盘前拦截，验证 Item 1 修复）。
+    mount_a = tmp_path / "mount" / "a"
+    mount_a.mkdir(parents=True)
+    (mount_a / "SKILL.md").write_text(_skill_md(name="dup", description="first"), encoding="utf-8")
+    (mount_a / "a.txt").write_text("A", encoding="utf-8")
+    mount_b = tmp_path / "mount" / "b"
+    mount_b.mkdir(parents=True)
+    (mount_b / "SKILL.md").write_text(_skill_md(name="dup", description="second"), encoding="utf-8")
+    (mount_b / "b.txt").write_text("B", encoding="utf-8")
+
+    res_a = _root("skill://h/a", {"source": "mounted", "mount_dir": str(mount_a)})
+    res_b = _root("skill://h/b", {"source": "mounted", "mount_dir": str(mount_b)})
+    reg = SkillRegistry()
+    home = tmp_path / "home"
+
+    names = await stage_mcp_skills(FakeManager([("srv", res_a), ("srv", res_b)]), reg, home)
+
+    assert names == ["mcp:srv:dup"]  # 仅第一个入册
+    assert len(reg) == 1
+    ref = reg.resolve("mcp:srv:dup")
+    assert ref is not None
+    assert ref["description"] == "first"  # 保留先到者
+    final = home / "mcp" / "srv" / "dup"
+    assert (final / "a.txt").exists()  # 先到者磁盘文件未被覆盖
+    assert not (final / "b.txt").exists()
 
 
 async def test_resource_without_source_meta_skipped(tmp_path: Path) -> None:


### PR DESCRIPTION
## 概述

S6：mcp 源 SKILL 物化 + `manager.list_skill_resources`。Closes #59（父 #39，依赖 #57 已合并）。

纯 SDK 实现（协议已发布）：依据 `skill.md` §3（mounted/archive/resources）/ §4（包根目录名=frontmatter.name）/ §12（Computer 完整消费 cursor）+ `design-0.2.1-skill-computer-management.md` §5.2。

## 变更

| 文件 | 内容 |
|---|---|
| `mcp_clients/manager.py` (改) | `list_skill_resources`（skill:// 过滤 + server 归属 + **完整消费 cursor 翻页**；错误 server 跳过不阻断）、`read_resource`（通用 resources/read 入口，供 resources 模式逐子资源读取） |
| `computer/skills/staging.py` (新增) | `stage_mcp_skills`：三模式物化 + frontmatter→ref + register/update |
| `computer/skills/__init__.py` (改) | 导出 `stage_mcp_skills` / `parse_skill_frontmatter` / `SkillStagingError` |
| `pyproject.toml` (改) | mypy overrides 增 `yaml`（沿用既有 untyped-lib `ignore_missing_imports` 范式，非运行时依赖） |
| `tests/.../test_manager_skill_resources.py` + `test_staging.py` (新增) | 13 用例 |

## 三种 source 模式物化

| 模式 | `_meta` | 物化 |
|---|---|---|
| **mounted** | `mount_dir` | 复制本地目录（`symlinks=False`，自包含、避免沙箱 realpath 外逃） |
| **archive** | `archive_uri`/`archive_format`/`archive_sha256?` | HTTP 拉取（aiohttp，可注入）→ 校验 sha256 → **安全解包**（tar.gz/zip 逐成员防 `..` 穿越、拒符号/硬链接） |
| **resources** | `source=resources` | 枚举 `skill://<root>/**` 子资源逐个 `read_resource` → 按相对路径**安全写入**（文本/blob 还原） |

物化后读 staged `SKILL.md` 的 YAML frontmatter 作权威元数据（§3 不镜像进 `_meta`），包根目录名校正为 `frontmatter.name`（§4），合成 `A2CSkillRef`（`name=mcp:<nserver>:<frontmatter.name>`）→ Registry。失败降级：任一 SKILL 失败 → 记 ERROR、清理、跳过，不阻断/不抛（§1.5）。

## 验收（#59）

- [x] mock MCP server：cursor 多页完整消费（`test_list_skill_resources_exhausts_cursor_and_filters`）
- [x] mounted / archive(tar.gz, zip) / resources 三模式各物化正确（落盘 + 注册）
- [x] `uv run poe lint` 净

附加安全/边界覆盖：sha256 不符不入册、归档 `../` 穿越成员拒绝且不逃逸、frontmatter.name 目录校正、缺 SKILL.md / 非根资源跳过、错误 server 跳过、resources 文本+blob 还原。

## 验证

- ruff ✅ / mypy ✅（70 源文件零告警）
- 新增 13 单测全过；全量 unit **779 passed / 4 xfailed** 零回归

解锁后续：#66（computer 接入 ← #55,#57,#59）。剩余同源：#60（user DropIn）、#61（marketplace git）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
