### PR TITLE
feat(computer): v0.2.1 SKILL sandbox（包根内沙箱 + .skillenv forbidden）(#55)

### DIFF
--- a/a2c_smcp/computer/skills/__init__.py
+++ b/a2c_smcp/computer/skills/__init__.py
@@ -14,6 +14,8 @@ Mirrors Claude Code marketplace local SKILL management. Landed modules:
 - :mod:`a2c_smcp.computer.skills.home`     —— SKILL Home 解析 + `0o700` 防御性写（隔离交 OS，对齐 CC）+ 安装目录布局（S1，#54）
 - :mod:`a2c_smcp.computer.skills.naming`   —— name 合成 + 段数消歧 lexer + MCP server 段规范化（S1，#54）
 - :mod:`a2c_smcp.computer.skills.registry` —— `name → A2CSkillRef` O(1) 物化索引 + 孤儿标记/恢复（S3，#57）
+- :mod:`a2c_smcp.computer.skills.staging`  —— 多 source 物化（mcp 源 + manager.list_skill_resources）（S6，#59）
+- :mod:`a2c_smcp.computer.skills.sandbox`  —— 包根内 `safe_join`+`realpath` 沙箱 + `.skillenv` forbidden + name 寻址防越权（S2，#55）
 
 协议依据 / Protocol: a2c-smcp-protocol docs/specification/skill.md §1 / §4 / §6 / §8 / §9.2。
 """
@@ -45,6 +47,14 @@ from a2c_smcp.computer.skills.naming import (
     synthesize_user_name,
 )
 from a2c_smcp.computer.skills.registry import SkillRegistry
+from a2c_smcp.computer.skills.sandbox import (
+    DEFAULT_SKILL_FILE,
+    FORBIDDEN_SKILL_FILES,
+    SkillSandboxError,
+    SkillSandboxReason,
+    ensure_within_size_cap,
+    resolve_skill_resource,
+)
 from a2c_smcp.computer.skills.staging import SkillStagingError, parse_skill_frontmatter, stage_mcp_skills
 
 __all__ = [
@@ -72,6 +82,13 @@ __all__ = [
     "synthesize_user_name",
     # registry
     "SkillRegistry",
+    # sandbox
+    "DEFAULT_SKILL_FILE",
+    "FORBIDDEN_SKILL_FILES",
+    "SkillSandboxError",
+    "SkillSandboxReason",
+    "ensure_within_size_cap",
+    "resolve_skill_resource",
     # staging
     "SkillStagingError",
     "parse_skill_frontmatter",

--- a/a2c_smcp/computer/skills/sandbox.py
+++ b/a2c_smcp/computer/skills/sandbox.py
@@ -1,0 +1,170 @@
+# -*- coding: utf-8 -*-
+# filename: sandbox.py
+# @Time    : 2026/05/25
+# @Author  : JQQ
+# @Email   : jqq1716@gmail.com
+# @Software: PyCharm
+"""
+SKILL 包根沙箱 / SKILL package-root sandbox (v0.2.1)
+
+协议依据 / Protocol: a2c-smcp-protocol docs/specification/skill.md §9 安全模型；
+                      error-handling.md §4017（Skill Resource Not Accessible）。
+SDK 设计 / Design: python-sdk docs/design-0.2.1-skill-computer-management.md §5 / §5.3。
+
+职责 / Responsibility:
+- ``safe_join`` + ``realpath`` 包根内校验：``rel_path`` 必须相对、无 ``..``、解析符号链接后仍落在
+  包根内；绝对路径 / ``..`` / symlink 逃逸 → ``traversal``。
+- ``.skillenv`` 等敏感凭证文件**任何 ``rel_path`` 下**命中即拒（``forbidden``），且**不泄漏存在性**
+  （存在与不存在返回同一 reason，命中判定纯词法、不 ``stat``）。
+- **name 寻址防越权**：本模块只收**包根绝对路径**（由 Registry 经 name 解析得到），**绝不**接收
+  SKILL name、**绝不**从 name / ``rel_path`` 推导 FS 路径——结构上杜绝越权寻址（skill.md §9.2 安全铁律）。
+
+所有违规经 :class:`SkillSandboxError` 表达，``reason`` 直映协议 4017 ``details.reason`` 开放枚举
+（``traversal`` / ``forbidden`` / ``not_found`` / ``too_large``）；调用方（``client:get_skill`` 处理器 /
+blob ``kind=skill`` resolver）据此构造 flat ``ErrorPayload`` 的 ``details``。
+
+This module is deliberately ``name``-free: it accepts an already-resolved package **root** path
+(obtained by the caller from the Skill Registry via name) plus a relative ``rel_path``, and never
+derives a filesystem path from a SKILL name — structurally enforcing the §9.2 addressing invariant.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Collection
+from pathlib import Path, PurePosixPath
+from typing import Literal
+
+from a2c_smcp.utils.path import is_within
+
+# rel_path 缺省 = 包根入口 SKILL.md / default rel_path = package-root entry SKILL.md（skill.md §6 / §9）。
+DEFAULT_SKILL_FILE = "SKILL.md"
+
+# 敏感凭证文件默认黑集 / default sensitive-credential basenames。
+# 协议只明文命名 ``.skillenv``；"及 Computer 判定的凭证类文件"（error-handling.md §4017）留给调用方
+# 经 ``forbidden_names`` 注入扩展，避免在 SDK 内硬编码猜测性策略（对齐 no-overengineering 约定）。
+# Protocol names only ``.skillenv``; the open-ended "and Computer-judged credential files" is left to
+# callers via ``forbidden_names`` rather than guessing a broader built-in set.
+FORBIDDEN_SKILL_FILES: frozenset[str] = frozenset({".skillenv"})
+
+# 4017 ``details.reason`` 开放枚举 / open enum for protocol 4017 ``details.reason``。
+SkillSandboxReason = Literal["traversal", "forbidden", "not_found", "too_large"]
+
+
+class SkillSandboxError(Exception):
+    """
+    SKILL 包内资源不可访问 / SKILL in-package resource not accessible.
+
+    映射协议 ``4017 Skill Resource Not Accessible``（error-handling.md §4017）。``reason`` 为开放枚举，
+    ``rel_path`` 回显请求路径，``total_size`` 仅 ``too_large`` 携带——三者直填 4017 ``details``。
+    Maps to protocol ``4017``; ``reason`` is an open enum, ``rel_path`` echoes the request, and
+    ``total_size`` is set only for ``too_large`` — all three populate the 4017 ``details`` object.
+
+    本异常**不**自带协议码常量（保持 sandbox 模块对 ``a2c_smcp.smcp`` 零依赖，对齐 ``naming.SkillNameError``）；
+    由调用方按需映射到 :data:`a2c_smcp.smcp.SMCPErrorCode.SKILL_RESOURCE_NOT_ACCESSIBLE`。
+    This exception embeds no protocol-code constant (keeps the module dependency-free of
+    ``a2c_smcp.smcp``, mirroring ``naming.SkillNameError``); callers map it as appropriate.
+    """
+
+    def __init__(self, reason: SkillSandboxReason, *, rel_path: str = "", total_size: int | None = None) -> None:
+        self.reason: SkillSandboxReason = reason
+        self.rel_path = rel_path
+        self.total_size = total_size
+        super().__init__(f"skill resource not accessible (reason={reason}, rel_path={rel_path!r})")
+
+
+def _guard_lexical(rel: str) -> PurePosixPath:
+    """
+    触 FS 前的纯词法 traversal 守卫 / Pre-FS lexical traversal guard。
+
+    拒绝：反斜杠（非 POSIX 分隔符，防 Windows 路径走私）/ 绝对路径 / 含 ``..`` 段 / 段内含 ``:``
+    （盘符 / scheme 走私）——任一命中 → :class:`SkillSandboxError` ``traversal``。返回解析后的
+    :class:`PurePosixPath`（``.`` 段已被 PurePosixPath 规整掉）。
+    """
+    # 反斜杠不是 POSIX 分隔符；存在即视为非法（防 ``..\`` / ``C:\`` 等 Windows 形态绕过词法检查）。
+    if "\\" in rel:
+        raise SkillSandboxError("traversal", rel_path=rel)
+    pure = PurePosixPath(rel)
+    if pure.is_absolute():
+        raise SkillSandboxError("traversal", rel_path=rel)
+    for part in pure.parts:
+        if part == ".." or ":" in part:
+            raise SkillSandboxError("traversal", rel_path=rel)
+    return pure
+
+
+def resolve_skill_resource(
+    root: Path,
+    rel_path: str | None = None,
+    *,
+    forbidden_names: Collection[str] = FORBIDDEN_SKILL_FILES,
+) -> Path:
+    """
+    在包根 ``root`` 内安全解析 ``rel_path``，返回已 ``resolve()`` 的资源绝对路径。
+    Safely resolve ``rel_path`` within package root ``root``; returns the ``resolve()``-d absolute path.
+
+    判定顺序（顺序保证「forbidden 不泄漏存在性」与「触 FS 前先挡 traversal」）/ Decision order:
+      1. ``rel_path`` 缺省 / 空 → :data:`DEFAULT_SKILL_FILE`（``SKILL.md``）。
+      2. 词法 traversal 守卫（绝对 / ``..`` / 反斜杠 / 盘符，**触 FS 前**）→ ``traversal``。
+      3. **forbidden 先于存在性**：目标 basename（大小写不敏感）命中 ``forbidden_names`` → ``forbidden``，
+         **不 ``stat``、不泄漏存在性**（存在与不存在同一 reason）。
+      4. ``realpath`` 容器校验：``(root/rel).resolve()`` 必须仍在 ``root.resolve()`` 内，否则 ``traversal``
+         （捕 symlink 逃逸）；对 realpath 后的 basename 复检 forbidden（symlink → ``.skillenv``）。
+      5. 目标须为既存普通文件，否则 ``not_found``（含不存在 / 目录）。
+
+    :param root: SKILL 包根绝对路径，**仅**由 Registry 经 name 解析得到（本函数不接收 name）。
+    :param rel_path: 包根 POSIX 相对路径；``None`` / ``""`` 取 ``SKILL.md``。
+    :param forbidden_names: 敏感文件 basename 集合（大小写不敏感比较，防大小写不敏感 FS 绕过）。
+    :raises SkillSandboxError: ``reason`` ∈ ``traversal`` / ``forbidden`` / ``not_found``。
+    """
+    rel = DEFAULT_SKILL_FILE if not rel_path else rel_path
+
+    # ② 词法守卫（触 FS 前） / lexical guard before touching the filesystem.
+    pure = _guard_lexical(rel)
+
+    # 大小写不敏感比较：macOS/APFS、Windows 默认大小写不敏感，``.SKILLENV`` 会落到同一文件，
+    # 故按 lower 比较以堵死大小写绕过 / case-insensitive to close case-folding FS bypass.
+    forbidden_lower = {n.lower() for n in forbidden_names}
+
+    # ③ forbidden 先于任何 FS 访问（纯词法，不泄漏存在性） / forbidden before any FS access.
+    if pure.name.lower() in forbidden_lower:
+        raise SkillSandboxError("forbidden", rel_path=rel)
+
+    # ④ realpath 容器校验（捕 symlink 逃逸） / realpath containment (catches symlink escape).
+    root_real = root.resolve()
+    target_real = (root_real / pure).resolve()
+    if not is_within(target_real, root_real):
+        raise SkillSandboxError("traversal", rel_path=rel)
+    # symlink 指向 ``.skillenv`` 等：realpath 后 basename 复检 / re-check after symlink resolution.
+    if target_real.name.lower() in forbidden_lower:
+        raise SkillSandboxError("forbidden", rel_path=rel)
+
+    # ⑤ 既存普通文件 / must be an existing regular file（不存在 / 目录 → not_found）。
+    if not target_real.is_file():
+        raise SkillSandboxError("not_found", rel_path=rel)
+
+    return target_real
+
+
+def ensure_within_size_cap(path: Path, cap: int, *, rel_path: str = "") -> int:
+    """
+    绝对上限校验 / Absolute size-cap check：``path`` 字节数 > ``cap`` → ``4017 too_large``（不铸句柄）。
+    Returns the file size when within cap.
+
+    协议依据 / Protocol: skill.md §9「铸造期决断 too_large，不铸句柄、零字节传输（防 DoS）」。触发点由
+    ``client:get_skill`` 铸造边界（#66）调用——本函数只负责 size 判定，``cap`` 为 SDK 可配上限。
+    The minting boundary decides ``too_large``; this helper only performs the size comparison.
+
+    TOCTOU：本函数的 ``stat`` 与 :func:`resolve_skill_resource` 的 ``is_file()`` 各一次，二者间存在窗口；
+    属可接受——协议 §9 要求每次 ``client:get_blob`` 解析时**重跑整套沙箱**，铸造期单点 TOCTOU 不构成持久漏洞。
+    The race between this ``stat`` and the resolver's ``is_file()`` is tolerated: §9 mandates re-running
+    the full sandbox on every ``client:get_blob`` resolution, so a momentary mint-time race is not durable.
+
+    :param path: 已经 :func:`resolve_skill_resource` 通过沙箱的资源路径。
+    :param cap: SDK 可配的内联 / 句柄绝对字节上限。
+    :param rel_path: 回显到异常的请求路径（便于 4017 ``details.rel_path``）。
+    :raises SkillSandboxError: ``reason="too_large"``，携带 ``total_size``。
+    """
+    size = path.stat().st_size
+    if size > cap:
+        raise SkillSandboxError("too_large", rel_path=rel_path, total_size=size)
+    return size

--- a/tests/unit_tests/computer/skills/test_sandbox.py
+++ b/tests/unit_tests/computer/skills/test_sandbox.py
@@ -1,0 +1,198 @@
+# -*- coding: utf-8 -*-
+# filename: test_sandbox.py
+# @Time    : 2026/05/25
+# @Author  : JQQ
+# @Email   : jqq1716@gmail.com
+# @Software: PyCharm
+"""
+SKILL 包根沙箱单元测试（v0.2.1，安全反例红→绿）
+Unit tests for the SKILL package-root sandbox (v0.2.1 security counter-examples).
+
+协议依据 / Protocol: a2c-smcp-protocol docs/specification/skill.md §9 安全模型；error-handling.md §4017。
+SDK 设计 / Design: python-sdk docs/design-0.2.1-skill-computer-management.md §5.3。
+
+测试意图 / Test intentions:
+- traversal：`..` / 绝对路径 / 反斜杠 / 盘符 / symlink 逃逸 → 4017 traversal
+- forbidden：`.skillenv` 命中（存在与不存在**同 reason**、嵌套、大小写不敏感、symlink 指向）→ 4017 forbidden
+- not_found：包内不存在 / 目录 → 4017 not_found
+- happy：缺省 SKILL.md / 子资源 / `.` 段规整
+- too_large：ensure_within_size_cap 超上限 → 4017 too_large（带 total_size）
+- name 寻址防越权：API 只收 root，无 name 形参（结构性不变量）
+"""
+
+import inspect
+import os
+from pathlib import Path
+
+import pytest
+
+from a2c_smcp.computer.skills.sandbox import (
+    DEFAULT_SKILL_FILE,
+    FORBIDDEN_SKILL_FILES,
+    SkillSandboxError,
+    ensure_within_size_cap,
+    resolve_skill_resource,
+)
+
+
+@pytest.fixture()
+def skill_root(tmp_path: Path) -> Path:
+    """构造一个最小 SKILL 包根：SKILL.md + references/x.txt + .skillenv。"""
+    root = tmp_path / "home" / "mcp" / "server" / "demo-skill"
+    (root / "references").mkdir(parents=True)
+    (root / DEFAULT_SKILL_FILE).write_text("# Demo Skill\nbody\n", encoding="utf-8")
+    (root / "references" / "x.txt").write_text("ref body\n", encoding="utf-8")
+    (root / ".skillenv").write_text("SECRET=token\n", encoding="utf-8")
+    return root
+
+
+# ---------------------------------------------------------------------------
+# traversal
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "rel_path",
+    [
+        "../../etc/passwd",  # 父级逃逸
+        "../sibling.txt",  # 单级父级
+        "/etc/passwd",  # 绝对路径
+        "..\\windows",  # 反斜杠（非 POSIX 分隔符）
+        "references\\..\\..\\x",  # 反斜杠走私
+        "C:/Windows/system32",  # 盘符
+        "references/../../outside",  # 词法 .. 段
+    ],
+)
+def test_traversal_rejected(skill_root: Path, rel_path: str) -> None:
+    with pytest.raises(SkillSandboxError) as ei:
+        resolve_skill_resource(skill_root, rel_path)
+    assert ei.value.reason == "traversal"
+    assert ei.value.rel_path == rel_path
+
+
+def test_symlink_escape_is_traversal(skill_root: Path, tmp_path: Path) -> None:
+    """包内 symlink 指向包外 → realpath 容器校验失败 → traversal。"""
+    secret = tmp_path / "outside-secret.txt"
+    secret.write_text("top secret\n", encoding="utf-8")
+    link = skill_root / "leak"
+    os.symlink(secret, link)
+    with pytest.raises(SkillSandboxError) as ei:
+        resolve_skill_resource(skill_root, "leak")
+    assert ei.value.reason == "traversal"
+
+
+# ---------------------------------------------------------------------------
+# forbidden（.skillenv 不泄漏存在性）
+# ---------------------------------------------------------------------------
+def test_skillenv_forbidden_when_exists(skill_root: Path) -> None:
+    with pytest.raises(SkillSandboxError) as ei:
+        resolve_skill_resource(skill_root, ".skillenv")
+    assert ei.value.reason == "forbidden"
+
+
+def test_skillenv_forbidden_when_absent_same_reason(skill_root: Path) -> None:
+    """不存在的 .skillenv 与存在的返回同一 reason（不泄漏存在性）。"""
+    (skill_root / ".skillenv").unlink()  # 删掉，确保物理不存在
+    with pytest.raises(SkillSandboxError) as ei:
+        resolve_skill_resource(skill_root, ".skillenv")
+    assert ei.value.reason == "forbidden"
+
+
+def test_skillenv_forbidden_nested(skill_root: Path) -> None:
+    """嵌套路径命中 .skillenv basename → forbidden（无需该文件存在）。"""
+    with pytest.raises(SkillSandboxError) as ei:
+        resolve_skill_resource(skill_root, "references/.skillenv")
+    assert ei.value.reason == "forbidden"
+
+
+def test_skillenv_forbidden_case_insensitive(skill_root: Path) -> None:
+    """大小写变体（防大小写不敏感 FS 绕过）→ forbidden。"""
+    with pytest.raises(SkillSandboxError) as ei:
+        resolve_skill_resource(skill_root, ".SKILLENV")
+    assert ei.value.reason == "forbidden"
+
+
+def test_symlink_to_skillenv_forbidden(skill_root: Path) -> None:
+    """包内 symlink 指向 .skillenv → realpath 后 basename 复检 → forbidden。"""
+    link = skill_root / "alias.txt"
+    os.symlink(skill_root / ".skillenv", link)
+    with pytest.raises(SkillSandboxError) as ei:
+        resolve_skill_resource(skill_root, "alias.txt")
+    assert ei.value.reason == "forbidden"
+
+
+def test_custom_forbidden_names(skill_root: Path) -> None:
+    """forbidden_names 可注入额外凭证类文件名（协议「Computer 判定的凭证类文件」扩展口）。"""
+    (skill_root / "credentials.json").write_text("{}", encoding="utf-8")
+    with pytest.raises(SkillSandboxError) as ei:
+        resolve_skill_resource(skill_root, "credentials.json", forbidden_names={".skillenv", "credentials.json"})
+    assert ei.value.reason == "forbidden"
+    # 默认集合下同一文件可正常解析（确认确属注入扩展而非内置）
+    assert resolve_skill_resource(skill_root, "credentials.json") == (skill_root / "credentials.json").resolve()
+
+
+# ---------------------------------------------------------------------------
+# not_found
+# ---------------------------------------------------------------------------
+def test_missing_file_not_found(skill_root: Path) -> None:
+    with pytest.raises(SkillSandboxError) as ei:
+        resolve_skill_resource(skill_root, "missing.md")
+    assert ei.value.reason == "not_found"
+
+
+def test_directory_is_not_found(skill_root: Path) -> None:
+    """目录不是可读资源 → not_found。"""
+    with pytest.raises(SkillSandboxError) as ei:
+        resolve_skill_resource(skill_root, "references")
+    assert ei.value.reason == "not_found"
+
+
+# ---------------------------------------------------------------------------
+# happy path
+# ---------------------------------------------------------------------------
+def test_default_resolves_skill_md(skill_root: Path) -> None:
+    assert resolve_skill_resource(skill_root, None) == (skill_root / DEFAULT_SKILL_FILE).resolve()
+
+
+def test_empty_rel_path_resolves_skill_md(skill_root: Path) -> None:
+    assert resolve_skill_resource(skill_root, "") == (skill_root / DEFAULT_SKILL_FILE).resolve()
+
+
+def test_subresource_resolves(skill_root: Path) -> None:
+    assert resolve_skill_resource(skill_root, "references/x.txt") == (skill_root / "references" / "x.txt").resolve()
+
+
+def test_dot_segments_normalized(skill_root: Path) -> None:
+    """`.` 段被 PurePosixPath 规整，合法解析（区别于 `..`）。"""
+    assert resolve_skill_resource(skill_root, "./references/./x.txt") == (skill_root / "references" / "x.txt").resolve()
+
+
+# ---------------------------------------------------------------------------
+# too_large
+# ---------------------------------------------------------------------------
+def test_size_within_cap_returns_size(skill_root: Path) -> None:
+    target = resolve_skill_resource(skill_root, "references/x.txt")
+    size = ensure_within_size_cap(target, cap=1024)
+    assert size == target.stat().st_size
+
+
+def test_size_exceeds_cap_too_large(skill_root: Path) -> None:
+    target = resolve_skill_resource(skill_root, "references/x.txt")
+    real_size = target.stat().st_size
+    with pytest.raises(SkillSandboxError) as ei:
+        ensure_within_size_cap(target, cap=0, rel_path="references/x.txt")
+    assert ei.value.reason == "too_large"
+    assert ei.value.total_size == real_size
+    assert ei.value.rel_path == "references/x.txt"
+
+
+# ---------------------------------------------------------------------------
+# name 寻址防越权（结构性不变量）/ name-addressing invariant
+# ---------------------------------------------------------------------------
+def test_api_takes_root_not_name() -> None:
+    """API 只收包根 root，**无** name 形参——结构上杜绝从 name 推导 FS 路径（skill.md §9.2）。"""
+    params = inspect.signature(resolve_skill_resource).parameters
+    assert "root" in params
+    assert "name" not in params
+
+
+def test_default_forbidden_files_contains_skillenv() -> None:
+    assert ".skillenv" in FORBIDDEN_SKILL_FILES


