### PR TITLE
feat(computer): v0.2.1 settings schema + 五级 scope merge（active-workdir + 能力层并集）(#56)

### DIFF
--- a/a2c_smcp/computer/settings/__init__.py
+++ b/a2c_smcp/computer/settings/__init__.py
@@ -1,0 +1,99 @@
+# -*- coding: utf-8 -*-
+# filename: __init__.py
+# @Time    : 2026/05/25
+# @Author  : JQQ
+# @Email   : jqq1716@gmail.com
+# @Software: PyCharm
+"""
+Computer 意图 / 治理层 settings 子系统 / Computer intent & governance settings subsystem（v0.2.1）
+
+承载 settings.json 的结构、五级 scope 合并与 policy 子源选取——CLI marketplace/plugin/skill 管理
+UX 的"意图层"。物化文件 store / reconciler / MCP 定义层为后续工单（#58 / #62 / #64）。
+The intent layer of the CLI marketplace/plugin/skill management UX. Materialized-file store /
+reconciler / MCP-definition layer land in follow-up tickets.
+
+已落地模块 / Landed modules：
+- :mod:`a2c_smcp.computer.settings.schema` —— settings.json TypedDict + 字段级容错校验
+  （passthrough / 无 version / policy-only 越权过滤）（S4，#56）
+- :mod:`a2c_smcp.computer.settings.scope`  —— 五级 scope 路径解析 + 读/写两套合并 customizer +
+  active-workdir 单根 / 能力层全局并集解析（S4，#56）
+- :mod:`a2c_smcp.computer.settings.policy` —— policy 四子源 first-source-wins（remote stub + OS-MDM +
+  managed-settings[+.d] + HKCU）（S4，#56）
+
+SDK 设计 / Design: python-sdk docs/design-0.2.1-cli-marketplace-ux.md §5。
+"""
+
+from __future__ import annotations
+
+from a2c_smcp.computer.settings.policy import (
+    PolicySource,
+    default_policy_sources,
+    load_macos_plist,
+    load_managed_settings,
+    load_windows_registry,
+    resolve_policy_settings,
+)
+from a2c_smcp.computer.settings.schema import (
+    BOOL_FIELDS,
+    CAPABILITY_FIELDS,
+    POLICY_ONLY_FIELDS,
+    STRING_ARRAY_FIELDS,
+    ComputerSettings,
+    SettingsScope,
+    SettingsValidationError,
+    is_valid_enabled_plugin_key,
+    is_valid_git_url,
+    is_valid_marketplace_name,
+    validate_settings,
+)
+from a2c_smcp.computer.settings.scope import (
+    DELETE,
+    ResolvedSettings,
+    apply_write,
+    filter_capability_fields,
+    load_settings_file,
+    merge_layers,
+    merge_read,
+    resolve_settings,
+    resolve_user_config_dir,
+    user_settings_path,
+    workdir_local_settings_path,
+    workdir_project_settings_path,
+    workdir_settings_dir,
+)
+
+__all__ = [
+    # schema
+    "BOOL_FIELDS",
+    "CAPABILITY_FIELDS",
+    "POLICY_ONLY_FIELDS",
+    "STRING_ARRAY_FIELDS",
+    "ComputerSettings",
+    "SettingsScope",
+    "SettingsValidationError",
+    "is_valid_enabled_plugin_key",
+    "is_valid_git_url",
+    "is_valid_marketplace_name",
+    "validate_settings",
+    # scope
+    "DELETE",
+    "ResolvedSettings",
+    "apply_write",
+    "filter_capability_fields",
+    "load_settings_file",
+    "merge_layers",
+    "merge_read",
+    "resolve_settings",
+    "resolve_user_config_dir",
+    "user_settings_path",
+    "workdir_local_settings_path",
+    "workdir_project_settings_path",
+    "workdir_settings_dir",
+    # policy
+    "PolicySource",
+    "default_policy_sources",
+    "load_macos_plist",
+    "load_managed_settings",
+    "load_windows_registry",
+    "resolve_policy_settings",
+]

--- a/a2c_smcp/computer/settings/policy.py
+++ b/a2c_smcp/computer/settings/policy.py
@@ -1,0 +1,250 @@
+# -*- coding: utf-8 -*-
+# filename: policy.py
+# @Time    : 2026/05/25
+# @Author  : JQQ
+# @Email   : jqq1716@gmail.com
+# @Software: PyCharm
+"""
+policy scope 四子源 first-source-wins（v0.2.1）
+Policy-scope four sub-sources, first-source-wins (v0.2.1).
+
+SDK 设计 / Design: python-sdk docs/design-0.2.1-cli-marketplace-ux.md §5.2 / §5.4。
+
+policy 是 settings 链**最高优先级**层（企业 / 运维强制）。其内部由四个子源构成，**不合并**——
+按优先级取**第一个有内容**者整体叠加进主链（first-source-wins，照 Claude Code：
+remote > OS-MDM > managed-settings.json[+.d] > HKCU）。
+Policy is the highest-priority settings layer. Its four sub-sources are NOT merged — the first
+(highest-priority) one with content wins wholesale.
+
+============== ========= ====================================================== ===========
+优先级           平台       位置                                                    v0.2.1
+============== ========= ====================================================== ===========
+1（最高）         全平台      Remote managed endpoint                                **stub**（不联网）
+2               macOS     /Library/Managed Preferences/com.a2c.computer.plist    ✓
+2               Windows   HKLM\\SOFTWARE\\Policies\\A2CComputer\\Settings          ✓（best-effort）
+3               全平台      managed-settings.json (+ managed-settings.d/*.json)    ✓
+4（最低）         Windows   HKCU\\SOFTWARE\\Policies\\A2CComputer\\Settings          ✓（best-effort）
+============== ========= ====================================================== ===========
+
+**v0.2.1 范围**：实现层级 2/3/4 的本地文件 / 注册表读取；Remote 留 stub、**不发起网络请求**
+（30 min poll + OAuth 留 v0.2.2+）。Linux/macOS/Windows 三平台都至少能读 layer 3。
+**v0.2.1 scope**: layers 2/3/4 local readers; Remote is a stub (no network). All three platforms
+read at least layer 3.
+
+本模块只做 **first-source-wins 选取**，返回原始 dict；类型 / scope 校验由
+:func:`a2c_smcp.computer.settings.scope.resolve_settings` 按 POLICY scope 统一执行。
+This module only performs the first-source-wins selection; type/scope validation is centralized
+in ``scope.resolve_settings`` under the POLICY scope.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from a2c_smcp.computer.settings.scope import merge_read
+from a2c_smcp.utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+# Remote managed endpoint（v0.2.2+ 实现）/ Remote managed endpoint base env (v0.2.2+).
+REMOTE_POLICY_BASE_ENV = "A2C_BASE_API_URL"
+REMOTE_POLICY_PATH = "/api/computer/settings"
+
+# Windows 注册表子键（HKLM / HKCU 共用）/ Windows registry subkey (shared by HKLM / HKCU).
+WINDOWS_POLICY_SUBKEY = r"SOFTWARE\Policies\A2CComputer\Settings"
+# 注册表内承载 settings JSON 的值名（best-effort）/ Registry value name carrying the settings JSON.
+WINDOWS_POLICY_VALUE_NAME = "Settings"
+
+# 各平台 managed-settings.json 位置（layer 3）/ Per-platform managed-settings.json locations (layer 3).
+MACOS_PLIST_PATH = Path("/Library/Managed Preferences/com.a2c.computer.plist")
+MACOS_MANAGED_DIR = Path("/Library/Application Support/A2CComputer")
+WINDOWS_MANAGED_DIR = Path(r"C:\Program Files\A2CComputer")
+LINUX_MANAGED_DIR = Path("/etc/a2c-computer")
+
+MANAGED_SETTINGS_FILENAME = "managed-settings.json"
+MANAGED_SETTINGS_DROPIN_DIRNAME = "managed-settings.d"
+
+
+@dataclass(frozen=True)
+class PolicySource:
+    """
+    一个 policy 子源 / A single policy sub-source。
+
+    ``priority`` 越小越高（1 = 最高）；``loader`` 返回该子源内容（``dict``）或 ``None``（缺席 / 不可读）。
+    Lower ``priority`` ranks higher (1 = highest); ``loader`` returns the content dict or ``None``.
+    """
+
+    name: str
+    priority: int
+    loader: Callable[[], dict[str, Any] | None]
+
+
+# ---------------------------------------------------------------------------
+# 子源读取器 / Sub-source readers
+# ---------------------------------------------------------------------------
+def _read_json_file(path: Path) -> dict[str, Any] | None:
+    """读取单个 JSON 文件 → dict（缺失 / 损坏 / 非对象 → None）/ Read one JSON file (missing/corrupt/non-object → None)."""
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.warning("Policy JSON %s unreadable/corrupt, skipped: %s", path, exc)
+        return None
+    if not isinstance(data, dict):
+        logger.warning("Policy JSON %s root is not an object, skipped", path)
+        return None
+    return data
+
+
+def load_managed_settings(managed_dir: Path) -> dict[str, Any] | None:
+    """
+    layer 3 读取器：``managed-settings.json`` + ``managed-settings.d/*.json`` 深合并 / layer-3 reader。
+
+    base 文件先读，随后按文件名字典序合并 ``managed-settings.d/*.json``（drop-in 覆盖 base，沿用
+    :func:`~a2c_smcp.computer.settings.scope.merge_read` 读语义）。皆缺 → ``None``。
+    Reads the base file then merges ``managed-settings.d/*.json`` in lexical order (drop-ins
+    override base, read-merge semantics). All absent → ``None``.
+    """
+    base = _read_json_file(managed_dir / MANAGED_SETTINGS_FILENAME)
+    merged: dict[str, Any] | None = base
+
+    dropin_dir = managed_dir / MANAGED_SETTINGS_DROPIN_DIRNAME
+    if dropin_dir.is_dir():
+        for entry in sorted(dropin_dir.glob("*.json")):
+            piece = _read_json_file(entry)
+            if piece is None:
+                continue
+            merged = piece if merged is None else merge_read(merged, piece)
+
+    return merged
+
+
+def load_macos_plist(path: Path = MACOS_PLIST_PATH) -> dict[str, Any] | None:
+    """layer 2（macOS）读取器：解析 Managed Preferences plist / layer-2 macOS plist reader。"""
+    if not path.exists():
+        return None
+    try:
+        import plistlib
+
+        data = plistlib.loads(path.read_bytes())
+    except Exception as exc:  # plistlib.InvalidFileException / OSError 等 / parse or IO error
+        logger.warning("Policy plist %s unreadable, skipped: %s", path, exc)
+        return None
+    if not isinstance(data, dict):
+        return None
+    return data
+
+
+def load_windows_registry(hive_name: str, subkey: str = WINDOWS_POLICY_SUBKEY) -> dict[str, Any] | None:
+    """
+    layer 2/4（Windows）读取器：从注册表值读取承载的 settings JSON / layer-2/4 Windows registry reader。
+
+    best-effort：读取 ``<hive>\\<subkey>`` 下名为 :data:`WINDOWS_POLICY_VALUE_NAME` 的字符串值并按
+    JSON 解析（registry 扁平、无法原生承载嵌套数组 / 对象，故约定承载 JSON 串）。非 Windows /
+    ``winreg`` 不可用 / 键缺失 → ``None``。
+    Best-effort: reads a JSON-string value named :data:`WINDOWS_POLICY_VALUE_NAME` under
+    ``<hive>\\<subkey>`` and parses it. Non-Windows / missing key → ``None``.
+    """
+    if sys.platform != "win32":
+        # 非 Windows：mypy 据 sys.platform 收窄判定以下不可达，故 winreg import 不被检查（无需 type:ignore）。
+        # Non-Windows: mypy narrows on sys.platform; the rest is unreachable, so the winreg import is not checked.
+        return None
+    import winreg
+
+    hive = getattr(winreg, hive_name, None)
+    if hive is None:
+        return None
+    try:
+        with winreg.OpenKey(hive, subkey) as key:
+            value, _ = winreg.QueryValueEx(key, WINDOWS_POLICY_VALUE_NAME)
+    except OSError:  # 键 / 值不存在 / key or value missing
+        return None
+    if not isinstance(value, str):
+        return None
+    try:
+        data = json.loads(value)
+    except json.JSONDecodeError as exc:  # pragma: no cover - 取决于运行机注册表内容
+        logger.warning("Windows policy registry value is not valid JSON, skipped: %s", exc)
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def load_remote_policy(env: Mapping[str, str]) -> dict[str, Any] | None:
+    """
+    layer 1（remote）读取器 —— **v0.2.1 stub，恒返回 None、不联网** / layer-1 remote reader (v0.2.1 stub).
+
+    v0.2.2+ 将实现 ``${A2C_BASE_API_URL}/api/computer/settings`` 的 30 min poll + OAuth/team
+    关联（见 §5.2）/ v0.2.2+ will add a 30-min poll + OAuth against that endpoint.
+    """
+    base = env.get(REMOTE_POLICY_BASE_ENV, "").strip()
+    if base:
+        logger.debug("Remote managed-policy endpoint configured (%s) but disabled in v0.2.1 (stub)", base)
+    return None
+
+
+# ---------------------------------------------------------------------------
+# 默认子源装配 + first-source-wins / Default sources + first-source-wins
+# ---------------------------------------------------------------------------
+def default_policy_sources(platform: str, env: Mapping[str, str]) -> list[PolicySource]:
+    """
+    按平台装配默认 policy 子源 / Assemble default policy sub-sources per platform（§5.2）。
+
+    :param platform: ``sys.platform`` 风格字符串（``"darwin"`` / ``"win32"`` / 其余按 Linux）。
+    """
+    sources: list[PolicySource] = [
+        PolicySource(name="remote", priority=1, loader=lambda: load_remote_policy(env)),
+    ]
+
+    if platform == "darwin":
+        sources.append(PolicySource(name="macos-plist", priority=2, loader=lambda: load_macos_plist()))
+        sources.append(PolicySource(name="managed-settings", priority=3, loader=lambda: load_managed_settings(MACOS_MANAGED_DIR)))
+    elif platform == "win32":
+        sources.append(PolicySource(name="hklm-registry", priority=2, loader=lambda: load_windows_registry("HKEY_LOCAL_MACHINE")))
+        sources.append(PolicySource(name="managed-settings", priority=3, loader=lambda: load_managed_settings(WINDOWS_MANAGED_DIR)))
+        sources.append(PolicySource(name="hkcu-registry", priority=4, loader=lambda: load_windows_registry("HKEY_CURRENT_USER")))
+    else:  # Linux / 其余 POSIX：无 OS 原生 MDM，仅 layer 3。
+        sources.append(PolicySource(name="managed-settings", priority=3, loader=lambda: load_managed_settings(LINUX_MANAGED_DIR)))
+
+    return sources
+
+
+def resolve_policy_settings(
+    *,
+    env: Mapping[str, str] | None = None,
+    platform: str | None = None,
+    sources: Sequence[PolicySource] | None = None,
+) -> dict[str, Any]:
+    """
+    first-source-wins 选取 policy 内容 / Select policy content by first-source-wins（§5.2 / §5.4）。
+
+    按 ``priority`` 升序（1 最高）逐源尝试，返回**第一个非空 dict**整体；皆空 → ``{}``。子源**不合并**
+    （照 CC：只取最高且有内容者）。单源 loader 抛错 → 记 WARN 跳过、继续下一源（不阻断启动）。
+    Tries sources by ascending priority, returns the first non-empty dict wholesale; all empty →
+    ``{}``. Sub-sources are not merged. A loader raising is logged and skipped (never blocks startup).
+
+    :param env: 环境映射，默认 ``os.environ`` / env mapping, defaults to ``os.environ``.
+    :param platform: 平台串，默认 ``sys.platform`` / platform string, defaults to ``sys.platform``.
+    :param sources: 自定义子源（便于测试注入）；缺省按 :func:`default_policy_sources` 装配 / injectable for tests.
+    """
+    environ: Mapping[str, str] = os.environ if env is None else env
+    plat = sys.platform if platform is None else platform
+    srcs = list(sources) if sources is not None else default_policy_sources(plat, environ)
+
+    for source in sorted(srcs, key=lambda s: s.priority):
+        try:
+            loaded = source.loader()
+        except Exception as exc:  # 单源读取异常不阻断 / a single source error must not block
+            logger.warning("Policy source %r failed to load, skipped: %s", source.name, exc)
+            continue
+        if loaded:  # 非 None 且非空 / non-None and non-empty
+            logger.debug("Policy resolved from sub-source %r (priority %d)", source.name, source.priority)
+            return loaded
+
+    return {}

--- a/a2c_smcp/computer/settings/schema.py
+++ b/a2c_smcp/computer/settings/schema.py
@@ -1,0 +1,388 @@
+# -*- coding: utf-8 -*-
+# filename: schema.py
+# @Time    : 2026/05/25
+# @Author  : JQQ
+# @Email   : jqq1716@gmail.com
+# @Software: PyCharm
+"""
+意图层 settings.json 结构与字段校验（v0.2.1）
+Intent-layer settings.json schema & field validation (v0.2.1)
+
+SDK 设计 / Design: python-sdk docs/design-0.2.1-cli-marketplace-ux.md §5.3 / §5.3.1 / §5.6。
+
+settings.json 是 Computer 的**意图 / 治理层**（plugin 启停、marketplace 声明、MCP 门控、trust
+policy），**不**承载 MCP server 定义 / inputs（那些在 ``.tfrobot/mcp.json``，§9.1）。
+settings.json is the Computer's **intent / governance** layer; it does NOT carry MCP server
+definitions / inputs (those live in ``.tfrobot/mcp.json``).
+
+前向兼容模型（复刻 Claude Code，§5.6）/ Forward-compat model (mirrors Claude Code):
+- **全字段可选 + 顶层 passthrough**：未知顶层键**静默保留**、不报错、不剥离（升降级都不丢）。
+  All fields optional + top-level passthrough: unknown keys are silently preserved.
+- **无 version 字段**：人编文件不背版本负担；``version`` 只在 CLI 维护的物化文件（§6）。
+  No ``version`` field: human-edited files carry no version burden.
+- **字段级容错**：单个已知键 / 单个 map 项 / 单个数组元素校验失败 → **逐条过滤**（回退默认）、
+  其余保留、错误收进 :class:`SettingsValidationError` 列表（照 CC：错误不阻断启动、不整文件作废）。
+  Field-level tolerance: a single bad known key / map entry / array element is filtered out
+  per-item, the rest is kept, and the error is collected — never invalidating the whole file.
+- **scope 越权**：``allowedMcpServers`` / ``deniedMcpServers`` 是 **policy-only**；出现在非 policy
+  scope → 过滤不用 + 记 ValidationError（杜绝用户态自我提权）。
+  Scope overreach: policy-only fields appearing in a non-policy scope are filtered + recorded.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any, NotRequired, TypedDict
+
+from a2c_smcp.utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+class SettingsScope(StrEnum):
+    """
+    settings 来源 scope（低 → 高，high 覆盖 low）/ Settings source scope (low → high)。
+
+    ``CAPABILITY`` 是 A2C 特有的**能力发现层**（最低优先级）：跨**全部登记工作目录**取
+    ``enabledPlugins`` / ``extraKnownMarketplaces`` 并集，让 Agent 能力面稳定、不随 active
+    workdir 跳变（§5.0/§5.1）。其余五级 = Claude Code 完整对齐（user/project/local/flag/policy）。
+    ``CAPABILITY`` is the A2C-specific capability-discovery layer (lowest); the other five align
+    with Claude Code.
+    """
+
+    CAPABILITY = "capability"  # 能力发现层（最低）/ capability-discovery (lowest)
+    USER = "user"
+    PROJECT = "project"
+    LOCAL = "local"
+    FLAG = "flag"
+    POLICY = "policy"  # 最高 / highest
+
+
+# ---------------------------------------------------------------------------
+# 已知字段名（camelCase，对齐 CC / JSON schema）/ Known field names (camelCase)
+# ---------------------------------------------------------------------------
+FIELD_SCHEMA = "$schema"
+FIELD_EXTRA_KNOWN_MARKETPLACES = "extraKnownMarketplaces"
+FIELD_ENABLED_PLUGINS = "enabledPlugins"
+FIELD_STRICT_KNOWN_MARKETPLACES = "strictKnownMarketplaces"
+FIELD_TRUSTED_MARKETPLACES = "trustedMarketplaces"
+FIELD_BLOCKED_MARKETPLACES = "blockedMarketplaces"
+FIELD_ENABLE_ALL_PROJECT_MCP = "enableAllProjectMcpServers"
+FIELD_ENABLED_MCPJSON_SERVERS = "enabledMcpjsonServers"
+FIELD_DISABLED_MCPJSON_SERVERS = "disabledMcpjsonServers"
+FIELD_ALLOWED_MCP_SERVERS = "allowedMcpServers"
+FIELD_DENIED_MCP_SERVERS = "deniedMcpServers"
+FIELD_PERMISSIONS = "permissions"
+
+# 仅能在能力发现层取并集的字段（§5.0 (A) 层）/ Fields contributed by the capability layer.
+CAPABILITY_FIELDS: frozenset[str] = frozenset({FIELD_ENABLED_PLUGINS, FIELD_EXTRA_KNOWN_MARKETPLACES})
+
+# policy-only 字段：出现在非 policy scope → 过滤 + 记错（§5.6）。
+# Policy-only fields: filtered + recorded if seen outside the policy scope.
+POLICY_ONLY_FIELDS: frozenset[str] = frozenset({FIELD_ALLOWED_MCP_SERVERS, FIELD_DENIED_MCP_SERVERS})
+
+# 字符串数组字段（读合并：拼接去重；写回：整体替换，§5.4）/ String-array fields.
+STRING_ARRAY_FIELDS: frozenset[str] = frozenset(
+    {
+        FIELD_TRUSTED_MARKETPLACES,
+        FIELD_BLOCKED_MARKETPLACES,
+        FIELD_ENABLED_MCPJSON_SERVERS,
+        FIELD_DISABLED_MCPJSON_SERVERS,
+        FIELD_ALLOWED_MCP_SERVERS,
+        FIELD_DENIED_MCP_SERVERS,
+    }
+)
+
+# 标量布尔字段（读合并：取最高 scope）/ Scalar bool fields (highest scope wins).
+BOOL_FIELDS: frozenset[str] = frozenset({FIELD_STRICT_KNOWN_MARKETPLACES, FIELD_ENABLE_ALL_PROJECT_MCP})
+
+# ---------------------------------------------------------------------------
+# 形态正则 / Shape regexes
+# ---------------------------------------------------------------------------
+# marketplace / plugin 名：严格 kebab（§3.1 名称字符集；与 naming.py leaf 一致）。
+# marketplace / plugin name: strict kebab.
+_KEBAB_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+
+# enabledPlugins key 形态 ``<plugin>@<marketplace>``（§5.3.1）/ key shape.
+_PLUGIN_AT_MP_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*@[a-z0-9]+(?:-[a-z0-9]+)*$")
+
+# git url 形态校验（§5.3.1）：scp-like ``user@host:path`` 或 URL scheme（ssh/git/http/https/file）。
+# git url shape: scp-like or URL scheme.
+_GIT_SCP_LIKE_RE = re.compile(r"^[\w.+-]+@[\w.-]+:.+$")
+_GIT_URL_SCHEME_RE = re.compile(r"^(?:ssh|git|https?|file)://.+$")
+
+MAX_NAME_LEN = 64
+
+
+def is_valid_marketplace_name(name: str) -> bool:
+    """marketplace / plugin 名是否合规（严格 kebab，1–64）/ Whether a marketplace/plugin name is valid."""
+    return isinstance(name, str) and 1 <= len(name) <= MAX_NAME_LEN and _KEBAB_RE.match(name) is not None
+
+
+def is_valid_enabled_plugin_key(key: str) -> bool:
+    """``enabledPlugins`` key 是否形如 ``<plugin>@<marketplace>`` / Whether the key matches ``<plugin>@<mp>``."""
+    if not isinstance(key, str) or _PLUGIN_AT_MP_RE.match(key) is None:
+        return False
+    plugin, _, marketplace = key.partition("@")
+    return len(plugin) <= MAX_NAME_LEN and len(marketplace) <= MAX_NAME_LEN
+
+
+def is_valid_git_url(url: str) -> bool:
+    """git url 形态是否合规（scp-like 或 ssh/git/http(s)/file scheme）/ Whether a git url is well-formed."""
+    if not isinstance(url, str) or not url.strip():
+        return False
+    return _GIT_URL_SCHEME_RE.match(url) is not None or _GIT_SCP_LIKE_RE.match(url) is not None
+
+
+# ---------------------------------------------------------------------------
+# TypedDict 结构（IDE / 文档用；运行时校验走 validate_settings）/ TypedDict shape
+# ---------------------------------------------------------------------------
+class GitSource(TypedDict):
+    """marketplace git 源 / marketplace git source（``extraKnownMarketplaces[].source``）。"""
+
+    type: str  # 固定 "git" / fixed "git"
+    url: str
+
+
+class MarketplaceEntry(TypedDict):
+    """``extraKnownMarketplaces`` 单条声明 / a single marketplace declaration。"""
+
+    source: GitSource
+    autoUpdate: NotRequired[bool]
+
+
+class PermissionsBlock(TypedDict, total=False):
+    """``permissions`` 块（§5.3.1）/ the ``permissions`` block。"""
+
+    additionalDirectories: list[str]
+
+
+class ComputerSettings(TypedDict, total=False):
+    """
+    settings.json 完整结构（全可选；未知键 passthrough，不在此声明）/ Full settings.json shape.
+
+    本 TypedDict **不含 version**（§5.6）；仅供类型提示，运行时容错校验见 :func:`validate_settings`。
+    No ``version`` field; for typing only — runtime tolerant validation lives in
+    :func:`validate_settings`.
+    """
+
+    extraKnownMarketplaces: dict[str, MarketplaceEntry]
+    enabledPlugins: dict[str, bool]
+    strictKnownMarketplaces: bool
+    trustedMarketplaces: list[str]
+    blockedMarketplaces: list[str]
+    enableAllProjectMcpServers: bool
+    enabledMcpjsonServers: list[str]
+    disabledMcpjsonServers: list[str]
+    allowedMcpServers: list[str]
+    deniedMcpServers: list[str]
+    permissions: PermissionsBlock
+
+
+# ---------------------------------------------------------------------------
+# 字段级容错校验 / Field-level tolerant validation
+# ---------------------------------------------------------------------------
+@dataclass(frozen=True, slots=True)
+class SettingsValidationError:
+    """
+    单条 settings 校验错误（不阻断启动，经 ``settings show`` / 诊断命令呈现，§5.6）。
+    A single non-fatal settings validation error (surfaced via ``settings show`` / diagnostics).
+
+    ``field`` 为点路径（如 ``extraKnownMarketplaces.my-mp.source.url``）；``scope`` 标明来源层；
+    ``source_path`` 为产生该错误的文件（可空，便于诊断定位）。
+    ``field`` is a dotted path; ``scope`` identifies the layer; ``source_path`` is the offending
+    file (optional, aids diagnosis).
+    """
+
+    scope: SettingsScope
+    field: str
+    reason: str
+    source_path: str | None = None
+
+
+# 哨兵：表示「整字段判废、回退默认」/ Sentinel: "drop the whole field, fall back to default".
+class _Drop:
+    __slots__ = ()
+
+
+_DROP = _Drop()
+
+
+def _err(scope: SettingsScope, field: str, reason: str) -> SettingsValidationError:
+    return SettingsValidationError(scope=scope, field=field, reason=reason)
+
+
+def _validate_bool(key: str, value: Any, scope: SettingsScope) -> tuple[Any, list[SettingsValidationError]]:
+    if isinstance(value, bool):
+        return value, []
+    return _DROP, [_err(scope, key, f"expected bool, got {type(value).__name__}")]
+
+
+def _validate_string_array(key: str, value: Any, scope: SettingsScope) -> tuple[Any, list[SettingsValidationError]]:
+    if not isinstance(value, list):
+        return _DROP, [_err(scope, key, f"expected array, got {type(value).__name__}")]
+    cleaned: list[str] = []
+    errors: list[SettingsValidationError] = []
+    for idx, item in enumerate(value):
+        if isinstance(item, str):
+            cleaned.append(item)
+        else:
+            errors.append(_err(scope, f"{key}[{idx}]", f"expected string, got {type(item).__name__}"))
+    return cleaned, errors
+
+
+def _validate_enabled_plugins(key: str, value: Any, scope: SettingsScope) -> tuple[Any, list[SettingsValidationError]]:
+    if not isinstance(value, dict):
+        return _DROP, [_err(scope, key, f"expected object, got {type(value).__name__}")]
+    cleaned: dict[str, bool] = {}
+    errors: list[SettingsValidationError] = []
+    for plugin_key, enabled in value.items():
+        if not is_valid_enabled_plugin_key(plugin_key):
+            errors.append(_err(scope, f"{key}.{plugin_key}", "key must be '<plugin>@<marketplace>' (strict kebab)"))
+            continue
+        if not isinstance(enabled, bool):
+            errors.append(_err(scope, f"{key}.{plugin_key}", f"value must be bool, got {type(enabled).__name__}"))
+            continue
+        cleaned[plugin_key] = enabled
+    return cleaned, errors
+
+
+def _validate_extra_marketplaces(key: str, value: Any, scope: SettingsScope) -> tuple[Any, list[SettingsValidationError]]:
+    if not isinstance(value, dict):
+        return _DROP, [_err(scope, key, f"expected object, got {type(value).__name__}")]
+    cleaned: dict[str, dict] = {}
+    errors: list[SettingsValidationError] = []
+    for name, entry in value.items():
+        path = f"{key}.{name}"
+        if not is_valid_marketplace_name(name):
+            errors.append(_err(scope, path, "marketplace name must be strict kebab (1-64)"))
+            continue
+        if not isinstance(entry, dict):
+            errors.append(_err(scope, path, f"entry must be object, got {type(entry).__name__}"))
+            continue
+        source = entry.get("source")
+        if not isinstance(source, dict):
+            errors.append(_err(scope, f"{path}.source", "missing or non-object 'source'"))
+            continue
+        if source.get("type") != "git":
+            errors.append(_err(scope, f"{path}.source.type", "only source.type == 'git' is supported"))
+            continue
+        if not is_valid_git_url(source.get("url", "")):
+            errors.append(_err(scope, f"{path}.source.url", "malformed git url"))
+            continue
+        auto_update = entry.get("autoUpdate")
+        if auto_update is not None and not isinstance(auto_update, bool):
+            errors.append(_err(scope, f"{path}.autoUpdate", f"must be bool, got {type(auto_update).__name__}"))
+            continue
+        # 仅保留规范化后的已知子字段（source / autoUpdate）；其余子键静默丢（爆炸半径 0，§3.2）。
+        normalized: dict[str, Any] = {"source": {"type": "git", "url": source["url"]}}
+        if auto_update is not None:
+            normalized["autoUpdate"] = auto_update
+        cleaned[name] = normalized
+    return cleaned, errors
+
+
+def _validate_permissions(key: str, value: Any, scope: SettingsScope) -> tuple[Any, list[SettingsValidationError]]:
+    if not isinstance(value, dict):
+        return _DROP, [_err(scope, key, f"expected object, got {type(value).__name__}")]
+    cleaned: dict[str, Any] = {}
+    errors: list[SettingsValidationError] = []
+    for sub_key, sub_value in value.items():
+        if sub_key == "additionalDirectories":
+            if not isinstance(sub_value, list):
+                errors.append(_err(scope, f"{key}.additionalDirectories", "expected array"))
+                continue
+            dirs: list[str] = []
+            for idx, item in enumerate(sub_value):
+                if not isinstance(item, str):
+                    errors.append(_err(scope, f"{key}.additionalDirectories[{idx}]", "expected string"))
+                elif not item.startswith("/") and not re.match(r"^[A-Za-z]:[\\/]", item):
+                    # 须绝对路径（POSIX ``/`` 或 Windows 盘符）；相对路径判废（§5.3.1）。
+                    errors.append(_err(scope, f"{key}.additionalDirectories[{idx}]", "must be an absolute path"))
+                else:
+                    dirs.append(item)
+            cleaned["additionalDirectories"] = dirs
+        else:
+            # permissions 下未知子键 passthrough（与顶层 passthrough 同纪律）。
+            cleaned[sub_key] = sub_value
+    return cleaned, errors
+
+
+# 字段 → 校验器映射（缺席 = 未知字段，passthrough）/ field → validator map (absent = unknown, passthrough).
+_FIELD_VALIDATORS = {
+    FIELD_EXTRA_KNOWN_MARKETPLACES: _validate_extra_marketplaces,
+    FIELD_ENABLED_PLUGINS: _validate_enabled_plugins,
+    FIELD_STRICT_KNOWN_MARKETPLACES: _validate_bool,
+    FIELD_TRUSTED_MARKETPLACES: _validate_string_array,
+    FIELD_BLOCKED_MARKETPLACES: _validate_string_array,
+    FIELD_ENABLE_ALL_PROJECT_MCP: _validate_bool,
+    FIELD_ENABLED_MCPJSON_SERVERS: _validate_string_array,
+    FIELD_DISABLED_MCPJSON_SERVERS: _validate_string_array,
+    FIELD_ALLOWED_MCP_SERVERS: _validate_string_array,
+    FIELD_DENIED_MCP_SERVERS: _validate_string_array,
+    FIELD_PERMISSIONS: _validate_permissions,
+}
+
+
+def validate_settings(
+    raw: Any,
+    scope: SettingsScope,
+    *,
+    source_path: str | None = None,
+) -> tuple[dict[str, Any], list[SettingsValidationError]]:
+    """
+    对单个 scope 的原始 settings dict 做**字段级容错**校验（§5.6）/ Field-level tolerant validation.
+
+    语义（照 Claude Code，错误不阻断启动）/ Semantics (Claude Code; never blocks startup):
+
+    - 非 dict 根 → 返回 ``({}, [error])``（整层判废，回退空）。Non-dict root → empty + error.
+    - ``$schema``：原样保留、CLI 不消费 / preserved verbatim, not consumed.
+    - **policy-only 字段在非 policy scope** → 过滤 + 记错 / filtered + recorded.
+    - 已知字段：经对应校验器**逐条过滤**非法 map 项 / 数组元素；整字段类型错 → 回退默认（剔除）。
+      Known fields: per-item filtered; whole-field type error → dropped (falls back to default).
+    - 未知字段：**静默保留**（passthrough）/ unknown fields: silently preserved.
+
+    返回 ``(cleaned, errors)``——``cleaned`` 供 :mod:`a2c_smcp.computer.settings.scope` 跨 scope
+    合并；磁盘文件**不**被本函数改写（passthrough 的「仍留在文件」由「不重写」保证）。
+    Returns ``(cleaned, errors)`` for cross-scope merge; the on-disk file is never rewritten here.
+
+    :param raw: 单个 settings 文件 parse 后的对象 / parsed object of one settings file.
+    :param scope: 该文件所属 scope / the scope this file belongs to.
+    :param source_path: 文件路径（用于错误溯源，可空）/ file path for error provenance (optional).
+    """
+    if not isinstance(raw, dict):
+        return {}, [SettingsValidationError(scope=scope, field="<root>", reason="settings root must be an object", source_path=source_path)]
+
+    cleaned: dict[str, Any] = {}
+    errors: list[SettingsValidationError] = []
+
+    for key, value in raw.items():
+        if key == FIELD_SCHEMA:
+            cleaned[key] = value  # 编辑器补全用，CLI 不消费 / for editors only.
+            continue
+        if key in POLICY_ONLY_FIELDS and scope is not SettingsScope.POLICY:
+            errors.append(_err(scope, key, "policy-only field not allowed outside the policy scope (filtered)"))
+            continue
+        validator = _FIELD_VALIDATORS.get(key)
+        if validator is None:
+            cleaned[key] = value  # passthrough 未知字段 / unknown field passthrough.
+            continue
+        result, field_errors = validator(key, value, scope)
+        errors.extend(_with_source(field_errors, source_path))
+        if result is _DROP:
+            continue
+        cleaned[key] = result
+
+    return cleaned, errors
+
+
+def _with_source(errors: list[SettingsValidationError], source_path: str | None) -> list[SettingsValidationError]:
+    """把 ``source_path`` 回填进一批错误（校验器内部不知道文件路径）/ Backfill the source path into errors."""
+    if source_path is None:
+        return errors
+    return [
+        SettingsValidationError(scope=e.scope, field=e.field, reason=e.reason, source_path=source_path)
+        for e in errors
+    ]

--- a/a2c_smcp/computer/settings/scope.py
+++ b/a2c_smcp/computer/settings/scope.py
@@ -1,0 +1,331 @@
+# -*- coding: utf-8 -*-
+# filename: scope.py
+# @Time    : 2026/05/25
+# @Author  : JQQ
+# @Email   : jqq1716@gmail.com
+# @Software: PyCharm
+"""
+五级 scope 路径解析 + 读/写两套合并语义 + active-workdir / 能力层解析（v0.2.1）
+Five-level scope path resolution + read/write merge customizers + active-workdir / capability resolution.
+
+SDK 设计 / Design: python-sdk docs/design-0.2.1-cli-marketplace-ux.md §5.0 / §5.1 / §5.4。
+
+合并语义（⚠️ 读 / 写相反，照 Claude Code ``settingsMergeCustomizer``）/ Merge semantics:
+
+**读合并**（启动加载、多 scope 叠加，low → high）/ Read merge (startup, low → high):
+- object/map → **递归深合并**（逐层按 key 取并集，仅同名叶子由高 scope 覆盖；嵌套对象继续向下、
+  **不整体替换**——``extraKnownMarketplaces[].source`` 关键用例）/ deep recursive merge.
+- array → **拼接去重** ``uniq([*low, *high])``（低 scope 在前）/ concat + dedup, low first.
+- scalar → 高 scope 整体覆盖 / scalar overwrite (highest scope wins).
+
+**写回单 scope**（CLI 改单文件、语义相反）/ Single-scope write-back (inverse):
+- array → **直接替换**（不拼接）/ replace wholesale.
+- 删字段 → 写 :data:`DELETE`（= 删 key）/ deletion via the :data:`DELETE` sentinel.
+
+scope 分层（low → high）/ Scope layering (§5.1)：
+能力发现层（全部登记目录并集，仅 ``enabledPlugins`` / ``extraKnownMarketplaces``）< user（主）
+< project（active workdir 单根）< local（active workdir 单根）< flag < policy。
+**无 active workdir** 时 project/local 全空，仅 user + 能力层（+ flag/policy）。
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from a2c_smcp.computer.settings.schema import (
+    CAPABILITY_FIELDS,
+    SettingsScope,
+    SettingsValidationError,
+    validate_settings,
+)
+from a2c_smcp.utils.logger import get_logger
+from a2c_smcp.utils.path import resolve_xdg_first
+
+logger = get_logger(__name__)
+
+# ---------------------------------------------------------------------------
+# 路径常量 / Path constants
+# ---------------------------------------------------------------------------
+XDG_CONFIG_HOME_ENV = "XDG_CONFIG_HOME"
+
+# workspace 工作目录下的治理子目录与文件名 / Per-workdir governance dir & filenames.
+TFROBOT_DIRNAME = ".tfrobot"
+PROJECT_SETTINGS_FILENAME = "settings.json"
+LOCAL_SETTINGS_FILENAME = "settings.local.json"
+USER_SETTINGS_FILENAME = "settings.json"
+
+_A2C_CONFIG_SUBDIR = "a2c"
+
+
+def resolve_user_config_dir(env: Mapping[str, str] | None = None) -> Path:
+    """
+    解析 user scope 配置目录 / Resolve the user-scope config dir。
+
+    优先 ``$XDG_CONFIG_HOME/a2c``（XDG_CONFIG_HOME 须为绝对路径，否则按 XDG 规范忽略），
+    回退 ``~/.config/a2c``。XDG-first 解析复用 :func:`a2c_smcp.utils.path.resolve_xdg_first`
+    （与 SKILL Home 同范式，区别：config 用 ``XDG_CONFIG_HOME``、data 用 ``XDG_DATA_HOME``）。
+    Prefers ``$XDG_CONFIG_HOME/a2c`` (must be absolute), falls back to ``~/.config/a2c``.
+    """
+    environ: Mapping[str, str] = os.environ if env is None else env
+    return resolve_xdg_first(
+        environ,
+        XDG_CONFIG_HOME_ENV,
+        _A2C_CONFIG_SUBDIR,
+        fallback=Path.home() / ".config" / _A2C_CONFIG_SUBDIR,
+    )
+
+
+def user_settings_path(env: Mapping[str, str] | None = None) -> Path:
+    """user scope settings.json 路径 / Path to the user-scope settings.json。"""
+    return resolve_user_config_dir(env) / USER_SETTINGS_FILENAME
+
+
+def workdir_settings_dir(workdir: Path) -> Path:
+    """工作目录治理子目录 ``<workdir>/.tfrobot`` / The per-workdir ``.tfrobot`` dir。"""
+    return Path(workdir) / TFROBOT_DIRNAME
+
+
+def workdir_project_settings_path(workdir: Path) -> Path:
+    """project scope 路径 ``<workdir>/.tfrobot/settings.json``（入 git）/ project-scope path。"""
+    return workdir_settings_dir(workdir) / PROJECT_SETTINGS_FILENAME
+
+
+def workdir_local_settings_path(workdir: Path) -> Path:
+    """local scope 路径 ``<workdir>/.tfrobot/settings.local.json``（不入 git）/ local-scope path。"""
+    return workdir_settings_dir(workdir) / LOCAL_SETTINGS_FILENAME
+
+
+# ---------------------------------------------------------------------------
+# 合并原语 / Merge primitives
+# ---------------------------------------------------------------------------
+# 写回时表示「删 key」的哨兵（复刻 CC 的 ``undefined`` 语义）/ Deletion sentinel for write-back.
+class _Delete:
+    __slots__ = ()
+
+    def __repr__(self) -> str:  # pragma: no cover - 仅调试可读性
+        return "<DELETE>"
+
+
+DELETE = _Delete()
+
+ConflictHook = Callable[[str, Any, Any], None]
+
+
+def _dedup_preserve_order(items: list[Any]) -> list[Any]:
+    """去重保序（首次出现胜出；兼容不可哈希元素）/ Order-preserving dedup (first wins; unhashable-safe)."""
+    out: list[Any] = []
+    for item in items:
+        if item not in out:
+            out.append(item)
+    return out
+
+
+def merge_read(low: Any, high: Any, *, on_conflict: ConflictHook | None = None, _path: str = "") -> Any:
+    """
+    读合并 customizer（深合并 / 数组拼接去重 / 标量高覆盖）/ Read-merge customizer。
+
+    与 Claude Code ``settingsMergeCustomizer`` 等价：customizer 只特判数组（拼接去重），其余交给
+    默认递归深合并；标量 / 类型不一致由高 scope 覆盖。``on_conflict(path, low, high)`` 在**叶子标量
+    被不同值覆盖**时回调（供能力层跨目录同名告警，§5.4）；普通 scope 叠加传 ``None``（高覆盖低是
+    既定语义、非冲突）。
+    Equivalent to Claude Code's customizer (arrays special-cased to concat+dedup, the rest deep
+    recursive merge); ``on_conflict`` fires only when a differing scalar leaf is overridden.
+    """
+    if isinstance(low, dict) and isinstance(high, dict):
+        merged = dict(low)
+        for key, hv in high.items():
+            child_path = f"{_path}.{key}" if _path else key
+            if key in merged:
+                merged[key] = merge_read(merged[key], hv, on_conflict=on_conflict, _path=child_path)
+            else:
+                merged[key] = hv
+        return merged
+    if isinstance(low, list) and isinstance(high, list):
+        # 数组：低在前拼接去重（不触发冲突回调——拼接是既定语义）。
+        return _dedup_preserve_order([*low, *high])
+    # 标量 / 类型不一致：高 scope 覆盖。
+    if on_conflict is not None and low != high:
+        on_conflict(_path, low, high)
+    return high
+
+
+def merge_layers(layers: Sequence[Mapping[str, Any]], *, on_conflict: ConflictHook | None = None) -> dict[str, Any]:
+    """
+    按 low → high 顺序折叠多层 settings（读合并）/ Fold multiple layers low → high (read merge)。
+
+    :param layers: 已校验的各 scope dict，**低优先级在前**（如 ``[capability, user, project, local, flag, policy]``）。
+    """
+    result: dict[str, Any] = {}
+    for layer in layers:
+        result = merge_read(result, dict(layer), on_conflict=on_conflict)
+    return result
+
+
+def apply_write(existing: Mapping[str, Any], updates: Mapping[str, Any]) -> dict[str, Any]:
+    """
+    写回单 scope（数组整体替换 + :data:`DELETE` 删 key，§5.4 写语义）/ Single-scope write-back。
+
+    与 :func:`merge_read` **语义相反**：数组**不拼接、直接替换**；值为 :data:`DELETE` 的 key 被删除；
+    嵌套对象继续递归（``settings set a.b.c`` 只动该叶子，不毁同级兄弟键）。返回**新 dict**（不就地改）。
+    Inverse of :func:`merge_read`: arrays replace wholesale; keys mapped to :data:`DELETE` are
+    removed; nested objects recurse. Returns a new dict (no in-place mutation).
+    """
+    result: dict[str, Any] = dict(existing)
+    for key, value in updates.items():
+        if isinstance(value, _Delete):
+            result.pop(key, None)
+            continue
+        cur = result.get(key)
+        if isinstance(cur, dict) and isinstance(value, Mapping):
+            result[key] = apply_write(cur, value)
+        else:
+            # 标量 / 数组 / 类型切换：整体替换（数组不拼接）。
+            result[key] = value
+    return result
+
+
+# ---------------------------------------------------------------------------
+# 文件加载 / File loading
+# ---------------------------------------------------------------------------
+def load_settings_file(path: Path, scope: SettingsScope) -> tuple[dict[str, Any], list[SettingsValidationError]]:
+    """
+    读取并字段级容错校验单个 settings 文件 / Load + field-level-validate one settings file。
+
+    缺失文件 → ``({}, [])``；JSON 损坏 → ``({}, [error])``（整文件回退空、**不**备份、**不**清盘，
+    照 CC「invalid file 不用但留盘」，§5.6）；正常 → :func:`validate_settings` 结果。
+    Missing file → empty; corrupt JSON → empty + one error (file untouched on disk); otherwise
+    the :func:`validate_settings` result.
+    """
+    p = Path(path)
+    if not p.exists():
+        return {}, []
+    try:
+        raw = json.loads(p.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.warning("Settings file %s unreadable/corrupt, ignored (kept on disk): %s", p, exc)
+        return {}, [SettingsValidationError(scope=scope, field="<file>", reason=f"unreadable or corrupt JSON: {exc}", source_path=str(p))]
+    return validate_settings(raw, scope, source_path=str(p))
+
+
+def filter_capability_fields(settings: Mapping[str, Any]) -> dict[str, Any]:
+    """只保留能力发现层字段（``enabledPlugins`` / ``extraKnownMarketplaces``）/ Keep only capability fields。"""
+    return {k: v for k, v in settings.items() if k in CAPABILITY_FIELDS}
+
+
+# ---------------------------------------------------------------------------
+# 解析编排 / Resolution orchestration
+# ---------------------------------------------------------------------------
+@dataclass(frozen=True, slots=True)
+class ResolvedSettings:
+    """
+    解析结果 / The resolved settings result。
+
+    ``settings`` 为六层合并后的最终视图；``errors`` 汇总各层字段级校验错误（不阻断启动，供
+    ``settings show`` / 诊断命令呈现，§5.6），已按出现顺序去重。
+    ``settings`` is the merged view; ``errors`` aggregates field-level validation errors
+    (non-fatal, deduped, surfaced via diagnostics).
+    """
+
+    settings: dict[str, Any]
+    errors: list[SettingsValidationError] = field(default_factory=list)
+
+
+def _build_capability_layer(
+    registered_workdirs: Sequence[Path],
+) -> tuple[dict[str, Any], list[SettingsValidationError]]:
+    """
+    能力发现层 (A)：跨**全部登记工作目录**取 ``enabledPlugins`` / ``extraKnownMarketplaces`` 并集。
+    Capability layer (A): union of capability fields across all registered workdirs。
+
+    单目录内 local 覆盖 project；跨目录按**登记顺序**后者覆盖前者并 WARN（§5.0「同名优先级」）。
+    Within a workdir local overrides project; across workdirs later registration wins + WARN.
+    """
+    errors: list[SettingsValidationError] = []
+    accumulated: dict[str, Any] = {}
+
+    def _on_conflict(path: str, old: Any, new: Any) -> None:
+        logger.warning(
+            "Capability-layer conflict on %r across registered workdirs: %r overridden by later registration %r",
+            path,
+            old,
+            new,
+        )
+
+    for workdir in registered_workdirs:
+        proj, proj_errors = load_settings_file(workdir_project_settings_path(workdir), SettingsScope.PROJECT)
+        local, local_errors = load_settings_file(workdir_local_settings_path(workdir), SettingsScope.LOCAL)
+        errors.extend(proj_errors)
+        errors.extend(local_errors)
+        # 单目录内：local 覆盖 project（仅能力字段）。
+        per_workdir = merge_read(filter_capability_fields(proj), filter_capability_fields(local))
+        accumulated = merge_read(accumulated, per_workdir, on_conflict=_on_conflict)
+
+    return accumulated, errors
+
+
+def _dedup_errors(errors: Sequence[SettingsValidationError]) -> list[SettingsValidationError]:
+    """按出现顺序去重（active workdir 文件在能力层 + B 层被读两次，错误天然重复）/ Order-preserving error dedup."""
+    return list(dict.fromkeys(errors))
+
+
+def resolve_settings(
+    *,
+    registered_workdirs: Sequence[Path] = (),
+    active_workdir: Path | None = None,
+    env: Mapping[str, str] | None = None,
+    flag_settings_path: Path | None = None,
+    policy_settings: Mapping[str, Any] | None = None,
+) -> ResolvedSettings:
+    """
+    解析六层 settings 视图（能力层 / user / project / local / flag / policy）/ Resolve the six-layer view。
+
+    两层模型（访谈定稿，§5.0 / §5.1）/ Two-layer model:
+    - **(A) 能力发现层**：``enabledPlugins`` / ``extraKnownMarketplaces`` 跨**全部** ``registered_workdirs``
+      取并集、置最低优先级（稳定能力面、不随 active 跳变）。
+    - **(B) active-workdir 单根**：project/local **只取** ``active_workdir`` 的 ``.tfrobot/settings[.local].json``，
+      不跨目录并集；**``active_workdir is None`` 时 project/local 全空**（仅 user + 能力层 + flag/policy）。
+
+    :param registered_workdirs: workspace 持久登记的全部工作目录（能力层来源）/ all registered workdirs.
+    :param active_workdir: 当前绑定任务的单根（project/local 来源）；``None`` = 空闲 / no active task.
+    :param env: 环境映射（解析 user config dir），默认 ``os.environ`` / env mapping for the user config dir.
+    :param flag_settings_path: ``--settings <file>`` 指定文件 / the ``--settings`` flag file, if any.
+    :param policy_settings: policy scope 原始 dict（来自 :mod:`a2c_smcp.computer.settings.policy`
+        的 first-source-wins 结果），在此按 POLICY scope 校验 / raw policy dict, validated here.
+    """
+    errors: list[SettingsValidationError] = []
+
+    # (A) 能力发现层（最低）/ capability layer (lowest)
+    capability_layer, cap_errors = _build_capability_layer(registered_workdirs)
+    errors.extend(cap_errors)
+
+    # user（主）/ user (primary)
+    user_layer, user_errors = load_settings_file(user_settings_path(env), SettingsScope.USER)
+    errors.extend(user_errors)
+
+    # (B) active-workdir 单根 project/local / active-workdir single-root
+    if active_workdir is not None:
+        project_layer, proj_errors = load_settings_file(workdir_project_settings_path(active_workdir), SettingsScope.PROJECT)
+        local_layer, local_errors = load_settings_file(workdir_local_settings_path(active_workdir), SettingsScope.LOCAL)
+        errors.extend(proj_errors)
+        errors.extend(local_errors)
+    else:
+        project_layer, local_layer = {}, {}
+
+    # flag / flag (``--settings``)
+    if flag_settings_path is not None:
+        flag_layer, flag_errors = load_settings_file(flag_settings_path, SettingsScope.FLAG)
+        errors.extend(flag_errors)
+    else:
+        flag_layer = {}
+
+    # policy（最高）/ policy (highest) — 在此按 POLICY scope 校验 first-source-wins 结果。
+    policy_layer, policy_errors = validate_settings(dict(policy_settings or {}), SettingsScope.POLICY)
+    errors.extend(policy_errors)
+
+    merged = merge_layers([capability_layer, user_layer, project_layer, local_layer, flag_layer, policy_layer])
+    return ResolvedSettings(settings=merged, errors=_dedup_errors(errors))

--- a/a2c_smcp/computer/skills/home.py
+++ b/a2c_smcp/computer/skills/home.py
@@ -46,6 +46,7 @@ from collections.abc import Mapping
 from pathlib import Path
 
 from a2c_smcp.utils.logger import get_logger
+from a2c_smcp.utils.path import resolve_xdg_first
 
 logger = get_logger(__name__)
 
@@ -80,22 +81,20 @@ def resolve_skill_home(env: Mapping[str, str] | None = None) -> Path:
 
     override = environ.get(SKILL_HOME_ENV, "").strip()
     if override:
-        home = Path(override).expanduser()
-        source = SKILL_HOME_ENV
-    else:
-        xdg = environ.get(XDG_DATA_HOME_ENV, "").strip()
-        xdg_path = Path(xdg) if xdg else None
-        # XDG 规范：XDG_DATA_HOME 必须为绝对路径，相对值按未设置处理。
-        # XDG spec: XDG_DATA_HOME must be absolute; treat relative values as unset.
-        if xdg_path is not None and xdg_path.is_absolute():
-            home = xdg_path.joinpath(*_A2C_DATA_SUBPATH)
-            source = XDG_DATA_HOME_ENV
-        else:
-            home = Path.home().joinpath(*_DOTDIR_SUBPATH)
-            source = "~"
+        # env 覆盖：最高优先级旋钮，绕过 XDG/fallback。/ env override: highest-priority knob.
+        resolved = Path(override).expanduser().resolve()
+        logger.debug("Resolved SKILL Home via %s → %s", SKILL_HOME_ENV, resolved)
+        return resolved
 
-    resolved = home.expanduser().resolve()
-    logger.debug("Resolved SKILL Home via %s → %s", source, resolved)
+    # 无覆盖：XDG-first（``$XDG_DATA_HOME/a2c/skills``）→ 回退 ``~/.a2c/skills``，复用共享解析。
+    # No override: XDG-first via the shared resolver, fallback ``~/.a2c/skills``.
+    resolved = resolve_xdg_first(
+        environ,
+        XDG_DATA_HOME_ENV,
+        *_A2C_DATA_SUBPATH,
+        fallback=Path.home().joinpath(*_DOTDIR_SUBPATH),
+    )
+    logger.debug("Resolved SKILL Home (XDG-first %s) → %s", XDG_DATA_HOME_ENV, resolved)
     return resolved
 
 

--- a/a2c_smcp/utils/__init__.py
+++ b/a2c_smcp/utils/__init__.py
@@ -10,11 +10,12 @@
 Export utilities
 """
 
-from .path import is_within
+from .path import is_within, resolve_xdg_first
 from .window_uri import WindowURI, is_window_uri
 
 __all__ = [
     "WindowURI",
     "is_within",
     "is_window_uri",
+    "resolve_xdg_first",
 ]

--- a/a2c_smcp/utils/path.py
+++ b/a2c_smcp/utils/path.py
@@ -13,7 +13,34 @@ Cross-subsystem pure path helpers (no a2c deps, stdlib only).
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from pathlib import Path
+
+
+def resolve_xdg_first(env: Mapping[str, str], xdg_var: str, *subpath: str, fallback: Path) -> Path:
+    """
+    XDG-first 路径解析 / XDG-first path resolution（镜像 Claude Code「XDG 优先 + 回退」范式）。
+
+    若 ``env[xdg_var]`` 为**绝对路径** → 取 ``$<xdg_var>/<*subpath>``；否则（未设置 / 相对值——按 XDG
+    规范相对值视为未设置）→ 取 ``fallback``。结果统一 ``expanduser().resolve()`` 返回绝对路径；**不**创建目录。
+    If ``env[xdg_var]`` is an **absolute** path, returns ``$<xdg_var>/<*subpath>``; otherwise
+    (unset, or a relative value treated as unset per the XDG spec) returns ``fallback``. The result
+    is ``expanduser().resolve()``-d to an absolute path; no directory is created.
+
+    供 SKILL Home（``XDG_DATA_HOME``）与 user 配置目录（``XDG_CONFIG_HOME``）等复用——两者仅 env 变量、
+    子路径、fallback 不同。env-override（如 ``A2C_SKILL_HOME``）等更高优先级旋钮由调用方在调用前自行处理。
+    Reused by SKILL Home and the user config dir; higher-priority env overrides are handled by callers.
+
+    :param env: 环境映射（便于测试注入）/ env mapping (injectable for tests).
+    :param xdg_var: XDG 环境变量名（如 ``XDG_DATA_HOME`` / ``XDG_CONFIG_HOME``）/ the XDG env var name.
+    :param subpath: 追加在 ``$<xdg_var>`` 之后的路径段 / segments appended under ``$<xdg_var>``.
+    :param fallback: XDG 未设置 / 非绝对时的回退路径 / fallback path when XDG is unset / non-absolute.
+    """
+    raw = env.get(xdg_var, "").strip()
+    xdg_path = Path(raw) if raw else None
+    # XDG 规范：变量必须为绝对路径，相对值按未设置处理。/ XDG spec: must be absolute; relative treated as unset.
+    base = xdg_path.joinpath(*subpath) if xdg_path is not None and xdg_path.is_absolute() else fallback
+    return base.expanduser().resolve()
 
 
 def is_within(path: Path, parent: Path) -> bool:

--- a/tests/unit_tests/computer/settings/__init__.py
+++ b/tests/unit_tests/computer/settings/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+# filename: __init__.py
+# @Time    : 2026/05/25
+# @Author  : JQQ
+# @Email   : jqq1716@gmail.com
+# @Software: PyCharm

--- a/tests/unit_tests/computer/settings/test_policy.py
+++ b/tests/unit_tests/computer/settings/test_policy.py
@@ -1,0 +1,229 @@
+# -*- coding: utf-8 -*-
+# filename: test_policy.py
+# @Time    : 2026/05/25
+# @Author  : JQQ
+# @Email   : jqq1716@gmail.com
+# @Software: PyCharm
+"""
+policy scope 四子源 first-source-wins 单元测试（v0.2.1）
+Unit tests for policy-scope four sub-sources first-source-wins (v0.2.1)
+
+SDK 设计 / Design: python-sdk docs/design-0.2.1-cli-marketplace-ux.md §5.2 / §5.4。
+
+测试意图 / Test intentions:
+- first-source-wins：高优先级**有内容**者整体胜出，低优先级**不合并**（即便它有额外键）
+- 空源跳过；皆空 → {}；单源 loader 抛错 → 跳过续下一源
+- layer 3 read：managed-settings.json + managed-settings.d/*.json 深合并；缺失 → None
+- remote 子源 v0.2.1 stub 恒 None（即便配置了 base env，也不联网）
+- 各平台默认子源装配（darwin / win32 / linux）优先级
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+import a2c_smcp.computer.settings.policy as policy_mod
+from a2c_smcp.computer.settings.policy import (
+    PolicySource,
+    default_policy_sources,
+    load_macos_plist,
+    load_managed_settings,
+    load_remote_policy,
+    load_windows_registry,
+    resolve_policy_settings,
+)
+
+
+def _src(name: str, priority: int, payload: dict | None) -> PolicySource:
+    return PolicySource(name=name, priority=priority, loader=lambda: payload)
+
+
+# ---------------------------------------------------------------------------
+# first-source-wins
+# ---------------------------------------------------------------------------
+def test_highest_priority_with_content_wins_no_merge() -> None:
+    sources = [
+        _src("p3-managed", 3, {"strictKnownMarketplaces": False, "extra": "low"}),
+        _src("p2-mdm", 2, {"strictKnownMarketplaces": True}),  # 高优先级、不带 extra
+    ]
+    result = resolve_policy_settings(sources=sources)
+    # p2 整体胜出，p3 的 extra 不被合并进来（first-source-wins，非 merge）。
+    assert result == {"strictKnownMarketplaces": True}
+
+
+def test_empty_sources_skipped_until_content() -> None:
+    sources = [
+        _src("p1-remote", 1, None),
+        _src("p2", 2, {}),  # 空 dict 视为无内容
+        _src("p3", 3, {"trustedMarketplaces": ["mp"]}),
+    ]
+    assert resolve_policy_settings(sources=sources) == {"trustedMarketplaces": ["mp"]}
+
+
+def test_all_empty_returns_empty_dict() -> None:
+    sources = [_src("a", 1, None), _src("b", 2, {})]
+    assert resolve_policy_settings(sources=sources) == {}
+
+
+def test_no_sources_returns_empty_dict() -> None:
+    assert resolve_policy_settings(sources=[]) == {}
+
+
+def test_loader_raising_is_skipped() -> None:
+    def _boom() -> dict:
+        raise RuntimeError("registry blew up")
+
+    sources = [
+        PolicySource(name="p2-explodes", priority=2, loader=_boom),
+        _src("p3-ok", 3, {"strictKnownMarketplaces": True}),
+    ]
+    assert resolve_policy_settings(sources=sources) == {"strictKnownMarketplaces": True}
+
+
+def test_priority_order_independent_of_list_order() -> None:
+    # 列表乱序，按 priority 升序选取。
+    sources = [
+        _src("p3", 3, {"k": "p3"}),
+        _src("p1", 1, None),
+        _src("p2", 2, {"k": "p2"}),
+    ]
+    assert resolve_policy_settings(sources=sources) == {"k": "p2"}
+
+
+# ---------------------------------------------------------------------------
+# layer 3：managed-settings.json + .d/*.json
+# ---------------------------------------------------------------------------
+def test_load_managed_settings_missing_returns_none(tmp_path: Path) -> None:
+    assert load_managed_settings(tmp_path / "nonexistent") is None
+
+
+def test_load_managed_settings_base_only(tmp_path: Path) -> None:
+    (tmp_path / "managed-settings.json").write_text(json.dumps({"strictKnownMarketplaces": True}), encoding="utf-8")
+    assert load_managed_settings(tmp_path) == {"strictKnownMarketplaces": True}
+
+
+def test_load_managed_settings_dropin_deep_merge(tmp_path: Path) -> None:
+    (tmp_path / "managed-settings.json").write_text(
+        json.dumps({"trustedMarketplaces": ["a"], "strictKnownMarketplaces": False}), encoding="utf-8"
+    )
+    d = tmp_path / "managed-settings.d"
+    d.mkdir()
+    (d / "10-team.json").write_text(json.dumps({"trustedMarketplaces": ["b"]}), encoding="utf-8")
+    (d / "20-override.json").write_text(json.dumps({"strictKnownMarketplaces": True}), encoding="utf-8")
+
+    merged = load_managed_settings(tmp_path)
+    assert merged is not None
+    # 数组拼接去重（read 语义），标量被 drop-in 覆盖。
+    assert merged["trustedMarketplaces"] == ["a", "b"]
+    assert merged["strictKnownMarketplaces"] is True
+
+
+def test_load_managed_settings_dropin_only(tmp_path: Path) -> None:
+    d = tmp_path / "managed-settings.d"
+    d.mkdir()
+    (d / "a.json").write_text(json.dumps({"trustedMarketplaces": ["only"]}), encoding="utf-8")
+    assert load_managed_settings(tmp_path) == {"trustedMarketplaces": ["only"]}
+
+
+# ---------------------------------------------------------------------------
+# remote stub
+# ---------------------------------------------------------------------------
+def test_remote_policy_is_stub_even_with_base_env() -> None:
+    assert load_remote_policy({}) is None
+    assert load_remote_policy({"A2C_BASE_API_URL": "https://api.example.com"}) is None
+
+
+# ---------------------------------------------------------------------------
+# 默认子源装配 / default source assembly
+# ---------------------------------------------------------------------------
+def test_default_sources_darwin() -> None:
+    names = {s.name: s.priority for s in default_policy_sources("darwin", {})}
+    assert names == {"remote": 1, "macos-plist": 2, "managed-settings": 3}
+
+
+def test_default_sources_win32() -> None:
+    names = {s.name: s.priority for s in default_policy_sources("win32", {})}
+    assert names == {"remote": 1, "hklm-registry": 2, "managed-settings": 3, "hkcu-registry": 4}
+
+
+def test_default_sources_linux() -> None:
+    names = {s.name: s.priority for s in default_policy_sources("linux", {})}
+    assert names == {"remote": 1, "managed-settings": 3}
+
+
+# ---------------------------------------------------------------------------
+# _read_json_file 降级路径（经 load_managed_settings 触达）/ degradation paths
+# ---------------------------------------------------------------------------
+def test_managed_settings_corrupt_base_returns_none(tmp_path: Path) -> None:
+    (tmp_path / "managed-settings.json").write_text("{not valid json", encoding="utf-8")
+    assert load_managed_settings(tmp_path) is None  # 损坏 base、无 dropin → None
+
+
+def test_managed_settings_non_object_root_returns_none(tmp_path: Path) -> None:
+    (tmp_path / "managed-settings.json").write_text(json.dumps([1, 2, 3]), encoding="utf-8")
+    assert load_managed_settings(tmp_path) is None  # 非对象根 → None
+
+
+def test_managed_settings_corrupt_dropin_skipped_base_kept(tmp_path: Path) -> None:
+    (tmp_path / "managed-settings.json").write_text(json.dumps({"strictKnownMarketplaces": True}), encoding="utf-8")
+    d = tmp_path / "managed-settings.d"
+    d.mkdir()
+    (d / "10-bad.json").write_text("{broken", encoding="utf-8")  # 损坏 drop-in 跳过
+    (d / "20-good.json").write_text(json.dumps({"trustedMarketplaces": ["x"]}), encoding="utf-8")
+    merged = load_managed_settings(tmp_path)
+    assert merged == {"strictKnownMarketplaces": True, "trustedMarketplaces": ["x"]}
+
+
+# ---------------------------------------------------------------------------
+# load_macos_plist 四态（darwin 可测，plistlib 造样本）/ four states
+# ---------------------------------------------------------------------------
+def test_macos_plist_missing_returns_none(tmp_path: Path) -> None:
+    assert load_macos_plist(tmp_path / "absent.plist") is None
+
+
+def test_macos_plist_valid_parsed(tmp_path: Path) -> None:
+    import plistlib
+
+    p = tmp_path / "policy.plist"
+    p.write_bytes(plistlib.dumps({"strictKnownMarketplaces": True, "trustedMarketplaces": ["mp"]}))
+    assert load_macos_plist(p) == {"strictKnownMarketplaces": True, "trustedMarketplaces": ["mp"]}
+
+
+def test_macos_plist_corrupt_returns_none(tmp_path: Path) -> None:
+    p = tmp_path / "bad.plist"
+    p.write_bytes(b"this is not a plist at all")
+    assert load_macos_plist(p) is None
+
+
+def test_macos_plist_non_dict_root_returns_none(tmp_path: Path) -> None:
+    import plistlib
+
+    p = tmp_path / "list.plist"
+    p.write_bytes(plistlib.dumps([1, 2, 3]))
+    assert load_macos_plist(p) is None
+
+
+# ---------------------------------------------------------------------------
+# load_windows_registry 非 Windows 早返回（darwin/linux 上即覆盖）/ non-win32 early return
+# ---------------------------------------------------------------------------
+def test_windows_registry_non_windows_returns_none() -> None:
+    # 测试运行于 darwin/linux：sys.platform != "win32" → 立即 None（不触 winreg）。
+    assert load_windows_registry("HKEY_LOCAL_MACHINE") is None
+    assert load_windows_registry("HKEY_CURRENT_USER") is None
+
+
+# ---------------------------------------------------------------------------
+# default_policy_sources 的 lambda loader 真被调用（端到端 first-source-wins）/ lambdas actually wired
+# ---------------------------------------------------------------------------
+def test_darwin_default_sources_plist_wins_over_managed(monkeypatch: pytest.MonkeyPatch) -> None:
+    # 验证 darwin 装配：priority-2 源 loader 真走 load_macos_plist；plist 有内容 → 胜过 managed(p3)。
+    monkeypatch.setattr(policy_mod, "load_macos_plist", lambda: {"k": "plist"})
+    monkeypatch.setattr(policy_mod, "load_managed_settings", lambda _dir: {"k": "managed"})
+    assert resolve_policy_settings(platform="darwin", env={}) == {"k": "plist"}
+
+
+def test_darwin_default_sources_managed_used_when_plist_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(policy_mod, "load_macos_plist", lambda: None)
+    monkeypatch.setattr(policy_mod, "load_managed_settings", lambda _dir: {"k": "managed"})
+    assert resolve_policy_settings(platform="darwin", env={}) == {"k": "managed"}

--- a/tests/unit_tests/computer/settings/test_schema.py
+++ b/tests/unit_tests/computer/settings/test_schema.py
@@ -1,0 +1,221 @@
+# -*- coding: utf-8 -*-
+# filename: test_schema.py
+# @Time    : 2026/05/25
+# @Author  : JQQ
+# @Email   : jqq1716@gmail.com
+# @Software: PyCharm
+"""
+settings schema 字段级容错校验单元测试（v0.2.1）
+Unit tests for settings schema field-level tolerant validation (v0.2.1)
+
+SDK 设计 / Design: python-sdk docs/design-0.2.1-cli-marketplace-ux.md §5.3 / §5.3.1 / §5.6。
+
+测试意图 / Test intentions:
+- 未知顶层字段 passthrough（静默保留）；``$schema`` 保留
+- policy-only 字段（allowedMcpServers/deniedMcpServers）在非 policy scope → 过滤 + 记 ValidationError；
+  policy scope → 保留
+- 已知字段逐条过滤：enabledPlugins / extraKnownMarketplaces 单项非法剔除、其余保留
+- 标量 / 数组类型错 → 回退默认 + 记错
+- 形态校验器：git url / <plugin>@<mp> key / marketplace 名
+- 非 dict 根 → 空 + 记错
+"""
+
+import pytest
+
+from a2c_smcp.computer.settings.schema import (
+    SettingsScope,
+    is_valid_enabled_plugin_key,
+    is_valid_git_url,
+    is_valid_marketplace_name,
+    validate_settings,
+)
+
+
+# ---------------------------------------------------------------------------
+# 形态校验器 / shape validators
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "url,ok",
+    [
+        ("git@github.com:team/skills.git", True),
+        ("https://github.com/team/skills.git", True),
+        ("http://example.com/x.git", True),
+        ("ssh://git@host:22/team/skills.git", True),
+        ("git://host/path", True),
+        ("file:///abs/path/repo", True),
+        ("not a url", False),
+        ("ftp://host/x", False),
+        ("", False),
+        ("   ", False),
+    ],
+)
+def test_is_valid_git_url(url: str, ok: bool) -> None:
+    assert is_valid_git_url(url) is ok
+
+
+@pytest.mark.parametrize(
+    "key,ok",
+    [
+        ("frontend-design@my-team-skills", True),
+        ("a@b", True),
+        ("foo", False),  # 缺 @
+        ("foo@", False),
+        ("@mp", False),
+        ("Foo@mp", False),  # 大写非 kebab
+        ("foo@my_mp", False),  # 下划线非 kebab
+        ("-foo@mp", False),  # 首字符 -
+    ],
+)
+def test_is_valid_enabled_plugin_key(key: str, ok: bool) -> None:
+    assert is_valid_enabled_plugin_key(key) is ok
+
+
+@pytest.mark.parametrize(
+    "name,ok",
+    [("my-team-skills", True), ("a", True), ("Foo", False), ("a--b", False), ("a_b", False), ("", False)],
+)
+def test_is_valid_marketplace_name(name: str, ok: bool) -> None:
+    assert is_valid_marketplace_name(name) is ok
+
+
+# ---------------------------------------------------------------------------
+# passthrough / $schema
+# ---------------------------------------------------------------------------
+def test_unknown_top_level_field_passthrough() -> None:
+    raw = {"futureUnknownField": {"x": 1}, "anotherOne": [1, 2, 3]}
+    cleaned, errors = validate_settings(raw, SettingsScope.USER)
+    assert cleaned == raw  # 未知键原样保留
+    assert errors == []
+
+
+def test_schema_field_preserved_not_consumed() -> None:
+    raw = {"$schema": "https://a2c-smcp.dev/schemas/computer-settings-0.2.1.json"}
+    cleaned, errors = validate_settings(raw, SettingsScope.USER)
+    assert cleaned == raw
+    assert errors == []
+
+
+def test_non_dict_root_falls_back_empty() -> None:
+    cleaned, errors = validate_settings(["not", "an", "object"], SettingsScope.USER)
+    assert cleaned == {}
+    assert len(errors) == 1
+    assert errors[0].field == "<root>"
+
+
+# ---------------------------------------------------------------------------
+# policy-only 越权 / policy-only overreach
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("scope", [SettingsScope.USER, SettingsScope.PROJECT, SettingsScope.LOCAL])
+def test_policy_only_fields_filtered_outside_policy(scope: SettingsScope) -> None:
+    raw = {"allowedMcpServers": ["a"], "deniedMcpServers": ["b"], "trustedMarketplaces": ["mp"]}
+    cleaned, errors = validate_settings(raw, scope)
+    assert "allowedMcpServers" not in cleaned
+    assert "deniedMcpServers" not in cleaned
+    assert cleaned["trustedMarketplaces"] == ["mp"]  # 非 policy-only 字段保留
+    bad_fields = {e.field for e in errors}
+    assert bad_fields == {"allowedMcpServers", "deniedMcpServers"}
+
+
+def test_policy_only_fields_kept_in_policy_scope() -> None:
+    raw = {"allowedMcpServers": ["a"], "deniedMcpServers": ["b"]}
+    cleaned, errors = validate_settings(raw, SettingsScope.POLICY)
+    assert cleaned == raw
+    assert errors == []
+
+
+# ---------------------------------------------------------------------------
+# enabledPlugins 逐条过滤 / per-entry filtering
+# ---------------------------------------------------------------------------
+def test_enabled_plugins_per_entry_filtering() -> None:
+    raw = {
+        "enabledPlugins": {
+            "good@mp": True,
+            "also-good@mp": False,
+            "badshape": True,  # 缺 @ → 过滤
+            "nonbool@mp": "yes",  # 值非 bool → 过滤
+        }
+    }
+    cleaned, errors = validate_settings(raw, SettingsScope.USER)
+    assert cleaned["enabledPlugins"] == {"good@mp": True, "also-good@mp": False}
+    bad = {e.field for e in errors}
+    assert bad == {"enabledPlugins.badshape", "enabledPlugins.nonbool@mp"}
+
+
+def test_enabled_plugins_non_object_dropped() -> None:
+    cleaned, errors = validate_settings({"enabledPlugins": ["nope"]}, SettingsScope.USER)
+    assert "enabledPlugins" not in cleaned
+    assert len(errors) == 1
+
+
+# ---------------------------------------------------------------------------
+# extraKnownMarketplaces 逐条过滤 + 规范化 / per-entry filter + normalize
+# ---------------------------------------------------------------------------
+def test_extra_marketplaces_valid_entry_normalized() -> None:
+    raw = {
+        "extraKnownMarketplaces": {
+            "my-team-skills": {
+                "source": {"type": "git", "url": "git@github.com:team/skills.git", "extra": "dropped"},
+                "autoUpdate": True,
+                "junk": 1,  # 顶层多余子键被丢
+            }
+        }
+    }
+    cleaned, errors = validate_settings(raw, SettingsScope.USER)
+    assert errors == []
+    assert cleaned["extraKnownMarketplaces"]["my-team-skills"] == {
+        "source": {"type": "git", "url": "git@github.com:team/skills.git"},
+        "autoUpdate": True,
+    }
+
+
+@pytest.mark.parametrize(
+    "name,entry,bad_field",
+    [
+        ("Bad_Name", {"source": {"type": "git", "url": "git@h:p"}}, "extraKnownMarketplaces.Bad_Name"),
+        ("ok-mp", {"source": {"type": "svn", "url": "x"}}, "extraKnownMarketplaces.ok-mp.source.type"),
+        ("ok-mp", {"source": {"type": "git", "url": "garbage"}}, "extraKnownMarketplaces.ok-mp.source.url"),
+        ("ok-mp", {"noSource": 1}, "extraKnownMarketplaces.ok-mp.source"),
+        ("ok-mp", {"source": {"type": "git", "url": "git@h:p"}, "autoUpdate": "yes"}, "extraKnownMarketplaces.ok-mp.autoUpdate"),
+    ],
+)
+def test_extra_marketplaces_bad_entry_filtered(name: str, entry: dict, bad_field: str) -> None:
+    cleaned, errors = validate_settings({"extraKnownMarketplaces": {name: entry}}, SettingsScope.USER)
+    assert cleaned.get("extraKnownMarketplaces", {}) == {}  # 唯一项被剔除
+    assert any(e.field == bad_field for e in errors)
+
+
+# ---------------------------------------------------------------------------
+# 标量 / 数组类型校验 / scalar & array typing
+# ---------------------------------------------------------------------------
+def test_bool_field_type_error_dropped() -> None:
+    cleaned, errors = validate_settings({"strictKnownMarketplaces": "true"}, SettingsScope.USER)
+    assert "strictKnownMarketplaces" not in cleaned
+    assert len(errors) == 1
+
+
+def test_string_array_element_filtering() -> None:
+    cleaned, errors = validate_settings({"trustedMarketplaces": ["a", 1, "b", None]}, SettingsScope.USER)
+    assert cleaned["trustedMarketplaces"] == ["a", "b"]
+    assert len(errors) == 2
+
+
+def test_string_array_non_list_dropped() -> None:
+    cleaned, errors = validate_settings({"trustedMarketplaces": "a,b"}, SettingsScope.USER)
+    assert "trustedMarketplaces" not in cleaned
+    assert len(errors) == 1
+
+
+# ---------------------------------------------------------------------------
+# permissions.additionalDirectories
+# ---------------------------------------------------------------------------
+def test_permissions_additional_directories_absolute_only() -> None:
+    raw = {"permissions": {"additionalDirectories": ["/abs/ok", "relative/no", 42], "unknownSub": "kept"}}
+    cleaned, errors = validate_settings(raw, SettingsScope.USER)
+    assert cleaned["permissions"]["additionalDirectories"] == ["/abs/ok"]
+    assert cleaned["permissions"]["unknownSub"] == "kept"  # permissions 下未知子键 passthrough
+    assert len(errors) == 2  # relative + 非 string
+
+
+def test_source_path_backfilled_into_errors() -> None:
+    _, errors = validate_settings({"strictKnownMarketplaces": 1}, SettingsScope.USER, source_path="/x/settings.json")
+    assert errors[0].source_path == "/x/settings.json"

--- a/tests/unit_tests/computer/settings/test_scope.py
+++ b/tests/unit_tests/computer/settings/test_scope.py
@@ -1,0 +1,305 @@
+# -*- coding: utf-8 -*-
+# filename: test_scope.py
+# @Time    : 2026/05/25
+# @Author  : JQQ
+# @Email   : jqq1716@gmail.com
+# @Software: PyCharm
+"""
+五级 scope 路径解析 + 读/写 merge + active-workdir / 能力层解析单元测试（v0.2.1）
+Unit tests for scope path resolution + read/write merge + active-workdir / capability resolution.
+
+SDK 设计 / Design: python-sdk docs/design-0.2.1-cli-marketplace-ux.md §5.0 / §5.1 / §5.4。
+
+测试意图 / Test intentions:
+- 读 merge 矩阵：标量高覆盖 / 数组拼接去重（低在前）/ 对象深合并；
+  **嵌套 extraKnownMarketplaces[].source 深合并不被整体替换**（关键用例，§5.4 例 2）
+- 写 merge：数组整体替换（不拼接）/ DELETE 删 key / 嵌套对象不毁兄弟键
+- 路径解析：user config dir XDG-first + 回退；workdir project/local 路径
+- active-workdir 解析：无 active → project/local 空；非 active 目录不贡献标量；
+  能力层（enabledPlugins/extraKnownMarketplaces）跨全部登记目录全局并集
+"""
+
+import json
+import logging
+from pathlib import Path
+
+import pytest
+
+import a2c_smcp.computer.settings.scope as scope_mod
+from a2c_smcp.computer.settings.scope import (
+    DELETE,
+    apply_write,
+    merge_layers,
+    merge_read,
+    resolve_settings,
+    resolve_user_config_dir,
+    user_settings_path,
+    workdir_local_settings_path,
+    workdir_project_settings_path,
+)
+
+
+def _write_json(path: Path, obj: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(obj), encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# 读 merge 矩阵 / read-merge matrix
+# ---------------------------------------------------------------------------
+def test_read_scalar_high_wins() -> None:
+    assert merge_read({"strictKnownMarketplaces": False}, {"strictKnownMarketplaces": True}) == {
+        "strictKnownMarketplaces": True
+    }
+
+
+def test_read_array_concat_dedup_low_first() -> None:
+    low = {"trustedMarketplaces": ["a", "b"]}
+    high = {"trustedMarketplaces": ["b", "c"]}
+    assert merge_read(low, high) == {"trustedMarketplaces": ["a", "b", "c"]}
+
+
+def test_read_object_leaf_override_keeps_siblings() -> None:
+    # 例 1：local false 覆盖 project true；project 独有 bar 保留。
+    low = {"enabledPlugins": {"foo@mp": True, "bar@mp": True}}
+    high = {"enabledPlugins": {"foo@mp": False}}
+    assert merge_read(low, high) == {"enabledPlugins": {"foo@mp": False, "bar@mp": True}}
+
+
+def test_read_nested_object_deep_merge_source_preserved() -> None:
+    # 例 2（关键）：高 scope 只给 autoUpdate，嵌套 source 不被整体替换。
+    low = {"extraKnownMarketplaces": {"mp": {"source": {"type": "git", "url": "u"}, "autoUpdate": False}}}
+    high = {"extraKnownMarketplaces": {"mp": {"autoUpdate": True}}}
+    merged = merge_read(low, high)
+    assert merged == {"extraKnownMarketplaces": {"mp": {"source": {"type": "git", "url": "u"}, "autoUpdate": True}}}
+
+
+def test_read_key_only_in_low_preserved() -> None:
+    assert merge_read({"a": 1}, {"b": 2}) == {"a": 1, "b": 2}
+
+
+def test_merge_layers_fold_low_to_high() -> None:
+    layers = [
+        {"strictKnownMarketplaces": False, "trustedMarketplaces": ["a"]},  # capability/low
+        {"strictKnownMarketplaces": True, "trustedMarketplaces": ["b"]},  # user
+        {"trustedMarketplaces": ["c"]},  # high
+    ]
+    merged = merge_layers(layers)
+    assert merged["strictKnownMarketplaces"] is True
+    assert merged["trustedMarketplaces"] == ["a", "b", "c"]
+
+
+def test_merge_read_conflict_hook_fires_on_scalar_only() -> None:
+    seen: list[tuple[str, object, object]] = []
+    merge_read(
+        {"x": 1, "arr": ["a"], "obj": {"k": 1}},
+        {"x": 2, "arr": ["b"], "obj": {"k": 2}},
+        on_conflict=lambda p, lo, hi: seen.append((p, lo, hi)),
+    )
+    # 标量 x 与嵌套叶子 obj.k 冲突回调；数组拼接不回调。
+    paths = {s[0] for s in seen}
+    assert paths == {"x", "obj.k"}
+
+
+# ---------------------------------------------------------------------------
+# 写 merge / write-merge
+# ---------------------------------------------------------------------------
+def test_write_array_replaced_not_concatenated() -> None:
+    existing = {"trustedMarketplaces": ["a", "b"]}
+    assert apply_write(existing, {"trustedMarketplaces": ["c"]}) == {"trustedMarketplaces": ["c"]}
+
+
+def test_write_delete_sentinel_removes_key() -> None:
+    existing = {"strictKnownMarketplaces": True, "trustedMarketplaces": ["a"]}
+    assert apply_write(existing, {"strictKnownMarketplaces": DELETE}) == {"trustedMarketplaces": ["a"]}
+
+
+def test_write_delete_missing_key_is_noop() -> None:
+    assert apply_write({"a": 1}, {"missing": DELETE}) == {"a": 1}
+
+
+def test_write_nested_object_keeps_siblings() -> None:
+    existing = {"enabledPlugins": {"foo@mp": True, "bar@mp": True}}
+    # 写 foo@mp=False，只动该叶子，bar 保留。
+    assert apply_write(existing, {"enabledPlugins": {"foo@mp": False}}) == {
+        "enabledPlugins": {"foo@mp": False, "bar@mp": True}
+    }
+
+
+def test_write_does_not_mutate_inputs() -> None:
+    existing = {"trustedMarketplaces": ["a"]}
+    apply_write(existing, {"trustedMarketplaces": ["c"]})
+    assert existing == {"trustedMarketplaces": ["a"]}  # 原对象不变
+
+
+# ---------------------------------------------------------------------------
+# 路径解析 / path resolution
+# ---------------------------------------------------------------------------
+def test_user_config_dir_xdg_first(tmp_path: Path) -> None:
+    xdg = tmp_path / "xdg-config"
+    assert resolve_user_config_dir({"XDG_CONFIG_HOME": str(xdg)}) == (xdg / "a2c").resolve()
+
+
+def test_user_config_dir_fallback_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    # 相对 XDG_CONFIG_HOME 按规范忽略 → 回退 ~/.config/a2c
+    assert resolve_user_config_dir({"XDG_CONFIG_HOME": "relative"}) == (tmp_path / ".config" / "a2c").resolve()
+
+
+def test_user_settings_path(tmp_path: Path) -> None:
+    xdg = tmp_path / "c"
+    assert user_settings_path({"XDG_CONFIG_HOME": str(xdg)}) == (xdg / "a2c" / "settings.json").resolve()
+
+
+def test_workdir_paths(tmp_path: Path) -> None:
+    assert workdir_project_settings_path(tmp_path) == tmp_path / ".tfrobot" / "settings.json"
+    assert workdir_local_settings_path(tmp_path) == tmp_path / ".tfrobot" / "settings.local.json"
+
+
+# ---------------------------------------------------------------------------
+# active-workdir / 能力层解析 / resolution
+# ---------------------------------------------------------------------------
+def _empty_user_env(tmp_path: Path) -> dict:
+    # 指向无 settings.json 的隔离 config dir，确保 user 层为空。
+    return {"XDG_CONFIG_HOME": str(tmp_path / "empty-config")}
+
+
+def test_no_active_workdir_project_local_empty(tmp_path: Path) -> None:
+    wd = tmp_path / "wd"
+    _write_json(workdir_project_settings_path(wd), {"strictKnownMarketplaces": True, "enabledPlugins": {"p@mp": True}})
+
+    resolved = resolve_settings(
+        registered_workdirs=[wd],
+        active_workdir=None,  # 无 active
+        env=_empty_user_env(tmp_path),
+    )
+    # 标量 strictKnownMarketplaces 是 project（B 层）键，无 active → 不贡献。
+    assert "strictKnownMarketplaces" not in resolved.settings
+    # enabledPlugins 属能力层（A 层），跨登记目录并集 → 仍在。
+    assert resolved.settings["enabledPlugins"] == {"p@mp": True}
+
+
+def test_non_active_dir_contributes_capability_not_scalars(tmp_path: Path) -> None:
+    wd_active = tmp_path / "active"
+    wd_other = tmp_path / "other"
+    _write_json(workdir_project_settings_path(wd_active), {"enabledPlugins": {"a@mp": True}})
+    _write_json(
+        workdir_project_settings_path(wd_other),
+        {"strictKnownMarketplaces": True, "enabledPlugins": {"b@mp": True}, "trustedMarketplaces": ["x"]},
+    )
+
+    resolved = resolve_settings(
+        registered_workdirs=[wd_active, wd_other],
+        active_workdir=wd_active,
+        env=_empty_user_env(tmp_path),
+    )
+    # 非 active 的 wd_other：标量 strictKnownMarketplaces / 数组 trustedMarketplaces 不贡献。
+    assert "strictKnownMarketplaces" not in resolved.settings
+    assert "trustedMarketplaces" not in resolved.settings
+    # 能力层全局并集：两个目录的 enabledPlugins 都进。
+    assert resolved.settings["enabledPlugins"] == {"a@mp": True, "b@mp": True}
+
+
+def test_active_workdir_full_contribution(tmp_path: Path) -> None:
+    wd = tmp_path / "wd"
+    _write_json(workdir_project_settings_path(wd), {"strictKnownMarketplaces": True})
+    _write_json(workdir_local_settings_path(wd), {"strictKnownMarketplaces": False, "trustedMarketplaces": ["m"]})
+
+    resolved = resolve_settings(
+        registered_workdirs=[wd],
+        active_workdir=wd,
+        env=_empty_user_env(tmp_path),
+    )
+    # local 覆盖 project（高 scope 赢）。
+    assert resolved.settings["strictKnownMarketplaces"] is False
+    assert resolved.settings["trustedMarketplaces"] == ["m"]
+
+
+def test_capability_union_across_extra_marketplaces(tmp_path: Path) -> None:
+    wd1 = tmp_path / "wd1"
+    wd2 = tmp_path / "wd2"
+    _write_json(
+        workdir_project_settings_path(wd1),
+        {"extraKnownMarketplaces": {"mp1": {"source": {"type": "git", "url": "git@h:a.git"}}}},
+    )
+    _write_json(
+        workdir_project_settings_path(wd2),
+        {"extraKnownMarketplaces": {"mp2": {"source": {"type": "git", "url": "git@h:b.git"}}}},
+    )
+    resolved = resolve_settings(
+        registered_workdirs=[wd1, wd2],
+        active_workdir=None,
+        env=_empty_user_env(tmp_path),
+    )
+    assert set(resolved.settings["extraKnownMarketplaces"]) == {"mp1", "mp2"}
+
+
+def test_policy_highest_priority_and_validated(tmp_path: Path) -> None:
+    wd = tmp_path / "wd"
+    _write_json(workdir_project_settings_path(wd), {"strictKnownMarketplaces": False})
+    resolved = resolve_settings(
+        registered_workdirs=[wd],
+        active_workdir=wd,
+        env=_empty_user_env(tmp_path),
+        policy_settings={"strictKnownMarketplaces": True, "allowedMcpServers": ["srv"]},
+    )
+    # policy 最高优先级覆盖 project。
+    assert resolved.settings["strictKnownMarketplaces"] is True
+    # policy-only 字段在 policy scope 合法保留。
+    assert resolved.settings["allowedMcpServers"] == ["srv"]
+
+
+def test_corrupt_settings_file_yields_error_not_crash(tmp_path: Path) -> None:
+    wd = tmp_path / "wd"
+    p = workdir_project_settings_path(wd)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text("{not valid json", encoding="utf-8")
+    resolved = resolve_settings(registered_workdirs=[wd], active_workdir=wd, env=_empty_user_env(tmp_path))
+    assert resolved.settings == {}  # 损坏文件回退空、不崩
+    assert any(e.field == "<file>" for e in resolved.errors)
+
+
+def test_errors_deduped_when_active_dir_read_twice(tmp_path: Path) -> None:
+    # active workdir 文件在能力层 + B 层各读一次；同一错误应去重。
+    wd = tmp_path / "wd"
+    _write_json(workdir_project_settings_path(wd), {"strictKnownMarketplaces": "bad"})
+    resolved = resolve_settings(registered_workdirs=[wd], active_workdir=wd, env=_empty_user_env(tmp_path))
+    scalar_errors = [e for e in resolved.errors if e.field == "strictKnownMarketplaces"]
+    assert len(scalar_errors) == 1
+
+
+def test_capability_cross_workdir_conflict_warns(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    # 两登记目录对同一 enabledPlugins["foo@mp"] 给不同 bool → 后者(wd2)覆盖 + WARN（§5.4）。
+    wd1 = tmp_path / "wd1"
+    wd2 = tmp_path / "wd2"
+    _write_json(workdir_project_settings_path(wd1), {"enabledPlugins": {"foo@mp": True}})
+    _write_json(workdir_project_settings_path(wd2), {"enabledPlugins": {"foo@mp": False}})
+
+    # 项目 logger 关闭 propagate，直接挂 caplog handler（同 test_registry.py 范式）。
+    scope_mod.logger.addHandler(caplog.handler)
+    caplog.set_level(logging.WARNING)
+    try:
+        resolved = resolve_settings(registered_workdirs=[wd1, wd2], active_workdir=None, env=_empty_user_env(tmp_path))
+    finally:
+        scope_mod.logger.removeHandler(caplog.handler)
+
+    assert resolved.settings["enabledPlugins"] == {"foo@mp": False}  # 后者胜出
+    assert any("Capability-layer conflict" in r.getMessage() for r in caplog.records)
+
+
+def test_flag_layer_overrides_user_and_project(tmp_path: Path) -> None:
+    # flag 层（--settings <file>）优先级高于 project，仅低于 policy。
+    wd = tmp_path / "wd"
+    _write_json(workdir_project_settings_path(wd), {"strictKnownMarketplaces": False, "trustedMarketplaces": ["proj"]})
+    flag_file = tmp_path / "flag-settings.json"
+    flag_file.write_text(json.dumps({"strictKnownMarketplaces": True, "trustedMarketplaces": ["flag"]}), encoding="utf-8")
+
+    resolved = resolve_settings(
+        registered_workdirs=[wd],
+        active_workdir=wd,
+        env=_empty_user_env(tmp_path),
+        flag_settings_path=flag_file,
+    )
+    assert resolved.settings["strictKnownMarketplaces"] is True  # flag 标量覆盖 project
+    # 数组拼接去重（低 project 在前 + 高 flag 在后）。
+    assert resolved.settings["trustedMarketplaces"] == ["proj", "flag"]

--- a/tests/unit_tests/utils/test_path.py
+++ b/tests/unit_tests/utils/test_path.py
@@ -10,13 +10,14 @@
 测试意图 / Test intentions:
 - is_within：相等 / 嵌套 / 兄弟 / 越界（parent 在 child 下）/ 相对路径（纯词法）
 - 纯词法语义：不解析符号链接、不规范化 ``..``（与 docstring 契约一致）
+- resolve_xdg_first：绝对 XDG 取 ``$VAR/<subpath>`` / 相对值按未设置回退 / 未设置回退 / ~ 展开
 """
 
 from pathlib import Path
 
 import pytest
 
-from a2c_smcp.utils import is_within
+from a2c_smcp.utils import is_within, resolve_xdg_first
 from a2c_smcp.utils.path import is_within as is_within_direct
 
 
@@ -45,3 +46,34 @@ def test_is_within(path: Path, parent: Path, expected: bool) -> None:
 def test_is_within_is_lexical_not_normalizing() -> None:
     """纯词法：不规范化 ``..``——``/a/b/../c`` 按字面段判定仍在 ``/a`` 下。"""
     assert is_within(Path("/a/b/../c"), Path("/a")) is True
+
+
+# ---------------------------------------------------------------------------
+# resolve_xdg_first（XDG-first 解析）/ XDG-first resolution
+# ---------------------------------------------------------------------------
+def test_xdg_absolute_used_with_subpath(tmp_path: Path) -> None:
+    xdg = tmp_path / "xdg"
+    assert resolve_xdg_first({"XDG_X": str(xdg)}, "XDG_X", "a2c", "skills", fallback=tmp_path / "fb") == (
+        xdg / "a2c" / "skills"
+    ).resolve()
+
+
+def test_xdg_relative_value_ignored_uses_fallback(tmp_path: Path) -> None:
+    # 相对值按 XDG 规范视为未设置 → 回退。
+    fb = tmp_path / "fb" / "a2c"
+    assert resolve_xdg_first({"XDG_X": "relative/path"}, "XDG_X", "a2c", fallback=fb) == fb.resolve()
+
+
+def test_xdg_unset_uses_fallback(tmp_path: Path) -> None:
+    fb = tmp_path / "fb"
+    assert resolve_xdg_first({}, "XDG_X", "a2c", fallback=fb) == fb.resolve()
+
+
+def test_xdg_blank_value_uses_fallback(tmp_path: Path) -> None:
+    fb = tmp_path / "fb"
+    assert resolve_xdg_first({"XDG_X": "   "}, "XDG_X", fallback=fb) == fb.resolve()
+
+
+def test_xdg_fallback_tilde_expanded(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    assert resolve_xdg_first({}, "XDG_X", fallback=Path("~/.config/a2c")) == (tmp_path / ".config" / "a2c").resolve()


### PR DESCRIPTION
## 概述

实现 #56（S4）：Computer 意图/治理层 `settings.json` 结构 + 五级 scope 合并 + policy 子源选取。**纯 Computer 本地层，不动 wire 协议**（`smcp.py` 不变，v0.2.1 已锁定）。

> base `develop-v0.2.1`（#42 集成分支策略）。**Part of #53 · #42**。

## 改动

**新增 `a2c_smcp/computer/settings/`**
- `schema.py` — settings.json TypedDict + 字段级容错校验：passthrough（未知键静默保留）/ 无 version / policy-only(`allowedMcpServers`·`deniedMcpServers`) 越权过滤 / 逐条过滤 map·array 非法项；`git url`·`<plugin>@<mp>` key 形态校验。
- `scope.py` — 五级 scope 路径解析；**读** customizer（对象深合并 / 数组 concat+dedup 低在前 / 标量高覆盖，照 CC `settingsMergeCustomizer`）；**写** customizer（数组整体替换 / `DELETE` 删 key）；**active-workdir 单根**(无 active 时 project/local 空) + **能力层全局并集**(`enabledPlugins`/`extraKnownMarketplaces` 跨全部登记目录)。
- `policy.py` — policy 四子源 **first-source-wins**（remote stub 不联网 / OS-MDM plist·registry / `managed-settings.json`+`.d` / HKCU）。

**DRY 重构**
- 抽 `utils/path.resolve_xdg_first`（XDG-first 解析）；`settings.scope` 与 `skills/home` 共用（消除重复，行为保持，`test_home` 零回归）。

**fix-review（discuss）落地**
- 删空壳 `ComputerSettingsModel`（无消费方、真正校验在 `validate_settings`）。
- 补 policy/scope 测试缺口：plist 四态、`_read_json_file` 降级、非 win32 早返回、`default_policy_sources` lambda 端到端、cross-workdir 冲突 WARN、flag 层覆盖。

## 验收（#56）

- [x] 读/写 merge 矩阵单测（含嵌套 `extraKnownMarketplaces[].source` 深合并不被整体替换）
- [x] active-workdir 解析：非 active 目录不贡献标量/敏感键；能力层全局并集；无 active 时 project/local 空
- [x] 未知字段 passthrough；policy-only 字段非 policy scope → 过滤 + 记 ValidationError
- [x] `uv run poe lint` 净（ruff + mypy 76 源文件）

## 验证

- lint/mypy 全绿；新增/扩充测试全过；全量 non-e2e 较基线 **+98 passed**，无新增失败。
- 覆盖率：`scope.py` 100% / `schema.py` 97% / `policy.py` 87%（余 `load_windows_registry` 的 win32-only 体在非 Windows 物理不可达）。

## 备注

- 发现并定位一处**预存** flaky CLI 测试（`test_cli_namespace_flag_propagates_to_client_handler_registration`，全量套件顺序下隔离泄漏）——已 stash 全部改动在 clean baseline 复现，与本 PR **无因果**，单独跟踪 #75。
- base 为 `develop-v0.2.1`（非默认分支），`Closes` 关键字不会自动触发，故 #56 手动关闭。