### PR TITLE
feat(computer): v0.2.1 SKILL computer 接入 + on_get_skills/skill + SkillBlobResolver (#66)

### DIFF
--- a/a2c_smcp/computer/blob/__init__.py
+++ b/a2c_smcp/computer/blob/__init__.py
@@ -8,7 +8,7 @@ Computer 侧通用二进制传输 / Generic binary transfer on the Computer side
 模块组成 / Module composition:
   - handle.py     blob_handle 编解码（单层 msgpack + base64url，无 MAC）
   - toolspool.py  tool_call 二进制溢写的内容寻址暂存（``.blobspool/<cid>``）
-  - resolver.py   BlobResolver Protocol + 内置 ToolspoolBlobResolver；skill resolver 占位待 #39 接管
+  - resolver.py   BlobResolver Protocol + 内置 ToolspoolBlobResolver / SkillBlobResolver（kind=skill 重跑沙箱）
   - thresholds.py inline budget / too_large cap / chunk max 默认值 + 环境变量覆盖
 
 设计依据 / Design source: ``docs/design-0.2.1-skill-computer-management.md`` §4.3 / §4.4.
@@ -30,7 +30,7 @@ from a2c_smcp.computer.blob.handle import (
 from a2c_smcp.computer.blob.resolver import (
     BlobResolver,
     ResolvedBlob,
-    SkillBlobResolverPending,
+    SkillBlobResolver,
     ToolspoolBlobResolver,
 )
 from a2c_smcp.computer.blob.thresholds import (
@@ -50,7 +50,7 @@ __all__ = [
     "BlobThresholds",
     "BlobTooLargeError",
     "ResolvedBlob",
-    "SkillBlobResolverPending",
+    "SkillBlobResolver",
     "SkillHandlePayload",
     "ToolspoolBlobResolver",
     "ToolspoolBlobStore",

--- a/a2c_smcp/computer/blob/resolver.py
+++ b/a2c_smcp/computer/blob/resolver.py
@@ -12,18 +12,22 @@
   - **重施铸造通道边界校验**（kind=skill → SKILL 沙箱；kind=toolspool → cid 白名单 + 路径围栏）；
   - 句柄内容**绝不**被直接信任（协议 ``blob-transfer.md`` §5.4）。
 
-#39 接管 / Handed over by #39: ``SkillBlobResolverPending`` 占位 → 被 ``SkillBlobResolver``
-（基于 Skill Registry + sandbox）替换；本 PR 仅提供 toolspool 完整实现 + skill 占位。
+#39 接管 / Handed over by #39 (#66): ``SkillBlobResolver``（基于 Skill Registry + sandbox + 消费字节
+视图）落地，取代早期 ``SkillBlobResolverPending`` 占位。
 """
 
 from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any, Protocol, runtime_checkable
 
-from a2c_smcp.computer.blob.handle import BlobHandleForbiddenError
+from a2c_smcp.computer.blob.handle import BlobHandleForbiddenError, BlobHandleGoneError
 from a2c_smcp.computer.blob.toolspool import ToolspoolBlobStore
+from a2c_smcp.computer.skills.registry import SkillRegistry
+from a2c_smcp.computer.skills.resource import resolve_skill_view
+from a2c_smcp.computer.skills.sandbox import SkillSandboxError
 
 # 惰性切片闭包类型 / Lazy slice closure type: (offset, length) -> bytes
 # Resolver 在 ``resolve()`` 中构造此闭包并注入 ResolvedBlob，handler 切片时按需回读。
@@ -164,23 +168,47 @@ class ToolspoolBlobResolver:
         )
 
 
-class SkillBlobResolverPending:
-    """``kind="skill"`` 解析器占位（PR #38 边界，#39 接管）.
+class SkillBlobResolver:
+    """``kind="skill"`` 解析器：name→Registry 解析包根 → ``rel_path`` 重跑 §6 沙箱 → 惰性切片回源.
 
-    Placeholder for ``kind="skill"`` resolution; the concrete implementation lands in #39 (Computer
-    SKILL subsystem) wiring up Skill Registry + sandbox. 本 PR 保留此占位是为了让 ``Computer``
-    层默认即拥有完整 kind 派发，#39 仅替换实现而无须改 handler。
+    无状态、确定性、幂等（设计 §4.3）：**忽略句柄内任何路径推导**（协议 ``blob-transfer.md`` §5.4
+    「不信任句柄内容」），仅以 ``name`` 经 :class:`SkillRegistry` O(1) 解析包根，再对 ``rel_path``
+    经 :func:`~a2c_smcp.computer.skills.resource.resolve_skill_view` **重跑沙箱**。``total_size`` /
+    ``sha256`` 基于消费字节（SKILL.md→frontmatter 剥离后 body；其它→原始字节），与 ``client:get_skill``
+    铸造期严格一致（设计 §4.4「资源字节三处一致」）。
+    Stateless / deterministic / idempotent: ignores any path embedded in the handle, resolves the
+    package root via ``name`` through the Registry, then re-runs the §6 sandbox on ``rel_path``.
+    ``total_size`` / ``sha256`` match the get_skill mint exactly (shared consumed-bytes view).
 
-    Behavior: ``resolve`` 一律抛 :class:`BlobHandleError`（``forbidden`` reason），等同
-    「resolver 未实现 → 视为铸造通道授权撤销」——保守且符合协议「不信任句柄」边界。
-    Raises ``BlobHandleError(reason="forbidden")``: until #39 plugs in, the channel is treated as
-    revoked — conservative and aligned with the "do not trust the handle" boundary.
+    §9.2 name 寻址防越权 / anti-escalation：包根**仅**由 Registry 经 name 解析；``resolve_skill_view``
+    只接受 ``root: Path``，绝不从 name/rel_path 推导 FS 路径。
+
+    错误映射（→ 协议 4018 ``details.reason``）/ Error mapping:
+      - Registry 未命中 / 孤儿 → :class:`BlobHandleGoneError`（``gone``：SKILL 已卸载 / 不可用）；
+      - 沙箱 ``not_found``（源文件铸造后消失）→ ``gone``；
+      - 沙箱 ``traversal`` / ``forbidden`` → :class:`BlobHandleForbiddenError`（``forbidden``）；
+      - msgpack 格式 / kind 不识别由 :func:`decode_blob_handle` 在更上层映射 ``invalid_handle``（不达此）。
     """
 
+    def __init__(self, registry: SkillRegistry) -> None:
+        self._registry = registry
+
     def resolve(self, payload: dict[str, Any]) -> ResolvedBlob:
-        # 故意保留参数签名以 satisfy BlobResolver Protocol（runtime_checkable）。
-        # Signature preserved to satisfy the runtime_checkable BlobResolver Protocol.
-        _ = payload
-        # 用子类直 raise 比设值 ``.reason`` 更 DRY，避免脏化基类实例属性
-        # Subclass-raise is DRYer than mutating ``.reason`` on the base class instance
-        raise BlobHandleForbiddenError("skill resolver pending #39 — kind=skill not wired in this PR")
+        name = payload["name"]
+        rel_path = payload["rel_path"]
+        ref = self._registry.resolve(name)
+        if ref is None:
+            # name 未注册 / 已孤儿 → 铸造通道授权已撤销，源不可服务（gone）。
+            raise BlobHandleGoneError(f"skill not resolvable: name={name!r} (unregistered or orphaned)")
+        root = Path(ref["path"])
+        try:
+            # get_blob 不传 too_large_cap：协议 4018 无 too_large 语义，超大资源由分块传输自然承载。
+            view = resolve_skill_view(root, rel_path)
+        except SkillSandboxError as e:
+            if e.reason == "not_found":
+                raise BlobHandleGoneError(f"skill resource gone: name={name!r} rel_path={rel_path!r}") from e
+            raise BlobHandleForbiddenError(
+                f"skill resource forbidden: name={name!r} rel_path={rel_path!r} reason={e.reason}",
+            ) from e
+        # view.slice 已满足 ``(offset, length) -> bytes`` 切片契约（含截断/边界校验），直接作 _slicer。
+        return ResolvedBlob(mime=view.mime, total_size=view.total_size, sha256=view.sha256, _slicer=view.slice)

--- a/a2c_smcp/computer/computer.py
+++ b/a2c_smcp/computer/computer.py
@@ -52,7 +52,7 @@ from a2c_smcp.computer.blob import (
     BlobResolver,
     BlobThresholds,
     BlobTooLargeError,
-    SkillBlobResolverPending,
+    SkillBlobResolver,
     ToolspoolBlobResolver,
     ToolspoolBlobStore,
     default_thresholds,
@@ -62,13 +62,24 @@ from a2c_smcp.computer.inputs.render import ConfigRender
 from a2c_smcp.computer.inputs.resolver import InputNotFoundError, InputResolver
 from a2c_smcp.computer.mcp_clients.manager import MCPServerManager
 from a2c_smcp.computer.mcp_clients.model import MCPServerConfig, MCPServerInput
+from a2c_smcp.computer.skills import (
+    SkillRegistry,
+    SkillResourceView,
+    ensure_skill_home,
+    resolve_skill_view,
+    stage_mcp_skills,
+)
 from a2c_smcp.computer.types import ToolCallRecord
-from a2c_smcp.smcp import Desktop, SMCPTool
+from a2c_smcp.smcp import A2CSkillRef, Desktop, SMCPTool
 from a2c_smcp.types import AttributeValue
 from a2c_smcp.utils.logger import get_logger, truncate
 from a2c_smcp.utils.window_uri import is_window_uri
 
 logger = get_logger("computer")
+
+# v0.2.1 SKILL 资源 URI scheme 前缀（与 manager.list_skill_resources 过滤一致）
+# v0.2.1 SKILL resource URI scheme prefix (consistent with manager.list_skill_resources filter)
+_SKILL_URI_PREFIX = "skill://"
 
 if TYPE_CHECKING:
     # 仅用于类型检查，避免运行时引入依赖/循环引用
@@ -88,6 +99,7 @@ class Computer(BaseComputer[PromptSession]):
         blob_cache_root: Path | None = None,
         blob_resolvers: dict[str, BlobResolver] | None = None,
         blob_thresholds: BlobThresholds | None = None,
+        skill_home: Path | None = None,
     ) -> None:
         """
         初始化 Computer 实例
@@ -115,6 +127,10 @@ class Computer(BaseComputer[PromptSession]):
                 wire ``toolspool`` (complete) and ``skill`` (#39 placeholder).
             blob_thresholds (BlobThresholds | None): SKILL / blob 阈值（inline / too_large / chunk_max）；
                 缺省经环境变量覆盖。Threshold bundle; defaults honor env overrides.
+            skill_home (Path | None): v0.2.1 SKILL Home 根覆盖（测试 / 部署注入）。缺省走
+                ``A2C_SKILL_HOME`` → ``$XDG_DATA_HOME/a2c/skills`` → ``~/.a2c/skills`` 解析链。
+                mcp 源 ``skill://`` 物化落盘于 ``<home>/mcp/<server>/<skill>/``。
+                SKILL Home root override (test/deploy injection); defaults to the env resolution chain.
         """
         self.name = name
         self.mcp_manager: MCPServerManager | None = None
@@ -139,16 +155,24 @@ class Computer(BaseComputer[PromptSession]):
         # Windows cache (only URIs that conform to WindowURI to avoid irrelevant refresh triggers)
         self._windows_cache: set[str] = set()
 
+        # v0.2.1 SKILL 子系统 / v0.2.1 SKILL subsystem（设计 §5.1，#66）
+        # 持有 name → A2CSkillRef 物化索引；SKILL Home 于 boot_up 解析落盘；skill:// 缓存仿窗口缓存。
+        # Hold the materialized Registry; SKILL Home resolved at boot_up; skill:// cache mirrors windows cache.
+        self._skill_registry: SkillRegistry = SkillRegistry()
+        self._skill_home_override: Path | None = skill_home
+        self._skill_home: Path | None = None
+        self._skills_cache: set[str] = set()
+
         # v0.2.1 通用二进制传输基础设施 / v0.2.1 generic blob-transfer infrastructure
         # 协议依据 / Protocol: blob-transfer.md；设计 / Design: §4.3 / §4.4
         self._blob_cache_root: Path = (blob_cache_root or Path.home() / ".a2c").expanduser().resolve()
         self._blob_cache_root.mkdir(parents=True, exist_ok=True)
         self._toolspool_store: ToolspoolBlobStore = ToolspoolBlobStore(self._blob_cache_root)
-        # 默认 resolver 装配：toolspool 完整、skill 占位（#39 接管后替换）
-        # Default resolver wiring: toolspool complete, skill placeholder (replaced by #39)
+        # 默认 resolver 装配：toolspool 完整、skill 经 Registry + 沙箱重跑回源（#66 接管占位）
+        # Default resolver wiring: toolspool complete; skill re-runs Registry + sandbox (replaces #39 placeholder)
         default_resolvers: dict[str, BlobResolver] = {
             "toolspool": ToolspoolBlobResolver(self._toolspool_store),
-            "skill": SkillBlobResolverPending(),
+            "skill": SkillBlobResolver(self._skill_registry),
         }
         if blob_resolvers is not None:
             default_resolvers.update(blob_resolvers)
@@ -286,6 +310,28 @@ class Computer(BaseComputer[PromptSession]):
 
         await self.mcp_manager.ainitialize(validated_servers)
 
+        # v0.2.1 SKILL 子系统启动初始化（设计 §5.1，#66）：解析 SKILL Home → 物化 mcp 源 skill:// →
+        # 填充 Registry → 初始化 skill:// 缓存。失败隔离：记 ERROR、**不**阻断 Computer 启动
+        # （skill.md §1.5：SKILL 通道对部分失败健壮）。marketplace/user 源 reconcile 见 #60/#61。
+        # SKILL subsystem boot init: resolve Home → materialize mcp-source skills → seed cache.
+        # Failure-isolated: log ERROR, never block Computer boot. marketplace/user sources land in #60/#61.
+        try:
+            self._skill_home = self._resolve_skill_home()
+            await self._restage_mcp_skills()
+            self._skills_cache = await self._acollect_skill_refs()
+        except Exception as e:  # pragma: no cover — 防御性兜底，正常路径已在内部各自降级
+            logger.error(f"SKILL 子系统启动初始化失败（不阻断 Computer 启动）/ SKILL boot init failed (non-blocking): {e}", exc_info=True)
+
+    def _resolve_skill_home(self) -> Path:
+        """解析并创建 SKILL Home（0o700 防御性写）/ Resolve & create SKILL Home。
+
+        显式注入 ``skill_home`` 时经 ``A2C_SKILL_HOME`` 覆盖；否则走默认 env 解析链
+        （``A2C_SKILL_HOME`` → ``$XDG_DATA_HOME/a2c/skills`` → ``~/.a2c/skills``）。
+        """
+        if self._skill_home_override is not None:
+            return ensure_skill_home({"A2C_SKILL_HOME": str(self._skill_home_override)})
+        return ensure_skill_home()
+
     async def _on_manager_change(
         self,
         message: RequestResponder[types.ServerRequest, types.ClientResult] | types.ServerNotification | Exception,
@@ -308,55 +354,107 @@ class Computer(BaseComputer[PromptSession]):
             except Exception as e:  # pragma: no cover
                 logger.error(f"上报工具变更失败: {e}", exc_info=True)
         elif isinstance(getattr(message, "root", None), ResourceListChangedNotification):
-            # 仅当 window:// 集合发生变化时触发刷新；否则记录日志以便后续策略调整
+            # 资源列表变化：window:// 与 skill:// **并行独立**处理（互不阻断，设计 §5.1）。
+            # Resource list changed: window:// and skill:// handled in parallel & independently.
             client = self.socketio_client
             if client is None:
-                logger.debug("Socket.IO 客户端不存在或已释放，忽略桌面刷新上报")
+                logger.debug("Socket.IO 客户端不存在或已释放，忽略资源列表变化上报")
                 return
-            try:
-                new_windows = await self._acollect_window_uris()
-            except Exception as e:  # pragma: no cover
-                logger.error(f"收集窗口资源失败，跳过刷新: {e}", exc_info=True)
+            await self._on_resource_list_changed_windows(client)
+            await self._on_resource_list_changed_skills(client)
+        elif isinstance(getattr(message, "root", None), ResourceUpdatedNotification):
+            # 资源内容更新按 scheme 分流：window:// → 桌面刷新；skill:// → 重物化并上报 SKILL 更新。
+            # Resource content updated, dispatched by scheme: window:// → desktop; skill:// → restage skills.
+            client = self.socketio_client
+            if client is None:
+                logger.debug("Socket.IO 客户端不存在或已释放，忽略资源更新上报")
                 return
-
-            if new_windows != self._windows_cache:
-                added = sorted(new_windows - self._windows_cache)
-                removed = sorted(self._windows_cache - new_windows)
-                logger.info(
-                    "WindowURI 列表发生变化，将触发桌面刷新 | Window list changed, refreshing desktop. "
-                    f"added={len(added)}, removed={len(removed)}",
-                )
-                if added:
-                    logger.debug(f"新增窗口: {added}")
-                if removed:
-                    logger.debug(f"移除窗口: {removed}")
-                self._windows_cache = new_windows
+            uri = getattr(getattr(getattr(message, "root", None), "params", None), "uri", None)
+            uri_str = str(uri) if uri is not None else ""
+            if uri is not None and is_window_uri(uri_str):
                 try:
                     await client.emit_refresh_desktop()
                 except Exception as e:  # pragma: no cover
-                    logger.error(f"上报桌面刷新失败: {e}", exc_info=True)
+                    logger.error(f"上报桌面刷新失败: {e}")
+            elif uri_str.startswith(_SKILL_URI_PREFIX):
+                await self._on_skill_resource_updated(client)
             else:
-                # 打印关键信息帮助开发者判断策略是否需要更新
-                logger.info(
-                    "收到 ResourceListChangedNotification 但 WindowURI 未变化，跳过刷新 / "
-                    "Resource list changed but WindowURI set unchanged, skip refresh",
-                )
-        elif isinstance(getattr(message, "root", None), ResourceUpdatedNotification):
-            # 资源内容更新：若是 window:// 则直接触发刷新（不比较集合，降低延迟）
-            client = self.socketio_client
-            if client is None:
-                logger.debug("Socket.IO 客户端不存在或已释放，忽略桌面刷新上报")
-                return
-            try:
-                uri = getattr(getattr(getattr(message, "root", None), "params", None), "uri", None)
-                if uri is None or not is_window_uri(str(uri)):
-                    logger.debug("收到资源更新但非 WindowURI，放行 / Non-window resource updated, ignore")
-                    return
-                await client.emit_refresh_desktop()
-            except Exception as e:  # pragma: no cover
-                logger.error(f"上报桌面刷新失败: {e}")
+                logger.debug("收到资源更新但非 window/skill scheme，放行 / Non-window/skill resource updated, ignore")
         else:
             logger.warning(f"收到未处理的变化类型: {truncate(message)}，当前版本仅处理工具列表变化")
+
+    async def _on_resource_list_changed_windows(self, client: "SMCPComputerClient") -> None:
+        """window:// 集合变化 → 比对缓存 → 触发桌面刷新（行为同 v0.2 既有逻辑，原样抽取）。
+
+        window:// set changed → compare cache → trigger desktop refresh (behavior-neutral extraction).
+        """
+        try:
+            new_windows = await self._acollect_window_uris()
+        except Exception as e:  # pragma: no cover
+            logger.error(f"收集窗口资源失败，跳过刷新: {e}", exc_info=True)
+            return
+
+        if new_windows != self._windows_cache:
+            added = sorted(new_windows - self._windows_cache)
+            removed = sorted(self._windows_cache - new_windows)
+            logger.info(
+                "WindowURI 列表发生变化，将触发桌面刷新 | Window list changed, refreshing desktop. "
+                f"added={len(added)}, removed={len(removed)}",
+            )
+            if added:
+                logger.debug(f"新增窗口: {added}")
+            if removed:
+                logger.debug(f"移除窗口: {removed}")
+            self._windows_cache = new_windows
+            try:
+                await client.emit_refresh_desktop()
+            except Exception as e:  # pragma: no cover
+                logger.error(f"上报桌面刷新失败: {e}", exc_info=True)
+        else:
+            # 打印关键信息帮助开发者判断策略是否需要更新
+            logger.info(
+                "收到 ResourceListChangedNotification 但 WindowURI 未变化，跳过刷新 / "
+                "Resource list changed but WindowURI set unchanged, skip refresh",
+            )
+
+    async def _on_resource_list_changed_skills(self, client: "SMCPComputerClient") -> None:
+        """skill:// 集合变化 → 重物化 mcp 源 + 孤儿对账 → ``emit_update_skills``（仿窗口缓存对比）。
+
+        集合未变化则仅 DEBUG 跳过（设计 §5.1：``_acollect_skill_refs`` 集合相同跳过）。
+        skill:// set changed → restage mcp source + orphan reconcile → emit; unchanged → DEBUG skip.
+        """
+        try:
+            new_skills = await self._acollect_skill_refs()
+        except Exception as e:  # pragma: no cover
+            logger.error(f"收集 skill:// 资源失败，跳过 SKILL 刷新: {e}", exc_info=True)
+            return
+
+        if new_skills == self._skills_cache:
+            logger.debug("收到 ResourceListChanged 但 skill:// 集合未变化，跳过 SKILL 重物化 / skill:// set unchanged, skip")
+            return
+
+        added = len(new_skills - self._skills_cache)
+        removed = len(self._skills_cache - new_skills)
+        logger.info(f"skill:// 列表发生变化，重物化并上报 SKILL 更新 | skill:// list changed. added={added}, removed={removed}")
+        try:
+            await self._restage_mcp_skills()
+            self._skills_cache = new_skills
+            await client.emit_update_skills()
+        except Exception as e:  # pragma: no cover
+            logger.error(f"SKILL 重物化/上报失败: {e}", exc_info=True)
+
+    async def _on_skill_resource_updated(self, client: "SMCPComputerClient") -> None:
+        """skill:// 资源内容更新 → 重物化 + 上报（不比较集合，降低延迟，仿 window ResourceUpdated）。
+
+        单 SKILL 增量物化的 server 归属无法仅从 URI 推断，故走全量重物化（正确优先；增量为后续优化）。
+        skill:// content updated → restage + emit (no set compare, lower latency). Full restage for
+        simplicity since per-skill server attribution isn't derivable from the URI alone.
+        """
+        try:
+            await self._restage_mcp_skills()
+            await client.emit_update_skills()
+        except Exception as e:  # pragma: no cover
+            logger.error(f"SKILL 内容更新重物化/上报失败: {e}", exc_info=True)
 
     async def _acollect_window_uris(self) -> set[str]:
         """
@@ -371,6 +469,57 @@ class Computer(BaseComputer[PromptSession]):
         pairs = await self.mcp_manager.list_windows()
         # 仅保留符合 WindowURI 协议的资源
         return {str(res.uri) for _srv, res in pairs if is_window_uri(str(res.uri))}
+
+    async def _acollect_skill_refs(self) -> set[str]:
+        """
+        收集当前所有 MCP Server 的 ``skill://`` 资源 URI 集合（去重）/ Collect deduplicated skill:// URI set。
+
+        用于 ``ResourceListChanged`` 缓存对比（集合相同跳过重物化，仿 :meth:`_acollect_window_uris`）。
+        ``manager.list_skill_resources`` 已按 ``skill://`` scheme 过滤并完整消费 cursor 翻页。
+
+        Returns:
+            set[str]: skill:// 资源 URI 集合（含子资源——任何变化都触发重物化，缓存对比更敏感）。
+        """
+        if not self.mcp_manager:
+            return set()
+        pairs = await self.mcp_manager.list_skill_resources()
+        return {str(res.uri) for _srv, res in pairs}
+
+    async def _restage_mcp_skills(self, server_name: str | None = None) -> list[str]:
+        """
+        物化 mcp 源 ``skill://`` → 注册进 :class:`SkillRegistry` / Materialize & register mcp-source skills。
+
+        全量重物化（``server_name is None``）后做孤儿对账：本轮未出现的 mcp 源 SKILL → 标孤儿
+        （从 ``get_skills`` 排除，保留以便 source 回归时恢复）。SKILL Home 未就绪 / 无 manager → 空列表。
+        Full restage reconciles orphans: mcp-source skills absent this run are marked orphaned.
+
+        Args:
+            server_name: 若提供仅重物化该 server（单 server 重枚举）；否则全部活跃 server + 孤儿对账。
+
+        Returns:
+            list[str]: 本轮成功注册（或刷新）的 SKILL name 列表。
+        """
+        if not self.mcp_manager or self._skill_home is None:
+            return []
+        registered = await stage_mcp_skills(self.mcp_manager, self._skill_registry, self._skill_home, server_name=server_name)
+        if server_name is None:
+            self._reconcile_mcp_orphans(set(registered))
+        return registered
+
+    def _reconcile_mcp_orphans(self, present_names: set[str]) -> None:
+        """
+        全量重物化后孤儿对账 / Orphan reconciliation after a full restage。
+
+        当前活跃但本轮未出现的 ``mcp:`` 源 SKILL → :meth:`SkillRegistry.mark_orphan`（消失即从
+        ``get_skills`` 排除；恢复由 staging 的 ``register`` 命中孤儿条目自动完成）。**仅**处理 mcp 源，
+        marketplace/user 源（#60/#61）由各自 reconciler 维护，不在此误标孤儿。
+        Only mcp-source skills are reconciled here; marketplace/user sources are owned by #60/#61.
+        """
+        for ref in self._skill_registry.active_refs():
+            source = ref.get("source", "") or ""
+            name = ref.get("name", "") or ""
+            if name and name not in present_names and source.startswith("mcp:"):
+                self._skill_registry.mark_orphan(name)
 
     async def _arender_and_validate_server(
         self,
@@ -826,6 +975,53 @@ class Computer(BaseComputer[PromptSession]):
         if not self.mcp_manager:
             raise RuntimeError("当前MCP Manager为空 / MCP Manager is not initialized")
         return await self.mcp_manager.list_resources(mcp_server, cursor)
+
+    # ------------------------
+    # SKILL 通道委托 / SKILL channel delegation (v0.2.1, #66)
+    # 协议依据 / Protocol: skill.md §6 / §9；设计 / Design: §5.1
+    # ------------------------
+    @property
+    def skill_registry(self) -> SkillRegistry:
+        """name → A2CSkillRef 物化索引（``client:get_skills`` / ``get_skill`` / ``get_blob`` 经此解析）。
+
+        The materialized name → A2CSkillRef index consumed by the SKILL channel handlers.
+        """
+        return self._skill_registry
+
+    def get_skills(self) -> list[A2CSkillRef]:
+        """当前已安装且可用 SKILL（排除孤儿；不排序、不去重）—— ``client:get_skills`` 数据源。
+
+        Active installed SKILLs (orphans excluded; unsorted, undeduped) — source for client:get_skills.
+        """
+        return self._skill_registry.active_refs()
+
+    def get_skill_ref(self, name: str) -> A2CSkillRef | None:
+        """O(1) 活跃精确解析 ``name`` → :class:`A2CSkillRef`（孤儿 / 未注册 → ``None``）。
+
+        这是 name→包根的唯一解析入口（§9.2 name 寻址防越权）。handler 据 ``None`` 回 ``4014``。
+        Single name→package-root resolution entry (§9.2); handler maps ``None`` to ``4014``.
+        """
+        return self._skill_registry.resolve(name)
+
+    def read_skill_resource(self, ref: A2CSkillRef, rel_path: str | None) -> SkillResourceView:
+        """沙箱解析 SKILL 包内资源 → 消费字节视图（铸造期带 ``too_large`` 守卫）。
+
+        §9.2：包根**仅**取自 ``ref["path"]``（由 Registry 经 name 解析），:func:`resolve_skill_view`
+        只接受 ``root: Path``，绝不从 name / rel_path 推导 FS 路径。``total_size`` / ``sha256`` 基于
+        消费字节（SKILL.md→frontmatter 剥离后 body；其它→原始字节），与 ``get_blob`` 解析期一致。
+
+        Args:
+            ref: 来自 :meth:`get_skill_ref` 的活跃 A2CSkillRef（``path`` 必为可读绝对包根）。
+            rel_path: 包根内 POSIX 相对路径；``None`` / 空 → 入口 ``SKILL.md``。
+
+        Returns:
+            SkillResourceView: 消费字节视图（mime / total_size / sha256 / is_text / 切片）。
+
+        Raises:
+            SkillSandboxError: 沙箱拒绝（traversal/forbidden/not_found）或 too_large（→ handler 映射 4017）。
+        """
+        root = Path(ref["path"])
+        return resolve_skill_view(root, rel_path, too_large_cap=self._blob_thresholds.too_large_cap)
 
     async def get_desktop(self, size: int | None = None, window_uri: str | None = None) -> list[Desktop]:
         """

--- a/a2c_smcp/computer/mcp_clients/model.py
+++ b/a2c_smcp/computer/mcp_clients/model.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, ClassVar, Literal, Protocol, TypeAlias, runtim
 from mcp import StdioServerParameters, Tool
 from mcp.client.session_group import SseServerParameters, StreamableHttpParameters
 from mcp.types import CallToolResult, ReadResourceResult, Resource
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 from vrl_python import VRLRuntime
 
 from a2c_smcp.types import SERVER_NAME, TOOL_NAME
@@ -198,3 +198,44 @@ class MCPClientProtocol(Protocol):
     async def get_window_detail(self, resource: Resource | str) -> ReadResourceResult:
         """获取当前Window的详细内容"""
         ...
+
+
+class GetSkillRet(BaseModel):
+    """
+    ``client:get_skill`` 响应的服务侧 Pydantic 校验模型（v0.2.1）/ Server-side validation model for the
+    ``client:get_skill`` response。
+
+    协议 ``data-structures.md §GetSkillRet`` / ``skill.md §9`` 规定 ``body`` 与 ``blob_handle``
+    **恰一存在**（exactly one）：文本且 ≤ 内联预算 → ``body``；二进制或过大文本 → ``blob_handle``。
+    本模型用 :meth:`_check_body_blob_xor` 在 Computer 返回前强制该不变量（服务侧自校验，父 #42 跨 PR
+    跟进项之一，明确合并到本 PR 范围）；smcp.py 的同名 ``GetSkillRet`` TypedDict 为线缆结构镜像。
+    The protocol mandates exactly one of ``body`` / ``blob_handle``; this model enforces that invariant
+    before the Computer returns. The TypedDict of the same name in smcp.py is the wire-shape mirror.
+
+    字段语义见 smcp.py ``GetSkillRet`` / Field semantics: see the smcp.py ``GetSkillRet`` TypedDict.
+    """
+
+    name: str
+    rel_path: str
+    mime_type: str
+    total_size: int
+    sha256: str
+    req_id: str
+    body: str | None = Field(default=None)
+    blob_handle: str | None = Field(default=None)
+
+    # extra="forbid"：服务侧自构造，多余字段即 SDK bug，应硬失败暴露。
+    model_config: ClassVar[ConfigDict] = ConfigDict(extra="forbid")
+
+    @model_validator(mode="after")
+    def _check_body_blob_xor(self) -> "GetSkillRet":
+        """``body`` 与 ``blob_handle`` 恰一存在（XOR）/ Enforce exactly-one-of(body, blob_handle)。"""
+        has_body = self.body is not None
+        has_handle = self.blob_handle is not None
+        if has_body == has_handle:
+            both_or_neither = "both" if has_body else "neither"
+            raise ValueError(
+                f"GetSkillRet MUST carry exactly one of 'body' / 'blob_handle' (got {both_or_neither}); "
+                "protocol data-structures.md §GetSkillRet / skill.md §9",
+            )
+        return self

--- a/a2c_smcp/computer/skills/__init__.py
+++ b/a2c_smcp/computer/skills/__init__.py
@@ -16,6 +16,7 @@ Mirrors Claude Code marketplace local SKILL management. Landed modules:
 - :mod:`a2c_smcp.computer.skills.registry` —— `name → A2CSkillRef` O(1) 物化索引 + 孤儿标记/恢复（S3，#57）
 - :mod:`a2c_smcp.computer.skills.staging`  —— 多 source 物化（mcp 源 + manager.list_skill_resources）（S6，#59）
 - :mod:`a2c_smcp.computer.skills.sandbox`  —— 包根内 `safe_join`+`realpath` 沙箱 + `.skillenv` forbidden + name 寻址防越权（S2，#55）
+- :mod:`a2c_smcp.computer.skills.resource` —— 沙箱解析 → 消费字节视图（mint/serve 字节基准一致：sha256/total_size）（S13，#66）
 
 协议依据 / Protocol: a2c-smcp-protocol docs/specification/skill.md §1 / §4 / §6 / §8 / §9.2。
 """
@@ -47,6 +48,12 @@ from a2c_smcp.computer.skills.naming import (
     synthesize_user_name,
 )
 from a2c_smcp.computer.skills.registry import SkillRegistry
+from a2c_smcp.computer.skills.resource import (
+    DEFAULT_SKILL_MIME,
+    SkillResourceView,
+    looks_textual,
+    resolve_skill_view,
+)
 from a2c_smcp.computer.skills.sandbox import (
     DEFAULT_SKILL_FILE,
     FORBIDDEN_SKILL_FILES,
@@ -55,7 +62,12 @@ from a2c_smcp.computer.skills.sandbox import (
     ensure_within_size_cap,
     resolve_skill_resource,
 )
-from a2c_smcp.computer.skills.staging import SkillStagingError, parse_skill_frontmatter, stage_mcp_skills
+from a2c_smcp.computer.skills.staging import (
+    SkillStagingError,
+    parse_skill_frontmatter,
+    stage_mcp_skills,
+    strip_skill_frontmatter,
+)
 
 __all__ = [
     # home
@@ -89,8 +101,14 @@ __all__ = [
     "SkillSandboxReason",
     "ensure_within_size_cap",
     "resolve_skill_resource",
+    # resource（消费字节视图：mint/serve 一致）
+    "DEFAULT_SKILL_MIME",
+    "SkillResourceView",
+    "looks_textual",
+    "resolve_skill_view",
     # staging
     "SkillStagingError",
     "parse_skill_frontmatter",
     "stage_mcp_skills",
+    "strip_skill_frontmatter",
 ]

--- a/a2c_smcp/computer/skills/resource.py
+++ b/a2c_smcp/computer/skills/resource.py
@@ -1,0 +1,221 @@
+# -*- coding: utf-8 -*-
+# filename: resource.py
+# @Time    : 2026/05/25
+# @Author  : JQQ
+# @Email   : jqq1716@gmail.com
+# @Software: PyCharm
+"""
+SKILL 包内资源读取视图（v0.2.1）/ In-package SKILL resource read view (v0.2.1)
+
+协议依据 / Protocol: a2c-smcp-protocol docs/specification/skill.md §9（沙箱）、blob-transfer.md §3
+                      （完整性）、§5（生产者通道）。
+SDK 设计 / Design: python-sdk docs/design-0.2.1-skill-computer-management.md §4.2 / §4.4 / §5.1。
+
+存在意义 / Why this module：
+    ``client:get_skill`` 铸造期（决定 inline body vs blob_handle）与 ``client:get_blob`` 解析期
+    （kind=skill 重施沙箱后回源切片）**必须**对「Agent 最终消费的资源字节」给出**一致**的
+    ``total_size`` / ``sha256``（设计 §4.4「资源字节三处一致」）。把「沙箱解析 + frontmatter 剥离
+    + MIME + 流式 sha256 + 惰性切片」收敛到本模块单一入口 :func:`resolve_skill_view`，让两处共用，
+    从根上杜绝实现漂移。
+    The get_skill mint (inline-vs-handle decision) and the get_blob resolve (re-sandbox + re-serve)
+    MUST agree on ``total_size`` / ``sha256`` for the bytes the Agent ultimately consumes. This
+    module is the single source of that logic so the two paths cannot drift.
+
+消费字节基准 / Consumed-bytes baseline（协议 blob-transfer.md §3 + 设计 §4.4）：
+    - **SKILL.md（入口）**：frontmatter 剥离后 body 的 UTF-8 字节；
+    - **其它包内资源**：原始字节；
+    - 占位符 ``$TFROBOT_*`` **不**在此展开（Agent SDK prompt 渲染层职责，非协议层）。
+"""
+
+from __future__ import annotations
+
+import hashlib
+import mimetypes
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from a2c_smcp.computer.skills.sandbox import DEFAULT_SKILL_FILE, SkillSandboxError, resolve_skill_resource
+from a2c_smcp.computer.skills.staging import strip_skill_frontmatter
+
+# SKILL.md 固定 MIME（frontmatter 剥离后仍是 markdown 正文）/ Fixed MIME for the SKILL.md entry doc.
+DEFAULT_SKILL_MIME = "text/markdown"
+# 流式 sha256 / 惰性切片的读块大小 / Read-block size for streaming sha256 & lazy slicing.
+_HASH_BLOCK = 1024 * 1024  # 1 MiB
+
+# 可内联为 ``body`` 的文本类 MIME 允许集（非 text/* 的常见文本格式）/ Textual MIME allowlist.
+_TEXTUAL_NON_TEXT_MIME = frozenset(
+    {
+        "application/json",
+        "application/xml",
+        "application/yaml",
+        "application/x-yaml",
+        "application/toml",
+        "application/javascript",
+    },
+)
+
+# 惰性切片闭包 / Lazy slice closure: (offset, length) -> bytes
+_Slicer = Callable[[int, int], bytes]
+
+
+def looks_textual(mime: str) -> bool:
+    """MIME 是否文本类（可内联为 ``body``）/ Whether a MIME is textual enough to inline as ``body``。
+
+    ``text/*`` 或常见文本格式（json/xml/yaml/...）→ ``True``；其余（含 ``application/octet-stream``
+    与各类二进制）→ ``False``（一律铸句柄）。最终能否内联仍需调用方叠加「≤ inline_budget」+「UTF-8
+    可解码」判定。
+    """
+    return mime.startswith("text/") or mime in _TEXTUAL_NON_TEXT_MIME
+
+
+@dataclass(frozen=True, eq=False)
+class SkillResourceView:
+    """沙箱解析后的 SKILL 资源描述符 / Sandboxed SKILL resource descriptor。
+
+    ``total_size`` / ``sha256`` 均基于**消费字节**（SKILL.md→剥离后 body；其它→原始字节）。
+    ``slice`` / ``read_all`` 同样返回消费字节，故 get_skill 内联与 get_blob 切片字节完全一致。
+
+    Attributes:
+        rel_path: 回显用相对路径（缺省请求回显 ``"SKILL.md"``）。
+        abs_path: 沙箱校验后的真实绝对路径（``realpath``）。
+        mime: 资源 MIME（SKILL.md 固定 ``text/markdown``；其它 ``mimetypes.guess_type``）。
+        total_size: 消费字节数。
+        sha256: 消费字节的 sha256 十六进制（流式计算，不全量驻留）。
+        is_entry: 是否服务「frontmatter 剥离后的 SKILL.md 入口」。
+        is_text: MIME 是否文本类（:func:`looks_textual`），供 inline 决策。
+        _slicer: 惰性切片闭包；SKILL.md 走内存剥离 body，其它走 disk seek+read。
+    """
+
+    rel_path: str
+    abs_path: Path
+    mime: str
+    total_size: int
+    sha256: str
+    is_entry: bool
+    is_text: bool
+    _slicer: _Slicer = field(repr=False)
+
+    def slice(self, offset: int, length: int) -> bytes:
+        """读取消费字节 ``[offset, offset+length)``，截断到 ``total_size``（语义同 ResolvedBlob.slice）。"""
+        if offset < 0 or length < 0:
+            raise ValueError(f"offset/length must be non-negative: offset={offset}, length={length}")
+        if offset > self.total_size:
+            raise ValueError(f"offset {offset} > total_size {self.total_size}")
+        if length == 0 or offset == self.total_size:
+            return b""
+        actual = min(length, self.total_size - offset)
+        return self._slicer(offset, actual)
+
+    def read_all(self) -> bytes:
+        """读取全部消费字节（供 get_skill 内联 ``body``；调用方应已确认 ≤ inline_budget）。"""
+        return self.slice(0, self.total_size)
+
+
+def _stream_sha256(path: Path) -> str:
+    """流式计算文件 sha256（O(_HASH_BLOCK) 内存）/ Streaming file sha256 (bounded memory)。"""
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        while True:
+            block = f.read(_HASH_BLOCK)
+            if not block:
+                break
+            h.update(block)
+    return h.hexdigest()
+
+
+def _disk_slicer(path: Path) -> _Slicer:
+    """构造从磁盘 seek+read 的惰性切片闭包（每次调用独立打开，幂等可并发）。"""
+
+    def _slice(offset: int, length: int) -> bytes:
+        with path.open("rb") as f:
+            f.seek(offset)
+            return f.read(length)
+
+    return _slice
+
+
+def _mem_slicer(data: bytes) -> _Slicer:
+    """构造从内存字节切片的闭包（SKILL.md 剥离后 body）。"""
+
+    def _slice(offset: int, length: int) -> bytes:
+        return data[offset : offset + length]
+
+    return _slice
+
+
+def resolve_skill_view(
+    root: Path,
+    rel_path: str | None,
+    *,
+    too_large_cap: int | None = None,
+) -> SkillResourceView:
+    """沙箱解析 SKILL 包内资源 → :class:`SkillResourceView`（mint / serve 共用唯一入口）。
+
+    流程 / Flow：
+      1. :func:`resolve_skill_resource` 包根内沙箱（``..`` / 绝对路径 / symlink 逃逸 → traversal；
+         ``.skillenv`` 等 → forbidden；缺失/目录 → not_found）——失败抛 :class:`SkillSandboxError`；
+      2. **DoS 守卫**（仅当传 ``too_large_cap``，即 get_skill 铸造期）：先 ``stat`` 原始字节，
+         超上限 → 抛 ``SkillSandboxError("too_large", total_size=raw_size)``，**不读文件**（避免 OOM）；
+         get_blob 解析期不传 cap（协议 4018 无 too_large 语义，分块传输自然受限）；
+      3. 消费字节基准：``SKILL.md`` 入口读全文 → :func:`strip_skill_frontmatter` → UTF-8 body 字节
+         （内存切片）；其它资源 → 原始磁盘字节（惰性 seek+read 切片）；
+      4. ``total_size`` / ``sha256`` 基于消费字节（SKILL.md 即剥离后 body；其它流式哈希原始文件）。
+
+    §9.2 name 寻址防越权不变量 / anti-escalation invariant：本函数**只**接受 ``root: Path``（由
+    Registry 经 name 解析得到的包根），**绝不**接受 name、**绝不**从 name/rel_path 推导 FS 路径。
+
+    Args:
+        root: SKILL 包根绝对目录（来自 ``A2CSkillRef.path``，经 Registry 解析）。
+        rel_path: 包根内 POSIX 相对路径；``None`` / 空 → 入口 ``SKILL.md``。
+        too_large_cap: 铸造期绝对字节上限；``None`` 表示不做 too_large 守卫（get_blob 解析期）。
+
+    Returns:
+        SkillResourceView: 消费字节视图。
+
+    Raises:
+        SkillSandboxError: 沙箱拒绝（traversal/forbidden/not_found）或 too_large（仅 mint 期）。
+    """
+    target = resolve_skill_resource(root, rel_path)
+    rel_echo = DEFAULT_SKILL_FILE if not rel_path else rel_path
+    is_entry = target.name == DEFAULT_SKILL_FILE
+
+    if is_entry:
+        # SKILL.md 入口：先 stat 守卫（避免读超大文件），再读全文剥 frontmatter。
+        if too_large_cap is not None:
+            raw_size = target.stat().st_size
+            if raw_size > too_large_cap:
+                raise SkillSandboxError("too_large", rel_path=rel_echo, total_size=raw_size)
+        raw_text = target.read_text(encoding="utf-8", errors="replace")
+        body_bytes = strip_skill_frontmatter(raw_text).encode("utf-8")
+        total_size = len(body_bytes)
+        # 守卫也覆盖剥离后 body（罕见：frontmatter 极小而 body 极大且原始未超）。
+        if too_large_cap is not None and total_size > too_large_cap:
+            raise SkillSandboxError("too_large", rel_path=rel_echo, total_size=total_size)
+        return SkillResourceView(
+            rel_path=rel_echo,
+            abs_path=target,
+            mime=DEFAULT_SKILL_MIME,
+            total_size=total_size,
+            sha256=hashlib.sha256(body_bytes).hexdigest(),
+            is_entry=True,
+            is_text=True,
+            _slicer=_mem_slicer(body_bytes),
+        )
+
+    # 其它包内资源：原始字节 + 惰性 disk 切片 + 流式 sha256。
+    raw_size = target.stat().st_size
+    if too_large_cap is not None and raw_size > too_large_cap:
+        raise SkillSandboxError("too_large", rel_path=rel_echo, total_size=raw_size)
+    guessed, _ = mimetypes.guess_type(target.name)
+    mime = guessed or "application/octet-stream"
+    return SkillResourceView(
+        rel_path=rel_echo,
+        abs_path=target,
+        mime=mime,
+        total_size=raw_size,
+        sha256=_stream_sha256(target),
+        is_entry=False,
+        is_text=looks_textual(mime),
+        _slicer=_disk_slicer(target),
+    )

--- a/a2c_smcp/computer/skills/staging.py
+++ b/a2c_smcp/computer/skills/staging.py
@@ -99,6 +99,32 @@ def parse_skill_frontmatter(skill_md_text: str) -> dict[str, Any]:
     return {}
 
 
+def strip_skill_frontmatter(skill_md_text: str) -> str:
+    """
+    剥离 SKILL.md 头部 YAML frontmatter，返回正文 body（Agent 最终消费内容）/ Strip leading YAML
+    frontmatter from SKILL.md, returning the body the Agent ultimately consumes。
+
+    与 :func:`parse_skill_frontmatter` 同源行级定位（首尾 ``---``）：无 frontmatter / 无闭合 ``---``
+    → 原样返回。剥离后正文 = 闭合 ``---`` 行之后的全部内容（保留原行尾，不额外 trim），故
+    ``client:get_skill`` 铸造期与 ``client:get_blob`` 解析期对 SKILL.md 的「消费字节」基准一致
+    （协议 ``blob-transfer.md`` §3 / 设计 §4.4「资源字节三处一致」）。
+    Same line-level fence detection as :func:`parse_skill_frontmatter`; no frontmatter / no closing
+    fence → returned unchanged. Body = everything after the closing ``---`` line (original line
+    endings preserved, no extra trimming), so the get_skill mint and the get_blob resolve agree on
+    the consumed bytes for SKILL.md.
+    """
+    if not skill_md_text.startswith("---"):
+        return skill_md_text
+    lines = skill_md_text.splitlines(keepends=True)
+    if not lines or lines[0].strip() != "---":
+        return skill_md_text
+    for i in range(1, len(lines)):
+        if lines[i].strip() == "---":
+            return "".join(lines[i + 1 :])
+    # 无闭合 fence → 视为无有效 frontmatter，原样返回（与 parse 一致）
+    return skill_md_text
+
+
 # ── 安全解包 / safe extraction ──────────────────────────────────────────────
 def _resolved_member_target(dest: Path, member_name: str) -> Path:
     """

--- a/a2c_smcp/computer/socketio/client.py
+++ b/a2c_smcp/computer/socketio/client.py
@@ -5,7 +5,7 @@
 # @Software: PyCharm
 import base64
 import hashlib
-from typing import Any
+from typing import Any, cast
 
 from mcp.types import CallToolResult, Resource
 from pydantic import TypeAdapter
@@ -16,15 +16,20 @@ from a2c_smcp.computer.blob import (
     BlobHandleError,
     BlobHandleInvalidError,
     decode_blob_handle,
+    encode_skill_handle,
 )
 from a2c_smcp.computer.computer import Computer
 from a2c_smcp.computer.mcp_clients.base_client import MCPCapabilityNotSupportedError, MCPServerNotFoundError
+from a2c_smcp.computer.mcp_clients.model import GetSkillRet as GetSkillRetModel
+from a2c_smcp.computer.skills import SkillNameError, SkillSandboxError, parse_skill_name
 from a2c_smcp.exceptions import SMCPNamespaceError
 from a2c_smcp.smcp import (
     GET_BLOB_EVENT,
     GET_CONFIG_EVENT,
     GET_DESKTOP_EVENT,
     GET_RESOURCES_EVENT,
+    GET_SKILL_EVENT,
+    GET_SKILLS_EVENT,
     GET_TOOLS_EVENT,
     JOIN_OFFICE_EVENT,
     LEAVE_OFFICE_EVENT,
@@ -32,6 +37,7 @@ from a2c_smcp.smcp import (
     TOOL_CALL_EVENT,
     UPDATE_CONFIG_EVENT,
     UPDATE_DESKTOP_EVENT,
+    UPDATE_SKILLS_EVENT,
     UPDATE_TOOL_LIST_EVENT,
     A2CResource,
     EnterOfficeReq,
@@ -45,6 +51,10 @@ from a2c_smcp.smcp import (
     GetDeskTopRet,
     GetResourcesReq,
     GetResourcesRet,
+    GetSkillReq,
+    GetSkillRet,
+    GetSkillsReq,
+    GetSkillsRet,
     GetToolsReq,
     GetToolsRet,
     LeaveOfficeReq,
@@ -152,6 +162,9 @@ class SMCPComputerClient(AsyncClient):
         self.on(GET_DESKTOP_EVENT, self.on_get_desktop, namespace=self._namespace)
         self.on(GET_RESOURCES_EVENT, self.on_get_resources, namespace=self._namespace)
         self.on(GET_BLOB_EVENT, self.on_get_blob, namespace=self._namespace)
+        # v0.2.1 SKILL 通道发现 / 渐进式披露 / SKILL channel discovery & progressive disclosure (#66)
+        self.on(GET_SKILLS_EVENT, self.on_get_skills, namespace=self._namespace)
+        self.on(GET_SKILL_EVENT, self.on_get_skill, namespace=self._namespace)
         self.office_id: str | None = None
 
     @property
@@ -304,6 +317,19 @@ class SMCPComputerClient(AsyncClient):
         """
         if self.office_id:
             await self.emit(UPDATE_DESKTOP_EVENT, UpdateComputerConfigReq(computer=self.computer.name))
+
+    async def emit_update_skills(self) -> None:
+        """
+        SKILL 集合变更（增/删/物化更新）时触发，向信令服务器推送 server:update_skills；服务端广播
+        notify:update_skills，Agent 据此自动重拉 client:get_skills（与既有 notify:update_* 自动刷新一致）。
+        When the SKILL set changes, emit server:update_skills; server broadcasts notify:update_skills.
+
+        复用 UpdateComputerConfigReq（协议 events.md §server:update_skills 明确复用，不新建结构）；
+        office_id 守卫与 :meth:`emit_update_tool_list` 一致——未入房间不发送。
+        Reuses UpdateComputerConfigReq (protocol reuses it); office_id guard mirrors emit_update_tool_list.
+        """
+        if self.office_id:
+            await self.emit(UPDATE_SKILLS_EVENT, UpdateComputerConfigReq(computer=self.computer.name))
 
     async def on_tool_call(self, data: ToolCallReq) -> dict:
         """
@@ -579,6 +605,128 @@ class SMCPComputerClient(AsyncClient):
         # Core logic extracted to module-level ``_process_get_blob``, shared with sync wire mock,
         # eliminating dual-maintenance of equivalent sync/async handler bodies (PR #52 fix-review).
         return _process_get_blob(data, self.computer)
+
+    async def on_get_skills(self, data: GetSkillsReq) -> GetSkillsRet:
+        """
+        SKILL 清单发现 / SKILL inventory discovery（``client:get_skills``）.
+
+        协议依据 / Protocol: events.md#client:get_skills；skill.md §6（排除孤儿 / 不排序 / 不去重 / 不读 body）。
+        从 Registry 取**活跃** SKILL 轻量元数据（``A2CSkillRef`` 列表，不含 SKILL.md body——body 由
+        ``client:get_skill`` 拉取）；孤儿（source 消失）由 :meth:`Computer.get_skills` 经 ``active_refs`` 排除。
+        Returns lightweight active SKILL refs (orphans excluded; no body). Body is fetched via get_skill.
+
+        Args:
+            data (GetSkillsReq): 请求数据（computer / req_id）。
+
+        Returns:
+            GetSkillsRet: ``skills`` 列表 + ``req_id``。
+        """
+        # Server 通过 session 保证请求来自同一 office；computer 标识仍需匹配（隔离不变量显式 raise）
+        if self.computer.name != data["computer"]:
+            raise SMCPNamespaceError("计算机标识不匹配")
+        return GetSkillsRet(skills=self.computer.get_skills(), req_id=data["req_id"])
+
+    async def on_get_skill(self, data: GetSkillReq) -> GetSkillRet | ErrorPayload:
+        """
+        SKILL 包内单资源渐进式披露 / Progressive disclosure of one in-package SKILL resource（``client:get_skill``）.
+
+        协议依据 / Protocol: events.md#client:get_skill；skill.md §9（安全模型）；blob-transfer.md §5（生产者通道）。
+
+        错误语义（flat ErrorPayload，经 Socket.IO ack 第一参回传，无嵌套 envelope）/ Errors:
+          - ``4016`` ``SKILL_NAME_INVALID``（``details.name``）：``name`` 违反 SKILL name lexer；
+          - ``4014``（复用 ``MCP_SERVER_NOT_FOUND``，``details.name``）：``name`` 合法但 Registry 未命中 / 孤儿；
+          - ``4017`` ``SKILL_RESOURCE_NOT_ACCESSIBLE``（``details.reason`` / ``rel_path`` / ``total_size``）：
+            ``rel_path`` 沙箱穿越 / ``.skillenv`` forbidden / not_found / too_large（too_large **不铸句柄**）。
+
+        成功路径 / Success path：
+          - 仅 **SKILL.md** 剥 frontmatter（消费字节 = 剥离后 body）；其它资源 = 原始字节；
+          - 文本且 ``total_size`` ≤ 内联预算 → ``body`` 内联；否则铸 ``blob_handle`` 转 ``client:get_blob``；
+          - ``body`` 与 ``blob_handle`` **恰一存在**（经 :class:`GetSkillRetModel` XOR 服务侧自校验）。
+
+        Args:
+            data (GetSkillReq): 请求数据（computer / name / 可选 rel_path / req_id）。
+
+        Returns:
+            GetSkillRet | ErrorPayload: 成功为单资源响应，失败为 flat ErrorPayload。
+        """
+        if self.computer.name != data["computer"]:
+            raise SMCPNamespaceError("计算机标识不匹配")
+        name = data["name"]
+        rel_path = data.get("rel_path")
+
+        # 1) name lexer → 4016（格式硬错）/ malformed name → 4016
+        try:
+            parse_skill_name(name)
+        except SkillNameError as e:
+            logger.warning(f"client:get_skill invalid skill name {name!r}: {e.reason}")
+            return _skill_name_invalid(name)
+
+        # 2) Registry 解析 → 4014（合法但未注册 / 孤儿）/ valid-but-absent → 4014
+        ref = self.computer.get_skill_ref(name)
+        if ref is None:
+            logger.warning(f"client:get_skill name not in registry (unregistered or orphaned): {name!r}")
+            return _skill_not_found(name)
+
+        # 3) 沙箱解析 + 消费字节视图 → 4017（traversal/forbidden/not_found/too_large）
+        try:
+            view = self.computer.read_skill_resource(ref, rel_path)
+        except SkillSandboxError as e:
+            logger.warning(f"client:get_skill resource not accessible: name={name!r} reason={e.reason} rel={e.rel_path!r}")
+            return _skill_resource_error(e)
+
+        # 4) inline body vs blob_handle（文本且 ≤ 内联预算 → body；否则铸句柄）
+        budget = self.computer.blob_thresholds.inline_budget
+        body: str | None = None
+        if view.is_text and view.total_size <= budget:
+            try:
+                body = view.read_all().decode("utf-8")
+            except UnicodeDecodeError:
+                # 声称文本但非 UTF-8 → 回退句柄路径（保守，避免内联破损字符串）
+                logger.debug(f"client:get_skill {name!r} rel={view.rel_path!r} textual mime but not UTF-8; routing to blob_handle")
+                body = None
+        blob_handle: str | None = None
+        if body is None:
+            # too_large 已在 read_skill_resource 铸造期拦截（抛 4017），此处铸句柄安全
+            blob_handle = encode_skill_handle(name, view.rel_path)
+
+        # 5) 服务侧 XOR 自校验 + 规整 wire 形态（exclude_none 丢弃缺席的 body/blob_handle）
+        model = GetSkillRetModel(
+            name=name,
+            rel_path=view.rel_path,
+            mime_type=view.mime,
+            total_size=view.total_size,
+            sha256=view.sha256,
+            req_id=data["req_id"],
+            body=body,
+            blob_handle=blob_handle,
+        )
+        return cast(GetSkillRet, model.model_dump(exclude_none=True))
+
+
+def _skill_name_invalid(name: str) -> ErrorPayload:
+    """``4016 SKILL_NAME_INVALID`` flat ErrorPayload（``details.name``，error-handling.md §4016）。"""
+    return ErrorPayload(code=int(ErrorCode.SKILL_NAME_INVALID), message="Invalid skill name", details={"name": name})
+
+
+def _skill_not_found(name: str) -> ErrorPayload:
+    """``4014`` 复用 flat ErrorPayload：name 合法但 Registry 未命中（未注册 / 卸载 / 孤儿）。
+
+    SKILL 通道复用 ``MCP_SERVER_NOT_FOUND`` 语义（error-handling.md §SKILL）；``name`` 经 ``details`` 下沉
+    （非 mcp_server，故不平铺 ``mcp_server_name``）。
+    """
+    return ErrorPayload(code=int(ErrorCode.MCP_SERVER_NOT_FOUND), message="Skill not found", details={"name": name})
+
+
+def _skill_resource_error(e: SkillSandboxError) -> ErrorPayload:
+    """``4017 SKILL_RESOURCE_NOT_ACCESSIBLE`` flat ErrorPayload（``details.reason`` / ``rel_path`` / ``total_size``）。
+
+    ``reason`` 为开放枚举（traversal/forbidden/not_found/too_large）；``total_size`` 仅 too_large 携带
+    （error-handling.md §4017）。``.skillenv`` 等敏感文件存在/不存在**同 reason** forbidden（不泄漏存在性）。
+    """
+    details: dict[str, Any] = {"reason": e.reason, "rel_path": e.rel_path}
+    if e.total_size is not None:
+        details["total_size"] = e.total_size
+    return ErrorPayload(code=int(ErrorCode.SKILL_RESOURCE_NOT_ACCESSIBLE), message="Skill resource not accessible", details=details)
 
 
 def _blob_error(*, reason: str) -> ErrorPayload:

--- a/tests/integration_tests/test_blob_transfer.py
+++ b/tests/integration_tests/test_blob_transfer.py
@@ -322,6 +322,84 @@ class TestInProcLazyInvariant:
         )
 
 
+class TestInProcSkillBlobRoundTrip:
+    """SKILL 生产者通道：``on_get_skill`` 铸句柄 → ``drain_blob`` 解析回源 → 字节/sha256 一致（#66）.
+
+    验证设计 §4.4「资源字节三处一致」的端到端契约：``client:get_skill`` 铸造期上报的
+    ``total_size`` / ``sha256``（消费字节基准）**必须**与 ``client:get_blob`` 重跑沙箱后回源、经
+    ``drain_blob`` 重组的字节完全一致。SKILL.md 走 frontmatter 剥离后 body；子资源走原始字节。
+    Verifies the get_skill mint and the get_blob resolve agree on consumed bytes end-to-end.
+    """
+
+    @staticmethod
+    def _register(comp: Computer, pkg) -> None:
+        assert comp.skill_registry.register({"name": "mcp:srv:demo", "source": "mcp:srv", "path": str(pkg)}) is True
+
+    @staticmethod
+    async def _get_skill(cli: SMCPComputerClient, name: str, rel_path: str | None = None) -> Mapping[str, Any]:
+        from a2c_smcp.smcp import GetSkillReq
+
+        req: GetSkillReq = {"agent": "agent-it", "req_id": "r-skill", "computer": cli.computer.name, "name": name}
+        if rel_path is not None:
+            req["rel_path"] = rel_path
+        return await cli.on_get_skill(req)
+
+    @pytest.mark.asyncio
+    async def test_skill_md_over_budget_handle_drain_consistency(
+        self,
+        computer_with_client: tuple[Computer, SMCPComputerClient],
+        tmp_path,
+    ) -> None:
+        comp, cli = computer_with_client
+        pkg = tmp_path / "home" / "mcp" / "srv" / "demo"
+        pkg.mkdir(parents=True)
+        # body > 32 KiB inline 预算 → 铸句柄；frontmatter 剥离后 body == big_body
+        big_body = "# Title\n\n" + ("lorem ipsum dolor sit amet 测试 中文\n" * 3000)
+        (pkg / "SKILL.md").write_text(f"---\nname: demo\nversion: 1.0.0\n---\n{big_body}", encoding="utf-8")
+        self._register(comp, pkg)
+
+        ret = await self._get_skill(cli, "mcp:srv:demo")
+        assert "blob_handle" in ret  # 超内联预算 → 铸句柄（非 body）
+        assert "body" not in ret
+        assert ret["mime_type"] == "text/markdown"
+
+        expected = big_body.encode("utf-8")
+        # get_skill 铸造期 sha256/total_size 基于剥离后 body
+        assert ret["sha256"] == hashlib.sha256(expected).hexdigest()
+        assert ret["total_size"] == len(expected)
+
+        # get_blob 重跑沙箱回源（chunk_size 强制多块）→ 重组字节与 sha256 一致
+        call = _make_in_proc_call(cli)
+        data, mime = await drain_blob(call, comp.name, ret["blob_handle"], chunk_size=4096)
+        assert data == expected
+        assert mime == "text/markdown"
+        assert hashlib.sha256(data).hexdigest() == ret["sha256"]
+
+    @pytest.mark.asyncio
+    async def test_binary_subresource_handle_drain_consistency(
+        self,
+        computer_with_client: tuple[Computer, SMCPComputerClient],
+        tmp_path,
+    ) -> None:
+        comp, cli = computer_with_client
+        pkg = tmp_path / "home" / "mcp" / "srv" / "demo"
+        (pkg / "assets").mkdir(parents=True)
+        (pkg / "SKILL.md").write_text("---\nname: demo\n---\nbody\n", encoding="utf-8")
+        blob = bytes((i * 7 + 3) % 256 for i in range(50 * 1024))  # 50 KiB 二进制
+        (pkg / "assets" / "img.png").write_bytes(blob)
+        self._register(comp, pkg)
+
+        ret = await self._get_skill(cli, "mcp:srv:demo", "assets/img.png")
+        assert ret["mime_type"] == "image/png"
+        assert "blob_handle" in ret  # 二进制 MIME 一律铸句柄
+        assert ret["sha256"] == hashlib.sha256(blob).hexdigest()
+
+        call = _make_in_proc_call(cli)
+        data, mime = await drain_blob(call, comp.name, ret["blob_handle"], chunk_size=4096)
+        assert data == blob  # 子资源 = 原始字节（不剥 frontmatter）
+        assert mime == "image/png"
+
+
 # ======================================================================
 # Part 2 — Real Socket.IO transport (async)
 # ======================================================================

--- a/tests/unit_tests/computer/blob/test_resolver.py
+++ b/tests/unit_tests/computer/blob/test_resolver.py
@@ -17,14 +17,25 @@ from pathlib import Path
 
 import pytest
 
-from a2c_smcp.computer.blob.handle import BlobHandleError, BlobHandleGoneError, BlobHandleInvalidError
+from a2c_smcp.computer.blob.handle import (
+    BlobHandleForbiddenError,
+    BlobHandleGoneError,
+    BlobHandleInvalidError,
+)
 from a2c_smcp.computer.blob.resolver import (
     BlobResolver,
     ResolvedBlob,
-    SkillBlobResolverPending,
+    SkillBlobResolver,
     ToolspoolBlobResolver,
 )
 from a2c_smcp.computer.blob.toolspool import ToolspoolBlobStore
+from a2c_smcp.computer.skills.registry import SkillRegistry
+from a2c_smcp.computer.skills.resource import DEFAULT_SKILL_MIME
+from a2c_smcp.smcp import A2CSkillRef
+
+_SKILL_MD = "---\nname: demo\nversion: 1.2.3\n---\n# Demo\n\nbody line\n"
+_SKILL_BODY = "# Demo\n\nbody line\n"  # frontmatter 剥离后（闭合 --- 行之后）/ body after closing fence
+_NOTE_BYTES = b"plain note bytes\n"
 
 
 class TestToolspoolBlobResolver:
@@ -75,20 +86,87 @@ class TestToolspoolBlobResolver:
         assert isinstance(resolver, BlobResolver)
 
 
-class TestSkillBlobResolverPending:
-    """``kind=skill`` 占位实现：本 PR 边界，#39 接管后替换.
-    Placeholder for ``kind=skill``; replaced by #39 wiring up Registry + sandbox."""
+class TestSkillBlobResolver:
+    """``kind=skill`` 解析器：name→Registry 解析包根 → rel_path 重跑沙箱 → 惰性切片（#66）.
 
-    def test_resolve_raises_forbidden(self) -> None:
-        """未接入即视为「铸造通道授权撤销」→ forbidden（保守，符合协议「不信任句柄」边界）.
-        Until #39 plugs in, treat as channel revoked → forbidden (conservative, protocol-aligned)."""
-        resolver = SkillBlobResolverPending()
-        with pytest.raises(BlobHandleError) as exc_info:
-            resolver.resolve({"name": "user:x:y", "rel_path": "SKILL.md"})
-        assert exc_info.value.reason == "forbidden"
+    协议依据 / Protocol: blob-transfer.md §5.4「重跑铸造通道边界校验，不信任句柄内容」；
+    skill.md §9 安全模型；§4.4「资源字节三处一致」。
+    """
+
+    @pytest.fixture
+    def registry(self, tmp_path: Path) -> SkillRegistry:
+        """构造一个含 SKILL.md / 子资源 / .skillenv 的包根，注册进 Registry。"""
+        pkg = tmp_path / "home" / "mcp" / "srv" / "demo"
+        (pkg / "references").mkdir(parents=True)
+        (pkg / "SKILL.md").write_text(_SKILL_MD, encoding="utf-8")
+        (pkg / "references" / "note.txt").write_bytes(_NOTE_BYTES)
+        (pkg / ".skillenv").write_text("SECRET=1\n", encoding="utf-8")
+        reg = SkillRegistry()
+        ref: A2CSkillRef = {"name": "mcp:srv:demo", "source": "mcp:srv", "path": str(pkg)}
+        assert reg.register(ref) is True
+        return reg
+
+    def test_resolve_skill_md_strips_frontmatter(self, registry: SkillRegistry) -> None:
+        """SKILL.md：消费字节 = frontmatter 剥离后 body；sha256/total_size 与铸造期一致。"""
+        resolver = SkillBlobResolver(registry)
+        resolved = resolver.resolve({"name": "mcp:srv:demo", "rel_path": "SKILL.md"})
+        assert isinstance(resolved, ResolvedBlob)
+        expected = _SKILL_BODY.encode("utf-8")
+        assert resolved.slice(0, resolved.total_size) == expected
+        assert resolved.total_size == len(expected)
+        assert resolved.sha256 == hashlib.sha256(expected).hexdigest()
+        assert resolved.mime == DEFAULT_SKILL_MIME
+
+    def test_resolve_subresource_raw_bytes(self, registry: SkillRegistry) -> None:
+        """子资源：原始字节（不剥 frontmatter）；sha256 基于原始字节。"""
+        resolver = SkillBlobResolver(registry)
+        resolved = resolver.resolve({"name": "mcp:srv:demo", "rel_path": "references/note.txt"})
+        assert resolved.slice(0, resolved.total_size) == _NOTE_BYTES
+        assert resolved.total_size == len(_NOTE_BYTES)
+        assert resolved.sha256 == hashlib.sha256(_NOTE_BYTES).hexdigest()
+
+    def test_resolve_gone_when_name_unregistered(self, registry: SkillRegistry) -> None:
+        """name 未注册 → ``4018 gone``（铸造通道授权撤销）。"""
+        resolver = SkillBlobResolver(registry)
+        with pytest.raises(BlobHandleGoneError):
+            resolver.resolve({"name": "mcp:srv:nope", "rel_path": "SKILL.md"})
+
+    def test_resolve_gone_when_orphaned(self, registry: SkillRegistry) -> None:
+        """name 已孤儿 → ``4018 gone``（source 消失，不可服务）。"""
+        registry.mark_orphan("mcp:srv:demo")
+        resolver = SkillBlobResolver(registry)
+        with pytest.raises(BlobHandleGoneError):
+            resolver.resolve({"name": "mcp:srv:demo", "rel_path": "SKILL.md"})
+
+    def test_resolve_gone_when_file_missing(self, registry: SkillRegistry) -> None:
+        """rel_path 不存在（源文件铸造后消失）→ not_found → ``4018 gone``。"""
+        resolver = SkillBlobResolver(registry)
+        with pytest.raises(BlobHandleGoneError):
+            resolver.resolve({"name": "mcp:srv:demo", "rel_path": "references/missing.txt"})
+
+    @pytest.mark.parametrize("rel_path", ["../outside.txt", "../../etc/passwd", "references/../../escape"])
+    def test_resolve_forbidden_on_traversal(self, registry: SkillRegistry, rel_path: str) -> None:
+        """句柄内 rel_path 穿越 → 重跑沙箱拒绝 → ``4018 forbidden``（不信任句柄）。"""
+        resolver = SkillBlobResolver(registry)
+        with pytest.raises(BlobHandleForbiddenError):
+            resolver.resolve({"name": "mcp:srv:demo", "rel_path": rel_path})
+
+    def test_resolve_forbidden_on_skillenv(self, registry: SkillRegistry) -> None:
+        """``.skillenv`` 任何路径命中 → ``4018 forbidden``（即使句柄声称该路径）。"""
+        resolver = SkillBlobResolver(registry)
+        with pytest.raises(BlobHandleForbiddenError):
+            resolver.resolve({"name": "mcp:srv:demo", "rel_path": ".skillenv"})
+
+    def test_handle_path_is_re_sandboxed_not_trusted(self, registry: SkillRegistry, tmp_path: Path) -> None:
+        """反例：伪造句柄注入绝对路径逃逸 → 重跑沙箱拒绝，绝不按句柄路径直读。"""
+        resolver = SkillBlobResolver(registry)
+        secret = tmp_path / "outside-secret.txt"
+        secret.write_text("TOPSECRET", encoding="utf-8")
+        with pytest.raises(BlobHandleForbiddenError):
+            resolver.resolve({"name": "mcp:srv:demo", "rel_path": str(secret)})
 
     def test_protocol_runtime_checkable(self) -> None:
-        resolver = SkillBlobResolverPending()
+        resolver = SkillBlobResolver(SkillRegistry())
         assert isinstance(resolver, BlobResolver)
 
 

--- a/tests/unit_tests/computer/cli/test_main.py
+++ b/tests/unit_tests/computer/cli/test_main.py
@@ -903,6 +903,8 @@ def test_cli_namespace_flag_propagates_to_client_handler_registration(
         GET_CONFIG_EVENT,
         GET_DESKTOP_EVENT,
         GET_RESOURCES_EVENT,
+        GET_SKILL_EVENT,
+        GET_SKILLS_EVENT,
         GET_TOOLS_EVENT,
         SMCP_NAMESPACE,
         TOOL_CALL_EVENT,
@@ -978,4 +980,6 @@ def test_cli_namespace_flag_propagates_to_client_handler_registration(
         GET_DESKTOP_EVENT,
         GET_RESOURCES_EVENT,
         GET_BLOB_EVENT,
+        GET_SKILLS_EVENT,
+        GET_SKILL_EVENT,
     }, f"Unexpected event handlers under {custom_ns!r}: {registered!r}"

--- a/tests/unit_tests/computer/mcp_clients/test_model_skill.py
+++ b/tests/unit_tests/computer/mcp_clients/test_model_skill.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+# filename: test_model_skill.py
+# @Time    : 2026/05/25
+# @Author  : JQQ
+# @Email   : jqq1716@gmail.com
+# @Software: PyCharm
+"""
+``GetSkillRet`` 服务侧 XOR 校验模型单元测试（v0.2.1 #66）
+Unit tests for the server-side ``GetSkillRet`` XOR validation model.
+
+协议依据 / Protocol: a2c-smcp-protocol data-structures.md §GetSkillRet；skill.md §9
+                      （``body`` 与 ``blob_handle`` **恰一存在**）。
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+
+from a2c_smcp.computer.mcp_clients.model import GetSkillRet
+
+_BASE: dict[str, Any] = {
+    "name": "mcp:srv:demo",
+    "rel_path": "SKILL.md",
+    "mime_type": "text/markdown",
+    "total_size": 12,
+    "sha256": "a" * 64,
+    "req_id": "r-1",
+}
+
+
+def test_body_only_valid() -> None:
+    m = GetSkillRet.model_validate({**_BASE, "body": "hello body\n"})
+    assert m.body == "hello body\n"
+    assert m.blob_handle is None
+    dumped = m.model_dump(exclude_none=True)
+    assert "body" in dumped and "blob_handle" not in dumped
+
+
+def test_blob_handle_only_valid() -> None:
+    m = GetSkillRet.model_validate({**_BASE, "blob_handle": "opaque-handle"})
+    assert m.blob_handle == "opaque-handle"
+    assert m.body is None
+    dumped = m.model_dump(exclude_none=True)
+    assert "blob_handle" in dumped and "body" not in dumped
+
+
+def test_both_present_rejected() -> None:
+    with pytest.raises(ValidationError, match="exactly one"):
+        GetSkillRet.model_validate({**_BASE, "body": "x", "blob_handle": "y"})
+
+
+def test_neither_present_rejected() -> None:
+    with pytest.raises(ValidationError, match="exactly one"):
+        GetSkillRet.model_validate(dict(_BASE))
+
+
+def test_extra_field_forbidden() -> None:
+    """extra='forbid'：服务侧自构造多余字段即 SDK bug，硬失败暴露。"""
+    with pytest.raises(ValidationError):
+        GetSkillRet.model_validate({**_BASE, "body": "x", "unexpected_field": 1})
+
+
+def test_empty_string_body_counts_as_present() -> None:
+    """空字符串 body（如剥离 frontmatter 后空正文）视为存在（None 才是缺席）。"""
+    m = GetSkillRet.model_validate({**_BASE, "body": ""})
+    assert m.body == ""
+    assert m.blob_handle is None

--- a/tests/unit_tests/computer/skills/test_resource.py
+++ b/tests/unit_tests/computer/skills/test_resource.py
@@ -1,0 +1,200 @@
+# -*- coding: utf-8 -*-
+# filename: test_resource.py
+# @Time    : 2026/05/25
+# @Author  : JQQ
+# @Email   : jqq1716@gmail.com
+# @Software: PyCharm
+"""
+SKILL 消费字节视图单元测试 / Unit tests for the SKILL consumed-bytes view (v0.2.1, #66)
+
+协议依据 / Protocol: a2c-smcp-protocol docs/specification/skill.md §9；blob-transfer.md §3 / §5。
+SDK 设计 / Design: python-sdk docs/design-0.2.1-skill-computer-management.md §4.2 / §4.4 / §5.1。
+
+测试意图 / Test intentions:
+- SKILL.md 入口剥 frontmatter（消费字节 = body）；其它资源原始字节；
+- ``total_size`` / ``sha256`` 基于消费字节（mint 与 serve 一致的根）；
+- ``too_large`` 守卫基于 stat（不读超大文件），仅 mint 期生效；
+- MIME 推断 + ``is_text`` 判定；切片 / read_all 语义；
+- 沙箱失败（traversal / forbidden / not_found）原样抛 SkillSandboxError（不在此映射协议错误码）。
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import pytest
+
+from a2c_smcp.computer.skills.resource import (
+    DEFAULT_SKILL_MIME,
+    looks_textual,
+    resolve_skill_view,
+)
+from a2c_smcp.computer.skills.sandbox import SkillSandboxError
+
+_SKILL_MD = "---\nname: demo\nversion: 1.0.0\n---\n# Title\n\nhello body\n"
+_SKILL_BODY = "# Title\n\nhello body\n"  # 闭合 --- 行之后 / after the closing fence line
+_NOTE = b"raw note bytes\n"
+
+
+@pytest.fixture
+def pkg(tmp_path: Path) -> Path:
+    """含 SKILL.md / 子资源 / .skillenv 的包根。"""
+    root = tmp_path / "demo-skill"
+    (root / "references").mkdir(parents=True)
+    (root / "SKILL.md").write_text(_SKILL_MD, encoding="utf-8")
+    (root / "references" / "note.txt").write_bytes(_NOTE)
+    (root / "data.json").write_text('{"k": 1}\n', encoding="utf-8")
+    (root / ".skillenv").write_text("SECRET=1\n", encoding="utf-8")
+    return root
+
+
+# ---------------------------------------------------------------------------
+# SKILL.md 入口：frontmatter 剥离 + 消费字节基准
+# ---------------------------------------------------------------------------
+def test_skill_md_default_strips_frontmatter(pkg: Path) -> None:
+    view = resolve_skill_view(pkg, None)  # 缺省 → SKILL.md
+    expected = _SKILL_BODY.encode("utf-8")
+    assert view.rel_path == "SKILL.md"
+    assert view.is_entry is True
+    assert view.mime == DEFAULT_SKILL_MIME
+    assert view.is_text is True
+    assert view.total_size == len(expected)
+    assert view.sha256 == hashlib.sha256(expected).hexdigest()
+    assert view.read_all() == expected
+
+
+def test_skill_md_explicit_rel_path_same_as_default(pkg: Path) -> None:
+    a = resolve_skill_view(pkg, "SKILL.md")
+    b = resolve_skill_view(pkg, None)
+    assert a.sha256 == b.sha256 and a.total_size == b.total_size
+
+
+def test_skill_md_total_size_excludes_frontmatter(pkg: Path) -> None:
+    """消费字节 < 原始文件字节（frontmatter 被剥离）。"""
+    raw_size = (pkg / "SKILL.md").stat().st_size
+    view = resolve_skill_view(pkg, "SKILL.md")
+    assert view.total_size < raw_size
+
+
+# ---------------------------------------------------------------------------
+# 其它资源：原始字节
+# ---------------------------------------------------------------------------
+def test_subresource_raw_bytes(pkg: Path) -> None:
+    view = resolve_skill_view(pkg, "references/note.txt")
+    assert view.is_entry is False
+    assert view.total_size == len(_NOTE)
+    assert view.sha256 == hashlib.sha256(_NOTE).hexdigest()
+    assert view.read_all() == _NOTE
+    assert view.mime == "text/plain"
+    assert view.is_text is True
+
+
+def test_json_subresource_is_textual(pkg: Path) -> None:
+    view = resolve_skill_view(pkg, "data.json")
+    assert view.is_text is True  # application/json ∈ 文本类允许集
+
+
+# ---------------------------------------------------------------------------
+# too_large 守卫（仅 mint 期；基于 stat，不读文件）
+# ---------------------------------------------------------------------------
+def test_too_large_subresource_rejected_by_stat(pkg: Path) -> None:
+    view_size = (pkg / "references" / "note.txt").stat().st_size
+    with pytest.raises(SkillSandboxError) as exc:
+        resolve_skill_view(pkg, "references/note.txt", too_large_cap=view_size - 1)
+    assert exc.value.reason == "too_large"
+    assert exc.value.total_size == view_size
+
+
+def test_too_large_skill_md_rejected(pkg: Path) -> None:
+    with pytest.raises(SkillSandboxError) as exc:
+        resolve_skill_view(pkg, "SKILL.md", too_large_cap=1)
+    assert exc.value.reason == "too_large"
+
+
+def test_within_cap_ok(pkg: Path) -> None:
+    view = resolve_skill_view(pkg, "references/note.txt", too_large_cap=10_000)
+    assert view.total_size == len(_NOTE)
+
+
+def test_skill_md_second_guard_on_replace_inflation(tmp_path: Path) -> None:
+    """二次 too_large 守卫：原始 ≤ cap，但 errors='replace' 把非法 UTF-8 膨胀成 U+FFFD 致 body > cap。
+
+    罕见但唯一能让 SKILL.md 剥离后 body 超过原始文件字节的路径（每个非法字节 → 3 字节 U+FFFD）。
+    守护 resource.py 剥离后再校验的防御分支。
+    """
+    root = tmp_path / "infl"
+    root.mkdir()
+    # frontmatter 16 字节 + 100 个非法 UTF-8 字节 → 原始 116；剥离后 body = 100×U+FFFD = 300 字节
+    (root / "SKILL.md").write_bytes(b"---\nname: d\n---\n" + b"\xff" * 100)
+    raw_size = (root / "SKILL.md").stat().st_size
+    cap = 200  # raw(116) ≤ cap < stripped(300)
+    assert raw_size <= cap
+    with pytest.raises(SkillSandboxError) as exc:
+        resolve_skill_view(root, "SKILL.md", too_large_cap=cap)
+    assert exc.value.reason == "too_large"
+    assert exc.value.total_size == 300  # 剥离后 body 字节（非原始文件字节）
+
+
+def test_no_cap_never_too_large(pkg: Path) -> None:
+    """get_blob 解析期（cap=None）不做 too_large 守卫。"""
+    view = resolve_skill_view(pkg, "references/note.txt")  # too_large_cap 默认 None
+    assert view.total_size == len(_NOTE)
+
+
+# ---------------------------------------------------------------------------
+# 沙箱失败原样抛出（错误码映射在上层 handler）
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("rel", ["../outside", "../../etc/passwd", "references/../../escape"])
+def test_traversal_raises_sandbox_error(pkg: Path, rel: str) -> None:
+    with pytest.raises(SkillSandboxError) as exc:
+        resolve_skill_view(pkg, rel)
+    assert exc.value.reason == "traversal"
+
+
+def test_skillenv_forbidden(pkg: Path) -> None:
+    with pytest.raises(SkillSandboxError) as exc:
+        resolve_skill_view(pkg, ".skillenv")
+    assert exc.value.reason == "forbidden"
+
+
+def test_missing_not_found(pkg: Path) -> None:
+    with pytest.raises(SkillSandboxError) as exc:
+        resolve_skill_view(pkg, "nope.txt")
+    assert exc.value.reason == "not_found"
+
+
+# ---------------------------------------------------------------------------
+# 切片语义
+# ---------------------------------------------------------------------------
+def test_slice_mid_and_eof(pkg: Path) -> None:
+    view = resolve_skill_view(pkg, "references/note.txt")
+    assert view.slice(0, 3) == _NOTE[:3]
+    assert view.slice(view.total_size, 10) == b""  # EOF probe
+    assert view.slice(4, 999) == _NOTE[4:]  # auto-truncate
+
+
+def test_slice_negative_and_oob(pkg: Path) -> None:
+    view = resolve_skill_view(pkg, "references/note.txt")
+    with pytest.raises(ValueError, match="non-negative"):
+        view.slice(-1, 1)
+    with pytest.raises(ValueError, match="> total_size"):
+        view.slice(view.total_size + 1, 1)
+
+
+# ---------------------------------------------------------------------------
+# looks_textual helper
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    ("mime", "expected"),
+    [
+        ("text/plain", True),
+        ("text/markdown", True),
+        ("application/json", True),
+        ("application/yaml", True),
+        ("image/png", False),
+        ("application/octet-stream", False),
+    ],
+)
+def test_looks_textual(mime: str, expected: bool) -> None:
+    assert looks_textual(mime) is expected

--- a/tests/unit_tests/computer/socketio/test_handshake_config.py
+++ b/tests/unit_tests/computer/socketio/test_handshake_config.py
@@ -23,6 +23,8 @@ from a2c_smcp.smcp import (
     GET_CONFIG_EVENT,
     GET_DESKTOP_EVENT,
     GET_RESOURCES_EVENT,
+    GET_SKILL_EVENT,
+    GET_SKILLS_EVENT,
     GET_TOOLS_EVENT,
     SMCP_NAMESPACE,
     TOOL_CALL_EVENT,
@@ -74,6 +76,8 @@ def test_computer_client_custom_namespace_registers_all_handlers() -> None:
         GET_DESKTOP_EVENT,
         GET_RESOURCES_EVENT,
         GET_BLOB_EVENT,
+        GET_SKILLS_EVENT,
+        GET_SKILL_EVENT,
     }
 
 

--- a/tests/unit_tests/computer/socketio/test_on_get_blob.py
+++ b/tests/unit_tests/computer/socketio/test_on_get_blob.py
@@ -161,12 +161,13 @@ class TestErrorPayloadReasons:
         assert ret["details"]["reason"] == "invalid_handle"  # type: ignore[index]
 
     @pytest.mark.asyncio
-    async def test_forbidden_from_skill_pending_resolver(self, client: SMCPComputerClient) -> None:
-        """skill resolver 占位（#39 接管前）→ ``forbidden`` / skill placeholder → forbidden."""
-        handle = encode_skill_handle(name="user:x:y", rel_path="SKILL.md")
+    async def test_gone_for_unregistered_skill(self, client: SMCPComputerClient) -> None:
+        """skill 句柄 name 未注册（空 Registry）→ ``gone``（#66：SkillBlobResolver 经 Registry 解析）.
+        Unregistered skill name → ``gone`` (Registry miss = channel revoked / source unavailable)."""
+        handle = encode_skill_handle(name="my-skill", rel_path="SKILL.md")
         ret = await client.on_get_blob(_req(handle))  # type: ignore[arg-type]
         assert ret["code"] == int(ErrorCode.BLOB_NOT_ACCESSIBLE)  # type: ignore[index]
-        assert ret["details"]["reason"] == "forbidden"  # type: ignore[index]
+        assert ret["details"]["reason"] == "gone"  # type: ignore[index]
 
     @pytest.mark.asyncio
     async def test_range_offset_negative(self, computer: Computer, client: SMCPComputerClient) -> None:

--- a/tests/unit_tests/computer/socketio/test_on_get_skill.py
+++ b/tests/unit_tests/computer/socketio/test_on_get_skill.py
@@ -1,0 +1,289 @@
+# -*- coding: utf-8 -*-
+# filename: test_on_get_skill.py
+# @Time    : 2026/05/25
+# @Author  : JQQ
+# @Email   : jqq1716@gmail.com
+# @Software: PyCharm
+"""
+``client:get_skills`` / ``client:get_skill`` / ``emit_update_skills`` handler 单元测试（v0.2.1 #66）
+Unit tests for the SKILL channel handlers on the Computer Socket.IO client.
+
+协议依据 / Protocol: a2c-smcp-protocol events.md#client:get_skill[s] / §server:update_skills；
+                      error-handling.md §4014 / §4016 / §4017；skill.md §6 / §9。
+设计依据 / Design: python-sdk docs/design-0.2.1-skill-computer-management.md §4.2 / §5.1 / §5.3。
+
+覆盖 / Coverage:
+  - on_get_skills：活跃集（排除孤儿）、发现序、office 隔离
+  - on_get_skill：4016 / 4014 / 4017(traversal/forbidden/not_found/too_large) / inline body / blob_handle / 二进制铸句柄
+  - too_large 不铸句柄（flat ErrorPayload）
+  - emit_update_skills：office_id 守卫
+  - 安全反例（§5.3）：穿越→traversal / .skillenv→forbidden（存在仍 forbidden）/ too_large 零字节
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from a2c_smcp.computer.blob import BlobThresholds, decode_blob_handle
+from a2c_smcp.computer.computer import Computer
+from a2c_smcp.computer.socketio.client import SMCPComputerClient
+from a2c_smcp.exceptions import SMCPNamespaceError
+from a2c_smcp.smcp import UPDATE_SKILLS_EVENT, A2CSkillRef, ErrorCode
+
+_SKILL_MD = "---\nname: demo\nversion: 1.0.0\n---\n# Demo\n\nshort body\n"
+_SKILL_BODY = "# Demo\n\nshort body\n"  # frontmatter 剥离后正文
+
+
+def _make_pkg(root: Path) -> Path:
+    pkg = root / "mcp" / "srv" / "demo"
+    (pkg / "references").mkdir(parents=True)
+    (pkg / "SKILL.md").write_text(_SKILL_MD, encoding="utf-8")
+    (pkg / "references" / "note.txt").write_text("note content\n", encoding="utf-8")
+    (pkg / ".skillenv").write_text("SECRET=1\n", encoding="utf-8")
+    (pkg / "logo.png").write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 40)
+    return pkg
+
+
+def _computer(tmp_path: Path, *, thresholds: BlobThresholds | None = None, name: str = "comp-test") -> Computer:
+    return Computer(
+        name=name,
+        blob_cache_root=tmp_path / "blobspool",
+        blob_thresholds=thresholds,
+        auto_connect=False,
+        auto_reconnect=False,
+    )
+
+
+def _register_demo(computer: Computer, pkg: Path) -> None:
+    ref: A2CSkillRef = {"name": "mcp:srv:demo", "source": "mcp:srv", "path": str(pkg)}
+    assert computer.skill_registry.register(ref) is True
+
+
+def _skill_req(name: str, *, rel_path: str | None = None, computer_name: str = "comp-test") -> dict[str, Any]:
+    req: dict[str, Any] = {"agent": "agent-1", "req_id": "r-1", "computer": computer_name, "name": name}
+    if rel_path is not None:
+        req["rel_path"] = rel_path
+    return req
+
+
+# ===========================================================================
+# on_get_skills
+# ===========================================================================
+class TestOnGetSkills:
+    @pytest.mark.asyncio
+    async def test_excludes_orphans_discovery_order(self, tmp_path: Path) -> None:
+        comp = _computer(tmp_path)
+        pkg = _make_pkg(tmp_path / "home")
+        # 发现序：demo → helper（孤儿 gone 不计入）
+        comp.skill_registry.register({"name": "mcp:srv:demo", "source": "mcp:srv", "path": str(pkg)})
+        comp.skill_registry.register({"name": "my-helper", "source": "user", "path": str(pkg)})
+        comp.skill_registry.register({"name": "mcp:srv:gone", "source": "mcp:srv", "path": str(pkg)})
+        comp.skill_registry.mark_orphan("mcp:srv:gone")
+
+        client = SMCPComputerClient(computer=comp)
+        ret = await client.on_get_skills(_skill_req("ignored-name"))  # type: ignore[arg-type]
+        names = [s["name"] for s in ret["skills"]]
+        assert names == ["mcp:srv:demo", "my-helper"]  # 排除孤儿 + 保留发现序
+        assert ret["req_id"] == "r-1"
+
+    @pytest.mark.asyncio
+    async def test_empty_registry(self, tmp_path: Path) -> None:
+        client = SMCPComputerClient(computer=_computer(tmp_path))
+        ret = await client.on_get_skills(_skill_req("x"))  # type: ignore[arg-type]
+        assert ret["skills"] == []
+
+    @pytest.mark.asyncio
+    async def test_computer_mismatch_raises(self, tmp_path: Path) -> None:
+        client = SMCPComputerClient(computer=_computer(tmp_path))
+        with pytest.raises(SMCPNamespaceError):
+            await client.on_get_skills(_skill_req("x", computer_name="other"))  # type: ignore[arg-type]
+
+
+# ===========================================================================
+# on_get_skill —— 错误码分支
+# ===========================================================================
+class TestOnGetSkillErrors:
+    @pytest.mark.asyncio
+    async def test_4016_invalid_name(self, tmp_path: Path) -> None:
+        client = SMCPComputerClient(computer=_computer(tmp_path))
+        ret = await client.on_get_skill(_skill_req("MySkill"))  # type: ignore[arg-type]  # 大写非法
+        assert ret["code"] == int(ErrorCode.SKILL_NAME_INVALID)
+        assert ret["details"]["name"] == "MySkill"
+        assert "message" in ret
+
+    @pytest.mark.asyncio
+    async def test_4014_valid_name_not_registered(self, tmp_path: Path) -> None:
+        client = SMCPComputerClient(computer=_computer(tmp_path))
+        ret = await client.on_get_skill(_skill_req("mcp:srv:absent"))  # type: ignore[arg-type]
+        assert ret["code"] == int(ErrorCode.MCP_SERVER_NOT_FOUND)  # 4014 复用
+        assert ret["details"]["name"] == "mcp:srv:absent"
+
+    @pytest.mark.asyncio
+    async def test_4014_orphaned(self, tmp_path: Path) -> None:
+        comp = _computer(tmp_path)
+        pkg = _make_pkg(tmp_path / "home")
+        _register_demo(comp, pkg)
+        comp.skill_registry.mark_orphan("mcp:srv:demo")
+        client = SMCPComputerClient(computer=comp)
+        ret = await client.on_get_skill(_skill_req("mcp:srv:demo"))  # type: ignore[arg-type]
+        assert ret["code"] == int(ErrorCode.MCP_SERVER_NOT_FOUND)
+
+    @pytest.mark.parametrize("rel_path", ["../escape", "../../etc/passwd", "references/../../out"])
+    @pytest.mark.asyncio
+    async def test_4017_traversal(self, tmp_path: Path, rel_path: str) -> None:
+        comp = _computer(tmp_path)
+        pkg = _make_pkg(tmp_path / "home")
+        _register_demo(comp, pkg)
+        client = SMCPComputerClient(computer=comp)
+        ret = await client.on_get_skill(_skill_req("mcp:srv:demo", rel_path=rel_path))  # type: ignore[arg-type]
+        assert ret["code"] == int(ErrorCode.SKILL_RESOURCE_NOT_ACCESSIBLE)
+        assert ret["details"]["reason"] == "traversal"
+
+    @pytest.mark.asyncio
+    async def test_4017_skillenv_forbidden_even_when_exists(self, tmp_path: Path) -> None:
+        """安全反例：.skillenv 真实存在仍 forbidden（不泄漏存在性）。"""
+        comp = _computer(tmp_path)
+        pkg = _make_pkg(tmp_path / "home")
+        assert (pkg / ".skillenv").exists()
+        _register_demo(comp, pkg)
+        client = SMCPComputerClient(computer=comp)
+        ret = await client.on_get_skill(_skill_req("mcp:srv:demo", rel_path=".skillenv"))  # type: ignore[arg-type]
+        assert ret["code"] == int(ErrorCode.SKILL_RESOURCE_NOT_ACCESSIBLE)
+        assert ret["details"]["reason"] == "forbidden"
+
+    @pytest.mark.asyncio
+    async def test_4017_not_found(self, tmp_path: Path) -> None:
+        comp = _computer(tmp_path)
+        pkg = _make_pkg(tmp_path / "home")
+        _register_demo(comp, pkg)
+        client = SMCPComputerClient(computer=comp)
+        ret = await client.on_get_skill(_skill_req("mcp:srv:demo", rel_path="nope.txt"))  # type: ignore[arg-type]
+        assert ret["code"] == int(ErrorCode.SKILL_RESOURCE_NOT_ACCESSIBLE)
+        assert ret["details"]["reason"] == "not_found"
+
+    @pytest.mark.asyncio
+    async def test_4017_too_large_no_handle_minted(self, tmp_path: Path) -> None:
+        """安全反例：超 too_large_cap → 4017 too_large，零字节、不铸句柄。"""
+        comp = _computer(tmp_path, thresholds=BlobThresholds(too_large_cap=4))
+        pkg = _make_pkg(tmp_path / "home")
+        _register_demo(comp, pkg)
+        client = SMCPComputerClient(computer=comp)
+        ret = await client.on_get_skill(_skill_req("mcp:srv:demo", rel_path="references/note.txt"))  # type: ignore[arg-type]
+        assert ret["code"] == int(ErrorCode.SKILL_RESOURCE_NOT_ACCESSIBLE)
+        assert ret["details"]["reason"] == "too_large"
+        assert ret["details"]["total_size"] == len(b"note content\n")
+        assert "blob_handle" not in ret  # 不铸句柄
+
+    @pytest.mark.asyncio
+    async def test_computer_mismatch_raises(self, tmp_path: Path) -> None:
+        client = SMCPComputerClient(computer=_computer(tmp_path))
+        with pytest.raises(SMCPNamespaceError):
+            await client.on_get_skill(_skill_req("mcp:srv:demo", computer_name="other"))  # type: ignore[arg-type]
+
+
+# ===========================================================================
+# on_get_skill —— 成功路径（inline vs handle）
+# ===========================================================================
+class TestOnGetSkillSuccess:
+    @pytest.mark.asyncio
+    async def test_skill_md_inline_body_frontmatter_stripped(self, tmp_path: Path) -> None:
+        comp = _computer(tmp_path)  # 默认 inline_budget 32KiB → 小 body 内联
+        pkg = _make_pkg(tmp_path / "home")
+        _register_demo(comp, pkg)
+        client = SMCPComputerClient(computer=comp)
+        ret = await client.on_get_skill(_skill_req("mcp:srv:demo"))  # type: ignore[arg-type]  # 缺省 rel_path
+        import hashlib
+
+        expected = _SKILL_BODY.encode("utf-8")
+        assert ret["name"] == "mcp:srv:demo"
+        assert ret["rel_path"] == "SKILL.md"
+        assert ret["mime_type"] == "text/markdown"
+        assert ret["body"] == _SKILL_BODY
+        assert "blob_handle" not in ret
+        assert ret["total_size"] == len(expected)
+        assert ret["sha256"] == hashlib.sha256(expected).hexdigest()
+
+    @pytest.mark.asyncio
+    async def test_text_over_inline_budget_mints_handle(self, tmp_path: Path) -> None:
+        comp = _computer(tmp_path, thresholds=BlobThresholds(inline_budget=4))  # 强制超预算
+        pkg = _make_pkg(tmp_path / "home")
+        _register_demo(comp, pkg)
+        client = SMCPComputerClient(computer=comp)
+        ret = await client.on_get_skill(_skill_req("mcp:srv:demo"))  # type: ignore[arg-type]
+        assert "body" not in ret
+        assert "blob_handle" in ret
+        kind, payload = decode_blob_handle(ret["blob_handle"])
+        assert kind == "skill"
+        assert payload == {"name": "mcp:srv:demo", "rel_path": "SKILL.md"}
+
+    @pytest.mark.asyncio
+    async def test_binary_always_mints_handle(self, tmp_path: Path) -> None:
+        """二进制 MIME（image/png）无论大小一律铸句柄（不内联）。"""
+        comp = _computer(tmp_path)  # 默认大预算
+        pkg = _make_pkg(tmp_path / "home")
+        _register_demo(comp, pkg)
+        client = SMCPComputerClient(computer=comp)
+        ret = await client.on_get_skill(_skill_req("mcp:srv:demo", rel_path="logo.png"))  # type: ignore[arg-type]
+        assert ret["mime_type"] == "image/png"
+        assert "body" not in ret
+        assert "blob_handle" in ret
+
+    @pytest.mark.asyncio
+    async def test_subresource_inline_text(self, tmp_path: Path) -> None:
+        comp = _computer(tmp_path)
+        pkg = _make_pkg(tmp_path / "home")
+        _register_demo(comp, pkg)
+        client = SMCPComputerClient(computer=comp)
+        ret = await client.on_get_skill(_skill_req("mcp:srv:demo", rel_path="references/note.txt"))  # type: ignore[arg-type]
+        assert ret["rel_path"] == "references/note.txt"
+        assert ret["body"] == "note content\n"  # 非 SKILL.md → 不剥 frontmatter（原始字节）
+        assert ret["mime_type"] == "text/plain"
+
+    @pytest.mark.asyncio
+    async def test_textual_mime_but_invalid_utf8_falls_back_to_handle(self, tmp_path: Path) -> None:
+        """文本 MIME（text/plain）但内容非 UTF-8 → decode 失败回退铸句柄（不内联破损字符串）。"""
+        comp = _computer(tmp_path)  # 默认大预算：≤budget 才进 decode 路径
+        pkg = _make_pkg(tmp_path / "home")
+        (pkg / "bad.txt").write_bytes(b"\xff\xfe\xff\xfe")  # 非法 UTF-8，.txt → text/plain
+        _register_demo(comp, pkg)
+        client = SMCPComputerClient(computer=comp)
+        ret = await client.on_get_skill(_skill_req("mcp:srv:demo", rel_path="bad.txt"))  # type: ignore[arg-type]
+        assert ret["mime_type"] == "text/plain"
+        assert "body" not in ret  # decode 失败 → 不内联
+        assert "blob_handle" in ret  # 回退铸句柄
+
+
+# ===========================================================================
+# emit_update_skills
+# ===========================================================================
+class TestEmitUpdateSkills:
+    @pytest.mark.asyncio
+    async def test_emits_when_in_office(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        client = SMCPComputerClient(computer=_computer(tmp_path, name="comp-x"))
+        client.office_id = "office-1"
+        called: dict[str, Any] = {}
+
+        async def fake_emit(self, event: str, data: Any = None, namespace: str | None = None, callback: Any = None) -> None:
+            called["event"] = event
+            called["data"] = data
+
+        monkeypatch.setattr(SMCPComputerClient, "emit", fake_emit)
+        await client.emit_update_skills()
+        assert called["event"] == UPDATE_SKILLS_EVENT
+        assert called["data"]["computer"] == "comp-x"
+
+    @pytest.mark.asyncio
+    async def test_noop_when_not_in_office(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        client = SMCPComputerClient(computer=_computer(tmp_path))
+        client.office_id = None
+        called: dict[str, Any] = {}
+
+        async def fake_emit(self, event: str, data: Any = None, namespace: str | None = None, callback: Any = None) -> None:
+            called["event"] = event
+
+        monkeypatch.setattr(SMCPComputerClient, "emit", fake_emit)
+        await client.emit_update_skills()
+        assert "event" not in called  # office_id 守卫：未入房间不发送

--- a/tests/unit_tests/computer/test_computer_skills.py
+++ b/tests/unit_tests/computer/test_computer_skills.py
@@ -1,0 +1,352 @@
+# -*- coding: utf-8 -*-
+# filename: test_computer_skills.py
+# @Time    : 2026/05/25
+# @Author  : JQQ
+# @Email   : jqq1716@gmail.com
+# @Software: PyCharm
+"""
+Computer SKILL 子系统接线单元测试（v0.2.1 #66）
+Unit tests for the Computer SKILL subsystem wiring.
+
+设计依据 / Design: python-sdk docs/design-0.2.1-skill-computer-management.md §5.1 / §5.3。
+协议依据 / Protocol: a2c-smcp-protocol skill.md §6 / §8 / §9。
+
+覆盖 / Coverage:
+- 持有 SkillRegistry + 真 SkillBlobResolver 接线（占位已替换）
+- 委托 get_skills / get_skill_ref / read_skill_resource（§9.2 包根仅取自 ref.path）
+- _acollect_skill_refs（manager 未就绪 → 空集；有 skill:// → URI 集）
+- _restage_mcp_skills 全量重物化 + 孤儿对账（消失→孤儿、回归→恢复）
+- _on_manager_change skill:// 分支：集合变化→emit_update_skills；未变→跳过；ResourceUpdated(skill://)→emit
+- window:// 与 skill:// 并行（互不影响既有窗口行为）
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from mcp.types import Resource
+
+from a2c_smcp.computer.blob.resolver import SkillBlobResolver
+from a2c_smcp.computer.computer import Computer
+from a2c_smcp.computer.skills.sandbox import SkillSandboxError
+from a2c_smcp.smcp import A2CSkillRef
+
+_SKILL_MD = "---\nname: demo\ndescription: d\nlicense: MIT\n---\n# Demo\nbody\n"
+
+
+# ── 测试替身 / doubles ──────────────────────────────────────────────────────
+class _DummyClient:
+    """伪 Socket.IO 客户端：计数三类 emit（含 v0.2.1 emit_update_skills）。"""
+
+    def __init__(self) -> None:
+        self.update_tool_called = 0
+        self.refresh_called = 0
+        self.update_skills_called = 0
+
+    async def emit_update_tool_list(self) -> None:
+        self.update_tool_called += 1
+
+    async def emit_refresh_desktop(self) -> None:
+        self.refresh_called += 1
+
+    async def emit_update_skills(self) -> None:
+        self.update_skills_called += 1
+
+
+class _FakeManager:
+    """提供 list_skill_resources 的最小 manager（mounted 模式无需 read_resource）。"""
+
+    def __init__(self, pairs: list[tuple[str, Resource]]) -> None:
+        self._pairs = pairs
+
+    def set_pairs(self, pairs: list[tuple[str, Resource]]) -> None:
+        self._pairs = pairs
+
+    async def list_skill_resources(self, server_name: str | None = None) -> list[tuple[str, Resource]]:
+        return [(s, r) for s, r in self._pairs if server_name is None or s == server_name]
+
+
+def _mounted_skill_resource(uri: str, src_dir: Path) -> Resource:
+    """构造一个 mounted 模式 skill:// 根资源（指向本地 src_dir）。"""
+    src_dir.mkdir(parents=True, exist_ok=True)
+    (src_dir / "SKILL.md").write_text(_SKILL_MD, encoding="utf-8")
+    return Resource(uri=uri, name=uri.rsplit("/", 1)[-1], _meta={"source": "mounted", "mount_dir": str(src_dir)})
+
+
+def _computer(tmp_path: Path) -> Computer:
+    return Computer(name="comp-test", blob_cache_root=tmp_path / "blobspool", auto_connect=False, auto_reconnect=False)
+
+
+# ===========================================================================
+# 接线 / wiring
+# ===========================================================================
+def test_holds_registry_and_real_skill_resolver(tmp_path: Path) -> None:
+    comp = _computer(tmp_path)
+    assert comp.skill_registry is not None
+    # 占位已被真 resolver 替换（#66）
+    assert isinstance(comp.blob_resolvers["skill"], SkillBlobResolver)
+
+
+def test_get_skills_excludes_orphans(tmp_path: Path) -> None:
+    comp = _computer(tmp_path)
+    pkg = tmp_path / "pkg"
+    pkg.mkdir()
+    comp.skill_registry.register({"name": "mcp:srv:a", "source": "mcp:srv", "path": str(pkg)})
+    comp.skill_registry.register({"name": "mcp:srv:b", "source": "mcp:srv", "path": str(pkg)})
+    comp.skill_registry.mark_orphan("mcp:srv:b")
+    names = [s["name"] for s in comp.get_skills()]
+    assert names == ["mcp:srv:a"]
+
+
+def test_get_skill_ref_none_for_absent_and_orphan(tmp_path: Path) -> None:
+    comp = _computer(tmp_path)
+    pkg = tmp_path / "pkg"
+    pkg.mkdir()
+    comp.skill_registry.register({"name": "mcp:srv:a", "source": "mcp:srv", "path": str(pkg)})
+    assert comp.get_skill_ref("mcp:srv:a") is not None
+    assert comp.get_skill_ref("mcp:srv:absent") is None
+    comp.skill_registry.mark_orphan("mcp:srv:a")
+    assert comp.get_skill_ref("mcp:srv:a") is None
+
+
+def test_read_skill_resource_uses_ref_path_not_name(tmp_path: Path) -> None:
+    comp = _computer(tmp_path)
+    pkg = tmp_path / "pkg"
+    pkg.mkdir()
+    (pkg / "SKILL.md").write_text(_SKILL_MD, encoding="utf-8")
+    ref: A2CSkillRef = {"name": "mcp:srv:demo", "source": "mcp:srv", "path": str(pkg)}
+    view = comp.read_skill_resource(ref, None)
+    assert view.rel_path == "SKILL.md"
+    assert view.abs_path == (pkg / "SKILL.md").resolve()
+
+
+def test_read_skill_resource_traversal_raises(tmp_path: Path) -> None:
+    comp = _computer(tmp_path)
+    pkg = tmp_path / "pkg"
+    pkg.mkdir()
+    (pkg / "SKILL.md").write_text(_SKILL_MD, encoding="utf-8")
+    ref: A2CSkillRef = {"name": "mcp:srv:demo", "source": "mcp:srv", "path": str(pkg)}
+    with pytest.raises(SkillSandboxError) as exc:
+        comp.read_skill_resource(ref, "../escape")
+    assert exc.value.reason == "traversal"
+
+
+# ===========================================================================
+# _acollect_skill_refs
+# ===========================================================================
+@pytest.mark.asyncio
+async def test_acollect_skill_refs_empty_when_no_manager(tmp_path: Path) -> None:
+    comp = _computer(tmp_path)
+    assert await comp._acollect_skill_refs() == set()
+
+
+@pytest.mark.asyncio
+async def test_acollect_skill_refs_returns_uri_set(tmp_path: Path) -> None:
+    comp = _computer(tmp_path)
+    res = _mounted_skill_resource("skill://srv/demo", tmp_path / "src")
+    comp.mcp_manager = _FakeManager([("srv", res)])  # type: ignore[assignment]
+    assert await comp._acollect_skill_refs() == {"skill://srv/demo"}
+
+
+# ===========================================================================
+# _restage_mcp_skills + 孤儿对账
+# ===========================================================================
+@pytest.mark.asyncio
+async def test_restage_registers_then_reconciles_orphans(tmp_path: Path) -> None:
+    comp = _computer(tmp_path)
+    comp._skill_home = tmp_path / "home"
+    comp._skill_home.mkdir()
+    res = _mounted_skill_resource("skill://srv/demo", tmp_path / "src")
+    mgr = _FakeManager([("srv", res)])
+    comp.mcp_manager = mgr  # type: ignore[assignment]
+
+    # 首轮：物化 + 注册
+    registered = await comp._restage_mcp_skills()
+    assert registered == ["mcp:srv:demo"]
+    assert comp.get_skill_ref("mcp:srv:demo") is not None
+
+    # skill 从源消失 → 全量重物化 → 孤儿对账标孤儿（从 get_skills 排除）
+    mgr.set_pairs([])
+    await comp._restage_mcp_skills()
+    assert comp.skill_registry.is_orphan("mcp:srv:demo") is True
+    assert [s["name"] for s in comp.get_skills()] == []
+
+    # skill 回归 → 重物化 → register 命中孤儿条目自动恢复
+    mgr.set_pairs([("srv", res)])
+    await comp._restage_mcp_skills()
+    assert comp.skill_registry.is_orphan("mcp:srv:demo") is False
+    assert comp.get_skill_ref("mcp:srv:demo") is not None
+
+
+@pytest.mark.asyncio
+async def test_reconcile_does_not_touch_non_mcp_sources(tmp_path: Path) -> None:
+    """孤儿对账仅处理 mcp: 源；user/marketplace 源不被误标孤儿（属 #60/#61）。"""
+    comp = _computer(tmp_path)
+    comp._skill_home = tmp_path / "home"
+    comp._skill_home.mkdir()
+    pkg = tmp_path / "userpkg"
+    pkg.mkdir()
+    comp.skill_registry.register({"name": "my-helper", "source": "user", "path": str(pkg)})
+    comp.mcp_manager = _FakeManager([])  # type: ignore[assignment]
+    await comp._restage_mcp_skills()  # 全量重物化（mcp 源为空）
+    # user 源不应被孤儿对账影响
+    assert comp.skill_registry.is_orphan("my-helper") is False
+    assert comp.get_skill_ref("my-helper") is not None
+
+
+# ===========================================================================
+# _on_manager_change skill:// 分支
+# ===========================================================================
+@pytest.mark.asyncio
+async def test_resource_list_changed_skill_set_changed_emits(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from mcp.types import ResourceListChangedNotification
+
+    comp = _computer(tmp_path)
+    client = _DummyClient()
+    comp.socketio_client = client  # type: ignore[assignment]
+
+    restaged: dict[str, int] = {"n": 0}
+
+    async def fake_restage(server_name: str | None = None) -> list[str]:
+        restaged["n"] += 1
+        return ["mcp:srv:demo"]
+
+    async def fake_collect_skills() -> set[str]:
+        return {"skill://srv/demo"}
+
+    async def fake_collect_windows() -> set[str]:
+        return set()
+
+    monkeypatch.setattr(comp, "_restage_mcp_skills", fake_restage)
+    monkeypatch.setattr(comp, "_acollect_skill_refs", fake_collect_skills)
+    monkeypatch.setattr(comp, "_acollect_window_uris", fake_collect_windows)
+    comp._skills_cache = set()  # 原为空 → 变化
+
+    await comp._on_manager_change(SimpleNamespace(root=ResourceListChangedNotification()))  # type: ignore[arg-type]
+    assert restaged["n"] == 1
+    assert client.update_skills_called == 1
+    assert comp._skills_cache == {"skill://srv/demo"}
+
+
+@pytest.mark.asyncio
+async def test_resource_list_changed_skill_set_unchanged_skips(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from mcp.types import ResourceListChangedNotification
+
+    comp = _computer(tmp_path)
+    client = _DummyClient()
+    comp.socketio_client = client  # type: ignore[assignment]
+
+    restaged: dict[str, int] = {"n": 0}
+
+    async def fake_restage(server_name: str | None = None) -> list[str]:
+        restaged["n"] += 1
+        return []
+
+    async def fake_collect_skills() -> set[str]:
+        return {"skill://srv/demo"}
+
+    async def fake_collect_windows() -> set[str]:
+        return set()
+
+    monkeypatch.setattr(comp, "_restage_mcp_skills", fake_restage)
+    monkeypatch.setattr(comp, "_acollect_skill_refs", fake_collect_skills)
+    monkeypatch.setattr(comp, "_acollect_window_uris", fake_collect_windows)
+    comp._skills_cache = {"skill://srv/demo"}  # 与采集一致 → 跳过
+
+    await comp._on_manager_change(SimpleNamespace(root=ResourceListChangedNotification()))  # type: ignore[arg-type]
+    assert restaged["n"] == 0
+    assert client.update_skills_called == 0
+
+
+@pytest.mark.asyncio
+async def test_resource_updated_skill_uri_emits(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from mcp.types import ResourceUpdatedNotification, ResourceUpdatedNotificationParams
+
+    comp = _computer(tmp_path)
+    client = _DummyClient()
+    comp.socketio_client = client  # type: ignore[assignment]
+
+    restaged: dict[str, int] = {"n": 0}
+
+    async def fake_restage(server_name: str | None = None) -> list[str]:
+        restaged["n"] += 1
+        return ["mcp:srv:demo"]
+
+    monkeypatch.setattr(comp, "_restage_mcp_skills", fake_restage)
+
+    note = ResourceUpdatedNotification(params=ResourceUpdatedNotificationParams(uri="skill://srv/demo"))
+    await comp._on_manager_change(SimpleNamespace(root=note))  # type: ignore[arg-type]
+    assert restaged["n"] == 1
+    assert client.update_skills_called == 1
+    assert client.refresh_called == 0  # 非 window，不刷新桌面
+
+
+@pytest.mark.asyncio
+async def test_resource_updated_non_skill_non_window_no_emit(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from mcp.types import ResourceUpdatedNotification, ResourceUpdatedNotificationParams
+
+    comp = _computer(tmp_path)
+    client = _DummyClient()
+    comp.socketio_client = client  # type: ignore[assignment]
+
+    called: dict[str, int] = {"n": 0}
+
+    async def fake_restage(server_name: str | None = None) -> list[str]:
+        called["n"] += 1
+        return []
+
+    monkeypatch.setattr(comp, "_restage_mcp_skills", fake_restage)
+
+    note = ResourceUpdatedNotification(params=ResourceUpdatedNotificationParams(uri="file://x"))
+    await comp._on_manager_change(SimpleNamespace(root=note))  # type: ignore[arg-type]
+    assert called["n"] == 0
+    assert client.update_skills_called == 0
+    assert client.refresh_called == 0
+
+
+# ===========================================================================
+# boot_up SKILL 子系统启动三步接线（解析 Home → 重物化 → 填充缓存）
+# ===========================================================================
+@pytest.mark.asyncio
+async def test_boot_up_wires_skill_subsystem(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """boot_up 三步接线集成缝隙守护：注入 skill_home，断言 Home 解析落盘 + Registry 被填充 + 缓存 seed。
+
+    三个子步骤各有直测；本测试守护它们在 boot_up 中被**按序接线**且结果落到实例状态。
+    """
+    from a2c_smcp.computer.mcp_clients.manager import MCPServerManager
+
+    skill_home = tmp_path / "skillhome"
+    comp = Computer(name="comp-boot", skill_home=skill_home, auto_connect=False, auto_reconnect=False)
+
+    # manager.ainitialize 置空，避免真实 MCP 连接 / no-op ainitialize to avoid real MCP I/O
+    async def _noop_ainit(self: MCPServerManager, servers: object) -> None:
+        return None
+
+    monkeypatch.setattr(MCPServerManager, "ainitialize", _noop_ainit)
+
+    # 模拟 staging 成功（其内部已有直测）：注册一个 ref，验证 boot 确实调用了重物化并落库
+    async def fake_restage(server_name: str | None = None) -> list[str]:
+        pkg = tmp_path / "pkg"
+        pkg.mkdir(exist_ok=True)
+        comp.skill_registry.register({"name": "mcp:srv:boot", "source": "mcp:srv", "path": str(pkg)})
+        return ["mcp:srv:boot"]
+
+    async def fake_collect() -> set[str]:
+        return {"skill://srv/boot"}
+
+    monkeypatch.setattr(comp, "_restage_mcp_skills", fake_restage)
+    monkeypatch.setattr(comp, "_acollect_skill_refs", fake_collect)
+
+    await comp.boot_up()
+
+    # 1) SKILL Home 解析并落盘 / Home resolved & created
+    assert comp._skill_home == skill_home.resolve()
+    assert comp._skill_home.is_dir()
+    # 2) Registry 被重物化填充 / Registry populated by restage
+    assert comp.get_skill_ref("mcp:srv:boot") is not None
+    # 3) skill:// 缓存被 seed / cache seeded
+    assert comp._skills_cache == {"skill://srv/boot"}
+
+    await comp.shutdown()


### PR DESCRIPTION
## 范围（#66 · S13 · 父 #39）

Computer 侧 SKILL 通道生产实现。**范围 A：仅 `mcp://` 源**——marketplace/user reconcile 入口随 `intent.py` 在 #60/#61 落地（依赖 #55✅/#57✅/#59✅ 全满足）。

## 改动

| 层 | 文件 | 要点 |
|---|---|---|
| 编排 | `computer.py` | 持有 `SkillRegistry` + SKILL Home；boot 物化 mcp 源 `skill://`；`_on_manager_change` **并行** `skill://` 分支（ResourceListChanged 缓存对比→重物化+孤儿对账→`emit_update_skills`；ResourceUpdated(`skill://`)→重物化+emit）；委托 `get_skills`/`get_skill_ref`/`read_skill_resource` |
| Handler | `socketio/client.py` | `on_get_skills`（排孤儿/发现序/不读 body）；`on_get_skill`（4016/4014/4017 各分支 + SKILL.md 剥 frontmatter + inline-vs-handle + too_large 不铸句柄 + 服务侧 XOR 自校验）；`emit_update_skills`（office 守卫） |
| Resolver | `blob/resolver.py` | `SkillBlobResolverPending` → 真 `SkillBlobResolver`（name→Registry 解析包根 → `rel_path` **重跑沙箱** → 惰性切片；Registry miss/孤儿/not_found→`gone`，traversal/forbidden→`forbidden`） |
| 共享视图 | `skills/resource.py`(新) | `resolve_skill_view` —— mint（get_skill）与 serve（get_blob）共用消费字节视图，`sha256`/`total_size` 基准一致（SKILL.md→frontmatter 剥离后 body；其它→原始字节） |
| 工具 | `skills/staging.py` | `strip_skill_frontmatter`（与 `parse_skill_frontmatter` 同源） |
| 校验 | `mcp_clients/model.py` | `GetSkillRet` Pydantic + `body`/`blob_handle` 恰一 XOR `@model_validator` |

## 行为变更
未注册 skill 句柄经 `client:get_blob` → **`4018 gone`**（原占位 resolver 一律 `forbidden`）。已同步 `test_on_get_blob.py`。

## 安全模型（§5.3 反例红→绿）
沙箱穿越→4017 traversal · `.skillenv` 存在/不存在**同 reason** forbidden · too_large 零字节不铸句柄 · 句柄不信任（get_blob 重跑沙箱，伪造路径不提权）· name 寻址（包根仅 Registry 经 name 解析）。

## 门
- `uv run poe lint` 净（ruff + mypy，72 源文件）
- 全量 **1111 passed / 2 skipped / 4 xfailed**
- 新增 get_skill↔get_blob 字节/sha256 一致集成 roundtrip

## 遗留（协议澄清，待 spec 推进）
SKILL 复用 `4014` 的 wire 形态（当前 `details.name`，未平铺 `mcp_server_name`）需在 `error-handling.md §4014/§SKILL` 明确，再让 rust-sdk 对齐。

Refs #66 · 父 #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)