### PR TITLE
feat(computer): v0.2.1 SKILL staging user 源 DropIn（就地发现 + 优先级覆盖）(#60)

### DIFF
--- a/a2c_smcp/computer/skills/__init__.py
+++ b/a2c_smcp/computer/skills/__init__.py
@@ -33,7 +33,9 @@ from a2c_smcp.computer.skills.home import (
     marketplace_skill_dir,
     mcp_skill_dir,
     resolve_skill_home,
+    user_dropin_root,
     user_skill_dir,
+    workdir_skill_root,
 )
 from a2c_smcp.computer.skills.naming import (
     MCP_SEGMENT,
@@ -66,6 +68,7 @@ from a2c_smcp.computer.skills.staging import (
     SkillStagingError,
     parse_skill_frontmatter,
     stage_mcp_skills,
+    stage_user_skills,
     strip_skill_frontmatter,
 )
 
@@ -80,7 +83,9 @@ __all__ = [
     "marketplace_skill_dir",
     "mcp_skill_dir",
     "resolve_skill_home",
+    "user_dropin_root",
     "user_skill_dir",
+    "workdir_skill_root",
     # naming
     "MCP_SEGMENT",
     "ParsedSkillName",
@@ -110,5 +115,6 @@ __all__ = [
     "SkillStagingError",
     "parse_skill_frontmatter",
     "stage_mcp_skills",
+    "stage_user_skills",
     "strip_skill_frontmatter",
 ]

--- a/a2c_smcp/computer/skills/home.py
+++ b/a2c_smcp/computer/skills/home.py
@@ -58,6 +58,9 @@ XDG_DATA_HOME_ENV = "XDG_DATA_HOME"
 _A2C_DATA_SUBPATH = ("a2c", "skills")
 _DOTDIR_SUBPATH = (".a2c", "skills")
 
+# workspace 登记工作目录内的 user 源 DropIn 子路径 / Per-workdir user-source DropIn subpath。
+_WORKDIR_SKILL_SUBPATH = (".tfrobot", "skills")
+
 # 每用户私有目录权限 / Per-user-private directory mode（防御性写，隔离交给 OS）。
 SKILL_HOME_MODE = 0o700
 
@@ -134,3 +137,22 @@ def marketplace_skill_dir(home: Path, repo: str, *inner: str) -> Path:
 def user_skill_dir(home: Path, skill: str) -> Path:
     """user 源安装目录 / user-source install dir：``<home>/user/<skill>/``。"""
     return home / SOURCE_USER / skill
+
+
+def user_dropin_root(home: Path) -> Path:
+    """SKILL Home 内的 user 源 DropIn 发现根 / Global user-source DropIn root：``<home>/user/``。"""
+    return home / SOURCE_USER
+
+
+def workdir_skill_root(workdir: Path) -> Path:
+    """
+    workspace 登记工作目录的 user 源 DropIn 发现根 / Per-workdir user-source DropIn root。
+
+    ``<workdir>/.tfrobot/skills/``——**就地发现、不 staging 进 SKILL Home**（与 marketplace clone 树相反，
+    见 design-0.2.1-cli-marketplace-ux.md §5.0）。skill 属能力发现层：跨**全部已登记工作目录**全局并集、
+    置最低优先级、**不随 active workdir 切换**（§2.3/§5.1）。
+    ``<workdir>/.tfrobot/skills/`` — discovered **in place** (not staged into SKILL Home, unlike the
+    marketplace clone tree). User skills form a workspace-global capability set across all registered
+    workdirs (lowest precedence, independent of the active workdir).
+    """
+    return workdir.joinpath(*_WORKDIR_SKILL_SUBPATH)

--- a/a2c_smcp/computer/skills/registry.py
+++ b/a2c_smcp/computer/skills/registry.py
@@ -131,6 +131,17 @@ class SkillRegistry:
         self._entries[name] = _RegistryEntry(ref=ref, orphaned=False)
         return True
 
+    def register_or_update(self, ref: A2CSkillRef) -> bool:
+        """
+        幂等写入：已注册同名 → :meth:`update`（刷新 + 孤儿恢复），否则 :meth:`register` / Idempotent upsert。
+
+        staging 重扫 / 跨 run 复现的统一入口（mcp 与 user 源共用），避免各处重复
+        ``update(ref) if name in registry else register(ref)`` 惯用法。``name`` 缺失 / 未注册走 register
+        分支，由其校验兜底（失败 → ERROR + ``False``）。
+        """
+        name = ref.get("name")
+        return self.update(ref) if name is not None and name in self._entries else self.register(ref)
+
     def mark_orphan(self, name: str) -> bool:
         """把已注册 SKILL 标为孤儿（从活跃集排除，保留以便恢复）/ Mark a registered SKILL orphaned."""
         entry = self._entries.get(name)

--- a/a2c_smcp/computer/skills/staging.py
+++ b/a2c_smcp/computer/skills/staging.py
@@ -5,17 +5,18 @@
 # @Email   : jqq1716@gmail.com
 # @Software: PyCharm
 """
-SKILL staging：mcp 源物化（v0.2.1）
-SKILL staging: mcp-source materialization (v0.2.1)
+SKILL staging：mcp 源物化 + user 源 DropIn 就地发现（v0.2.1）
+SKILL staging: mcp-source materialization + user-source in-place DropIn discovery (v0.2.1)
 
 协议依据 / Protocol: a2c-smcp-protocol docs/specification/skill.md §3（MCP source 模式 mounted/archive/
                       resources）、§4（包根目录名 = frontmatter.name）、§12（Computer 完整消费 cursor）。
-SDK 设计 / Design: python-sdk docs/design-0.2.1-skill-computer-management.md §5.2。
+SDK 设计 / Design: python-sdk docs/design-0.2.1-skill-computer-management.md §5.2；
+                   docs/design-0.2.1-cli-marketplace-ux.md §2.3 / §5.0（user 源 DropIn）。
 
-本模块只实现 **mcp 源** 物化（#59）；marketplace git（#61）/ user DropIn（#60）另见对应模块。
-This module implements **mcp-source** materialization only (#59).
+本模块实现 **mcp 源** 物化（#59）与 **user 源** DropIn 发现（#60）；marketplace git（#61）另见对应模块。
+This module implements **mcp-source** materialization (#59) and **user-source** DropIn discovery (#60).
 
-流程 / Flow：
+mcp 流程 / mcp flow：
 1. 经 ``manager.list_skill_resources`` 完整消费 cursor 拿到 server 全量 ``skill://`` 资源；
 2. 其中带 ``_meta.source∈{mounted,archive,resources}`` 者为 **SKILL 根**，按模式物化到
    ``<home>/mcp/<normalized-server>/<skill>/``（marketplace SKILL v1 §2 包结构）：
@@ -26,6 +27,16 @@ This module implements **mcp-source** materialization only (#59).
 3. 读 staged ``SKILL.md`` 的 YAML frontmatter 作为元数据权威源（§3：不镜像进 ``_meta``）；
    包根目录名校正为 ``frontmatter.name``（§4）；
 4. 合成 ``A2CSkillRef``（name = ``mcp:<normalized-server>:<frontmatter.name>``）→ 注册进 :class:`SkillRegistry`。
+
+user 流程 / user flow（与 mcp 的关键差异）：**就地发现、不复制进 SKILL Home**。扫描发现根
+``$A2C_SKILL_HOME/user/``（全局个人）+ **全部已登记工作目录** ``<workdir>/.tfrobot/skills/``（能力发现层、
+跨目录全局并集、不随 active workdir 切换）；发现单元 ``<root>/<skill>/SKILL.md``（根下**一级**）。
+- **name = 目录 basename**（单段裸名，§5.0）——就地目录不可改名，与 sandbox 的 name 寻址（S2）一致；
+  ``frontmatter.name`` 仅参考（不一致记 DEBUG）；basename 非严格 kebab → 跳过。
+- **优先级（低→高）**：``user/`` < 各 workdir（按登记序，**后者覆盖前者** + WARN）。
+- 深于一级的 ``SKILL.md``（``<root>/a/b/SKILL.md``）→ 忽略 + DEBUG（user 源单段命名，不嵌套）。
+- 重扫幂等：已注册 → ``update``（含孤儿恢复），否则 ``register``；磁盘删除项的孤儿标记交 reconciler（#62）/
+  watcher（#67）按返回的发现 name 列表 diff，本函数不负责。
 
 失败降级 / Failure isolation：任一 SKILL 物化/解析失败 → 记 ERROR、清理半成品、跳过该 SKILL，
 **不**阻断其余、**不**抛给上层（skill.md §1.5：batch 接口对部分失败健壮）。
@@ -40,7 +51,7 @@ import shutil
 import tarfile
 import zipfile
 from collections import defaultdict
-from collections.abc import Awaitable, Callable, Sequence
+from collections.abc import Awaitable, Callable, Iterator, Sequence
 from functools import partial
 from pathlib import Path
 from typing import Any
@@ -48,8 +59,13 @@ from typing import Any
 import yaml
 from mcp.types import BlobResourceContents, ReadResourceResult, Resource, TextResourceContents
 
-from a2c_smcp.computer.skills.home import mcp_skill_dir
-from a2c_smcp.computer.skills.naming import SkillNameError, normalize_mcp_server_segment, synthesize_mcp_name
+from a2c_smcp.computer.skills.home import SOURCE_USER, mcp_skill_dir, user_dropin_root, workdir_skill_root
+from a2c_smcp.computer.skills.naming import (
+    SkillNameError,
+    normalize_mcp_server_segment,
+    synthesize_mcp_name,
+    synthesize_user_name,
+)
 from a2c_smcp.computer.skills.registry import SkillRegistry
 from a2c_smcp.smcp import A2CSkillRef
 from a2c_smcp.utils.logger import get_logger
@@ -308,6 +324,24 @@ def _uri_leaf(uri: str) -> str:
 
 
 # ── A2CSkillRef 合成 / ref construction ─────────────────────────────────────
+def _apply_frontmatter_optional_fields(ref: A2CSkillRef, frontmatter: dict[str, Any]) -> None:
+    """
+    把 frontmatter 派生的**可选**字段写入 ref（两源共用）/ Apply frontmatter-derived optional fields。
+
+    ``license`` / ``compatibility`` / ``allowed-tools`` / ``metadata`` 的语义不分源；``name`` / ``source`` /
+    ``path`` / ``description`` / ``version`` 由各源各自填（语义不同，见 :func:`_build_ref` / :func:`_build_user_ref`）。
+    """
+    if frontmatter.get("license") is not None:
+        ref["license"] = str(frontmatter["license"])
+    if frontmatter.get("compatibility") is not None:
+        ref["compatibility"] = str(frontmatter["compatibility"])
+    allowed = frontmatter.get("allowed-tools", frontmatter.get("allowed_tools"))
+    if allowed is not None:
+        ref["allowed_tools"] = [str(t) for t in allowed] if isinstance(allowed, (list, tuple)) else [str(allowed)]
+    if isinstance(frontmatter.get("metadata"), dict):
+        ref["skill_metadata"] = frontmatter["metadata"]
+
+
 def _build_ref(
     name: str,
     normalized_server: str,
@@ -324,15 +358,7 @@ def _build_ref(
         "path": str(path),
         "description": str(frontmatter["description"]),
     }
-    if frontmatter.get("license") is not None:
-        ref["license"] = str(frontmatter["license"])
-    if frontmatter.get("compatibility") is not None:
-        ref["compatibility"] = str(frontmatter["compatibility"])
-    allowed = frontmatter.get("allowed-tools", frontmatter.get("allowed_tools"))
-    if allowed is not None:
-        ref["allowed_tools"] = [str(t) for t in allowed] if isinstance(allowed, (list, tuple)) else [str(allowed)]
-    if isinstance(frontmatter.get("metadata"), dict):
-        ref["skill_metadata"] = frontmatter["metadata"]
+    _apply_frontmatter_optional_fields(ref, frontmatter)
     version = meta.get("version")
     if version is not None:
         ref["version"] = str(version)
@@ -449,5 +475,130 @@ def _finalize_and_register(
 
     ref = _build_ref(name, normalized_server, frontmatter, meta, final, root_uri)
     # 本 run 已 seen 去重；此处 name in registry 必为跨 run 既存的同一 SKILL → update（刷新/孤儿恢复）
-    ok = registry.update(ref) if name in registry else registry.register(ref)
+    ok = registry.register_or_update(ref)
     return name if ok else None
+
+
+# ── user 源 DropIn（就地发现，不 staging）/ user-source in-place DropIn ────────
+def _user_dropin_roots(home: Path, workdirs: Sequence[Path]) -> list[Path]:
+    """
+    user 源 DropIn 发现根，按优先级**升序**（低→高，后者覆盖）+ 解析去重 / Ascending-priority deduped roots。
+
+    顺序 = ``[<home>/user]`` + ``[<workdir>/.tfrobot/skills ...]``（登记序）。``resolve()`` 后按路径去重保序，
+    避免同一目录被登记两次造成重复扫描 + 假 WARN（首次出现定其优先级槽位）。
+    """
+    ordered: list[Path] = [user_dropin_root(home).resolve()]
+    ordered.extend(workdir_skill_root(wd).resolve() for wd in workdirs)
+    seen: set[Path] = set()
+    deduped: list[Path] = []
+    for root in ordered:
+        if root not in seen:
+            seen.add(root)
+            deduped.append(root)
+    return deduped
+
+
+def _iter_user_skill_dirs(root: Path) -> Iterator[Path]:
+    """
+    枚举发现根下的 SKILL 目录 / Yield ``<root>/<skill>/`` whose ``<skill>/SKILL.md`` exists（根下**一级**）。
+
+    只扫根下一级（``iterdir``，O(顶层条目)）：子目录含直接 ``SKILL.md`` → 即一个 SKILL，**不再深入其包内**
+    （包内 scripts/、assets/ 等附属文件不递归遍历——避免大包性能开销与 symlink 打转）。无直接 ``SKILL.md``
+    的「wrapper 目录」（异常摆放）→ 仅对其补扫深层 ``SKILL.md`` 记 DEBUG 忽略（深于一级，user 源单段命名、
+    不嵌套，对齐 watcher §8.3）。``sorted`` 保证同根内确定序（WARN 可复现）。
+    """
+    if not root.is_dir():
+        return
+    for child in sorted(root.iterdir()):
+        if not child.is_dir():
+            if child.name == SKILL_MD:  # 根下直接的 <root>/SKILL.md（无 <skill>/ 包装）→ 非发现单元
+                logger.debug("user DropIn ignoring SKILL.md directly under root (not in a skill dir): %s", child)
+            continue
+        if (child / SKILL_MD).is_file():
+            yield child  # 一级 SKILL 包，不深入其内部
+        else:
+            # wrapper 目录无直接 SKILL.md：补扫深层 SKILL.md 仅为记 DEBUG（不进入有效包，故仅扫此异常分支）
+            for deeper in sorted(child.rglob(SKILL_MD)):
+                logger.debug("user DropIn ignoring SKILL.md not at one-level depth under %s: %s", root, deeper)
+
+
+def _build_user_ref(name: str, skill_dir: Path) -> A2CSkillRef | None:
+    """
+    读就地 ``SKILL.md`` frontmatter 组装 user 源 A2CSkillRef / Build a user-source ref from in-place SKILL.md。
+
+    ``source="user"``、**无 ``uri``**（协议表面 user 源不带 ``skill://``）；``path`` = 就地包根（**不复制**）。
+    缺 ``description`` / SKILL.md 不可读 → 记 ERROR + ``None``（跳过该 SKILL）。``frontmatter.name`` 与
+    目录 basename 不一致 → DEBUG（basename 权威，就地不可改名）。
+
+    **无 ``version``**：SKILL.md frontmatter 恰好 6 字段（name/description/license/compatibility/metadata/
+    allowed-tools），不含 version（协议 skill.md §6 / 设计 §1.2）；``version`` 仅来自 manifest——mcp 取自
+    ``_meta``、marketplace 取自 plugin.json/entry，而 user 源无任何 manifest，故 user SKILL 不带 version。
+    """
+    skill_md = skill_dir / SKILL_MD
+    try:
+        text = skill_md.read_text(encoding="utf-8")
+    except OSError as e:
+        logger.error("user SKILL %r SKILL.md unreadable, skipped: %s (%s)", name, skill_md, e)
+        return None
+    frontmatter = parse_skill_frontmatter(text)
+    if not frontmatter.get("description"):
+        logger.error("user SKILL %r frontmatter missing required 'description', skipped: %s", name, skill_md)
+        return None
+    fm_name = frontmatter.get("name")
+    if fm_name and str(fm_name) != name:
+        logger.debug("user SKILL dir basename %r != frontmatter.name %r; basename is authoritative (in-place addressing)", name, fm_name)
+    ref: A2CSkillRef = {
+        "name": name,
+        "source": SOURCE_USER,
+        "path": str(skill_dir.resolve()),
+        "description": str(frontmatter["description"]),
+    }
+    _apply_frontmatter_optional_fields(ref, frontmatter)
+    return ref
+
+
+def stage_user_skills(
+    registry: SkillRegistry,
+    home: Path,
+    workdirs: Sequence[Path] = (),
+) -> list[str]:
+    """
+    枚举 user 源 DropIn 并注册进 Registry（**就地发现、不复制**）/ Discover user-source DropIn skills in place。
+
+    扫描 ``<home>/user/`` + 各 ``<workdir>/.tfrobot/skills/``（能力发现层全局并集，**不随 active workdir 切换**）；
+    发现单元 ``<root>/<skill>/SKILL.md``（根下一级），name = 目录 basename（单段裸名）。同名按发现根优先级
+    **后者覆盖前者**（``user/`` 最低 < 各 workdir 登记序），覆盖时记 WARN（便于诊断「为何我的 skill 不显示」）。
+
+    :param registry: 目标 :class:`SkillRegistry`。
+    :param home: SKILL Home 绝对根（见 :mod:`~a2c_smcp.computer.skills.home`）。
+    :param workdirs: workspace **已登记工作目录**（按登记序；调用方提供，本函数不耦合 workspace 登记模块）。
+    :return: 本次发现并成功注册/刷新的 SKILL name 列表 / discovered & registered names（供 reconciler/watcher diff 孤儿）。
+    """
+    winners: dict[str, tuple[A2CSkillRef, Path]] = {}  # name → (ref, 发现目录)；后者覆盖前者
+    for root in _user_dropin_roots(home, workdirs):
+        for skill_dir in _iter_user_skill_dirs(root):
+            basename = skill_dir.name
+            try:
+                name = synthesize_user_name(basename)  # 校验严格 kebab（§1.5 失败不入册）
+            except SkillNameError as e:
+                logger.error("user DropIn skill dir name invalid, skipped: %s (%s)", skill_dir, e.reason)
+                continue
+            ref = _build_user_ref(name, skill_dir)
+            if ref is None:
+                continue
+            prev = winners.get(name)
+            if prev is not None:
+                logger.warning(
+                    "user SKILL %r at %s shadows earlier DropIn at %s (later root wins)",
+                    name,
+                    skill_dir,
+                    prev[1],
+                )
+            winners[name] = (ref, skill_dir)
+
+    registered: list[str] = []
+    for name, (ref, _) in winners.items():
+        # 跨 run 既存（active 或 orphan）→ update（刷新 / 孤儿恢复）；否则 register。
+        if registry.register_or_update(ref):
+            registered.append(name)
+    return registered

--- a/tests/unit_tests/computer/skills/test_registry.py
+++ b/tests/unit_tests/computer/skills/test_registry.py
@@ -239,3 +239,38 @@ def test_active_refs_returns_deepcopies() -> None:
     fresh = reg.active_refs()
     assert fresh[0]["description"] == "d"
     assert fresh[0]["allowed_tools"] == ["a"]
+
+
+# ── register_or_update（幂等 upsert，mcp/user 共用入口）────────────────────────
+def test_register_or_update_registers_when_absent() -> None:
+    reg = SkillRegistry()
+    assert reg.register_or_update(_ref("brand-new", description="v1")) is True
+    assert reg.resolve("brand-new") is not None  # type: ignore[union-attr]
+
+
+def test_register_or_update_updates_when_active() -> None:
+    # 已 active 同名 → 走 update（刷新，不触发 register 的「拒绝第二注册者」）
+    reg = SkillRegistry()
+    reg.register(_ref("dup", description="v1"))
+    assert reg.register_or_update(_ref("dup", description="v2")) is True
+    assert reg.resolve("dup")["description"] == "v2"  # type: ignore[index]
+    assert len(reg) == 1
+
+
+def test_register_or_update_recovers_orphan() -> None:
+    # 已孤儿同名 → update 刷新并置活跃（孤儿恢复）
+    reg = SkillRegistry()
+    reg.register(_ref("ghost", description="v1"))
+    reg.mark_orphan("ghost")
+    assert reg.resolve("ghost") is None  # 孤儿不在 active
+    assert reg.register_or_update(_ref("ghost", description="v2")) is True
+    assert reg.resolve("ghost")["description"] == "v2"  # 恢复为活跃 + 刷新  # type: ignore[index]
+
+
+def test_register_or_update_invalid_ref_returns_false(capture_errors: pytest.LogCaptureFixture) -> None:
+    # 缺 path（未注册 → 走 register 分支，由其校验兜底）→ ERROR + False，不入册
+    reg = SkillRegistry()
+    bad: A2CSkillRef = {"name": "no-path", "source": "user", "description": "d"}
+    assert reg.register_or_update(bad) is False
+    assert len(reg) == 0
+    assert any(r.levelno == logging.ERROR for r in capture_errors.records)

--- a/tests/unit_tests/computer/skills/test_staging.py
+++ b/tests/unit_tests/computer/skills/test_staging.py
@@ -19,15 +19,18 @@ SKILL staging（mcp 源）单元测试（v0.2.1 #59）
 import base64
 import hashlib
 import io
+import logging
 import tarfile
 import zipfile
+from collections.abc import Iterator
 from pathlib import Path
 
+import pytest
 from mcp.types import BlobResourceContents, ReadResourceResult, Resource, TextResourceContents
 
 import a2c_smcp.computer.skills.staging as staging_mod
 from a2c_smcp.computer.skills.registry import SkillRegistry
-from a2c_smcp.computer.skills.staging import stage_mcp_skills
+from a2c_smcp.computer.skills.staging import stage_mcp_skills, stage_user_skills
 
 
 # ── 测试替身 / doubles ───────────────────────────────────────────────────────
@@ -300,3 +303,213 @@ async def test_resource_without_source_meta_skipped(tmp_path: Path) -> None:
     names = await stage_mcp_skills(FakeManager([("srv", plain)]), reg, tmp_path / "home")
     assert names == []
     assert len(reg) == 0
+
+
+# ── user 源 DropIn（就地发现，不 staging，#60）────────────────────────────────
+@pytest.fixture
+def staging_logs(caplog: pytest.LogCaptureFixture) -> Iterator[pytest.LogCaptureFixture]:
+    """捕获 staging 模块日志（项目 logger 关闭 propagate，直接挂 handler）/ capture staging logs。"""
+    staging_mod.logger.addHandler(caplog.handler)
+    caplog.set_level(logging.DEBUG)
+    try:
+        yield caplog
+    finally:
+        staging_mod.logger.removeHandler(caplog.handler)
+
+
+def _write_user_skill(root: Path, skill_dir_name: str, *, fm_name: str | None = None, description: str = "do thing") -> Path:
+    """在发现根下写一个 ``<skill_dir_name>/SKILL.md`` / write a DropIn skill dir under a root。"""
+    d = root / skill_dir_name
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "SKILL.md").write_text(_skill_md(name=skill_dir_name if fm_name is None else fm_name, description=description), encoding="utf-8")
+    return d
+
+
+def test_user_global_only_in_place(tmp_path: Path) -> None:
+    # 仅 $A2C_SKILL_HOME/user/ 全局源：就地发现、不复制；name=basename、source=user、无 uri
+    home = tmp_path / "home"
+    _write_user_skill(home / "user", "alpha", description="第一")
+    _write_user_skill(home / "user", "beta", description="第二")
+    reg = SkillRegistry()
+
+    names = stage_user_skills(reg, home)
+
+    assert sorted(names) == ["alpha", "beta"]
+    ref = reg.resolve("alpha")
+    assert ref is not None
+    assert ref["source"] == "user"
+    assert "uri" not in ref  # user 源协议表面不带 skill://
+    assert ref["path"] == str((home / "user" / "alpha").resolve())  # 就地包根，未复制
+    assert ref["description"] == "第一"
+    assert ref["license"] == "MIT"
+    assert ref["allowed_tools"] == ["read", "write"]
+
+
+def test_user_global_plus_multi_workdir_union(tmp_path: Path) -> None:
+    # 全局 + 多 workdir 全局并集；能力层不随 active workdir 切换——传入的全部 workdir 一律生效
+    home = tmp_path / "home"
+    _write_user_skill(home / "user", "global-skill")
+    wd1 = tmp_path / "ws1"
+    wd2 = tmp_path / "ws2"
+    _write_user_skill(wd1 / ".tfrobot" / "skills", "proj-a")
+    _write_user_skill(wd2 / ".tfrobot" / "skills", "proj-b")
+    reg = SkillRegistry()
+
+    names = stage_user_skills(reg, home, [wd1, wd2])
+
+    assert sorted(names) == ["global-skill", "proj-a", "proj-b"]
+    # workdir skill 就地发现于各自 .tfrobot/skills，未复制进 home
+    assert reg.resolve("proj-a")["path"] == str((wd1 / ".tfrobot" / "skills" / "proj-a").resolve())  # type: ignore[index]
+    assert not (home / "user" / "proj-a").exists()
+
+
+def test_workdir_overrides_user_home_with_warning(tmp_path: Path, staging_logs: pytest.LogCaptureFixture) -> None:
+    # 同名：workspace skill 覆盖 user-home 全局（§2.3「workspace skill 覆盖 user」）+ WARN
+    home = tmp_path / "home"
+    _write_user_skill(home / "user", "shared", description="from-home")
+    wd = tmp_path / "ws"
+    _write_user_skill(wd / ".tfrobot" / "skills", "shared", description="from-workdir")
+    reg = SkillRegistry()
+
+    names = stage_user_skills(reg, home, [wd])
+
+    assert names == ["shared"]
+    assert reg.resolve("shared")["description"] == "from-workdir"  # workdir 胜  # type: ignore[index]
+    assert any(r.levelno == logging.WARNING and "shadows earlier" in r.getMessage() for r in staging_logs.records)
+
+
+def test_later_workdir_overrides_earlier_in_registration_order(tmp_path: Path, staging_logs: pytest.LogCaptureFixture) -> None:
+    # 登记目录间同名 → 按登记序后者覆盖前者 + WARN（验收第 1 条）
+    home = tmp_path / "home"
+    wd1 = tmp_path / "ws1"
+    wd2 = tmp_path / "ws2"
+    _write_user_skill(wd1 / ".tfrobot" / "skills", "dup", description="first")
+    _write_user_skill(wd2 / ".tfrobot" / "skills", "dup", description="second")
+    reg = SkillRegistry()
+
+    names = stage_user_skills(reg, home, [wd1, wd2])  # 登记序 wd1 → wd2
+
+    assert names == ["dup"]
+    assert reg.resolve("dup")["description"] == "second"  # 后登记者胜  # type: ignore[index]
+    assert any(r.levelno == logging.WARNING for r in staging_logs.records)
+
+
+def test_user_basename_not_kebab_skipped(tmp_path: Path, staging_logs: pytest.LogCaptureFixture) -> None:
+    # 目录 basename 非严格 kebab → 跳过 + ERROR；合法兄弟仍入册（部分失败健壮）
+    home = tmp_path / "home"
+    _write_user_skill(home / "user", "Bad_Name")  # 含大写 + 下划线 → 非 kebab
+    _write_user_skill(home / "user", "good-one")
+    reg = SkillRegistry()
+
+    names = stage_user_skills(reg, home)
+
+    assert names == ["good-one"]
+    assert len(reg) == 1
+    assert any(r.levelno == logging.ERROR and "name invalid" in r.getMessage() for r in staging_logs.records)
+
+
+def test_user_deeper_skill_md_ignored_with_debug(tmp_path: Path, staging_logs: pytest.LogCaptureFixture) -> None:
+    # 深于一级的 SKILL.md（<root>/a/b/SKILL.md）→ 忽略 + DEBUG；根下一级的仍发现（验收第 2 条）
+    home = tmp_path / "home"
+    root = home / "user"
+    _write_user_skill(root, "ok-skill")
+    nested = root / "wrapper" / "inner"
+    nested.mkdir(parents=True)
+    (nested / "SKILL.md").write_text(_skill_md(name="inner", description="too deep"), encoding="utf-8")
+    reg = SkillRegistry()
+
+    names = stage_user_skills(reg, home)
+
+    assert names == ["ok-skill"]  # inner（二级）被忽略
+    assert any(r.levelno == logging.DEBUG and "not at one-level depth" in r.getMessage() for r in staging_logs.records)
+
+
+def test_user_missing_description_skipped(tmp_path: Path, staging_logs: pytest.LogCaptureFixture) -> None:
+    # frontmatter 缺 description（A2CSkillRef 必填）→ 跳过 + ERROR
+    home = tmp_path / "home"
+    d = home / "user" / "no-desc"
+    d.mkdir(parents=True)
+    (d / "SKILL.md").write_text("---\nname: no-desc\n---\n# body\n", encoding="utf-8")
+    reg = SkillRegistry()
+
+    names = stage_user_skills(reg, home)
+
+    assert names == []
+    assert len(reg) == 0
+    assert any(r.levelno == logging.ERROR and "missing required 'description'" in r.getMessage() for r in staging_logs.records)
+
+
+def test_user_frontmatter_name_mismatch_basename_wins(tmp_path: Path, staging_logs: pytest.LogCaptureFixture) -> None:
+    # frontmatter.name 与目录 basename 不一致 → basename 权威（就地不可改名）+ DEBUG
+    home = tmp_path / "home"
+    _write_user_skill(home / "user", "real-dir", fm_name="other-name")
+    reg = SkillRegistry()
+
+    names = stage_user_skills(reg, home)
+
+    assert names == ["real-dir"]  # 目录 basename 胜，非 frontmatter.name
+    assert reg.resolve("other-name") is None
+    assert any(r.levelno == logging.DEBUG and "basename is authoritative" in r.getMessage() for r in staging_logs.records)
+
+
+def test_user_rescan_idempotent_updates(tmp_path: Path) -> None:
+    # 重扫幂等：已注册 → update（不重复、不报错），内容变更被刷新
+    home = tmp_path / "home"
+    skill = _write_user_skill(home / "user", "iter-skill", description="v1")
+    reg = SkillRegistry()
+
+    first = stage_user_skills(reg, home)
+    assert first == ["iter-skill"]
+    assert reg.resolve("iter-skill")["description"] == "v1"  # type: ignore[index]
+
+    (skill / "SKILL.md").write_text(_skill_md(name="iter-skill", description="v2"), encoding="utf-8")
+    second = stage_user_skills(reg, home)
+
+    assert second == ["iter-skill"]
+    assert len(reg) == 1  # 未重复注册
+    assert reg.resolve("iter-skill")["description"] == "v2"  # 刷新生效  # type: ignore[index]
+
+
+def test_user_missing_roots_tolerated(tmp_path: Path) -> None:
+    # 发现根不存在（home/user 与 workdir 都没建）→ 返回空、不抛
+    home = tmp_path / "nonexistent-home"
+    reg = SkillRegistry()
+    names = stage_user_skills(reg, home, [tmp_path / "no-such-ws"])
+    assert names == []
+    assert len(reg) == 0
+
+
+def test_user_skill_md_unreadable_skipped(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, staging_logs: pytest.LogCaptureFixture) -> None:
+    # 发现后 SKILL.md 不可读（TOCTOU）→ _build_user_ref 的 OSError 分支 → 跳过 + ERROR、不抛
+    home = tmp_path / "home"
+    _write_user_skill(home / "user", "toctou")
+    reg = SkillRegistry()
+
+    orig_read = Path.read_text
+
+    def boom(self: Path, *a: object, **k: object) -> str:
+        if self.name == "SKILL.md":
+            raise OSError("simulated unreadable after discovery (TOCTOU)")
+        return orig_read(self, *a, **k)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(Path, "read_text", boom)  # 发现走 is_file()，不读；仅 _build_user_ref 读 → 触发分支
+
+    names = stage_user_skills(reg, home)
+
+    assert names == []
+    assert len(reg) == 0
+    assert any(r.levelno == logging.ERROR and "unreadable" in r.getMessage() for r in staging_logs.records)
+
+
+def test_user_dropin_roots_dedup_no_spurious_warning(tmp_path: Path, staging_logs: pytest.LogCaptureFixture) -> None:
+    # 同一 workdir 登记两次 → _user_dropin_roots 按解析路径去重 → 只扫一次、不产生「shadows earlier」假 WARN
+    home = tmp_path / "home"
+    wd = tmp_path / "ws"
+    _write_user_skill(wd / ".tfrobot" / "skills", "uniq")
+    reg = SkillRegistry()
+
+    names = stage_user_skills(reg, home, [wd, wd])
+
+    assert names == ["uniq"]
+    assert len(reg) == 1
+    assert not any(r.levelno == logging.WARNING for r in staging_logs.records)


### PR DESCRIPTION
## 概述

S7（#60）：新增 **user 源 DropIn 就地发现**，闭合 #39「三源 staging」之一（mcp #59 已合并、marketplace #61 待起）。

与 mcp/marketplace 的关键差异：**就地发现、不 staging 进 SKILL Home**（`A2CSkillRef.path` 直指就地包根），纯 FS 扫描、sync。

## 改动

- **`skills/staging.py`** — `stage_user_skills(registry, home, workdirs)`
  - 发现根优先级升序：`<home>/user/`（最低）< 各 `<workdir>/.tfrobot/skills/`（登记序，**后者覆盖 + WARN**）
  - `name = 目录 basename`（单段裸名，就地不可改名 → 与 sandbox name 寻址一致）；`frontmatter.name` 仅参考（不一致 DEBUG）
  - 一级发现（`iterdir`，**不深入有效包**）；深层/wrapper 摆放记 DEBUG（对齐 watcher §8.3）
  - **不随 active workdir 切换**（能力层全局并集）；重扫幂等
  - user 源无 manifest → **不带 version**（frontmatter 恰好 6 字段，§1.2 / 协议 `skill.md §6`）
  - 抽 `_apply_frontmatter_optional_fields` 供 mcp/user 两源共用
- **`skills/home.py`** — `user_dropin_root` / `workdir_skill_root` 路径 helper
- **`skills/registry.py`** — `register_or_update` 幂等 upsert（mcp + user 共用，消除重复惯用法）
- **`skills/__init__.py`** — 导出新符号

## 验收（#60）

- [x] 全局 + 多 workdir DropIn 并集；登记序后者覆盖 + WARN
- [x] 深于一级的 SKILL.md 忽略（DEBUG）
- [x] 不随 active workdir 切换（能力层全局）
- [x] `uv run poe lint` 净

## 范围边界

磁盘删除项的孤儿标记/清理 → 交 #62 reconciler / #67 watcher 按 `stage_user_skills` 返回的发现集 diff（#39 既定分工）。

## 设计依据

`design-0.2.1-cli-marketplace-ux.md` §2.3/§5.0；`design-0.2.1-skill-computer-management.md` §2.1 注。

## 测试 / 验证

- `test_staging.py` +12（union / 覆盖+WARN / basename 校验 / 深层 DEBUG / 缺 description / 就地不复制 / 幂等 / OSError TOCTOU / dedup 去重）
- `test_registry.py` +4（`register_or_update`：register / update / 孤儿恢复 / 非法 ref）
- lint 净（ruff + mypy 78 文件）；全量 **1255 passed / 2 skipped / 4 xfailed / 0 failed**

> base 为 `develop-v0.2.1`（非默认分支），`Closes` 关键字不自动触发；#60 手动关闭、#39 勾选已同步。

🤖 Generated with [Claude Code](https://claude.com/claude-code)