### PR DESCRIPTION
## 概述

v0.2.1 SKILL 子系统 **S2 sandbox**（父 #39 · Milestone「v0.2.1 SKILL 通道 + 通用二进制传输」）。新增包根内路径沙箱安全原语，落地协议 `skill.md §9` 安全模型 / `error-handling.md §4017`（**均已发布，无协议变更**）。**依赖：无**。

走 `/add-feature` 协议先行门控：Step 0 判定 A2C 线但落在既有协议内 → Step 2 合规（4017 已发布）→ 直达 Step 6 实现。

## 改动

| 文件 | 变更 |
|---|---|
| `a2c_smcp/computer/skills/sandbox.py` | **新增** 沙箱原语 |
| `a2c_smcp/computer/skills/__init__.py` | 导出 6 符号 + docstring 列入 sandbox/staging |
| `tests/unit_tests/computer/skills/test_sandbox.py` | **新增** 24 用例（安全反例红→绿）|

## 安全不变量（对齐协议 §9 / §4017）

- **traversal**：绝对 / `..` / 反斜杠 / 盘符（**触 FS 前**词法挡）+ symlink 逃逸（realpath `is_within`）
- **forbidden**：`.skillenv` 命中——纯词法**先于存在性**（存在/不存在**同 reason**，不泄漏存在性）+ 大小写不敏感（堵 macOS/Windows 大小写 FS 绕过）+ realpath 后 basename 复检（symlink→`.skillenv`）+ `forbidden_names` 可注入扩展
- **not_found**：不存在 / 目录
- **too_large**：`ensure_within_size_cap` 超上限带 `total_size`（触发点留 #66 铸造边界）
- **name 寻址防越权结构化**：API 只收 `root: Path`，无 `name` 形参

## 验收（#55）

- [x] `..` / 绝对路径 / symlink 逃逸 → `4017 traversal`
- [x] `.skillenv` 命中 → `4017 forbidden`，存在与不存在**同一 reason**
- [x] name 寻址：API 无法从 name/rel_path 推导包根 FS 路径（inspect 契约断言）
- [x] `uv run poe lint` 净（ruff + mypy，71 files）；安全反例单测绿（24/24）
- [x] 全量单测零回归（808 passed / 4 xfailed）

## Review 处理（`/fix-review discuss`）

2 条 🟡（无 🔴）经讨论均**保持现状**（与审查者推荐一致）：① 双 stat/TOCTOU 由协议 §9 每次 `get_blob` 重跑沙箱兜底（补 docstring 说明）；② `:` 段拒绝为跨平台盘符走私防御的有意 trade-off。

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)