### PR TITLE
feat(computer): v0.2.1 物化文件 store（原子写 + 锁 + .bak 恢复）+ atomic_io 抽取 (#58)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# macOS
+.DS_Store
+**/.DS_Store
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[codz]

--- a/a2c_smcp/computer/blob/toolspool.py
+++ b/a2c_smcp/computer/blob/toolspool.py
@@ -23,13 +23,12 @@ from __future__ import annotations
 
 import hashlib
 import logging
-import os
-import uuid
 from collections.abc import Iterator
 from dataclasses import dataclass
 from pathlib import Path
 
 from a2c_smcp.computer.blob.handle import BlobHandleGoneError, BlobHandleInvalidError
+from a2c_smcp.utils.atomic_io import atomic_write_bytes, atomic_write_text
 from a2c_smcp.utils.path import is_within
 
 logger = logging.getLogger(__name__)
@@ -107,10 +106,10 @@ class ToolspoolBlobStore:
         if blob_path.exists():
             # 幂等：内容存在则直接复用 / Idempotent: reuse existing content
             # 仍刷新 mime 以兜底首次写盘失败的极端场景 / refresh mime to recover stale state
-            _atomic_write_text(mime_path, mime)
+            atomic_write_text(mime_path, mime)
             return cid
-        _atomic_write_bytes(blob_path, payload)
-        _atomic_write_text(mime_path, mime)
+        atomic_write_bytes(blob_path, payload)
+        atomic_write_text(mime_path, mime)
         return cid
 
     def get(self, cid: str) -> tuple[bytes, str]:
@@ -254,29 +253,3 @@ def _validate_cid(cid: str) -> None:
     """
     if not isinstance(cid, str) or len(cid) != _CID_LEN or not all(ch in _HEX_CHARS for ch in cid):
         raise BlobHandleInvalidError(f"invalid cid form (must be sha256 hex): {cid!r}")
-
-
-def _unique_tmp_path(path: Path) -> Path:
-    """生成进程/线程唯一的临时文件名（``<name>.<pid>.<uuid8>.tmp``）.
-    Build a process+thread-unique tmp filename to avoid cross-process collisions.
-
-    若多个 Computer 进程共享 ``cache_root`` 且并发写同一 cid（同字节内容），固定 ``<cid>.tmp``
-    会让两次写共用一个临时文件——第二次 ``os.replace`` 源已被前者 rename 走 → ``FileNotFoundError``。
-    Cross-process concurrent puts of the same cid (same bytes) would share a fixed ``<cid>.tmp``;
-    the second ``os.replace`` could find its source already renamed → ``FileNotFoundError``.
-    """
-    unique = f"{os.getpid()}.{uuid.uuid4().hex[:8]}"
-    return path.with_suffix(f"{path.suffix}.{unique}.tmp")
-
-
-def _atomic_write_bytes(path: Path, payload: bytes) -> None:
-    """原子写：先写**唯一**临时文件，再 rename 覆盖目标（POSIX 跨内核保证）/ Atomic write via unique tmp + rename."""
-    tmp = _unique_tmp_path(path)
-    tmp.write_bytes(payload)
-    os.replace(tmp, path)
-
-
-def _atomic_write_text(path: Path, text: str) -> None:
-    tmp = _unique_tmp_path(path)
-    tmp.write_text(text, encoding="utf-8")
-    os.replace(tmp, path)

--- a/a2c_smcp/computer/settings/__init__.py
+++ b/a2c_smcp/computer/settings/__init__.py
@@ -7,10 +7,10 @@
 """
 Computer 意图 / 治理层 settings 子系统 / Computer intent & governance settings subsystem（v0.2.1）
 
-承载 settings.json 的结构、五级 scope 合并与 policy 子源选取——CLI marketplace/plugin/skill 管理
-UX 的"意图层"。物化文件 store / reconciler / MCP 定义层为后续工单（#58 / #62 / #64）。
-The intent layer of the CLI marketplace/plugin/skill management UX. Materialized-file store /
-reconciler / MCP-definition layer land in follow-up tickets.
+承载 settings.json 的结构、五级 scope 合并、policy 子源选取与物化层文件 store——CLI
+marketplace/plugin/skill 管理 UX 的"意图层 + 物化层"。reconciler / MCP 定义层为后续工单（#62 / #64）。
+The intent + materialized layers of the CLI marketplace/plugin/skill management UX. Reconciler /
+MCP-definition layer land in follow-up tickets.
 
 已落地模块 / Landed modules：
 - :mod:`a2c_smcp.computer.settings.schema` —— settings.json TypedDict + 字段级容错校验
@@ -19,6 +19,8 @@ reconciler / MCP-definition layer land in follow-up tickets.
   active-workdir 单根 / 能力层全局并集解析（S4，#56）
 - :mod:`a2c_smcp.computer.settings.policy` —— policy 四子源 first-source-wins（remote stub + OS-MDM +
   managed-settings[+.d] + HKCU）（S4，#56）
+- :mod:`a2c_smcp.computer.settings.store`  —— 物化文件（known_marketplaces / installed_plugins）原子写 +
+  文件锁 + ``.corrupt-<ts>.bak`` 损坏恢复 + 写保护头（带 version）（S5，#58）
 
 SDK 设计 / Design: python-sdk docs/design-0.2.1-cli-marketplace-ux.md §5。
 """
@@ -61,6 +63,31 @@ from a2c_smcp.computer.settings.scope import (
     workdir_project_settings_path,
     workdir_settings_dir,
 )
+from a2c_smcp.computer.settings.store import (
+    INSTALLED_PLUGINS_FILENAME,
+    KNOWN_MARKETPLACES_FILENAME,
+    MATERIALIZED_VERSION,
+    WRITE_PROTECTION_HEADER,
+    InstalledPluginRecord,
+    InstalledPluginsFile,
+    KnownMarketplacesFile,
+    MarketplaceRecord,
+    SettingsLockError,
+    atomic_write_json,
+    atomic_write_text,
+    empty_installed_plugins,
+    empty_known_marketplaces,
+    file_lock,
+    installed_plugins_path,
+    known_marketplaces_path,
+    load_installed_plugins,
+    load_known_marketplaces,
+    read_jsonc_with_recovery,
+    save_installed_plugins,
+    save_known_marketplaces,
+    update_installed_plugins,
+    update_known_marketplaces,
+)
 
 __all__ = [
     # schema
@@ -96,4 +123,28 @@ __all__ = [
     "load_managed_settings",
     "load_windows_registry",
     "resolve_policy_settings",
+    # store
+    "INSTALLED_PLUGINS_FILENAME",
+    "KNOWN_MARKETPLACES_FILENAME",
+    "MATERIALIZED_VERSION",
+    "WRITE_PROTECTION_HEADER",
+    "InstalledPluginRecord",
+    "InstalledPluginsFile",
+    "KnownMarketplacesFile",
+    "MarketplaceRecord",
+    "SettingsLockError",
+    "atomic_write_json",
+    "atomic_write_text",
+    "empty_installed_plugins",
+    "empty_known_marketplaces",
+    "file_lock",
+    "installed_plugins_path",
+    "known_marketplaces_path",
+    "load_installed_plugins",
+    "load_known_marketplaces",
+    "read_jsonc_with_recovery",
+    "save_installed_plugins",
+    "save_known_marketplaces",
+    "update_installed_plugins",
+    "update_known_marketplaces",
 ]

--- a/a2c_smcp/computer/settings/store.py
+++ b/a2c_smcp/computer/settings/store.py
@@ -1,0 +1,494 @@
+# -*- coding: utf-8 -*-
+# filename: store.py
+# @Time    : 2026/05/25
+# @Author  : JQQ
+# @Email   : jqq1716@gmail.com
+# @Software: PyCharm
+"""
+物化层文件 store：原子写 + 文件锁 + 损坏恢复（v0.2.1）
+Materialized-file store: atomic write + file lock + corruption recovery (v0.2.1).
+
+SDK 设计 / Design: python-sdk docs/design-0.2.1-cli-marketplace-ux.md §6.1 / §6.2 / §6.3。
+
+本模块是物化层（CLI 自动维护、**不可手编**）的持久化 I/O 底座，供 reconciler（#62）/ plugin
+manager（#63）调用。承载两个文件：``known_marketplaces.json``（§6.1）与 ``installed_plugins.json``
+（§6.2）；二者**带 ``version`` 字段**（区别于 settings.json 意图层 —— 后者无 version，见
+:mod:`a2c_smcp.computer.settings.schema`）。
+The durable I/O backbone of the materialized layer (CLI-maintained, hand-edit-forbidden), consumed
+by the reconciler / plugin manager. Holds two files, both carrying a ``version`` field (unlike the
+human-edited settings.json intent layer).
+
+三条「优于 Claude Code 现状」的可靠性保证 / Three reliability guarantees (improving on CC):
+
+- **原子写**：唯一临时文件 + ``fsync`` + atomic ``os.replace``——进程中途死不留半截 JSON。CC 用
+  ``writeFileSync``（非原子、无锁，CC 开发者自评"反面教材"），A2C 不抄。/ Atomic write via unique
+  tmp + ``fsync`` + ``os.replace`` (CC uses non-atomic ``writeFileSync``).
+- **文件锁**：旁车 ``<path>.lock`` 排他锁（POSIX ``fcntl`` / win32 ``msvcrt``）防同用户多实例撕裂；
+  退避重试仍拿不到 → 抛 :class:`SettingsLockError`（fail-fast，**绝不无锁写**）。POSIX 路径有单测；
+  win32 ``msvcrt`` 路径为 best-effort、**未经 CI 验证**（无 Windows lane，对齐 policy.py win32 姿态）。
+  读-改-写须用 :func:`update_known_marketplaces` / :func:`update_installed_plugins`（单把锁内 RMW），
+  **不可**在持锁上下文内再调 ``save_*``。/ Sidecar exclusive lock; POSIX tested, win32 best-effort
+  (not CI-verified). Use the ``update_*`` helpers for read-modify-write; never call ``save_*`` while
+  holding the lock.
+- **损坏恢复**：load 失败先备份 ``.corrupt-<ts>.bak`` **再**降级空配置（CC 静默重置无备份，紧接 save
+  永久覆盖损坏数据）。/ On corruption, back up before degrading (CC silently resets without backup).
+
+写保护：物化文件顶端写一行 JSONC 注释 :data:`WRITE_PROTECTION_HEADER`；读时容错剥离前导 ``//`` 行
+再解析。发现手编痕迹（version 不符 / 未知顶层键）→ WARN + 用 in-memory 解析、下次 save 重写覆盖。
+Write protection: a leading JSONC ``//`` header is written and tolerantly stripped on read; hand-edit
+traces (version mismatch / unknown top-level keys) → WARN + in-memory parse + rewrite on next save.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from collections.abc import Callable, Iterator, Mapping
+from contextlib import contextmanager
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, NotRequired, TypedDict
+
+from a2c_smcp.computer.settings.schema import GitSource
+from a2c_smcp.computer.skills.home import resolve_skill_home
+from a2c_smcp.utils.atomic_io import atomic_write_text
+from a2c_smcp.utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+# ---------------------------------------------------------------------------
+# 常量 / Constants
+# ---------------------------------------------------------------------------
+# 物化文件顶端写保护注释（JSONC 单行；读时被 _strip_jsonc_header 剥离）/ Write-protection header line.
+WRITE_PROTECTION_HEADER = "// Maintained automatically by a2c-computer. DO NOT EDIT."
+
+# 物化文件 schema 版本（区别于无 version 的 settings.json 意图层）/ Materialized-file schema version.
+MATERIALIZED_VERSION = 1
+
+KNOWN_MARKETPLACES_FILENAME = "known_marketplaces.json"
+INSTALLED_PLUGINS_FILENAME = "installed_plugins.json"
+
+# 文件锁退避默认参数（指数退避，封顶）/ Default lock backoff knobs (exponential, capped).
+DEFAULT_LOCK_RETRIES = 10
+DEFAULT_LOCK_BACKOFF_BASE = 0.05  # 秒 / seconds
+DEFAULT_LOCK_BACKOFF_MAX = 1.0  # 秒 / seconds
+
+
+class SettingsLockError(RuntimeError):
+    """文件锁退避重试后仍无法获取 / The file lock could not be acquired after backoff retries (§6.3)."""
+
+
+# ---------------------------------------------------------------------------
+# 物化文件结构（IDE / 文档用；运行时容错见 load_* 的 _coerce_*）/ Materialized-file shapes
+# ---------------------------------------------------------------------------
+class MarketplaceRecord(TypedDict):
+    """``known_marketplaces.json`` 单条 marketplace 物化记录（§6.1）/ a materialized marketplace record。"""
+
+    source: GitSource
+    installLocation: str  # 绝对路径 / absolute path
+    lastUpdated: NotRequired[str]  # ISO-8601 UTC
+    commitSha: NotRequired[str]
+    autoUpdate: NotRequired[bool]
+
+
+class KnownMarketplacesFile(TypedDict):
+    """``known_marketplaces.json`` 整文件结构（§6.1）/ the full known_marketplaces.json shape。"""
+
+    version: int
+    marketplaces: dict[str, MarketplaceRecord]
+
+
+class InstalledPluginRecord(TypedDict):
+    """
+    ``installed_plugins.json`` 单条安装记录（§6.2，对齐 CC V2 schema）/ a single plugin install record。
+
+    数组化按 scope 维度（``scope`` + ``projectPath`` 精确匹配），为「user + workspace 同时装、不同版本」
+    预留；``bundledMcpServers`` 为 A2C 扩展字段（CC 无），供 uninstall 级联精准清理 bundled MCP server。
+    """
+
+    scope: str  # managed | user | project | local
+    installPath: str
+    projectPath: NotRequired[str]  # project / local scope 必填 / required for project/local
+    version: NotRequired[str]
+    commitSha: NotRequired[str]
+    installedAt: NotRequired[str]
+    lastUpdated: NotRequired[str]
+    bundledMcpServers: NotRequired[list[str]]  # A2C 扩展 / A2C extension
+
+
+class InstalledPluginsFile(TypedDict):
+    """``installed_plugins.json`` 整文件结构（§6.2）/ the full installed_plugins.json shape。"""
+
+    version: int
+    plugins: dict[str, list[InstalledPluginRecord]]
+
+
+# ---------------------------------------------------------------------------
+# 原子写 JSON / Atomic JSON write
+# ---------------------------------------------------------------------------
+# 原子写文本原语（唯一临时文件 + fsync + rename + 失败清理）抽到 a2c_smcp.utils.atomic_io，
+# 与 blob/toolspool 共用（见 fix-review #58 §6）；此处仅做 JSON + JSONC 写保护头的封装。
+# The atomic text-write primitive lives in a2c_smcp.utils.atomic_io (shared with blob/toolspool);
+# here we only wrap JSON serialization + the JSONC write-protection header.
+def atomic_write_json(path: Path, obj: Mapping[str, Any], *, header: str | None = None) -> None:
+    """
+    原子写 JSON（可选 JSONC 顶部写保护注释）/ Atomic JSON write with an optional JSONC header line。
+
+    ``indent=2`` + ``ensure_ascii=False``（可读、保留非 ASCII）；末尾补换行。``header`` 写在首行
+    （形如 ``// ...``），与 :func:`read_jsonc_with_recovery` 的前导 ``//`` 剥离对称。落盘经
+    :func:`a2c_smcp.utils.atomic_io.atomic_write_text`（唯一临时文件 + ``fsync`` + ``os.replace``）。
+    """
+    body = json.dumps(obj, ensure_ascii=False, indent=2)
+    text = f"{header}\n{body}\n" if header else f"{body}\n"
+    atomic_write_text(path, text)
+
+
+# ---------------------------------------------------------------------------
+# 文件锁（旁车 .lock，跨平台）/ File lock (sidecar .lock, cross-platform)
+# ---------------------------------------------------------------------------
+def _lock_fd(fd: int) -> None:
+    """
+    对 fd 加排他非阻塞锁（POSIX ``fcntl.flock`` / win32 ``msvcrt.locking``）；被占抛 OSError。
+
+    .. note::
+       win32 分支为 best-effort、**未经 CI 验证**（无 Windows lane），与 policy.py 的 win32 注册表
+       读取同姿态；POSIX ``fcntl`` 分支有单测覆盖。``msvcrt.locking`` 锁的是「当前位置起 N 字节」，
+       对 0 字节锁文件在 offset 0 加锁偏脆弱——故先占位 1 字节再 ``seek(0)`` 规避。
+    """
+    if sys.platform == "win32":
+        # 非 win32 上 mypy 据 sys.platform 收窄为不可达，故 msvcrt import 不被检查（无需 type:ignore）。
+        import msvcrt
+
+        # 确保锁文件 ≥1 字节并把位置归零，再锁 [0,1)；规避 0 字节文件 offset 0 加锁的脆弱惯用法。
+        os.lseek(fd, 0, os.SEEK_SET)
+        os.write(fd, b"\0")
+        os.lseek(fd, 0, os.SEEK_SET)
+        msvcrt.locking(fd, msvcrt.LK_NBLCK, 1)
+        return
+    import fcntl
+
+    fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+
+
+def _unlock_fd(fd: int) -> None:
+    """释放 fd 上的锁（best-effort，释放失败仅记 debug）/ Release the lock (best-effort)."""
+    try:
+        if sys.platform == "win32":
+            import msvcrt
+
+            msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
+            return
+        import fcntl
+
+        fcntl.flock(fd, fcntl.LOCK_UN)
+    except OSError as exc:  # pragma: no cover - 释放失败极罕见，关闭 fd 时内核仍会释放
+        logger.debug("Lock release on fd %d failed (ignored): %s", fd, exc)
+
+
+@contextmanager
+def file_lock(
+    path: Path,
+    *,
+    retries: int = DEFAULT_LOCK_RETRIES,
+    backoff_base: float = DEFAULT_LOCK_BACKOFF_BASE,
+    backoff_max: float = DEFAULT_LOCK_BACKOFF_MAX,
+) -> Iterator[None]:
+    """
+    获取 ``<path>.lock`` 旁车排他文件锁（§6.3）/ Acquire an exclusive lock on the sidecar ``<path>.lock``。
+
+    锁加在**旁车** ``.lock`` 文件而非数据文件本身——数据文件每次写都被 ``os.replace`` 换掉，持有其
+    inode 上的锁会随 rename 失效。被占时按**指数退避**重试 ``retries`` 次（每次 WARN，延迟封顶
+    ``backoff_max``）；仍拿不到 → 抛 :class:`SettingsLockError`（fail-fast，绝不无锁写）。
+    Locks a sidecar ``.lock`` (the data file is swapped by ``os.replace`` each write, so an inode
+    lock on it would be lost). On contention, exponential backoff for ``retries`` attempts, then
+    raises :class:`SettingsLockError`.
+
+    :raises SettingsLockError: 退避重试后仍无法获取锁 / lock still unavailable after retries.
+    """
+    p = Path(path)
+    lock_path = p.with_name(f"{p.name}.lock")
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    fd = os.open(str(lock_path), os.O_RDWR | os.O_CREAT, 0o600)
+    try:
+        delay = backoff_base
+        last_exc: OSError | None = None
+        for attempt in range(retries + 1):
+            try:
+                _lock_fd(fd)
+                break
+            except OSError as exc:  # 锁被其他进程占用 / held by another process
+                last_exc = exc
+                if attempt >= retries:
+                    raise SettingsLockError(
+                        f"could not acquire lock {lock_path} after {retries} retries",
+                    ) from last_exc
+                logger.warning(
+                    "Lock %s busy (attempt %d/%d), backing off %.0fms",
+                    lock_path,
+                    attempt + 1,
+                    retries,
+                    delay * 1000,
+                )
+                time.sleep(delay)
+                delay = min(delay * 2, backoff_max)
+        try:
+            yield
+        finally:
+            _unlock_fd(fd)
+    finally:
+        os.close(fd)
+
+
+# ---------------------------------------------------------------------------
+# JSONC 读取 + 损坏恢复 / JSONC read + corruption recovery
+# ---------------------------------------------------------------------------
+def _strip_jsonc_header(text: str) -> str:
+    """
+    剥离**前导**整行 ``//`` 注释（写保护头）与前导空行 / Strip the leading ``//`` header + blank lines。
+
+    仅处理文件顶部连续的整行注释 / 空行，遇首个内容行即停——不是通用 JSONC（不处理行尾 ``//``、块
+    注释、字符串内 ``//``），够用且对数据零误伤。Only the file-top run of whole-line comments / blanks.
+    """
+    lines = text.splitlines()
+    idx = 0
+    for line in lines:
+        stripped = line.lstrip()
+        if stripped == "" or stripped.startswith("//"):
+            idx += 1
+            continue
+        break
+    return "\n".join(lines[idx:])
+
+
+def _backup_corrupt(path: Path) -> Path | None:
+    """
+    把损坏文件**移走**为 ``<name>.corrupt-<ts>.bak``（§6.3）/ Move a corrupt file aside to a ``.bak``。
+
+    用 ``os.replace`` 整体移动（保留损坏内容到 .bak），原路径腾空——下次 save 重建全新文件，损坏数据
+    不被静默永久覆盖。备份本身失败仅记 ERROR、返回 ``None``（不阻断降级）。
+    """
+    ts = datetime.now(UTC).strftime("%Y%m%dT%H%M%S%fZ")
+    backup = path.with_name(f"{path.name}.corrupt-{ts}.bak")
+    try:
+        os.replace(path, backup)
+    except OSError as exc:
+        logger.error("Failed to back up corrupt file %s → %s: %s", path, backup, exc)
+        return None
+    logger.warning("Corrupt materialized file %s backed up to %s, degrading to empty config", path, backup)
+    return backup
+
+
+def read_jsonc_with_recovery(path: Path) -> dict[str, Any] | None:
+    """
+    读取 JSONC 物化文件（容错前导 ``//`` 头）+ 损坏恢复 / Read a JSONC materialized file with recovery。
+
+    - 文件缺失 → ``None``（调用方按空配置处理）/ missing → ``None``.
+    - IO 读取错误 → ``None``、**不**备份（文件可能仍完好、只是暂时不可读）/ IO error → ``None`` (no backup).
+    - JSON 解析失败 / 根非对象（损坏）→ 备份 ``.corrupt-<ts>.bak`` **再**返回 ``None``（§6.3）/ corrupt →
+      back up then ``None``.
+    - 成功 → 原始 dict（version / shape 校验交给上层 ``load_*``）/ ok → the raw dict.
+    """
+    p = Path(path)
+    if not p.exists():
+        return None
+    try:
+        raw = p.read_text(encoding="utf-8")
+    except OSError as exc:
+        logger.warning("Materialized file %s unreadable (kept on disk): %s", p, exc)
+        return None
+    try:
+        data = json.loads(_strip_jsonc_header(raw))
+    except json.JSONDecodeError as exc:
+        logger.warning("Materialized file %s corrupt (%s), backing up before degrade", p, exc)
+        _backup_corrupt(p)
+        return None
+    if not isinstance(data, dict):
+        logger.warning("Materialized file %s root is not an object, backing up before degrade", p)
+        _backup_corrupt(p)
+        return None
+    return data
+
+
+# ---------------------------------------------------------------------------
+# 路径解析 / Path resolution（基于 $A2C_SKILL_HOME）
+# ---------------------------------------------------------------------------
+def known_marketplaces_path(home: Path | None = None, env: Mapping[str, str] | None = None) -> Path:
+    """``$A2C_SKILL_HOME/known_marketplaces.json`` 路径 / Path to known_marketplaces.json。"""
+    return (home or resolve_skill_home(env)) / KNOWN_MARKETPLACES_FILENAME
+
+
+def installed_plugins_path(home: Path | None = None, env: Mapping[str, str] | None = None) -> Path:
+    """``$A2C_SKILL_HOME/installed_plugins.json`` 路径 / Path to installed_plugins.json。"""
+    return (home or resolve_skill_home(env)) / INSTALLED_PLUGINS_FILENAME
+
+
+# ---------------------------------------------------------------------------
+# 手编痕迹容错 / Hand-edit tolerance（§6.3：WARN + in-memory + 下次 save 重写）
+# ---------------------------------------------------------------------------
+def _warn_hand_edit(path: Path, version: Any, known_keys: set[str], data: Mapping[str, Any]) -> None:
+    """检测手编痕迹（version 不符 / 未知顶层键）并 WARN（不阻断、不丢已知字段）/ Warn on hand-edit traces。"""
+    if version != MATERIALIZED_VERSION:
+        logger.warning(
+            "Materialized file %s has unexpected version %r (expected %d); using in-memory, will rewrite on next save",
+            path,
+            version,
+            MATERIALIZED_VERSION,
+        )
+    unknown = set(data) - known_keys
+    if unknown:
+        logger.warning(
+            "Materialized file %s has unexpected top-level keys %s (hand-edited?); ignoring them",
+            path,
+            sorted(unknown),
+        )
+
+
+def _coerce_known_marketplaces(data: Mapping[str, Any], path: Path) -> KnownMarketplacesFile:
+    """把读到的 dict 规整为 :class:`KnownMarketplacesFile`（容错 + 手编 WARN）/ Coerce to the typed shape。"""
+    _warn_hand_edit(path, data.get("version"), {"version", "marketplaces"}, data)
+    marketplaces = data.get("marketplaces")
+    if not isinstance(marketplaces, dict):
+        if marketplaces is not None:
+            logger.warning("Materialized file %s field 'marketplaces' is not an object; treating as empty", path)
+        marketplaces = {}
+    return {"version": MATERIALIZED_VERSION, "marketplaces": marketplaces}
+
+
+def _coerce_installed_plugins(data: Mapping[str, Any], path: Path) -> InstalledPluginsFile:
+    """把读到的 dict 规整为 :class:`InstalledPluginsFile`（容错 + 手编 WARN）/ Coerce to the typed shape。"""
+    _warn_hand_edit(path, data.get("version"), {"version", "plugins"}, data)
+    plugins = data.get("plugins")
+    if not isinstance(plugins, dict):
+        if plugins is not None:
+            logger.warning("Materialized file %s field 'plugins' is not an object; treating as empty", path)
+        plugins = {}
+    return {"version": MATERIALIZED_VERSION, "plugins": plugins}
+
+
+# ---------------------------------------------------------------------------
+# 高层读写 / High-level load & save
+# ---------------------------------------------------------------------------
+def empty_known_marketplaces() -> KnownMarketplacesFile:
+    """空的 known_marketplaces 物化结构 / An empty known_marketplaces file。"""
+    return {"version": MATERIALIZED_VERSION, "marketplaces": {}}
+
+
+def empty_installed_plugins() -> InstalledPluginsFile:
+    """空的 installed_plugins 物化结构 / An empty installed_plugins file。"""
+    return {"version": MATERIALIZED_VERSION, "plugins": {}}
+
+
+def load_known_marketplaces(home: Path | None = None, env: Mapping[str, str] | None = None) -> KnownMarketplacesFile:
+    """
+    加载 ``known_marketplaces.json``（缺失 / 损坏 → 空配置）/ Load known_marketplaces.json (missing/corrupt → empty)。
+
+    损坏文件先备份 ``.corrupt-<ts>.bak`` 再降级（见 :func:`read_jsonc_with_recovery`）。
+    """
+    path = known_marketplaces_path(home, env)
+    data = read_jsonc_with_recovery(path)
+    if data is None:
+        return empty_known_marketplaces()
+    return _coerce_known_marketplaces(data, path)
+
+
+def load_installed_plugins(home: Path | None = None, env: Mapping[str, str] | None = None) -> InstalledPluginsFile:
+    """加载 ``installed_plugins.json``（缺失 / 损坏 → 空配置）/ Load installed_plugins.json (missing/corrupt → empty)。"""
+    path = installed_plugins_path(home, env)
+    data = read_jsonc_with_recovery(path)
+    if data is None:
+        return empty_installed_plugins()
+    return _coerce_installed_plugins(data, path)
+
+
+def save_known_marketplaces(
+    data: Mapping[str, Any],
+    home: Path | None = None,
+    env: Mapping[str, str] | None = None,
+) -> Path:
+    """
+    加锁 + 原子写 ``known_marketplaces.json``（带写保护头 + ``version``）/ Locked atomic write。
+
+    缺省补齐 ``version`` 字段（物化文件强制带 version，§6）；返回写入路径。锁不可得 → 抛
+    :class:`SettingsLockError`（不无锁写）。
+
+    ⚠️ **不可**在已持有 :func:`file_lock` 的上下文内调用（同进程新 fd 的 flock 互斥 →
+    :class:`SettingsLockError`）；读-改-写请改用 :func:`update_known_marketplaces`。
+    ⚠️ Do not call inside a held :func:`file_lock` (same-process flock is mutually exclusive); use
+    :func:`update_known_marketplaces` for read-modify-write.
+    """
+    path = known_marketplaces_path(home, env)
+    payload: dict[str, Any] = dict(data)
+    payload.setdefault("version", MATERIALIZED_VERSION)
+    with file_lock(path):
+        atomic_write_json(path, payload, header=WRITE_PROTECTION_HEADER)
+    return path
+
+
+def save_installed_plugins(
+    data: Mapping[str, Any],
+    home: Path | None = None,
+    env: Mapping[str, str] | None = None,
+) -> Path:
+    """
+    加锁 + 原子写 ``installed_plugins.json``（带写保护头 + ``version``）/ Locked atomic write。
+
+    ⚠️ **不可**在已持有 :func:`file_lock` 的上下文内调用（同 :func:`save_known_marketplaces`）；
+    读-改-写请改用 :func:`update_installed_plugins`。
+    """
+    path = installed_plugins_path(home, env)
+    payload: dict[str, Any] = dict(data)
+    payload.setdefault("version", MATERIALIZED_VERSION)
+    with file_lock(path):
+        atomic_write_json(path, payload, header=WRITE_PROTECTION_HEADER)
+    return path
+
+
+# ---------------------------------------------------------------------------
+# 持锁原子读-改-写 / Locked atomic read-modify-write（供 reconciler #62 等）
+# ---------------------------------------------------------------------------
+def update_known_marketplaces(
+    mutator: Callable[[KnownMarketplacesFile], KnownMarketplacesFile | None],
+    home: Path | None = None,
+    env: Mapping[str, str] | None = None,
+) -> KnownMarketplacesFile:
+    """
+    持锁原子读-改-写 ``known_marketplaces.json``（§6.3）/ Locked atomic read-modify-write。
+
+    **单把锁**覆盖 load→mutate→save，杜绝并发进程间的丢更新窗口——供 reconciler（#62）等 RMW 场景。
+    ``mutator`` 收到当前（已规整；缺失 / 损坏则为空）结构，可**就地改并返回 ``None``**，或返回新结构；
+    二者皆补齐 ``version`` 后原子落盘。返回最终写入的结构。
+    A single lock spans load→mutate→save (no lost-update window) — for the reconciler etc. The
+    mutator may mutate in place and return ``None``, or return a new structure; either way
+    ``version`` is backfilled and atomically written. Returns the final written structure.
+
+    这是「持锁 RMW」的推荐入口；**不要**自行 ``with file_lock(p): ...; save_*(...)``（save_* 会再次
+    加锁 → :class:`SettingsLockError`，见 :func:`save_known_marketplaces`）。
+    """
+    path = known_marketplaces_path(home, env)
+    with file_lock(path):
+        raw = read_jsonc_with_recovery(path)
+        current = empty_known_marketplaces() if raw is None else _coerce_known_marketplaces(raw, path)
+        result = mutator(current)
+        to_save: dict[str, Any] = dict(result if result is not None else current)
+        to_save.setdefault("version", MATERIALIZED_VERSION)
+        atomic_write_json(path, to_save, header=WRITE_PROTECTION_HEADER)
+    return _coerce_known_marketplaces(to_save, path)
+
+
+def update_installed_plugins(
+    mutator: Callable[[InstalledPluginsFile], InstalledPluginsFile | None],
+    home: Path | None = None,
+    env: Mapping[str, str] | None = None,
+) -> InstalledPluginsFile:
+    """持锁原子读-改-写 ``installed_plugins.json``（语义同 :func:`update_known_marketplaces`）/ Locked atomic RMW。"""
+    path = installed_plugins_path(home, env)
+    with file_lock(path):
+        raw = read_jsonc_with_recovery(path)
+        current = empty_installed_plugins() if raw is None else _coerce_installed_plugins(raw, path)
+        result = mutator(current)
+        to_save: dict[str, Any] = dict(result if result is not None else current)
+        to_save.setdefault("version", MATERIALIZED_VERSION)
+        atomic_write_json(path, to_save, header=WRITE_PROTECTION_HEADER)
+    return _coerce_installed_plugins(to_save, path)

--- a/a2c_smcp/utils/__init__.py
+++ b/a2c_smcp/utils/__init__.py
@@ -10,12 +10,16 @@
 Export utilities
 """
 
+from .atomic_io import atomic_write_bytes, atomic_write_text, unique_tmp_path
 from .path import is_within, resolve_xdg_first
 from .window_uri import WindowURI, is_window_uri
 
 __all__ = [
     "WindowURI",
+    "atomic_write_bytes",
+    "atomic_write_text",
     "is_within",
     "is_window_uri",
     "resolve_xdg_first",
+    "unique_tmp_path",
 ]

--- a/a2c_smcp/utils/atomic_io.py
+++ b/a2c_smcp/utils/atomic_io.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+# filename: atomic_io.py
+# @Time    : 2026/05/25
+# @Author  : JQQ
+# @Email   : jqq1716@gmail.com
+# @Software: PyCharm
+"""
+原子文件写入工具：唯一临时文件 + ``fsync`` + 原子 ``rename``。
+Atomic file-write helpers: unique tmp + ``fsync`` + atomic ``rename``.
+
+抽取自 ``blob/toolspool`` 与 ``settings/store`` 的共用原语（S5 fix-review #58），消除两份漂移的原子写
+实现。本实现带三重硬化（落盘保证 + 失败清理 + 父目录创建），迁移后 ``toolspool`` 一并获得（其原实现
+无 ``fsync``、失败留垃圾）。
+Extracted from the duplicated primitives in ``blob/toolspool`` and ``settings/store``. This hardened
+version (fsync + on-failure cleanup + parent mkdir) is now shared, upgrading ``toolspool`` (whose old
+impl had no fsync and left tmp garbage on failure).
+
+纯 stdlib、无 a2c 内部依赖，故落在 :mod:`a2c_smcp.utils` / Pure stdlib, no a2c deps.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from pathlib import Path
+
+
+def unique_tmp_path(path: Path) -> Path:
+    """
+    生成进程唯一的临时文件名 ``<name>.<pid>.<uuid8>.tmp`` / Build a process-unique tmp filename。
+
+    若多个进程共享目录且并发写同一目标，固定 ``<name>.tmp`` 会让两次写共用一个临时文件——第二次
+    ``os.replace`` 源已被前者 rename 走 → ``FileNotFoundError``。进程 + 随机后缀彻底规避撞名。
+    A fixed ``<name>.tmp`` would collide under concurrent writers (the 2nd ``os.replace`` finds its
+    source already renamed → ``FileNotFoundError``); the pid + random suffix avoids this.
+    """
+    unique = f"{os.getpid()}.{uuid.uuid4().hex[:8]}"
+    return path.with_suffix(f"{path.suffix}.{unique}.tmp")
+
+
+def atomic_write_bytes(path: Path, payload: bytes) -> None:
+    """
+    原子写字节：父目录 ``mkdir`` + 唯一临时文件 + ``flush`` + ``fsync`` + ``os.replace``。
+    Atomic bytes write (POSIX cross-kernel guarantee via unique tmp + ``fsync`` + ``os.replace``).
+
+    rename 前 ``fsync`` 保证数据已落盘；任意失败（含 ``KeyboardInterrupt``）清理半截临时文件，目标
+    文件保持原子完好（要么旧内容、要么新内容，绝无半截）。
+    """
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    tmp = unique_tmp_path(p)
+    try:
+        with open(tmp, "wb") as fh:
+            fh.write(payload)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(tmp, p)
+    except BaseException:
+        tmp.unlink(missing_ok=True)
+        raise
+
+
+def atomic_write_text(path: Path, text: str, *, encoding: str = "utf-8") -> None:
+    """
+    原子写文本：按 ``encoding`` 编码后走 :func:`atomic_write_bytes`（二进制写，不做平台换行翻译）。
+    Atomic text write: encode then delegate to :func:`atomic_write_bytes` (binary, no newline xlate).
+    """
+    atomic_write_bytes(path, text.encode(encoding))

--- a/tests/unit_tests/computer/settings/test_store.py
+++ b/tests/unit_tests/computer/settings/test_store.py
@@ -1,0 +1,357 @@
+# -*- coding: utf-8 -*-
+# filename: test_store.py
+# @Time    : 2026/05/25
+# @Author  : JQQ
+# @Email   : jqq1716@gmail.com
+# @Software: PyCharm
+"""
+物化层 store 单元测试（v0.2.1）
+Unit tests for the materialized-file store (v0.2.1).
+
+SDK 设计 / Design: python-sdk docs/design-0.2.1-cli-marketplace-ux.md §6.1 / §6.2 / §6.3。
+
+测试意图 / Test intentions:
+- 原子写：中途失败（os.replace 抛错）不留半截 JSON、目标文件保持原值、临时文件被清理
+- 写保护头：保存文件首行为 JSONC ``// Maintained...``；读时容错剥离前导 ``//`` 再解析
+- 文件锁：拿不到锁退避重试后抛 SettingsLockError（fail-fast，不无锁写）
+- 损坏恢复：corrupt / 非对象根 → 先备份 ``.corrupt-<ts>.bak`` 再降级空配置；IO 错误不备份
+- 手编痕迹：version 不符 / 未知顶层键 → WARN + in-memory（丢未知键、不阻断）
+- 物化文件强制带 version；缺失文件 → 空配置带 version
+- 路径解析：home 显式注入 / ``A2C_SKILL_HOME`` env 覆盖
+- round-trip：save → load 内容一致（含 installed_plugins 多字段记录）
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+from pathlib import Path
+
+import pytest
+
+import a2c_smcp.computer.settings.store as store_mod
+from a2c_smcp.computer.settings.store import (
+    INSTALLED_PLUGINS_FILENAME,
+    KNOWN_MARKETPLACES_FILENAME,
+    MATERIALIZED_VERSION,
+    WRITE_PROTECTION_HEADER,
+    SettingsLockError,
+    atomic_write_json,
+    atomic_write_text,
+    empty_installed_plugins,
+    empty_known_marketplaces,
+    file_lock,
+    installed_plugins_path,
+    known_marketplaces_path,
+    load_installed_plugins,
+    load_known_marketplaces,
+    read_jsonc_with_recovery,
+    save_installed_plugins,
+    save_known_marketplaces,
+    update_installed_plugins,
+    update_known_marketplaces,
+)
+
+
+# ---------------------------------------------------------------------------
+# 原子写 / atomic write
+# ---------------------------------------------------------------------------
+def test_atomic_write_text_creates_parent_and_writes(tmp_path: Path) -> None:
+    target = tmp_path / "nested" / "deep" / "f.txt"
+    atomic_write_text(target, "hello")
+    assert target.read_text(encoding="utf-8") == "hello"
+
+
+def test_atomic_write_json_header_and_body(tmp_path: Path) -> None:
+    target = tmp_path / "f.json"
+    atomic_write_json(target, {"a": 1, "中文": "值"}, header=WRITE_PROTECTION_HEADER)
+    text = target.read_text(encoding="utf-8")
+    assert text.splitlines()[0] == WRITE_PROTECTION_HEADER
+    # ensure_ascii=False 保留非 ASCII。
+    assert "中文" in text
+    # 去掉首行注释后是合法 JSON。
+    body = "\n".join(text.splitlines()[1:])
+    assert json.loads(body) == {"a": 1, "中文": "值"}
+
+
+def test_atomic_write_json_without_header(tmp_path: Path) -> None:
+    # header=None 分支：纯 JSON、无前导注释行。
+    target = tmp_path / "f.json"
+    atomic_write_json(target, {"a": 1})
+    text = target.read_text(encoding="utf-8")
+    assert not text.lstrip().startswith("//")
+    assert json.loads(text) == {"a": 1}
+
+
+# ---------------------------------------------------------------------------
+# 文件锁 / file lock
+# ---------------------------------------------------------------------------
+def test_file_lock_acquire_release_roundtrip(tmp_path: Path) -> None:
+    target = tmp_path / "f.json"
+    with file_lock(target):
+        atomic_write_text(target, "{}")
+    # 释放后可再次获取。
+    with file_lock(target):
+        pass
+    assert target.read_text(encoding="utf-8") == "{}"
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="msvcrt lock semantics differ; POSIX flock 在此验证")
+def test_file_lock_contention_raises(tmp_path: Path) -> None:
+    target = tmp_path / "f.json"
+    # 同进程不同 fd 的 flock 互相独立——外层持锁时内层（新 fd）拿不到 → 退避后抛 SettingsLockError。
+    with file_lock(target):
+        with pytest.raises(SettingsLockError, match="could not acquire lock"):
+            with file_lock(target, retries=1, backoff_base=0.001, backoff_max=0.001):
+                pass
+
+
+# ---------------------------------------------------------------------------
+# JSONC 读取 + 损坏恢复 / JSONC read + corruption recovery
+# ---------------------------------------------------------------------------
+def test_read_missing_returns_none(tmp_path: Path) -> None:
+    assert read_jsonc_with_recovery(tmp_path / "nope.json") is None
+
+
+def test_read_strips_leading_jsonc_header(tmp_path: Path) -> None:
+    p = tmp_path / "f.json"
+    p.write_text(f"{WRITE_PROTECTION_HEADER}\n\n{{\"version\": 1}}\n", encoding="utf-8")
+    assert read_jsonc_with_recovery(p) == {"version": 1}
+
+
+def test_read_corrupt_backs_up_then_degrades(tmp_path: Path) -> None:
+    p = tmp_path / KNOWN_MARKETPLACES_FILENAME
+    p.write_text("{not valid json", encoding="utf-8")
+    assert read_jsonc_with_recovery(p) is None
+    # 原文件被移走，备份 .corrupt-<ts>.bak 留存（不静默永久丢数据）。
+    assert not p.exists()
+    backups = list(tmp_path.glob(f"{KNOWN_MARKETPLACES_FILENAME}.corrupt-*.bak"))
+    assert len(backups) == 1
+    assert backups[0].read_text(encoding="utf-8") == "{not valid json"
+
+
+def test_read_non_object_root_backs_up(tmp_path: Path) -> None:
+    p = tmp_path / "f.json"
+    p.write_text("[1, 2, 3]", encoding="utf-8")
+    assert read_jsonc_with_recovery(p) is None
+    assert len(list(tmp_path.glob("f.json.corrupt-*.bak"))) == 1
+
+
+def test_read_io_error_no_backup(tmp_path: Path) -> None:
+    # 路径是目录 → exists() 真但 read_text 抛 OSError（IsADirectoryError）→ 返回 None、不备份。
+    p = tmp_path / "adir.json"
+    p.mkdir()
+    assert read_jsonc_with_recovery(p) is None
+    assert list(tmp_path.glob("*.corrupt-*.bak")) == []
+    assert p.is_dir()  # 未被动
+
+
+def test_backup_corrupt_replace_failure_returns_none(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    # _backup_corrupt 的 os.replace 失败分支：备份失败仍返回 None（不阻断降级），无 .bak、损坏文件原地保留。
+    p = tmp_path / KNOWN_MARKETPLACES_FILENAME
+    p.write_text("{broken", encoding="utf-8")
+
+    def boom(*_a: object, **_k: object) -> None:
+        raise OSError("cannot rename to backup")
+
+    monkeypatch.setattr(store_mod.os, "replace", boom)
+    store_mod.logger.addHandler(caplog.handler)
+    caplog.set_level(logging.ERROR)
+    try:
+        assert read_jsonc_with_recovery(p) is None
+    finally:
+        store_mod.logger.removeHandler(caplog.handler)
+    assert list(tmp_path.glob("*.corrupt-*.bak")) == []  # 备份失败、无 .bak
+    assert p.read_text(encoding="utf-8") == "{broken"  # 损坏文件原地保留（未被移走）
+    assert any("Failed to back up corrupt file" in r.getMessage() for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# 手编痕迹 WARN / hand-edit warnings
+# ---------------------------------------------------------------------------
+def _attach_caplog(caplog: pytest.LogCaptureFixture) -> None:
+    # 项目 logger 关闭 propagate，直接挂 caplog handler（同 test_scope.py / test_registry.py 范式）。
+    store_mod.logger.addHandler(caplog.handler)
+    caplog.set_level(logging.WARNING)
+
+
+def test_version_mismatch_warns_and_keeps_inmemory(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    p = known_marketplaces_path(home=tmp_path)
+    p.write_text(json.dumps({"version": 99, "marketplaces": {"mp": {}}}), encoding="utf-8")
+    _attach_caplog(caplog)
+    try:
+        loaded = load_known_marketplaces(home=tmp_path)
+    finally:
+        store_mod.logger.removeHandler(caplog.handler)
+    assert loaded["version"] == MATERIALIZED_VERSION  # 规整回当前版本
+    assert loaded["marketplaces"] == {"mp": {}}  # 已知字段保留
+    assert any("unexpected version" in r.getMessage() for r in caplog.records)
+
+
+def test_unknown_top_level_key_warns_and_dropped(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    p = known_marketplaces_path(home=tmp_path)
+    p.write_text(json.dumps({"version": 1, "marketplaces": {}, "handEditedJunk": 1}), encoding="utf-8")
+    _attach_caplog(caplog)
+    try:
+        loaded = load_known_marketplaces(home=tmp_path)
+    finally:
+        store_mod.logger.removeHandler(caplog.handler)
+    assert "handEditedJunk" not in loaded  # 未知顶层键被丢
+    assert any("unexpected top-level keys" in r.getMessage() for r in caplog.records)
+
+
+def test_container_not_object_treated_empty(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    p = installed_plugins_path(home=tmp_path)
+    p.write_text(json.dumps({"version": 1, "plugins": ["not", "a", "dict"]}), encoding="utf-8")
+    _attach_caplog(caplog)
+    try:
+        loaded = load_installed_plugins(home=tmp_path)
+    finally:
+        store_mod.logger.removeHandler(caplog.handler)
+    assert loaded["plugins"] == {}
+    assert any("not an object" in r.getMessage() for r in caplog.records)
+
+
+def test_coerce_known_marketplaces_non_dict(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    # marketplaces 非 dict（与 plugins 侧对称）→ 视作空 + WARN。
+    p = known_marketplaces_path(home=tmp_path)
+    p.write_text(json.dumps({"version": 1, "marketplaces": ["not", "a", "dict"]}), encoding="utf-8")
+    _attach_caplog(caplog)
+    try:
+        loaded = load_known_marketplaces(home=tmp_path)
+    finally:
+        store_mod.logger.removeHandler(caplog.handler)
+    assert loaded["marketplaces"] == {}
+    assert any("not an object" in r.getMessage() for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# version 强制 + 空配置 / forced version & empty config
+# ---------------------------------------------------------------------------
+def test_empty_helpers_carry_version() -> None:
+    assert empty_known_marketplaces() == {"version": MATERIALIZED_VERSION, "marketplaces": {}}
+    assert empty_installed_plugins() == {"version": MATERIALIZED_VERSION, "plugins": {}}
+
+
+def test_missing_file_loads_empty_with_version(tmp_path: Path) -> None:
+    assert load_known_marketplaces(home=tmp_path) == empty_known_marketplaces()
+    assert load_installed_plugins(home=tmp_path) == empty_installed_plugins()
+
+
+def test_save_backfills_version_and_header(tmp_path: Path) -> None:
+    # 不带 version 保存 → 落盘补齐 version + 写保护头。
+    path = save_known_marketplaces({"marketplaces": {}}, home=tmp_path)
+    text = path.read_text(encoding="utf-8")
+    assert text.splitlines()[0] == WRITE_PROTECTION_HEADER
+    body = json.loads("\n".join(text.splitlines()[1:]))
+    assert body["version"] == MATERIALIZED_VERSION
+
+
+# ---------------------------------------------------------------------------
+# 路径解析 / path resolution
+# ---------------------------------------------------------------------------
+def test_paths_with_explicit_home(tmp_path: Path) -> None:
+    assert known_marketplaces_path(home=tmp_path) == tmp_path / KNOWN_MARKETPLACES_FILENAME
+    assert installed_plugins_path(home=tmp_path) == tmp_path / INSTALLED_PLUGINS_FILENAME
+
+
+def test_paths_with_env_skill_home(tmp_path: Path) -> None:
+    home = tmp_path / "skillhome"
+    env = {"A2C_SKILL_HOME": str(home)}
+    assert known_marketplaces_path(env=env) == home.resolve() / KNOWN_MARKETPLACES_FILENAME
+    assert installed_plugins_path(env=env) == home.resolve() / INSTALLED_PLUGINS_FILENAME
+
+
+# ---------------------------------------------------------------------------
+# round-trip / save → load 一致
+# ---------------------------------------------------------------------------
+def test_known_marketplaces_roundtrip(tmp_path: Path) -> None:
+    data = {
+        "version": MATERIALIZED_VERSION,
+        "marketplaces": {
+            "my-team-skills": {
+                "source": {"type": "git", "url": "git@github.com:team/skills.git"},
+                "installLocation": "/abs/path/my-team-skills",
+                "lastUpdated": "2026-05-21T10:30:00Z",
+                "commitSha": "abc1234",
+                "autoUpdate": True,
+            }
+        },
+    }
+    save_known_marketplaces(data, home=tmp_path)
+    assert load_known_marketplaces(home=tmp_path) == data
+
+
+def test_installed_plugins_roundtrip(tmp_path: Path) -> None:
+    data = {
+        "version": MATERIALIZED_VERSION,
+        "plugins": {
+            "frontend-design@my-team-skills": [
+                {
+                    "scope": "user",
+                    "installPath": "/abs/path/frontend-design",
+                    "version": "1.2.0",
+                    "commitSha": "abc1234",
+                    "installedAt": "2026-05-10T00:00:00Z",
+                    "lastUpdated": "2026-05-10T00:00:00Z",
+                    "bundledMcpServers": ["figma-mcp"],
+                }
+            ]
+        },
+    }
+    save_installed_plugins(data, home=tmp_path)
+    assert load_installed_plugins(home=tmp_path) == data
+
+
+def test_corrupt_then_load_recovers_empty_and_backs_up(tmp_path: Path) -> None:
+    # 损坏文件 → load 降级空配置 + 留 .bak；随后 save 重建全新文件可正常 round-trip。
+    p = known_marketplaces_path(home=tmp_path)
+    p.write_text("GARBAGE@@@", encoding="utf-8")
+    assert load_known_marketplaces(home=tmp_path) == empty_known_marketplaces()
+    assert len(list(tmp_path.glob(f"{KNOWN_MARKETPLACES_FILENAME}.corrupt-*.bak"))) == 1
+    save_known_marketplaces(empty_known_marketplaces(), home=tmp_path)
+    assert load_known_marketplaces(home=tmp_path) == empty_known_marketplaces()
+
+
+# ---------------------------------------------------------------------------
+# 持锁 RMW / locked read-modify-write（update_*）
+# ---------------------------------------------------------------------------
+def test_update_known_marketplaces_inplace_mutator(tmp_path: Path) -> None:
+    # mutator 就地改并返回 None → 落盘 + 返回最终结构（单把锁内 load→mutate→save）。
+    def add_mp(data: dict) -> None:
+        data["marketplaces"]["mp-a"] = {"source": {"type": "git", "url": "git@h:p"}, "installLocation": "/x"}
+        return None
+
+    result = update_known_marketplaces(add_mp, home=tmp_path)
+    assert "mp-a" in result["marketplaces"]
+    assert result["version"] == MATERIALIZED_VERSION
+    assert load_known_marketplaces(home=tmp_path) == result  # 已落盘
+
+
+def test_update_installed_plugins_returns_new_structure(tmp_path: Path) -> None:
+    # mutator 返回全新结构（缺 version）→ 采用之并回填 version。
+    def replace(_data: dict) -> dict:
+        return {"plugins": {"p@mp": [{"scope": "user", "installPath": "/i"}]}}
+
+    result = update_installed_plugins(replace, home=tmp_path)
+    assert result["version"] == MATERIALIZED_VERSION
+    assert result["plugins"]["p@mp"][0]["scope"] == "user"
+    assert load_installed_plugins(home=tmp_path) == result
+
+
+def test_update_is_atomic_rmw_over_existing(tmp_path: Path) -> None:
+    # 已有内容时 RMW 读到当前值再改，不丢已有条目（reconciler #62 的核心语义）。
+    save_known_marketplaces(
+        {"marketplaces": {"old": {"source": {"type": "git", "url": "git@h:p"}, "installLocation": "/o"}}},
+        home=tmp_path,
+    )
+
+    def add_new(data: dict) -> None:
+        data["marketplaces"]["new"] = {"source": {"type": "git", "url": "git@h:q"}, "installLocation": "/n"}
+        return None
+
+    result = update_known_marketplaces(add_new, home=tmp_path)
+    assert set(result["marketplaces"]) == {"old", "new"}

--- a/tests/unit_tests/utils/test_atomic_io.py
+++ b/tests/unit_tests/utils/test_atomic_io.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+# filename: test_atomic_io.py
+# @Time    : 2026/05/25
+# @Author  : JQQ
+# @Email   : jqq1716@gmail.com
+# @Software: PyCharm
+"""
+原子写工具单元测试 / Unit tests for a2c_smcp.utils.atomic_io.
+
+抽取自 settings/store 与 blob/toolspool 的共用原语（fix-review #58）；重点验证落盘正确性、父目录
+自动创建，以及中途失败时**不留半截文件 + 清理临时文件**（原 toolspool 弱实现欠缺、本实现硬化）。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import a2c_smcp.utils.atomic_io as atomic_io_mod
+from a2c_smcp.utils.atomic_io import atomic_write_bytes, atomic_write_text, unique_tmp_path
+
+
+def test_unique_tmp_path_is_unique_and_suffixed() -> None:
+    target = Path("/tmp/known_marketplaces.json")
+    a = unique_tmp_path(target)
+    b = unique_tmp_path(target)
+    assert a != b  # 随机后缀互异
+    assert a.name.endswith(".tmp")
+    assert a.parent == target.parent
+
+
+def test_atomic_write_bytes_roundtrip_and_parent_mkdir(tmp_path: Path) -> None:
+    target = tmp_path / "nested" / "deep" / "blob.bin"
+    payload = b"\x00\x01\x02\xff binary"
+    atomic_write_bytes(target, payload)
+    assert target.read_bytes() == payload  # 父目录自动创建 + 内容一致
+
+
+def test_atomic_write_text_roundtrip_non_ascii(tmp_path: Path) -> None:
+    target = tmp_path / "f.txt"
+    atomic_write_text(target, "中文 + emoji 🚀\n")
+    assert target.read_text(encoding="utf-8") == "中文 + emoji 🚀\n"
+
+
+def test_atomic_write_interrupted_leaves_no_half_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    target = tmp_path / "f.txt"
+    atomic_write_text(target, "ORIGINAL")  # 先有一个完好文件
+
+    def boom(*_a: object, **_k: object) -> None:
+        raise OSError("simulated disk failure during rename")
+
+    # 原语用的是 atomic_io 自己的 os，patch 该模块的 os.replace。
+    monkeypatch.setattr(atomic_io_mod.os, "replace", boom)
+    with pytest.raises(OSError, match="simulated disk failure"):
+        atomic_write_text(target, "NEW-SHOULD-NOT-LAND")
+
+    assert target.read_text(encoding="utf-8") == "ORIGINAL"  # 目标保持原值（rename 失败、未被破坏）
+    assert list(tmp_path.glob("*.tmp")) == []  # 临时文件被清理，不留垃圾


### PR DESCRIPTION
## 概述

S5 物化层文件 store（#58 ← #56），实现 `design-0.2.1-cli-marketplace-ux.md` §6.1/§6.2/§6.3：CLI 自动维护、不可手编的 `known_marketplaces.json` / `installed_plugins.json` 的持久化 I/O 底座，供后续 reconciler（#62）/ plugin manager（#63）调用。

**Part of #53**（CLI marketplace/plugin/skill 管理 tracking）。base 沿用集成分支 `develop-v0.2.1`（#42 策略）。

## 实现要点（§6）

- **原子写**：唯一临时文件 + `fsync` + atomic `os.replace` + 失败清理（优于 CC `writeFileSync` 非原子/无锁/留半截）
- **文件锁**：旁车 `<path>.lock` 排他锁（POSIX `fcntl` / win32 `msvcrt`），指数退避重试；拿不到 → `SettingsLockError`（fail-fast，绝不无锁写）
- **损坏恢复**：corrupt / 非对象根 → 备份 `.corrupt-<ts>.bak` **再**降级空配置（不静默覆盖永久丢数据）
- **写保护**：JSONC 顶部 `// Maintained automatically by a2c-computer. DO NOT EDIT.`；读时容错剥离前导 `//`；手编痕迹（version 不符 / 未知顶层键）WARN + in-memory
- **物化模型**：`KnownMarketplacesFile` / `InstalledPluginsFile`（TypedDict，**带 `version`**，区别于无 version 的 settings.json 意图层），含 A2C 扩展 `bundledMcpServers`
- **持锁 RMW**：`update_known_marketplaces` / `update_installed_plugins`（单把锁内 load→mutate→save，供 #62 reconciler 杜绝丢更新窗口）

## fix-review 一并消化（discuss 共识后实施）

| 项 | 处理 |
|---|---|
| 🟡1 DRY | 抽 `utils/atomic_io.py`（共用原子写原语），store + `blob/toolspool` 共用；toolspool 顺带获得 fsync/失败清理（回灌强化其原弱实现） |
| 🟡2 RMW 缺口 | 新增 `update_*`（单锁 RMW）+ `save_*`/`file_lock` footgun docstring |
| 🟡3 .gitignore | 补 `.DS_Store` / `**/.DS_Store` |
| 🟡4 覆盖缺口 | 补 header=None / `_backup_corrupt` 失败 / marketplaces 非 dict 用例 |
| 🟡5 win32 | 占 1 字节 + seek(0) 硬化；docstring 据实标注 best-effort/未经 CI 验证 |

## 验证

- `uv run poe lint`：ruff `All checks passed` + mypy 78 文件无错
- 全量 `uv run poe test`：**1239 passed / 2 skipped / 4 xfailed / 0 failed**（受影响子集 settings+utils+blob 280 passed）
- toolspool 迁移后行为兼容（blob 全量测试通过）

## 说明

- base 为 `develop-v0.2.1`（非默认分支），GitHub `Closes` 关键字不自动触发，**手动关闭 #58**。
- win32 锁路径无 CI 实跑（无 Windows lane），已 docstring 据实标注，与 policy.py win32 姿态一致。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
