### PR TITLE
feat(computer): v0.2.1 S14 SKILL watcher + debouncer + emit 链路 (#67)

### DIFF
--- a/a2c_smcp/computer/computer.py
+++ b/a2c_smcp/computer/computer.py
@@ -27,9 +27,10 @@ All classes and methods use Google style docstrings (bilingual: Chinese and Engl
 
 import asyncio
 import json
+import os
 import weakref
 from collections import deque
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional
@@ -63,11 +64,17 @@ from a2c_smcp.computer.inputs.resolver import InputNotFoundError, InputResolver
 from a2c_smcp.computer.mcp_clients.manager import MCPServerManager
 from a2c_smcp.computer.mcp_clients.model import MCPServerConfig, MCPServerInput
 from a2c_smcp.computer.skills import (
+    SOURCE_USER,
+    SkillEventDebouncer,
+    SkillFileWatcher,
     SkillRegistry,
     SkillResourceView,
     ensure_skill_home,
     resolve_skill_view,
     stage_mcp_skills,
+    stage_user_skills,
+    user_dropin_root,
+    workdir_skill_root,
 )
 from a2c_smcp.computer.types import ToolCallRecord
 from a2c_smcp.smcp import A2CSkillRef, Desktop, SMCPTool
@@ -100,6 +107,7 @@ class Computer(BaseComputer[PromptSession]):
         blob_resolvers: dict[str, BlobResolver] | None = None,
         blob_thresholds: BlobThresholds | None = None,
         skill_home: Path | None = None,
+        registered_workdirs: Sequence[Path] | None = None,
     ) -> None:
         """
         初始化 Computer 实例
@@ -131,6 +139,11 @@ class Computer(BaseComputer[PromptSession]):
                 ``A2C_SKILL_HOME`` → ``$XDG_DATA_HOME/a2c/skills`` → ``~/.a2c/skills`` 解析链。
                 mcp 源 ``skill://`` 物化落盘于 ``<home>/mcp/<server>/<skill>/``。
                 SKILL Home root override (test/deploy injection); defaults to the env resolution chain.
+            registered_workdirs (Sequence[Path] | None): v0.2.1 已登记工作目录（能力发现层，#60/#67）。
+                user 源 DropIn 跨 ``<home>/user/`` + 各 ``<workdir>/.tfrobot/skills/`` 全局并集就地发现，
+                并被文件 watcher 递归监控；**登记持久化由 CLI 工单维护，本类仅按注入参数消费**（默认空）。
+                Registered workdirs (capability layer): user-source DropIn discovery + file watcher span
+                these in place; persistence of the registration is owned by the CLI, consumed here as-is.
         """
         self.name = name
         self.mcp_manager: MCPServerManager | None = None
@@ -162,6 +175,23 @@ class Computer(BaseComputer[PromptSession]):
         self._skill_home_override: Path | None = skill_home
         self._skill_home: Path | None = None
         self._skills_cache: set[str] = set()
+
+        # v0.2.1 事件触发链（S14，#67，设计 §8）：多源 SKILL 变更 → 去抖器标脏 → 缓存失效 + 单次 emit。
+        # user 源 DropIn 文件 watcher 递归监控 user/ + 各登记 workdir/.tfrobot/skills/，SKILL.md 变更经去抖器汇聚。
+        # The debouncer coalesces multi-source SKILL changes into a single emit; the file watcher feeds user-source changes.
+        self._registered_workdirs: tuple[Path, ...] = tuple(registered_workdirs or ())
+        self._skill_debouncer: SkillEventDebouncer = SkillEventDebouncer(
+            self._emit_update_skills_now,
+            invalidate=self._invalidate_user_skills,
+        )
+        self._skill_watcher: SkillFileWatcher | None = None
+        # 原生 Observer 不支持的 FS（网络挂载 / overlayfs）可经此环境变量切 PollingObserver 兜底。
+        self._skill_watch_polling: bool = os.environ.get("A2C_SKILL_WATCH_POLLING", "").strip().lower() in {
+            "1",
+            "true",
+            "yes",
+            "on",
+        }
 
         # v0.2.1 通用二进制传输基础设施 / v0.2.1 generic blob-transfer infrastructure
         # 协议依据 / Protocol: blob-transfer.md；设计 / Design: §4.3 / §4.4
@@ -322,6 +352,17 @@ class Computer(BaseComputer[PromptSession]):
         except Exception as e:  # pragma: no cover — 防御性兜底，正常路径已在内部各自降级
             logger.error(f"SKILL 子系统启动初始化失败（不阻断 Computer 启动）/ SKILL boot init failed (non-blocking): {e}", exc_info=True)
 
+        # v0.2.1 user 源 DropIn 就地发现 + 文件 watcher（S14，#67，设计 §8.3）：启动时全量扫 user 源 →
+        # 注册；启动递归 watcher 监控 user/ + 各登记 workdir/.tfrobot/skills/，SKILL.md 变更经去抖器触发 emit。
+        # 失败隔离：记 ERROR、**不**阻断 Computer 启动。
+        # User-source in-place discovery + file watcher: initial full scan + start recursive watcher (failure-isolated).
+        try:
+            if self._skill_home is not None:
+                await self._invalidate_user_skills()  # 初次全量发现 user 源 / initial full user-source discovery
+                self._start_skill_watcher()
+        except Exception as e:  # pragma: no cover — 防御性兜底
+            logger.error(f"user 源 DropIn 发现 / watcher 启动失败（不阻断启动）/ user DropIn boot failed: {e}", exc_info=True)
+
     def _resolve_skill_home(self) -> Path:
         """解析并创建 SKILL Home（0o700 防御性写）/ Resolve & create SKILL Home。
 
@@ -361,7 +402,7 @@ class Computer(BaseComputer[PromptSession]):
                 logger.debug("Socket.IO 客户端不存在或已释放，忽略资源列表变化上报")
                 return
             await self._on_resource_list_changed_windows(client)
-            await self._on_resource_list_changed_skills(client)
+            await self._on_resource_list_changed_skills()
         elif isinstance(getattr(message, "root", None), ResourceUpdatedNotification):
             # 资源内容更新按 scheme 分流：window:// → 桌面刷新；skill:// → 重物化并上报 SKILL 更新。
             # Resource content updated, dispatched by scheme: window:// → desktop; skill:// → restage skills.
@@ -377,7 +418,7 @@ class Computer(BaseComputer[PromptSession]):
                 except Exception as e:  # pragma: no cover
                     logger.error(f"上报桌面刷新失败: {e}")
             elif uri_str.startswith(_SKILL_URI_PREFIX):
-                await self._on_skill_resource_updated(client)
+                await self._on_skill_resource_updated()
             else:
                 logger.debug("收到资源更新但非 window/skill scheme，放行 / Non-window/skill resource updated, ignore")
         else:
@@ -417,11 +458,12 @@ class Computer(BaseComputer[PromptSession]):
                 "Resource list changed but WindowURI set unchanged, skip refresh",
             )
 
-    async def _on_resource_list_changed_skills(self, client: "SMCPComputerClient") -> None:
-        """skill:// 集合变化 → 重物化 mcp 源 + 孤儿对账 → ``emit_update_skills``（仿窗口缓存对比）。
+    async def _on_resource_list_changed_skills(self) -> None:
+        """skill:// 集合变化 → 重物化 mcp 源 + 孤儿对账 → 去抖器标脏（仿窗口缓存对比）。
 
-        集合未变化则仅 DEBUG 跳过（设计 §5.1：``_acollect_skill_refs`` 集合相同跳过）。
-        skill:// set changed → restage mcp source + orphan reconcile → emit; unchanged → DEBUG skip.
+        集合未变化则仅 DEBUG 跳过（设计 §5.1：``_acollect_skill_refs`` 集合相同跳过）。变化时重物化 mcp 源
+        并 :meth:`SkillEventDebouncer.mark_dirty`——emit 经去抖器与其它源在 300ms 窗口内合并为一次（设计 §8.1）。
+        skill:// set changed → restage mcp source + orphan reconcile → debouncer.mark_dirty; unchanged → DEBUG skip.
         """
         try:
             new_skills = await self._acollect_skill_refs()
@@ -435,26 +477,25 @@ class Computer(BaseComputer[PromptSession]):
 
         added = len(new_skills - self._skills_cache)
         removed = len(self._skills_cache - new_skills)
-        logger.info(f"skill:// 列表发生变化，重物化并上报 SKILL 更新 | skill:// list changed. added={added}, removed={removed}")
+        logger.info(f"skill:// 列表发生变化，重物化并标脏 SKILL 更新 | skill:// list changed. added={added}, removed={removed}")
         try:
             await self._restage_mcp_skills()
             self._skills_cache = new_skills
-            await client.emit_update_skills()
+            self._skill_debouncer.mark_dirty()
         except Exception as e:  # pragma: no cover
-            logger.error(f"SKILL 重物化/上报失败: {e}", exc_info=True)
+            logger.error(f"SKILL 重物化/标脏失败: {e}", exc_info=True)
 
-    async def _on_skill_resource_updated(self, client: "SMCPComputerClient") -> None:
-        """skill:// 资源内容更新 → 重物化 + 上报（不比较集合，降低延迟，仿 window ResourceUpdated）。
+    async def _on_skill_resource_updated(self) -> None:
+        """skill:// 资源内容更新 → 重物化 + 去抖器标脏（不比较集合，降低延迟，仿 window ResourceUpdated）。
 
         单 SKILL 增量物化的 server 归属无法仅从 URI 推断，故走全量重物化（正确优先；增量为后续优化）。
-        skill:// content updated → restage + emit (no set compare, lower latency). Full restage for
-        simplicity since per-skill server attribution isn't derivable from the URI alone.
+        skill:// content updated → restage + debouncer.mark_dirty (no set compare, lower latency).
         """
         try:
             await self._restage_mcp_skills()
-            await client.emit_update_skills()
+            self._skill_debouncer.mark_dirty()
         except Exception as e:  # pragma: no cover
-            logger.error(f"SKILL 内容更新重物化/上报失败: {e}", exc_info=True)
+            logger.error(f"SKILL 内容更新重物化/标脏失败: {e}", exc_info=True)
 
     async def _acollect_window_uris(self) -> set[str]:
         """
@@ -503,23 +544,98 @@ class Computer(BaseComputer[PromptSession]):
             return []
         registered = await stage_mcp_skills(self.mcp_manager, self._skill_registry, self._skill_home, server_name=server_name)
         if server_name is None:
-            self._reconcile_mcp_orphans(set(registered))
+            self._reconcile_orphans(set(registered), lambda s: s.startswith("mcp:"))
         return registered
 
-    def _reconcile_mcp_orphans(self, present_names: set[str]) -> None:
+    def _reconcile_orphans(self, present_names: set[str], source_pred: Callable[[str], bool]) -> None:
         """
-        全量重物化后孤儿对账 / Orphan reconciliation after a full restage。
+        全量重物化 / 重扫后的孤儿对账（按源谓词限定）/ Orphan reconciliation after a full restage/rescan。
 
-        当前活跃但本轮未出现的 ``mcp:`` 源 SKILL → :meth:`SkillRegistry.mark_orphan`（消失即从
-        ``get_skills`` 排除；恢复由 staging 的 ``register`` 命中孤儿条目自动完成）。**仅**处理 mcp 源，
-        marketplace/user 源（#60/#61）由各自 reconciler 维护，不在此误标孤儿。
-        Only mcp-source skills are reconciled here; marketplace/user sources are owned by #60/#61.
+        当前活跃、``source_pred(source)`` 命中、但本轮 ``present_names`` 未出现的 SKILL →
+        :meth:`SkillRegistry.mark_orphan`（消失即从 ``get_skills`` 排除；恢复由 staging 的 ``register_or_update``
+        命中孤儿条目自动完成）。``source_pred`` 把对账**限定在单一源**——mcp（``startswith("mcp:")``）/ user
+        （``== SOURCE_USER``）/ 后续 marketplace（#61）各自传入谓词，互不误标。
+        ``source_pred`` confines reconciliation to a single source so the others are never mis-orphaned.
         """
         for ref in self._skill_registry.active_refs():
             source = ref.get("source", "") or ""
             name = ref.get("name", "") or ""
-            if name and name not in present_names and source.startswith("mcp:"):
+            if name and name not in present_names and source_pred(source):
                 self._skill_registry.mark_orphan(name)
+
+    # ── v0.2.1 事件触发链：去抖结算 + user 源 watcher（S14，#67）────────────────
+    async def _emit_update_skills_now(self) -> None:
+        """
+        去抖器结算末端：向信令服务器推送 ``server:update_skills`` / Debouncer settlement sink。
+
+        无 Socket.IO 客户端 / 未入房间 → no-op（emit 的 office_id 守卫在 client 侧）。该协程是
+        :class:`SkillEventDebouncer` 的 ``on_emit``，**不**应被事件处理器裸调（一律经去抖器 :meth:`mark_dirty`）。
+        """
+        client = self.socketio_client
+        if client is None:
+            logger.debug("Socket.IO 客户端不存在或已释放，跳过 SKILL 更新上报 / no client, skip update_skills")
+            return
+        await client.emit_update_skills()
+
+    async def _invalidate_user_skills(self) -> None:
+        """
+        缓存失效（文件源重扫）：就地重扫 user 源 DropIn 并对账孤儿 / Invalidate by rescanning user-source DropIn。
+
+        设计 §8.1「缓存失效」对**文件源**的落实——watcher/CLI 标脏后、emit 前重扫 ``<home>/user/`` +
+        各登记 ``<workdir>/.tfrobot/skills/``（``stage_user_skills`` 幂等 ``register_or_update``），并把本轮
+        未发现的 user 源 SKILL 标孤儿（磁盘删除即从 ``get_skills`` 排除）。mcp 源由其 ``ResourceListChanged``
+        处理器即时重物化，**不**在此重复。SKILL Home 未就绪 → no-op。
+
+        **同步执行、不卸载线程池**：:class:`SkillRegistry` 按设计为单事件循环线程访问、无锁；``stage_user_skills``
+        会写 Registry，若经 ``asyncio.to_thread`` 在 worker 线程改 ``_entries``，将与循环线程的 ``active_refs``
+        迭代（``client:get_skills``）/ mcp 重物化产生数据竞争（``dict changed size during iteration`` / 撕裂写）。
+        user DropIn 扫描仅遍历少量目录、读少量 ``SKILL.md``（亚毫秒~低毫秒），同步执行不构成有意义阻塞，
+        并守住 Registry 单线程不变量。Run synchronously on the loop thread to preserve the Registry's
+        single-thread (lock-free) invariant; the user-DropIn scan is tiny and does not meaningfully block.
+        """
+        if self._skill_home is None:
+            return
+        try:
+            discovered = stage_user_skills(self._skill_registry, self._skill_home, self._registered_workdirs)
+            self._reconcile_orphans(set(discovered), lambda s: s == SOURCE_USER)
+        except Exception as e:  # pragma: no cover — 防御性兜底（staging 内部已各自降级）
+            logger.error(f"user 源重扫 / 对账失败 / user-source rescan failed: {e}", exc_info=True)
+
+    def _start_skill_watcher(self) -> None:
+        """
+        启动 user 源 DropIn 文件 watcher / Start the user-source DropIn file watcher。
+
+        监控根 = ``<home>/user/`` + 各登记 ``<workdir>/.tfrobot/skills/``（递归、过滤 ``SKILL.md``，**不**监
+        marketplace clone 树）。watchdog 回调在独立线程触发 → 经 ``loop.call_soon_threadsafe`` marshal 回事件
+        循环线程调去抖器 :meth:`mark_dirty`。已有 watcher → 先停。SKILL Home 未就绪 → no-op。
+        """
+        if self._skill_home is None:
+            return
+        if self._skill_watcher is not None:
+            self._skill_watcher.stop()
+        loop = asyncio.get_running_loop()
+        debouncer = self._skill_debouncer
+
+        def _marshal() -> None:
+            try:
+                loop.call_soon_threadsafe(debouncer.mark_dirty)
+            except RuntimeError:  # pragma: no cover — 事件循环已关闭（停机竞态）/ loop closed during shutdown
+                pass
+
+        watcher = SkillFileWatcher(_marshal, use_polling=self._skill_watch_polling)
+        roots = [user_dropin_root(self._skill_home), *(workdir_skill_root(wd) for wd in self._registered_workdirs)]
+        watcher.watch(roots)
+        self._skill_watcher = watcher
+
+    def mark_skill_internal_write(self, path: str | Path) -> None:
+        """
+        给 SKILL 文件 watcher 打内部写标记 / Mark an internal write for the SKILL file watcher。
+
+        供 CLI / SDK 在**写入被监控的 user 源 DropIn 路径**后调用，避免自写触发 watcher 重载循环（对标 CC
+        ``markInternalWrite``）。watcher 未启动 → no-op。
+        """
+        if self._skill_watcher is not None:
+            self._skill_watcher.mark_internal_write(path)
 
     async def _arender_and_validate_server(
         self,
@@ -742,7 +858,14 @@ class Computer(BaseComputer[PromptSession]):
         """
         关闭计算机，关闭 MCP 服务器管理器。
         Shutdown the computer and close the MCP server manager.
+
+        v0.2.1（#67）：先停 user 源文件 watcher（不再产生新事件），再关去抖器（丢弃挂起 emit），最后关
+        MCP 管理器。Stop the file watcher, close the debouncer (drop pending emit), then the MCP manager.
         """
+        if self._skill_watcher is not None:
+            self._skill_watcher.stop()
+            self._skill_watcher = None
+        await self._skill_debouncer.aclose()
         if self.mcp_manager:
             await self.mcp_manager.aclose()
         self.mcp_manager = None

--- a/a2c_smcp/computer/computer.py
+++ b/a2c_smcp/computer/computer.py
@@ -27,7 +27,6 @@ All classes and methods use Google style docstrings (bilingual: Chinese and Engl
 
 import asyncio
 import json
-import os
 import weakref
 from collections import deque
 from collections.abc import Callable, Sequence
@@ -79,6 +78,7 @@ from a2c_smcp.computer.skills import (
 from a2c_smcp.computer.types import ToolCallRecord
 from a2c_smcp.smcp import A2CSkillRef, Desktop, SMCPTool
 from a2c_smcp.types import AttributeValue
+from a2c_smcp.utils.env import env_truthy
 from a2c_smcp.utils.logger import get_logger, truncate
 from a2c_smcp.utils.window_uri import is_window_uri
 
@@ -186,12 +186,7 @@ class Computer(BaseComputer[PromptSession]):
         )
         self._skill_watcher: SkillFileWatcher | None = None
         # 原生 Observer 不支持的 FS（网络挂载 / overlayfs）可经此环境变量切 PollingObserver 兜底。
-        self._skill_watch_polling: bool = os.environ.get("A2C_SKILL_WATCH_POLLING", "").strip().lower() in {
-            "1",
-            "true",
-            "yes",
-            "on",
-        }
+        self._skill_watch_polling: bool = env_truthy("A2C_SKILL_WATCH_POLLING")
 
         # v0.2.1 通用二进制传输基础设施 / v0.2.1 generic blob-transfer infrastructure
         # 协议依据 / Protocol: blob-transfer.md；设计 / Design: §4.3 / §4.4

--- a/a2c_smcp/computer/skills/__init__.py
+++ b/a2c_smcp/computer/skills/__init__.py
@@ -17,12 +17,18 @@ Mirrors Claude Code marketplace local SKILL management. Landed modules:
 - :mod:`a2c_smcp.computer.skills.staging`  —— 多 source 物化（mcp 源 + manager.list_skill_resources）（S6，#59）
 - :mod:`a2c_smcp.computer.skills.sandbox`  —— 包根内 `safe_join`+`realpath` 沙箱 + `.skillenv` forbidden + name 寻址防越权（S2，#55）
 - :mod:`a2c_smcp.computer.skills.resource` —— 沙箱解析 → 消费字节视图（mint/serve 字节基准一致：sha256/total_size）（S13，#66）
+- :mod:`a2c_smcp.computer.skills.debouncer`—— 缓存失效 + 300ms debounce + 单次 emit（事件触发链，S14，#67）
+- :mod:`a2c_smcp.computer.skills.watcher`  —— user 源 DropIn 文件 watcher（watchdog 递归监 SKILL.md + markInternalWrite）（S14，#67）
 
 协议依据 / Protocol: a2c-smcp-protocol docs/specification/skill.md §1 / §4 / §6 / §8 / §9.2。
 """
 
 from __future__ import annotations
 
+from a2c_smcp.computer.skills.debouncer import (
+    DEFAULT_DEBOUNCE_MS,
+    SkillEventDebouncer,
+)
 from a2c_smcp.computer.skills.home import (
     SKILL_HOME_ENV,
     SKILL_HOME_MODE,
@@ -71,8 +77,17 @@ from a2c_smcp.computer.skills.staging import (
     stage_user_skills,
     strip_skill_frontmatter,
 )
+from a2c_smcp.computer.skills.watcher import (
+    DEFAULT_INTERNAL_WRITE_TTL_S,
+    SkillFileWatcher,
+)
 
 __all__ = [
+    # debouncer / watcher（事件触发链：缓存失效 + 300ms debounce + 文件监控）
+    "DEFAULT_DEBOUNCE_MS",
+    "DEFAULT_INTERNAL_WRITE_TTL_S",
+    "SkillEventDebouncer",
+    "SkillFileWatcher",
     # home
     "SKILL_HOME_ENV",
     "SKILL_HOME_MODE",

--- a/a2c_smcp/computer/skills/debouncer.py
+++ b/a2c_smcp/computer/skills/debouncer.py
@@ -61,14 +61,24 @@ class SkillEventDebouncer:
         self._invalidate = invalidate
         self._window_ms = max(0, window_ms)
         self._task: asyncio.Task[None] | None = None
+        self._closed = False
 
     def mark_dirty(self) -> None:
         """
         标脏并重排一次结算 / Mark dirty and (re)schedule a settlement。
 
-        窗口内多次调用 → 取消未到期 task、重排，**末次胜出**（多事件合并为一次 emit）。
-        必须在事件循环线程内调用（跨线程触发先经 ``loop.call_soon_threadsafe``）。
+        窗口内多次调用 → 取消未到期 task、重排，**末次胜出**（多事件合并为一次 emit）。必须在事件循环线程内
+        调用（跨线程触发先经 ``loop.call_soon_threadsafe``）。:meth:`aclose` 后为 **no-op**——中和停机临终
+        投递、滞留循环队列的跨线程 mark_dirty，杜绝停机后复活挂起 emit。
+
+        **权衡：纯尾部去抖、无 max-wait 上限**——若事件持续以 ``< window_ms`` 间隔到来，结算被无限推迟
+        （emit 饿死）。离散 SKILL.md 编辑不会触发，与 CC ``skillChangeDetector`` 同义；仅 PollingObserver
+        兜底下的批量同步（网络盘）值得留意，必要时后续引入 leading+trailing max-wait 上限。
+        Pure trailing debounce, no max-wait cap: continuous sub-window churn starves the emit (won't
+        happen for discrete edits; matches CC). No-op after :meth:`aclose`.
         """
+        if self._closed:
+            return
         if self._task is not None and not self._task.done():
             self._task.cancel()
         self._task = asyncio.create_task(self._settle_after_delay())
@@ -114,8 +124,11 @@ class SkillEventDebouncer:
         """
         关闭去抖器，丢弃未结算的挂起 emit / Close the debouncer, dropping any pending unsettled emit。
 
-        生命周期清理（停机）：取消挂起 task 并等待其结束（幂等）。**不**冲刷——停机时无需再广播。
+        生命周期清理（停机）：先置 ``_closed``（此后 :meth:`mark_dirty` 一律 no-op——中和 watcher 停机临终
+        投递、滞留事件循环队列的跨线程 mark_dirty，杜绝停机后复活挂起 emit / ``Task destroyed pending`` 告警），
+        再取消挂起 task 并等待其结束（幂等）。**不**冲刷——停机时无需再广播。
         """
+        self._closed = True
         task = self._task
         self._task = None
         if task is not None and not task.done():

--- a/a2c_smcp/computer/skills/debouncer.py
+++ b/a2c_smcp/computer/skills/debouncer.py
@@ -1,0 +1,126 @@
+# -*- coding: utf-8 -*-
+# filename: debouncer.py
+# @Time    : 2026/05/26
+# @Author  : JQQ
+# @Email   : jqq1716@gmail.com
+# @Software: PyCharm
+"""
+SKILL 事件去抖器：缓存失效 + 300ms debounce + 单次 emit（v0.2.1）
+SKILL event debouncer: cache invalidation + 300ms debounce + single emit (v0.2.1)
+
+SDK 设计 / Design: python-sdk docs/design-0.2.1-cli-marketplace-ux.md §8.1 / §8.2
+                   （借鉴 Claude Code ``clearAllCaches`` + ``skillChangeDetector`` 300ms debounce）。
+
+多源 SKILL 变更（mcp ``ResourceListChanged`` / user 源文件 watcher / 后续 CLI marketplace·plugin 操作）
+统一喂给本去抖器的 :meth:`mark_dirty`，在 ``window_ms``（默认 300ms）窗口内合并为**一次** emit：
+1. 窗口到期 → 先 ``invalidate()`` 做缓存失效（重扫文件源等），再 ``on_emit()`` 推送 ``server:update_skills``；
+2. 窗口内多次 ``mark_dirty`` → 取消未到期 task、重排，**末次胜出**（避免抖动期间多次广播）；
+3. ``on_emit`` 失败 → ERROR 日志 + **单次重试**（设计 §12「emit 失败重试」），仍失败则放弃本轮。
+All SKILL-change sources funnel into :meth:`mark_dirty`; events within ``window_ms`` coalesce into a
+single ``invalidate → emit`` settlement (latest-wins; emit failure retried once then dropped).
+
+线程模型 / Threading: 本去抖器假定在 Computer 单 asyncio 事件循环线程内被驱动；来自其它线程（如 watchdog
+观察者线程）的触发**必须**先经 ``loop.call_soon_threadsafe`` marshal 回事件循环线程，再调 :meth:`mark_dirty`
+（见 :class:`~a2c_smcp.computer.skills.watcher.SkillFileWatcher` 的接入）。
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+
+from a2c_smcp.utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+# 默认去抖窗口（毫秒）/ Default debounce window (ms)。对齐 CC skillChangeDetector 的 300ms。
+DEFAULT_DEBOUNCE_MS = 300
+
+# 结算回调类型 / Settlement callback types。
+EmitCallback = Callable[[], Awaitable[None]]
+InvalidateCallback = Callable[[], Awaitable[None]]
+
+
+class SkillEventDebouncer:
+    """
+    SKILL 变更去抖器 / SKILL-change debouncer（设计 §8.2）。
+
+    :param on_emit: 结算末端的 emit 协程（通常 → ``client.emit_update_skills``）；无副作用幂等更佳。
+    :param invalidate: 结算前的缓存失效协程（重扫文件源 / 清缓存）；``None`` 表示无需失效，直接 emit。
+    :param window_ms: 去抖窗口毫秒数（默认 :data:`DEFAULT_DEBOUNCE_MS`）；``<=0`` 表示下个事件循环 tick 即结算。
+    """
+
+    def __init__(
+        self,
+        on_emit: EmitCallback,
+        *,
+        invalidate: InvalidateCallback | None = None,
+        window_ms: int = DEFAULT_DEBOUNCE_MS,
+    ) -> None:
+        self._on_emit = on_emit
+        self._invalidate = invalidate
+        self._window_ms = max(0, window_ms)
+        self._task: asyncio.Task[None] | None = None
+
+    def mark_dirty(self) -> None:
+        """
+        标脏并重排一次结算 / Mark dirty and (re)schedule a settlement。
+
+        窗口内多次调用 → 取消未到期 task、重排，**末次胜出**（多事件合并为一次 emit）。
+        必须在事件循环线程内调用（跨线程触发先经 ``loop.call_soon_threadsafe``）。
+        """
+        if self._task is not None and not self._task.done():
+            self._task.cancel()
+        self._task = asyncio.create_task(self._settle_after_delay())
+
+    async def _settle_after_delay(self) -> None:
+        """等待去抖窗口后结算；窗口内被新的 :meth:`mark_dirty` 取消则放弃本次（末次胜出）。"""
+        await asyncio.sleep(self._window_ms / 1000)
+        await self._run_settlement()
+
+    async def _run_settlement(self) -> None:
+        """结算一次：先缓存失效（失败不阻断 emit），再 emit（失败 ERROR + 单次重试）。"""
+        if self._invalidate is not None:
+            try:
+                await self._invalidate()
+            except Exception as e:
+                logger.error("SKILL 缓存失效失败（仍继续 emit）/ invalidate failed (emit anyway): %s", e, exc_info=True)
+        try:
+            await self._on_emit()
+        except Exception as e:
+            logger.error("emit_update_skills 失败，重试一次 / emit failed, retrying once: %s", e, exc_info=True)
+            try:
+                await self._on_emit()
+            except Exception as e2:
+                logger.error("emit_update_skills 重试仍失败，放弃本轮 / emit retry failed, giving up: %s", e2, exc_info=True)
+
+    async def aflush(self) -> None:
+        """
+        立即结算挂起窗口 / Settle the pending window immediately。
+
+        取消去抖等待，直接 ``invalidate → emit``；**无挂起则 no-op**（不会凭空 emit）。
+        主要供单元测试**确定性结算**（免 ``sleep`` 猜时）；停机不走本方法——:meth:`Computer.shutdown` 用
+        :meth:`aclose` **丢弃**挂起 emit（停机时无需再广播）。
+        Mainly for deterministic settlement in tests; shutdown uses :meth:`aclose` (drops the pending emit).
+        """
+        task = self._task
+        if task is None or task.done():
+            return
+        task.cancel()
+        self._task = None
+        await self._run_settlement()
+
+    async def aclose(self) -> None:
+        """
+        关闭去抖器，丢弃未结算的挂起 emit / Close the debouncer, dropping any pending unsettled emit。
+
+        生命周期清理（停机）：取消挂起 task 并等待其结束（幂等）。**不**冲刷——停机时无需再广播。
+        """
+        task = self._task
+        self._task = None
+        if task is not None and not task.done():
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass

--- a/a2c_smcp/computer/skills/watcher.py
+++ b/a2c_smcp/computer/skills/watcher.py
@@ -1,0 +1,225 @@
+# -*- coding: utf-8 -*-
+# filename: watcher.py
+# @Time    : 2026/05/26
+# @Author  : JQQ
+# @Email   : jqq1716@gmail.com
+# @Software: PyCharm
+"""
+SKILL 文件 watcher：监控 user 源 DropIn 发现根，SKILL.md 变更 → 去抖 emit（v0.2.1）
+SKILL file watcher: watch user-source DropIn roots, SKILL.md change → debounced emit (v0.2.1)
+
+SDK 设计 / Design: python-sdk docs/design-0.2.1-cli-marketplace-ux.md §8.3。
+
+监控范围 / Scope（§8.3）：
+- 监控根（**递归**）= ``$A2C_SKILL_HOME/user/`` + **全部已登记** ``<workdir>/.tfrobot/skills/``（能力发现层、
+  全局并集、不随 active workdir 切换）；过滤器为 ``**/SKILL.md``。**绝不监** marketplace clone 树
+  （``<home>/marketplace/<mp>/...``）——clone 树是物化产物，变更只经 CLI 操作发生（操作自调去抖标脏），
+  监控它会引发 ``git pull`` 雪崩并破坏「意图层 / 物化层」单向同步边界（§8.3 三条理由）。
+- **监控范围 ≠ 发现单元**：watcher 监根递归子树并过滤 ``SKILL.md``；SKILL 的「发现单元」是
+  ``<root>/<skill>/SKILL.md``（根下一级），深度过滤由 :func:`~a2c_smcp.computer.skills.staging.stage_user_skills`
+  在重扫时负责，watcher 只管「有 SKILL.md 变更 → 标脏」。
+
+触发规则 / Trigger rule：
+- ``SKILL.md`` 文件 created/modified/deleted/moved → 触发（经 :meth:`mark_internal_write` 打标的自写除外）；
+- **目录** deleted/moved → 触发（``rm -rf <skill>/`` / ``mv`` 在部分平台仅报目录事件、不逐文件，避免漏删）；
+- 其余（目录 created/modified、非 SKILL.md 附属文件）→ 忽略。
+偶发过触发由下游 300ms 去抖 + 重扫集合对比吸收（宁可多扫一次，不可漏掉删除）。
+
+线程模型 / Threading：watchdog 观察者回调在**独立线程**触发。本 watcher 的 ``on_change`` 回调由调用方注入，
+**必须**自行做线程安全 marshal（通常 ``loop.call_soon_threadsafe(debouncer.mark_dirty)``），见
+:meth:`~a2c_smcp.computer.computer.Computer._start_skill_watcher`。
+
+实现 / Impl：默认原生 :class:`~watchdog.observers.Observer`（inotify/FSEvents/ReadDirectoryChangesW）；
+``use_polling=True`` 切 :class:`~watchdog.observers.polling.PollingObserver`，给不支持原生事件的 FS
+（某些网络挂载 / 容器 overlayfs）兜底。
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+import time
+from collections.abc import Callable, Iterable
+from pathlib import Path
+
+from watchdog.events import FileSystemEvent, FileSystemEventHandler
+from watchdog.observers import Observer
+from watchdog.observers.api import BaseObserver
+from watchdog.observers.polling import PollingObserver
+
+from a2c_smcp.computer.skills.sandbox import DEFAULT_SKILL_FILE
+from a2c_smcp.utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+# 内部写打标默认存活窗口（秒）/ Default TTL for internal-write marks (seconds)。对齐 CC ~2s。
+DEFAULT_INTERNAL_WRITE_TTL_S = 2.0
+
+# PollingObserver 下的 TTL 下限（秒）/ TTL floor under PollingObserver。
+# 轮询模式自写事件最迟于下个轮询周期（watchdog 默认 ~1s）才上报，若 TTL < 轮询周期，自写事件可能在打标过期后
+# 才到达 → 逃过抑制 → 触发「写回 → watcher → 重载」自触发。故 polling 时把 TTL 抬到 ≥ 轮询周期 + 余量。
+# A self-write surfaces only at the next poll (~1s default); TTL must exceed the poll period to suppress it.
+POLLING_INTERNAL_WRITE_TTL_FLOOR_S = 5.0
+
+
+class _SkillMdEventHandler(FileSystemEventHandler):
+    """
+    watchdog 事件过滤器 / watchdog event filter。
+
+    仅对 ``SKILL.md`` 文件事件（排除内部写）与目录删/移事件回调 ``on_change``；其余忽略（见模块「触发规则」）。
+    注：覆盖方法参数加宽为 :class:`FileSystemEvent`（基类签名为各具体事件类型，加宽参数对 LSP 安全）。
+    """
+
+    def __init__(self, on_change: Callable[[], None], is_internal: Callable[[str], bool]) -> None:
+        self._on_change = on_change
+        self._is_internal = is_internal
+
+    def _fire_if_skill_md(self, raw_path: str | bytes) -> None:
+        """路径 basename 为 SKILL.md 且非内部写 → 触发 ``on_change``。"""
+        path = os.fsdecode(raw_path)
+        if os.path.basename(path) != DEFAULT_SKILL_FILE:
+            return
+        if self._is_internal(path):
+            logger.debug("SKILL watcher 忽略内部写自触发 / ignore internal-write self-trigger: %s", path)
+            return
+        self._on_change()
+
+    def on_created(self, event: FileSystemEvent) -> None:
+        if not event.is_directory:
+            self._fire_if_skill_md(event.src_path)
+
+    def on_modified(self, event: FileSystemEvent) -> None:
+        if not event.is_directory:
+            self._fire_if_skill_md(event.src_path)
+
+    def on_deleted(self, event: FileSystemEvent) -> None:
+        if event.is_directory:
+            # rm -rf <skill>/ 在部分平台仅报目录删除（不逐文件）→ 直接标脏，交重扫对账孤儿。
+            self._on_change()
+        else:
+            self._fire_if_skill_md(event.src_path)
+
+    def on_moved(self, event: FileSystemEvent) -> None:
+        if event.is_directory:
+            self._on_change()
+        else:
+            self._fire_if_skill_md(event.src_path)
+            # dest 落点为 SKILL.md（如 other → SKILL.md 改名）也应触发；dest_path 在基类即存在（非移动事件为空串）。
+            self._fire_if_skill_md(event.dest_path)
+
+
+class SkillFileWatcher:
+    """
+    user 源 DropIn 文件 watcher（watchdog 集成）/ User-source DropIn file watcher。
+
+    :param on_change: 检测到相关变更时调用的**线程安全** marshaller（通常
+        ``lambda: loop.call_soon_threadsafe(debouncer.mark_dirty)``）；在 watchdog 观察者线程内被调用。
+    :param use_polling: ``True`` 用 :class:`PollingObserver`（不支持原生事件的 FS 兜底），默认原生 Observer。
+    :param internal_write_ttl_s: :meth:`mark_internal_write` 打标的存活窗口（秒）。
+    """
+
+    def __init__(
+        self,
+        on_change: Callable[[], None],
+        *,
+        use_polling: bool = False,
+        internal_write_ttl_s: float = DEFAULT_INTERNAL_WRITE_TTL_S,
+    ) -> None:
+        self._on_change = on_change
+        self._use_polling = use_polling
+        # polling 模式抬高 TTL 到 ≥ 轮询周期，避免迟到的自写事件逃过抑制（见 POLLING_INTERNAL_WRITE_TTL_FLOOR_S）。
+        self._internal_ttl = max(internal_write_ttl_s, POLLING_INTERNAL_WRITE_TTL_FLOOR_S) if use_polling else internal_write_ttl_s
+        self._handler = _SkillMdEventHandler(on_change, self._is_internal_write)
+        self._observer: BaseObserver | None = None
+        self._watched: list[Path] = []
+        self._internal_writes: dict[str, float] = {}
+        self._lock = threading.Lock()
+
+    # ── 内部写打标（避免回写自触发）/ internal-write marking ─────────────────
+    def mark_internal_write(self, path: str | Path) -> None:
+        """
+        登记一次 SDK 自写路径 / Mark a path the SDK itself just wrote。
+
+        其 ``internal_write_ttl_s`` 窗口内对该路径的 SKILL.md 事件将被忽略，避免「写回 → watcher →
+        重载 → 写回」自触发循环（对标 CC ``settings.ts`` ``markInternalWrite``）。线程安全。
+        """
+        key = self._normalize(path)
+        with self._lock:
+            self._internal_writes[key] = time.monotonic() + self._internal_ttl
+
+    def _is_internal_write(self, path: str) -> bool:
+        """路径是否处于未过期的内部写打标窗口内（顺带清理过期项）/ Whether path is within an unexpired mark。"""
+        key = self._normalize(path)
+        now = time.monotonic()
+        with self._lock:
+            expired = [k for k, exp in self._internal_writes.items() if exp <= now]
+            for k in expired:
+                del self._internal_writes[k]
+            exp = self._internal_writes.get(key)
+            return exp is not None and exp > now
+
+    @staticmethod
+    def _normalize(path: str | Path) -> str:
+        """归一为 realpath 字符串（与 watchdog 上报路径对齐）；解析失败回退原值。"""
+        try:
+            return str(Path(path).resolve())
+        except OSError:  # pragma: no cover - 防御性（路径解析极少抛）
+            return str(path)
+
+    # ── 生命周期 / lifecycle ─────────────────────────────────────────────────
+    def watch(self, roots: Iterable[Path]) -> None:
+        """
+        对全部**存在**的发现根注册递归监控并启动 Observer / Schedule recursive watches on existing roots。
+
+        缺失根跳过 + DEBUG（容错：user/ 或某 workdir 尚未创建很正常）；重复根去重；**无可监控根 → 不启动线程**
+        （避免空 Observer 线程）。重复调用前请先 :meth:`stop`。
+        """
+        existing: list[Path] = []
+        seen: set[str] = set()
+        for root in roots:
+            rp = root.resolve()
+            key = str(rp)
+            if key in seen:
+                continue
+            seen.add(key)
+            if not rp.is_dir():
+                logger.debug("SKILL watcher 跳过不存在的发现根 / skip missing root: %s", rp)
+                continue
+            existing.append(rp)
+
+        if not existing:
+            logger.debug("SKILL watcher 无可监控发现根，Observer 不启动 / no watchable roots, observer not started")
+            return
+
+        observer: BaseObserver = PollingObserver() if self._use_polling else Observer()
+        for rp in existing:
+            observer.schedule(self._handler, str(rp), recursive=True)
+            logger.debug("SKILL watcher 注册递归监控 / watching (recursive): %s", rp)
+        observer.daemon = True
+        observer.start()
+        self._observer = observer
+        self._watched = existing
+        logger.info("SKILL 文件 watcher 已启动，监控 %d 个发现根 / started, watching %d root(s)", len(existing), len(existing))
+
+    def stop(self, *, timeout: float = 2.0) -> None:
+        """停止并 join Observer 线程（幂等；未启动 → no-op）/ Stop and join the observer thread (idempotent)。"""
+        observer = self._observer
+        self._observer = None
+        self._watched = []
+        if observer is None:
+            return
+        try:
+            observer.stop()
+            observer.join(timeout=timeout)
+        except Exception as e:  # pragma: no cover - 防御性（停机竞态）
+            logger.error("SKILL watcher 停止异常 / stop failed: %s", e, exc_info=True)
+
+    @property
+    def is_running(self) -> bool:
+        """Observer 是否在运行 / Whether the observer thread is running。"""
+        return self._observer is not None
+
+    @property
+    def watched_roots(self) -> tuple[Path, ...]:
+        """当前实际监控的发现根（已存在并 schedule 的）/ Currently scheduled (existing) roots。"""
+        return tuple(self._watched)

--- a/a2c_smcp/computer/socketio/client.py
+++ b/a2c_smcp/computer/socketio/client.py
@@ -327,6 +327,12 @@ class SMCPComputerClient(AsyncClient):
         复用 UpdateComputerConfigReq（协议 events.md §server:update_skills 明确复用，不新建结构）；
         office_id 守卫与 :meth:`emit_update_tool_list` 一致——未入房间不发送。
         Reuses UpdateComputerConfigReq (protocol reuses it); office_id guard mirrors emit_update_tool_list.
+
+        v0.2.1（S14，#67）：本方法是 :class:`~a2c_smcp.computer.skills.debouncer.SkillEventDebouncer` 的
+        **低层 emit sink**——多源 SKILL 变更（mcp ``ResourceListChanged`` / user 源文件 watcher / CLI 操作）
+        统一经 ``Computer`` 持有的去抖器在 300ms 窗口内合并后调用本方法，事件处理器**不**应裸调它（设计 §8.1）。
+        This is the low-level emit sink for the Computer-owned ``SkillEventDebouncer``; event handlers must
+        route through the debouncer (300ms coalescing) rather than calling this directly.
         """
         if self.office_id:
             await self.emit(UPDATE_SKILLS_EVENT, UpdateComputerConfigReq(computer=self.computer.name))

--- a/a2c_smcp/utils/env.py
+++ b/a2c_smcp/utils/env.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+# filename: env.py
+# @Time    : 2026/05/26
+# @Author  : JQQ
+# @Email   : jqq1716@gmail.com
+# @Software: PyCharm
+"""
+环境变量解析工具 / Environment-variable parsing helpers。
+
+统一布尔环境变量的**真值集**，避免各处内联 ``... .lower() in (...)`` 解析因集合不一致而漂移
+（如某处认 ``"on"`` 而另一处不认）。
+Unifies the canonical truth set for boolean env vars so inline parses don't drift across modules.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+
+# 规范真值集 / Canonical truthy set（解析前统一 ``strip().lower()``，故此处只列小写裸值）。
+_TRUTHY: frozenset[str] = frozenset({"1", "true", "yes", "on"})
+
+
+def env_truthy(key: str, *, default: bool = False, env: Mapping[str, str] | None = None) -> bool:
+    """
+    判断布尔型环境变量是否为真 / Whether a boolean-style env var is truthy。
+
+    取 ``env[key]``（缺省 ``os.environ``）后 ``strip().lower()``，命中 :data:`_TRUTHY`
+    （``1`` / ``true`` / ``yes`` / ``on``）为真；**未设置或空白** → ``default``；其它值（如 ``0`` /
+    ``false`` / ``off``）→ ``False``。
+
+    :param key: 环境变量名 / env var name.
+    :param default: 未设置或空白时的回退值 / fallback when unset or blank.
+    :param env: 环境映射，便于测试注入 / env mapping, defaults to ``os.environ``.
+    """
+    environ: Mapping[str, str] = os.environ if env is None else env
+    raw = environ.get(key)
+    if raw is None:
+        return default
+    norm = raw.strip().lower()
+    if not norm:
+        return default
+    return norm in _TRUTHY

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "tzlocal (>=5.0.0,<6.0.0)",
     "aiohttp >=3.12.15,<4.0.0",
     "msgpack >=1.1.0,<2.0.0",
+    "watchdog (>=6.0.0,<7.0.0)",
 ]
 
 [project.scripts]

--- a/tests/unit_tests/computer/skills/test_debouncer.py
+++ b/tests/unit_tests/computer/skills/test_debouncer.py
@@ -1,0 +1,166 @@
+# -*- coding: utf-8 -*-
+# filename: test_debouncer.py
+# @Time    : 2026/05/26
+# @Author  : JQQ
+# @Email   : jqq1716@gmail.com
+# @Software: PyCharm
+"""
+SkillEventDebouncer 单元测试（v0.2.1，#67）/ Unit tests for SkillEventDebouncer。
+
+设计依据 / Design: docs/design-0.2.1-cli-marketplace-ux.md §8.1 / §8.2。
+
+测试意图 / Test intentions:
+- 窗口到期触发：invalidate → emit（顺序）；多次 mark_dirty 窗口内合并为单次 emit（末次胜出）；
+- aflush 确定性结算挂起窗口（免 sleep）；无挂起则 no-op（不凭空 emit）；
+- emit 失败 ERROR + 单次重试；invalidate 失败不阻断 emit；
+- aclose 取消挂起、丢弃未结算 emit；无 invalidate 回调也能 emit。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+import pytest
+
+import a2c_smcp.computer.skills.debouncer as debouncer_mod
+from a2c_smcp.computer.skills.debouncer import SkillEventDebouncer
+
+
+class _Recorder:
+    """记录 invalidate/emit 调用次数与顺序；可配置 emit 前 N 次失败 / Records calls; emit fails first N times。"""
+
+    def __init__(self, *, emit_fail_times: int = 0, invalidate_raises: bool = False) -> None:
+        self.order: list[str] = []
+        self.emit_calls = 0
+        self.invalidate_calls = 0
+        self._emit_fail_times = emit_fail_times
+        self._invalidate_raises = invalidate_raises
+
+    async def emit(self) -> None:
+        self.emit_calls += 1
+        self.order.append("emit")
+        if self.emit_calls <= self._emit_fail_times:
+            raise RuntimeError("emit boom")
+
+    async def invalidate(self) -> None:
+        self.invalidate_calls += 1
+        self.order.append("invalidate")
+        if self._invalidate_raises:
+            raise RuntimeError("invalidate boom")
+
+
+# ── 窗口结算 + 合并 / window settlement + coalescing ─────────────────────────
+async def test_emits_after_window() -> None:
+    rec = _Recorder()
+    deb = SkillEventDebouncer(rec.emit, invalidate=rec.invalidate, window_ms=40)
+    deb.mark_dirty()
+    await asyncio.sleep(0.12)
+    assert rec.emit_calls == 1
+    assert rec.invalidate_calls == 1
+    assert rec.order == ["invalidate", "emit"]  # 先失效后 emit
+
+
+async def test_resched_delays_emit() -> None:
+    # 窗口内再次 mark_dirty → 取消前次、重排（末次胜出），原窗口到期不应 emit。
+    rec = _Recorder()
+    deb = SkillEventDebouncer(rec.emit, invalidate=rec.invalidate, window_ms=80)
+    deb.mark_dirty()
+    await asyncio.sleep(0.04)
+    deb.mark_dirty()  # 重排：从此刻起再等 80ms
+    await asyncio.sleep(0.04)  # 距第二次仅 40ms < 80ms，且第一次已被取消
+    assert rec.emit_calls == 0
+    await asyncio.sleep(0.12)
+    assert rec.emit_calls == 1  # 仅第二次窗口结算
+
+
+async def test_multiple_marks_coalesce_single_emit() -> None:
+    rec = _Recorder()
+    deb = SkillEventDebouncer(rec.emit, invalidate=rec.invalidate, window_ms=10_000)
+    deb.mark_dirty()
+    deb.mark_dirty()
+    deb.mark_dirty()
+    await deb.aflush()  # 确定性结算（免等 10s）
+    assert rec.emit_calls == 1
+    assert rec.invalidate_calls == 1
+
+
+# ── aflush ───────────────────────────────────────────────────────────────────
+async def test_aflush_no_pending_is_noop() -> None:
+    rec = _Recorder()
+    deb = SkillEventDebouncer(rec.emit, invalidate=rec.invalidate, window_ms=50)
+    await deb.aflush()  # 从未 mark_dirty → 不应 emit
+    assert rec.emit_calls == 0
+    assert rec.invalidate_calls == 0
+
+
+async def test_aflush_settles_pending_immediately() -> None:
+    rec = _Recorder()
+    deb = SkillEventDebouncer(rec.emit, invalidate=rec.invalidate, window_ms=10_000)
+    deb.mark_dirty()
+    await deb.aflush()  # 立即结算，无需等 10s 窗口
+    assert rec.emit_calls == 1
+    # 结算后再 aflush 为 no-op（无新挂起）
+    await deb.aflush()
+    assert rec.emit_calls == 1
+
+
+# ── 失败降级 / failure isolation ─────────────────────────────────────────────
+async def test_emit_failure_retried_once_then_succeeds(caplog: pytest.LogCaptureFixture) -> None:
+    rec = _Recorder(emit_fail_times=1)  # 首次失败、重试成功
+    deb = SkillEventDebouncer(rec.emit, window_ms=5_000)
+    deb.mark_dirty()
+    debouncer_mod.logger.addHandler(caplog.handler)
+    caplog.set_level(logging.ERROR)
+    try:
+        await deb.aflush()  # 不应抛
+    finally:
+        debouncer_mod.logger.removeHandler(caplog.handler)
+    assert rec.emit_calls == 2  # 失败一次 + 重试一次
+    assert any(r.levelno == logging.ERROR for r in caplog.records)
+
+
+async def test_emit_failure_retry_also_fails_swallowed() -> None:
+    rec = _Recorder(emit_fail_times=99)  # 始终失败
+    deb = SkillEventDebouncer(rec.emit, window_ms=5_000)
+    deb.mark_dirty()
+    await deb.aflush()  # 重试仍失败 → 吞掉，不抛
+    assert rec.emit_calls == 2  # 仅重试一次（共两次）
+
+
+async def test_invalidate_failure_does_not_block_emit() -> None:
+    rec = _Recorder(invalidate_raises=True)
+    deb = SkillEventDebouncer(rec.emit, invalidate=rec.invalidate, window_ms=5_000)
+    deb.mark_dirty()
+    await deb.aflush()
+    assert rec.invalidate_calls == 1
+    assert rec.emit_calls == 1  # invalidate 抛了，emit 仍执行
+
+
+async def test_no_invalidate_callback_emits() -> None:
+    rec = _Recorder()
+    deb = SkillEventDebouncer(rec.emit, window_ms=5_000)  # invalidate=None
+    deb.mark_dirty()
+    await deb.aflush()
+    assert rec.emit_calls == 1
+    assert rec.invalidate_calls == 0
+
+
+# ── aclose ─────────────────────────────────────────────────────────────────
+async def test_aclose_cancels_pending_no_emit() -> None:
+    rec = _Recorder()
+    deb = SkillEventDebouncer(rec.emit, invalidate=rec.invalidate, window_ms=10_000)
+    deb.mark_dirty()
+    await deb.aclose()  # 丢弃挂起 emit
+    assert rec.emit_calls == 0
+    # 给被取消的 task 一个调度机会，确认无延迟 emit 漏出
+    await asyncio.sleep(0.02)
+    assert rec.emit_calls == 0
+
+
+async def test_aclose_idempotent_without_pending() -> None:
+    rec = _Recorder()
+    deb = SkillEventDebouncer(rec.emit, window_ms=50)
+    await deb.aclose()  # 无挂起
+    await deb.aclose()  # 重复
+    assert rec.emit_calls == 0

--- a/tests/unit_tests/computer/skills/test_debouncer.py
+++ b/tests/unit_tests/computer/skills/test_debouncer.py
@@ -164,3 +164,15 @@ async def test_aclose_idempotent_without_pending() -> None:
     await deb.aclose()  # 无挂起
     await deb.aclose()  # 重复
     assert rec.emit_calls == 0
+
+
+async def test_mark_dirty_after_aclose_is_noop() -> None:
+    # 关闭后的 mark_dirty（含停机临终滞留的跨线程投递）必须 no-op，不复活挂起 emit。
+    rec = _Recorder()
+    deb = SkillEventDebouncer(rec.emit, invalidate=rec.invalidate, window_ms=10)
+    await deb.aclose()
+    deb.mark_dirty()
+    assert deb._task is None  # 未排程
+    await asyncio.sleep(0.03)  # 给潜在排程一个调度机会
+    assert rec.emit_calls == 0
+    assert rec.invalidate_calls == 0

--- a/tests/unit_tests/computer/skills/test_watcher.py
+++ b/tests/unit_tests/computer/skills/test_watcher.py
@@ -1,0 +1,182 @@
+# -*- coding: utf-8 -*-
+# filename: test_watcher.py
+# @Time    : 2026/05/26
+# @Author  : JQQ
+# @Email   : jqq1716@gmail.com
+# @Software: PyCharm
+"""
+SkillFileWatcher 单元测试（v0.2.1，#67）/ Unit tests for SkillFileWatcher。
+
+设计依据 / Design: docs/design-0.2.1-cli-marketplace-ux.md §8.3。
+
+测试意图 / Test intentions:
+- 事件过滤（确定性、免真实 FS 计时）：SKILL.md 文件增删改移 → 触发；非 SKILL.md / 目录增改 → 忽略；
+  目录删/移 → 触发（rm -rf / mv 整个 skill 目录，部分平台仅报目录事件）；改名落点为 SKILL.md → 触发。
+- markInternalWrite：打标窗口内对该路径的 SKILL.md 事件被忽略（避免自写回触发重载循环）。
+- watch/stop 生命周期与簿记：缺失根不启动；重复根去重；仅监控传入的根（marketplace clone 树不监）；stop 幂等。
+- PollingObserver 真实事件冒烟：创建 SKILL.md → 回调被触发（验证 watchdog↔handler 接线确实送达）。
+"""
+
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+
+from watchdog.events import (
+    DirCreatedEvent,
+    DirDeletedEvent,
+    DirModifiedEvent,
+    DirMovedEvent,
+    FileCreatedEvent,
+    FileDeletedEvent,
+    FileModifiedEvent,
+    FileMovedEvent,
+)
+
+from a2c_smcp.computer.skills.watcher import SkillFileWatcher, _SkillMdEventHandler
+
+
+class _Counter:
+    def __init__(self) -> None:
+        self.n = 0
+
+    def __call__(self) -> None:
+        self.n += 1
+
+
+def _handler(counter: _Counter, *, internal=lambda _p: False) -> _SkillMdEventHandler:  # noqa: ANN001
+    return _SkillMdEventHandler(counter, internal)
+
+
+# ── 事件过滤（直注合成事件，确定性）/ event filtering ────────────────────────
+def test_skill_md_file_events_fire() -> None:
+    c = _Counter()
+    h = _handler(c)
+    h.on_created(FileCreatedEvent("/abs/skills/demo/SKILL.md"))
+    h.on_modified(FileModifiedEvent("/abs/skills/demo/SKILL.md"))
+    h.on_deleted(FileDeletedEvent("/abs/skills/demo/SKILL.md"))
+    h.on_moved(FileMovedEvent("/abs/skills/demo/SKILL.md", "/abs/skills/demo/SKILL.md.bak"))
+    assert c.n == 4
+
+
+def test_non_skill_md_file_ignored() -> None:
+    c = _Counter()
+    h = _handler(c)
+    h.on_created(FileCreatedEvent("/abs/skills/demo/reference.md"))
+    h.on_modified(FileModifiedEvent("/abs/skills/demo/scripts/run.py"))
+    h.on_deleted(FileDeletedEvent("/abs/skills/demo/notes.txt"))
+    assert c.n == 0
+
+
+def test_dir_created_modified_ignored() -> None:
+    c = _Counter()
+    h = _handler(c)
+    h.on_created(DirCreatedEvent("/abs/skills/demo"))
+    h.on_modified(DirModifiedEvent("/abs/skills/demo"))
+    assert c.n == 0
+
+
+def test_dir_deleted_and_moved_fire() -> None:
+    # rm -rf <skill>/ 或 mv <skill>/ 在部分平台仅报目录事件 → 必须触发以免漏删。
+    c = _Counter()
+    h = _handler(c)
+    h.on_deleted(DirDeletedEvent("/abs/skills/demo"))
+    h.on_moved(DirMovedEvent("/abs/skills/demo", "/abs/skills/demo2"))
+    assert c.n == 2
+
+
+def test_moved_into_skill_md_fires() -> None:
+    # other.md → SKILL.md 改名：dest 落点为 SKILL.md，也应触发。
+    c = _Counter()
+    h = _handler(c)
+    h.on_moved(FileMovedEvent("/abs/skills/demo/draft.md", "/abs/skills/demo/SKILL.md"))
+    assert c.n == 1
+
+
+# ── markInternalWrite 抑制自触发 / internal-write suppression ────────────────
+def test_mark_internal_write_suppresses_then_other_path_fires(tmp_path: Path) -> None:
+    c = _Counter()
+    w = SkillFileWatcher(c)
+    target = tmp_path / "demo" / "SKILL.md"
+    other = tmp_path / "other" / "SKILL.md"
+
+    w.mark_internal_write(target)
+    # 打标路径的 SKILL.md 事件被忽略 / marked path suppressed
+    w._handler.on_modified(FileModifiedEvent(str(target)))
+    assert c.n == 0
+    # 未打标路径正常触发 / unmarked path fires
+    w._handler.on_modified(FileModifiedEvent(str(other)))
+    assert c.n == 1
+
+
+def test_internal_write_expires(tmp_path: Path) -> None:
+    c = _Counter()
+    w = SkillFileWatcher(c, internal_write_ttl_s=0.0)  # 立即过期
+    target = tmp_path / "demo" / "SKILL.md"
+    w.mark_internal_write(target)
+    w._handler.on_modified(FileModifiedEvent(str(target)))  # TTL=0 → 不抑制
+    assert c.n == 1
+
+
+# ── watch / stop 生命周期与簿记 / lifecycle & bookkeeping ────────────────────
+def test_watch_missing_roots_not_started(tmp_path: Path) -> None:
+    w = SkillFileWatcher(_Counter())
+    w.watch([tmp_path / "does-not-exist"])
+    assert w.is_running is False
+    assert w.watched_roots == ()
+
+
+def test_watch_dedup_existing_root(tmp_path: Path) -> None:
+    root = tmp_path / "user"
+    root.mkdir()
+    w = SkillFileWatcher(_Counter())
+    try:
+        w.watch([root, root])  # 同根传两次 → 去重，无重复 schedule / 假 WARN
+        assert w.is_running is True
+        assert w.watched_roots == (root.resolve(),)
+    finally:
+        w.stop()
+    assert w.is_running is False
+
+
+def test_watch_only_given_roots_marketplace_excluded(tmp_path: Path) -> None:
+    # clone 树不监：只监控显式传入的发现根，marketplace 目录即便存在也不在监控集。
+    user_root = tmp_path / "user"
+    marketplace = tmp_path / "marketplace"
+    user_root.mkdir()
+    marketplace.mkdir()
+    w = SkillFileWatcher(_Counter())
+    try:
+        w.watch([user_root])
+        assert w.watched_roots == (user_root.resolve(),)
+        assert marketplace.resolve() not in w.watched_roots
+    finally:
+        w.stop()
+
+
+def test_stop_idempotent(tmp_path: Path) -> None:
+    root = tmp_path / "user"
+    root.mkdir()
+    w = SkillFileWatcher(_Counter())
+    w.watch([root])
+    w.stop()
+    w.stop()  # 重复停止不报错
+    assert w.is_running is False
+
+
+# ── PollingObserver 真实事件冒烟（验证接线送达）/ real-event smoke ───────────
+def test_polling_observer_detects_skill_md_create(tmp_path: Path) -> None:
+    root = tmp_path / "user"
+    root.mkdir()
+    fired = threading.Event()
+    w = SkillFileWatcher(fired.set, use_polling=True)
+    try:
+        w.watch([root])
+        assert w.is_running is True
+        skill_dir = root / "demo"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text("---\nname: demo\n---\n", encoding="utf-8")
+        # PollingObserver 轮询（默认 ~1s）→ 留足窗口；非阻塞超时断言
+        assert fired.wait(timeout=8.0), "watcher 未在超时内检测到 SKILL.md 创建"
+    finally:
+        w.stop()

--- a/tests/unit_tests/computer/test_computer_skills.py
+++ b/tests/unit_tests/computer/test_computer_skills.py
@@ -22,6 +22,7 @@ Unit tests for the Computer SKILL subsystem wiring.
 
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -30,6 +31,7 @@ from mcp.types import Resource
 
 from a2c_smcp.computer.blob.resolver import SkillBlobResolver
 from a2c_smcp.computer.computer import Computer
+from a2c_smcp.computer.skills.debouncer import SkillEventDebouncer
 from a2c_smcp.computer.skills.sandbox import SkillSandboxError
 from a2c_smcp.smcp import A2CSkillRef
 
@@ -226,8 +228,9 @@ async def test_resource_list_changed_skill_set_changed_emits(tmp_path: Path, mon
 
     await comp._on_manager_change(SimpleNamespace(root=ResourceListChangedNotification()))  # type: ignore[arg-type]
     assert restaged["n"] == 1
+    assert comp._skills_cache == {"skill://srv/demo"}  # 缓存在处理器内同步更新
+    await comp._skill_debouncer.aflush()  # 结算去抖窗口 → emit（#67：emit 经去抖器，不再裸调）
     assert client.update_skills_called == 1
-    assert comp._skills_cache == {"skill://srv/demo"}
 
 
 @pytest.mark.asyncio
@@ -279,6 +282,7 @@ async def test_resource_updated_skill_uri_emits(tmp_path: Path, monkeypatch: pyt
     note = ResourceUpdatedNotification(params=ResourceUpdatedNotificationParams(uri="skill://srv/demo"))
     await comp._on_manager_change(SimpleNamespace(root=note))  # type: ignore[arg-type]
     assert restaged["n"] == 1
+    await comp._skill_debouncer.aflush()  # 结算去抖窗口 → emit
     assert client.update_skills_called == 1
     assert client.refresh_called == 0  # 非 window，不刷新桌面
 
@@ -350,3 +354,187 @@ async def test_boot_up_wires_skill_subsystem(tmp_path: Path, monkeypatch: pytest
     assert comp._skills_cache == {"skill://srv/boot"}
 
     await comp.shutdown()
+
+
+# ===========================================================================
+# v0.2.1 user 源 DropIn 接入 + 文件 watcher 生命周期（S14，#67）
+# ===========================================================================
+_USER_SKILL_MD = "---\nname: helper\ndescription: a user skill\n---\n# Helper\n"
+
+
+@pytest.mark.asyncio
+async def test_invalidate_user_skills_registers_then_orphans_on_delete(tmp_path: Path) -> None:
+    """去抖器 invalidate：就地重扫 user 源注册；磁盘删除后重扫 → 标孤儿（从 get_skills 排除，保留以便恢复）。"""
+    import shutil
+
+    skill_home = tmp_path / "sh"
+    user_skill = skill_home / "user" / "helper"
+    user_skill.mkdir(parents=True)
+    (user_skill / "SKILL.md").write_text(_USER_SKILL_MD, encoding="utf-8")
+
+    comp = Computer(name="c", skill_home=skill_home, auto_connect=False, auto_reconnect=False)
+    comp._skill_home = comp._resolve_skill_home()  # 解析并建 home（不走完整 boot_up）
+
+    await comp._invalidate_user_skills()
+    ref = comp.get_skill_ref("helper")
+    assert ref is not None
+    assert ref["source"] == "user"
+    assert Path(ref["path"]) == user_skill.resolve()  # 就地发现：path 指向原目录，未复制
+
+    # 磁盘删除 → 重扫对账 → 标孤儿
+    shutil.rmtree(user_skill)
+    await comp._invalidate_user_skills()
+    assert comp.get_skill_ref("helper") is None  # 孤儿不在 active
+    assert "helper" in comp.skill_registry  # 仍在册以便恢复
+
+
+@pytest.mark.asyncio
+async def test_boot_up_starts_user_watcher_and_shutdown_stops(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """user/ 存在 → boot_up 启动文件 watcher；mark_skill_internal_write 透传；shutdown 停止并清空。"""
+    from a2c_smcp.computer.mcp_clients.manager import MCPServerManager
+
+    monkeypatch.setenv("A2C_SKILL_WATCH_POLLING", "1")  # 用 PollingObserver，启停确定性
+    skill_home = tmp_path / "sh"
+    (skill_home / "user").mkdir(parents=True)  # 发现根存在 → watcher 启动
+
+    comp = Computer(name="c", skill_home=skill_home, auto_connect=False, auto_reconnect=False)
+
+    async def _noop_ainit(self: MCPServerManager, servers: object) -> None:
+        return None
+
+    async def fake_restage(server_name: str | None = None) -> list[str]:
+        return []
+
+    async def fake_collect() -> set[str]:
+        return set()
+
+    monkeypatch.setattr(MCPServerManager, "ainitialize", _noop_ainit)
+    monkeypatch.setattr(comp, "_restage_mcp_skills", fake_restage)
+    monkeypatch.setattr(comp, "_acollect_skill_refs", fake_collect)
+
+    await comp.boot_up()
+    assert comp._skill_watcher is not None
+    assert comp._skill_watcher.is_running is True
+    # 内部写打标透传（不报错；watcher 已启动）
+    comp.mark_skill_internal_write(skill_home / "user" / "helper" / "SKILL.md")
+
+    await comp.shutdown()
+    assert comp._skill_watcher is None  # 停机后清空
+
+
+@pytest.mark.asyncio
+async def test_boot_up_no_user_watcher_when_no_roots(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """无任何发现根（user/ 不存在、无登记 workdir）→ watcher 对象建但不启动线程。"""
+    from a2c_smcp.computer.mcp_clients.manager import MCPServerManager
+
+    skill_home = tmp_path / "sh"  # 仅 boot 时建 <sh>，不建 <sh>/user
+
+    comp = Computer(name="c", skill_home=skill_home, auto_connect=False, auto_reconnect=False)
+
+    async def _noop_ainit(self: MCPServerManager, servers: object) -> None:
+        return None
+
+    async def fake_restage(server_name: str | None = None) -> list[str]:
+        return []
+
+    async def fake_collect() -> set[str]:
+        return set()
+
+    monkeypatch.setattr(MCPServerManager, "ainitialize", _noop_ainit)
+    monkeypatch.setattr(comp, "_restage_mcp_skills", fake_restage)
+    monkeypatch.setattr(comp, "_acollect_skill_refs", fake_collect)
+
+    await comp.boot_up()
+    assert comp._skill_watcher is not None
+    assert comp._skill_watcher.is_running is False  # 无可监控根 → 未启动
+    await comp.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_emit_update_skills_now_no_client_is_noop(tmp_path: Path) -> None:
+    """无 Socket.IO 客户端时去抖结算末端 no-op（不抛）/ debouncer sink no-op without client。"""
+    comp = _computer(tmp_path)  # 未设置 socketio_client
+    await comp._emit_update_skills_now()  # 不应抛
+
+
+@pytest.mark.asyncio
+async def test_start_skill_watcher_restart_stops_previous(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """重复 _start_skill_watcher → 先停旧 watcher、装配新对象（覆盖重启分支）。"""
+    monkeypatch.setenv("A2C_SKILL_WATCH_POLLING", "1")
+    skill_home = tmp_path / "sh"
+    (skill_home / "user").mkdir(parents=True)
+
+    comp = Computer(name="c", skill_home=skill_home, auto_connect=False, auto_reconnect=False)
+    comp._skill_home = comp._resolve_skill_home()
+
+    comp._start_skill_watcher()
+    first = comp._skill_watcher
+    assert first is not None
+    assert first.is_running is True
+
+    comp._start_skill_watcher()  # 重启：旧的应被停，新的接管
+    try:
+        assert comp._skill_watcher is not first
+        assert first.is_running is False
+        assert comp._skill_watcher is not None
+        assert comp._skill_watcher.is_running is True
+    finally:
+        if comp._skill_watcher is not None:
+            comp._skill_watcher.stop()
+
+
+@pytest.mark.asyncio
+async def test_end_to_end_real_watch_event_triggers_emit(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """端到端接线：Computer 启动后真实文件事件 → _marshal → 去抖器 → invalidate(重扫注册) → emit。
+
+    覆盖生产 marshal 闭包（watchdog 线程 → loop.call_soon_threadsafe → mark_dirty）这一拼接处。
+    用 PollingObserver + 缩短去抖窗口；轮询/去抖均异步到达，故带超时轮询断言。
+    """
+    from a2c_smcp.computer.mcp_clients.manager import MCPServerManager
+
+    monkeypatch.setenv("A2C_SKILL_WATCH_POLLING", "1")
+    skill_home = tmp_path / "sh"
+    (skill_home / "user").mkdir(parents=True)
+
+    comp = Computer(name="c", skill_home=skill_home, auto_connect=False, auto_reconnect=False)
+    client = _DummyClient()
+    comp.socketio_client = client  # type: ignore[assignment]
+    # 缩短去抖窗口加速测试（boot 时 _start_skill_watcher 闭包捕获此 debouncer）
+    comp._skill_debouncer = SkillEventDebouncer(
+        comp._emit_update_skills_now,
+        invalidate=comp._invalidate_user_skills,
+        window_ms=20,
+    )
+
+    async def _noop_ainit(self: MCPServerManager, servers: object) -> None:
+        return None
+
+    async def fake_restage(server_name: str | None = None) -> list[str]:
+        return []
+
+    async def fake_collect() -> set[str]:
+        return set()
+
+    monkeypatch.setattr(MCPServerManager, "ainitialize", _noop_ainit)
+    monkeypatch.setattr(comp, "_restage_mcp_skills", fake_restage)
+    monkeypatch.setattr(comp, "_acollect_skill_refs", fake_collect)
+
+    await comp.boot_up()
+    assert comp._skill_watcher is not None and comp._skill_watcher.is_running is True
+
+    # 启动后落一个 user skill → 触发真实 watchdog 事件链
+    skill_dir = skill_home / "user" / "helper"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(_USER_SKILL_MD, encoding="utf-8")
+
+    # 轮询（~1s）+ 去抖（20ms）均异步：超时内轮询等待 emit 到达
+    for _ in range(60):
+        if client.update_skills_called >= 1:
+            break
+        await asyncio.sleep(0.2)
+
+    try:
+        assert client.update_skills_called >= 1, "真实文件事件未经 _marshal→去抖→emit 链路触发上报"
+        assert comp.get_skill_ref("helper") is not None  # invalidate 重扫已注册该 user skill
+    finally:
+        await comp.shutdown()

--- a/tests/unit_tests/utils/test_env.py
+++ b/tests/unit_tests/utils/test_env.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+# filename: test_env.py
+# @Time    : 2026/05/26
+# @Author  : JQQ
+# @Email   : jqq1716@gmail.com
+# @Software: PyCharm
+"""
+env_truthy 单元测试 / Unit tests for env_truthy。
+
+意图：统一真值集（1/true/yes/on，大小写 + 空白不敏感）；未设置/空白回退 default；其它值为 False；
+默认读 os.environ、支持注入 env 映射。
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from a2c_smcp.utils.env import env_truthy
+
+
+@pytest.mark.parametrize("value", ["1", "true", "TRUE", "Yes", "on", "ON", "  true  ", "\tyes\n"])
+def test_truthy_values(value: str) -> None:
+    assert env_truthy("K", env={"K": value}) is True
+
+
+@pytest.mark.parametrize("value", ["0", "false", "no", "off", "random", "2", "-1"])
+def test_explicit_non_truthy_is_false(value: str) -> None:
+    assert env_truthy("K", env={"K": value}) is False
+
+
+def test_unset_returns_default() -> None:
+    assert env_truthy("K", env={}) is False
+    assert env_truthy("K", env={}, default=True) is True
+
+
+@pytest.mark.parametrize("blank", ["", "   ", "\t\n"])
+def test_blank_returns_default(blank: str) -> None:
+    assert env_truthy("K", env={"K": blank}) is False  # default False
+    assert env_truthy("K", env={"K": blank}, default=True) is True  # 空白回退 default
+
+
+def test_uses_os_environ_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("A2C_TEST_ENV_TRUTHY", "yes")
+    assert env_truthy("A2C_TEST_ENV_TRUTHY") is True
+    monkeypatch.delenv("A2C_TEST_ENV_TRUTHY", raising=False)
+    assert env_truthy("A2C_TEST_ENV_TRUTHY") is False

--- a/uv.lock
+++ b/uv.lock
@@ -15,6 +15,7 @@ dependencies = [
     { name = "transitions" },
     { name = "tzlocal" },
     { name = "vrl-python" },
+    { name = "watchdog" },
 ]
 
 [package.optional-dependencies]
@@ -60,6 +61,7 @@ requires-dist = [
     { name = "typer", marker = "extra == 'cli'", specifier = ">=0.17.4,<1.0.0" },
     { name = "tzlocal", specifier = ">=5.0.0,<6.0.0" },
     { name = "vrl-python", specifier = ">=0.1.0,<0.2.0" },
+    { name = "watchdog", specifier = ">=6.0.0,<7.0.0" },
 ]
 provides-extras = ["cli"]
 
@@ -1987,6 +1989,33 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/30/3f/fd0d068a19a3f7608d05368daf76d0a0aaef6b7a3963be1f7f04e86ccfca/vrl_python-0.1.0-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:82ac56f7e9c19a5fb53b8ef87432baac88b685b6ccf2ed3ec9fccd89d7d2f24a", size = 7082378, upload-time = "2025-10-06T05:17:25.281Z" },
     { url = "https://files.pythonhosted.org/packages/3b/3d/b886f5012d94ab9efe715bf59ac11376f6d1d110edd8ef58dd72baf60889/vrl_python-0.1.0-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b84144c5337e60ab89751cef56025000b861d4983e3d94f517f8de046ec65787", size = 7377323, upload-time = "2025-10-06T05:17:27.281Z" },
     { url = "https://files.pythonhosted.org/packages/e8/3c/94a9056bee5ce58e4e6ce5a52c4c0b8028d5af28b367d0ab1a8cf5865cff/vrl_python-0.1.0-cp38-abi3-win_amd64.whl", hash = "sha256:bf7dd64cef9796b8ed3c292b62d8fd9da87425a61bf183e5980b3ea54a577591", size = 6808864, upload-time = "2025-10-06T05:17:28.811Z" },
+]
+
+[[package]]
+name = "watchdog"
+version = "6.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/7d/7f3d619e951c88ed75c6037b246ddcf2d322812ee8ea189be89511721d54/watchdog-6.0.0.tar.gz", hash = "sha256:9ddf7c82fda3ae8e24decda1338ede66e1c99883db93711d8fb941eaa2d8c282", size = 131220, upload-time = "2024-11-01T14:07:13.037Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/24/d9be5cd6642a6aa68352ded4b4b10fb0d7889cb7f45814fb92cecd35f101/watchdog-6.0.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:6eb11feb5a0d452ee41f824e271ca311a09e250441c262ca2fd7ebcf2461a06c", size = 96393, upload-time = "2024-11-01T14:06:31.756Z" },
+    { url = "https://files.pythonhosted.org/packages/63/7a/6013b0d8dbc56adca7fdd4f0beed381c59f6752341b12fa0886fa7afc78b/watchdog-6.0.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:ef810fbf7b781a5a593894e4f439773830bdecb885e6880d957d5b9382a960d2", size = 88392, upload-time = "2024-11-01T14:06:32.99Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/40/b75381494851556de56281e053700e46bff5b37bf4c7267e858640af5a7f/watchdog-6.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:afd0fe1b2270917c5e23c2a65ce50c2a4abb63daafb0d419fde368e272a76b7c", size = 89019, upload-time = "2024-11-01T14:06:34.963Z" },
+    { url = "https://files.pythonhosted.org/packages/39/ea/3930d07dafc9e286ed356a679aa02d777c06e9bfd1164fa7c19c288a5483/watchdog-6.0.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:bdd4e6f14b8b18c334febb9c4425a878a2ac20efd1e0b231978e7b150f92a948", size = 96471, upload-time = "2024-11-01T14:06:37.745Z" },
+    { url = "https://files.pythonhosted.org/packages/12/87/48361531f70b1f87928b045df868a9fd4e253d9ae087fa4cf3f7113be363/watchdog-6.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c7c15dda13c4eb00d6fb6fc508b3c0ed88b9d5d374056b239c4ad1611125c860", size = 88449, upload-time = "2024-11-01T14:06:39.748Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/7e/8f322f5e600812e6f9a31b75d242631068ca8f4ef0582dd3ae6e72daecc8/watchdog-6.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6f10cb2d5902447c7d0da897e2c6768bca89174d0c6e1e30abec5421af97a5b0", size = 89054, upload-time = "2024-11-01T14:06:41.009Z" },
+    { url = "https://files.pythonhosted.org/packages/68/98/b0345cabdce2041a01293ba483333582891a3bd5769b08eceb0d406056ef/watchdog-6.0.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:490ab2ef84f11129844c23fb14ecf30ef3d8a6abafd3754a6f75ca1e6654136c", size = 96480, upload-time = "2024-11-01T14:06:42.952Z" },
+    { url = "https://files.pythonhosted.org/packages/85/83/cdf13902c626b28eedef7ec4f10745c52aad8a8fe7eb04ed7b1f111ca20e/watchdog-6.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:76aae96b00ae814b181bb25b1b98076d5fc84e8a53cd8885a318b42b6d3a5134", size = 88451, upload-time = "2024-11-01T14:06:45.084Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/c4/225c87bae08c8b9ec99030cd48ae9c4eca050a59bf5c2255853e18c87b50/watchdog-6.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a175f755fc2279e0b7312c0035d52e27211a5bc39719dd529625b1930917345b", size = 89057, upload-time = "2024-11-01T14:06:47.324Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/c7/ca4bf3e518cb57a686b2feb4f55a1892fd9a3dd13f470fca14e00f80ea36/watchdog-6.0.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:7607498efa04a3542ae3e05e64da8202e58159aa1fa4acddf7678d34a35d4f13", size = 79079, upload-time = "2024-11-01T14:06:59.472Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/51/d46dc9332f9a647593c947b4b88e2381c8dfc0942d15b8edc0310fa4abb1/watchdog-6.0.0-py3-none-manylinux2014_armv7l.whl", hash = "sha256:9041567ee8953024c83343288ccc458fd0a2d811d6a0fd68c4c22609e3490379", size = 79078, upload-time = "2024-11-01T14:07:01.431Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/57/04edbf5e169cd318d5f07b4766fee38e825d64b6913ca157ca32d1a42267/watchdog-6.0.0-py3-none-manylinux2014_i686.whl", hash = "sha256:82dc3e3143c7e38ec49d61af98d6558288c415eac98486a5c581726e0737c00e", size = 79076, upload-time = "2024-11-01T14:07:02.568Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/cc/da8422b300e13cb187d2203f20b9253e91058aaf7db65b74142013478e66/watchdog-6.0.0-py3-none-manylinux2014_ppc64.whl", hash = "sha256:212ac9b8bf1161dc91bd09c048048a95ca3a4c4f5e5d4a7d1b1a7d5752a7f96f", size = 79077, upload-time = "2024-11-01T14:07:03.893Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/3b/b8964e04ae1a025c44ba8e4291f86e97fac443bca31de8bd98d3263d2fcf/watchdog-6.0.0-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:e3df4cbb9a450c6d49318f6d14f4bbc80d763fa587ba46ec86f99f9e6876bb26", size = 79078, upload-time = "2024-11-01T14:07:05.189Z" },
+    { url = "https://files.pythonhosted.org/packages/62/ae/a696eb424bedff7407801c257d4b1afda455fe40821a2be430e173660e81/watchdog-6.0.0-py3-none-manylinux2014_s390x.whl", hash = "sha256:2cce7cfc2008eb51feb6aab51251fd79b85d9894e98ba847408f662b3395ca3c", size = 79077, upload-time = "2024-11-01T14:07:06.376Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/e8/dbf020b4d98251a9860752a094d09a65e1b436ad181faf929983f697048f/watchdog-6.0.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:20ffe5b202af80ab4266dcd3e91aae72bf2da48c0d33bdb15c66658e685e94e2", size = 79078, upload-time = "2024-11-01T14:07:07.547Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f6/d0e5b343768e8bcb4cda79f0f2f55051bf26177ecd5651f84c07567461cf/watchdog-6.0.0-py3-none-win32.whl", hash = "sha256:07df1fdd701c5d4c8e55ef6cf55b8f0120fe1aef7ef39a1c6fc6bc2e606d517a", size = 79065, upload-time = "2024-11-01T14:07:09.525Z" },
+    { url = "https://files.pythonhosted.org/packages/db/d9/c495884c6e548fce18a8f40568ff120bc3a4b7b99813081c8ac0c936fa64/watchdog-6.0.0-py3-none-win_amd64.whl", hash = "sha256:cbafb470cf848d93b5d013e2ecb245d4aa1c8fd0504e863ccefa32445359d680", size = 79070, upload-time = "2024-11-01T14:07:10.686Z" },
+    { url = "https://files.pythonhosted.org/packages/33/e8/e40370e6d74ddba47f002a32919d91310d6074130fe4e17dabcafc15cbf1/watchdog-6.0.0-py3-none-win_ia64.whl", hash = "sha256:a1914259fa9e1454315171103c6a30961236f508b9b623eae470268bbcc6a22f", size = 79067, upload-time = "2024-11-01T14:07:11.845Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 概述
实现 **#67（S14，父任务 #53）**：SKILL 事件触发链 —— 多源 SKILL 变更经统一去抖器在 300ms 窗口内合并为**一次** `emit_update_skills`。无协议变更（`server:update_skills`/`notify:update_skills` 已于 v0.2.1 落地），仅接入本地触发链。依赖 #60(user 源)/#66(S13) 均已合并。

## 改动
**新增模块**
- `skills/debouncer.py` — `SkillEventDebouncer`：`mark_dirty`（末次胜出）→ 300ms →（缓存失效）`invalidate` → `emit`；emit 失败 ERROR + 单次重试；`aflush`（确定性结算/测试）+ `aclose`（停机丢弃挂起）
- `skills/watcher.py` — `SkillFileWatcher`：watchdog 递归监控 `$A2C_SKILL_HOME/user/` + 各登记 `<workdir>/.tfrobot/skills/` 的 `**/SKILL.md`（文件增删改移 + 目录删/移）；`mark_internal_write` 抑制自写自触发；缺失根容错 / 去重；**不监 marketplace clone 树**；`PollingObserver` 兜底

**接入 / 配套**
- `computer.py`：boot 扫 user 源 + 启 watcher；mcp 两处理器改走去抖器 `mark_dirty`（不再裸调 emit、保留集合对比跳过）；`_reconcile_orphans(present, source_pred)` 统一 mcp/user 孤儿对账；shutdown 先停 watcher 再关 debouncer
- `socketio/client.py`：`emit_update_skills` 标注为去抖器低层 sink（§12）
- `pyproject.toml` / `uv.lock`：新依赖 `watchdog (>=6.0.0,<7.0.0)`

## 验收（#67 四条）
- [x] 300ms 内多事件合并为一次 emit
- [x] watcher 触发 → 缓存失效 → emit；clone 树变更**不**经 watcher
- [x] 内部写打标后不自触发重载
- [x] `uv run poe lint` 净

## Code review 修复（本 PR 已闭合）
- 🔴 **并发缺陷**：`_invalidate_user_skills` 去掉 `asyncio.to_thread`，**同步在事件循环线程**重扫 —— 守住 `SkillRegistry` 单线程无锁不变量（避免 worker 线程改 `_entries` 与循环线程 `active_refs` 迭代竞争）
- 🟡 抽取 `_reconcile_orphans(present, source_pred)`（为 #61 marketplace 复用）
- 🟡 补端到端接线测试（Computer→真实 watchdog 事件→`_marshal`→去抖→emit）+ no-client / watcher 重启分支
- 🟡 修正 `aflush` docstring（停机走 `aclose`）
- 🟡 polling 模式抬高内部写 TTL ≥ 轮询周期（注释 + floor）

## 验证
- `uv run poe lint`：ruff 净 + **mypy 80 文件无错**
- `uv run poe test`：**1284 passed / 2 skipped / 4 xfailed / 0 failed**

> base 为 `develop-v0.2.1`（非默认分支），合并不会自动关闭 #67；合并后需手动关 #67 + 勾选 #53 的对应子任务。

🤖 Generated with [Claude Code](https://claude.com/claude-code)