### PR TITLE
feat(computer): v0.2.1 S8 SKILL marketplace git 源 staging + source 5 类 (#61)

### DIFF
--- a/a2c_smcp/computer/skills/__init__.py
+++ b/a2c_smcp/computer/skills/__init__.py
@@ -14,7 +14,8 @@ Mirrors Claude Code marketplace local SKILL management. Landed modules:
 - :mod:`a2c_smcp.computer.skills.home`     —— SKILL Home 解析 + `0o700` 防御性写（隔离交 OS，对齐 CC）+ 安装目录布局（S1，#54）
 - :mod:`a2c_smcp.computer.skills.naming`   —— name 合成 + 段数消歧 lexer + MCP server 段规范化（S1，#54）
 - :mod:`a2c_smcp.computer.skills.registry` —— `name → A2CSkillRef` O(1) 物化索引 + 孤儿标记/恢复（S3，#57）
-- :mod:`a2c_smcp.computer.skills.staging`  —— 多 source 物化（mcp 源 + manager.list_skill_resources）（S6，#59）
+- :mod:`a2c_smcp.computer.skills.staging`  —— 三源 staging（mcp #59 + user #60 + marketplace git #61）
+- :mod:`a2c_smcp.computer.skills.sources`  —— marketplace plugin source 5 类解析 + github/cnb 简写糖归一化（S8，#61）
 - :mod:`a2c_smcp.computer.skills.sandbox`  —— 包根内 `safe_join`+`realpath` 沙箱 + `.skillenv` forbidden + name 寻址防越权（S2，#55）
 - :mod:`a2c_smcp.computer.skills.resource` —— 沙箱解析 → 消费字节视图（mint/serve 字节基准一致：sha256/total_size）（S13，#66）
 - :mod:`a2c_smcp.computer.skills.debouncer`—— 缓存失效 + 300ms debounce + 单次 emit（事件触发链，S14，#67）
@@ -70,9 +71,20 @@ from a2c_smcp.computer.skills.sandbox import (
     ensure_within_size_cap,
     resolve_skill_resource,
 )
+from a2c_smcp.computer.skills.sources import (
+    DEFAULT_PLUGIN_ROOT,
+    GitCloneSpec,
+    LocalPluginSource,
+    ResolvedPluginSource,
+    SkillSourceError,
+    marketplace_clone_url,
+    normalize_repo_shorthand,
+    resolve_plugin_source,
+)
 from a2c_smcp.computer.skills.staging import (
     SkillStagingError,
     parse_skill_frontmatter,
+    stage_marketplace_skills,
     stage_mcp_skills,
     stage_user_skills,
     strip_skill_frontmatter,
@@ -126,9 +138,19 @@ __all__ = [
     "SkillResourceView",
     "looks_textual",
     "resolve_skill_view",
+    # sources（marketplace plugin source 5 类解析 + 简写糖归一化）
+    "DEFAULT_PLUGIN_ROOT",
+    "GitCloneSpec",
+    "LocalPluginSource",
+    "ResolvedPluginSource",
+    "SkillSourceError",
+    "marketplace_clone_url",
+    "normalize_repo_shorthand",
+    "resolve_plugin_source",
     # staging
     "SkillStagingError",
     "parse_skill_frontmatter",
+    "stage_marketplace_skills",
     "stage_mcp_skills",
     "stage_user_skills",
     "strip_skill_frontmatter",

--- a/a2c_smcp/computer/skills/sources.py
+++ b/a2c_smcp/computer/skills/sources.py
@@ -1,0 +1,244 @@
+# -*- coding: utf-8 -*-
+# filename: sources.py
+# @Time    : 2026/05/26
+# @Author  : JQQ
+# @Email   : jqq1716@gmail.com
+# @Software: PyCharm
+"""
+SKILL marketplace source 解析：plugin source 5 类 + 简写糖归一化（v0.2.1）
+SKILL marketplace source resolution: plugin source (5 kinds) + shorthand normalization (v0.2.1).
+
+协议依据 / Protocol: tfrobot-marketplace docs/marketplace/protocol-v1.md §5（Plugin source 字段规范，
+                      5 类 disjoint union + github/cnb 简写糖 + git-subdir sparse clone）、§3.2（``metadata.
+                      pluginRoot`` 使裸名 ``"x"`` 等价 ``"./<pluginRoot>/x"``）。
+SDK 设计 / Design: python-sdk docs/design-0.2.1-cli-marketplace-ux.md §3.2 / §5.3。
+
+本模块**纯解析、零 I/O、零 git**：把 ``marketplace.json`` 中每个 plugin 条目的 ``source`` 字段
+（``str`` 相对路径 / 5 类 source 对象之一）归一化为可供 staging（#61）执行的克隆/定位规格：
+- :class:`LocalPluginSource` —— 相对路径（含裸名经 ``pluginRoot`` 解析），指向 **marketplace clone 内**子目录；
+- :class:`GitCloneSpec` —— 需独立 ``git clone`` 的源（``url`` / ``github`` / ``cnb`` / ``git-subdir``），
+  ``github`` / ``cnb`` 的 ``owner/repo`` 简写糖归一化为 ``https://<host>/<repo>.git``，``git-subdir`` 额外
+  携带 ``subdir`` 供 sparse clone（plugin 根 = ``<clone>/<subdir>``）。
+This module is pure parsing (no I/O, no git): it normalizes a plugin entry's ``source`` field into a
+:class:`LocalPluginSource` (within the marketplace clone) or a :class:`GitCloneSpec` (needs its own
+clone). ``github`` / ``cnb`` shorthand is normalized to an ``https://`` URL; ``git-subdir`` carries a
+``subdir`` for sparse checkout.
+
+Marketplace source（用户添加 marketplace 的 ``{type:"git", url}``，与 plugin source **两套独立 schema**，
+disjoint union，协议 §5.3）的克隆 url 提取见 :func:`marketplace_clone_url`。
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from a2c_smcp.computer.settings.schema import is_valid_git_url
+from a2c_smcp.utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+# 简写糖归一化目标 host / Shorthand normalization hosts（协议 §5.2.1 / §5.2.4）。
+GITHUB_HOST = "github.com"
+CNB_HOST = "cnb.cool"
+
+# 裸名经 metadata.pluginRoot 解析的默认前缀（协议 §3.2）/ Default pluginRoot for bare-name plugin sources.
+DEFAULT_PLUGIN_ROOT = "./plugins"
+
+# ``owner/repo`` 简写糖：恰两段，段内无空白 / 无 ``/``（协议 §5.2 ``owner/repo`` / ``group/project``）。
+_REPO_SHORTHAND_RE = re.compile(r"^[^\s/]+/[^\s/]+$")
+
+# 完整 40 字符 hex commit SHA（协议 §5.2 ``sha`` 字段）/ Full 40-char hex commit SHA.
+_FULL_SHA_RE = re.compile(r"^[0-9a-fA-F]{40}$")
+
+
+class SkillSourceError(ValueError):
+    """
+    plugin / marketplace source 形态非法 / Malformed plugin or marketplace source.
+
+    由 staging（:func:`~a2c_smcp.computer.skills.staging.stage_marketplace_skills`）捕获并按失败降级
+    铁律处理（记 ERROR、该源不入 Registry、不阻断其余、不向 Agent 硬报错）。本异常**不**自带协议码
+    （marketplace source 解析失败属本地配置问题，非协议错误码语义）。
+    Caught by staging and handled per the failure-isolation rule (logged ERROR, not registered, does
+    not block other sources). Carries no protocol code.
+    """
+
+    def __init__(self, raw: object, reason: str) -> None:
+        self.raw = raw
+        self.reason = reason
+        super().__init__(f"invalid skill source {raw!r}: {reason}")
+
+
+@dataclass(frozen=True, slots=True)
+class GitCloneSpec:
+    """
+    需独立 ``git clone`` 的 plugin 源规格 / Spec for a plugin source requiring its own ``git clone``。
+
+    :ivar url: 归一化后的 git URL（``github`` / ``cnb`` 简写糖已展开）/ normalized git URL.
+    :ivar ref: 分支或 tag（可选）/ branch or tag (optional).
+    :ivar sha: 完整 40 字符 commit SHA（可选，精确锁版本）/ full 40-char commit SHA (optional, version lock).
+    :ivar subdir: 非 ``None`` → ``git-subdir`` sparse clone，plugin 根 = ``<clone>/<subdir>``（仓库相对，
+        已校验无 ``..`` / 非绝对）/ when set, sparse-clone subdir; plugin root = ``<clone>/<subdir>``.
+    """
+
+    url: str
+    ref: str | None = None
+    sha: str | None = None
+    subdir: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class LocalPluginSource:
+    """
+    相对路径 plugin 源 / Relative-path plugin source（指向 **marketplace clone 内**子目录，无需独立 clone）。
+
+    :ivar rel_path: 归一化的仓库相对路径（去前导 ``./``、POSIX 分隔、无 ``..``）；裸名形态已由
+        :data:`DEFAULT_PLUGIN_ROOT` / ``metadata.pluginRoot`` 前缀展开（协议 §3.2）。
+        Normalized repo-relative path (leading ``./`` stripped, POSIX-separated, no ``..``); bare-name
+        form is already expanded under ``pluginRoot``.
+    """
+
+    rel_path: str
+
+
+# plugin source 解析结果（disjoint union，协议 §5.3）/ Resolved plugin source (disjoint union).
+ResolvedPluginSource = GitCloneSpec | LocalPluginSource
+
+
+# ── 内部辅助 / internal helpers ──────────────────────────────────────────────
+def _require_str(d: Mapping[str, Any], key: str) -> str:
+    """取必填字符串字段（缺失 / 非字符串 / 空 → 抛）/ Require a non-empty string field。"""
+    v = d.get(key)
+    if not isinstance(v, str) or not v.strip():
+        raise SkillSourceError(dict(d), f"required field {key!r} missing or not a non-empty string")
+    return v.strip()
+
+
+def _extract_ref_sha(d: Mapping[str, Any]) -> tuple[str | None, str | None]:
+    """提取可选 ``ref`` / ``sha``（``sha`` 须为完整 40 字符 hex）/ Extract optional ``ref`` / ``sha``。"""
+    ref = d.get("ref")
+    if ref is not None and (not isinstance(ref, str) or not ref.strip()):
+        raise SkillSourceError(dict(d), "'ref' must be a non-empty string when present")
+    sha = d.get("sha")
+    if sha is not None and (not isinstance(sha, str) or _FULL_SHA_RE.match(sha.strip()) is None):
+        raise SkillSourceError(dict(d), "'sha' must be a full 40-char hex commit SHA when present")
+    return (
+        ref.strip() if isinstance(ref, str) else None,
+        sha.strip().lower() if isinstance(sha, str) else None,
+    )
+
+
+def _is_repo_shorthand(s: str) -> bool:
+    """是否为 ``owner/repo`` 两段简写糖（非完整 URL / 非 scp-like）/ Whether ``s`` is an ``owner/repo`` shorthand。"""
+    return "://" not in s and "@" not in s and _REPO_SHORTHAND_RE.match(s) is not None
+
+
+def normalize_repo_shorthand(repo: str, host: str) -> str:
+    """
+    ``owner/repo`` 简写糖归一化为 ``https://<host>/<repo>.git`` / Normalize ``owner/repo`` shorthand。
+
+    用于 ``github``（host=:data:`GITHUB_HOST`）与 ``cnb``（host=:data:`CNB_HOST`）两类（协议 §5.2.1 /
+    §5.2.4，归一化逻辑同构）。``repo`` 非 ``owner/repo`` 两段简写（如携带 scheme / scp-like ``@``）→ 抛。
+    Used by ``github`` / ``cnb`` (same normalization). Raises if ``repo`` is not a two-segment shorthand.
+    """
+    if not isinstance(repo, str) or not _is_repo_shorthand(repo.strip()):
+        raise SkillSourceError(repo, f"'repo' must be an '<owner>/<repo>' shorthand, not a full URL (got {repo!r})")
+    r = repo.strip().removesuffix(".git")
+    return f"https://{host}/{r}.git"
+
+
+def _norm_rel_segments(rel: str, *, raw: object) -> str:
+    """归一化仓库相对路径：POSIX 分隔、去 ``.``、禁 ``..`` / 绝对、非空 / Normalize a repo-relative path。"""
+    parts = [seg for seg in rel.replace("\\", "/").split("/") if seg not in ("", ".")]
+    if any(seg == ".." for seg in parts):
+        raise SkillSourceError(raw, "path must not contain '..'")
+    if not parts:
+        raise SkillSourceError(raw, "path is empty / resolves to repo root")
+    return "/".join(parts)
+
+
+def _resolve_relative(raw: str, plugin_root: str) -> LocalPluginSource:
+    """
+    解析相对路径 plugin 源（含裸名经 ``pluginRoot`` 解析）/ Resolve a relative-path (or bare-name) source。
+
+    - ``"./x/y"`` → 仓库根相对 ``x/y``（协议 §5.1：必须以 ``./`` 开头、禁 ``..``）；
+    - 裸名 ``"x"``（无 ``/``、无前导 ``./``）→ ``<pluginRoot>/x``（协议 §3.2 ``metadata.pluginRoot``）。
+    """
+    s = raw.strip()
+    if s.startswith("./"):
+        rel = s[2:]
+    elif "/" not in s and s not in ("", ".", ".."):
+        # 裸名：经 metadata.pluginRoot 前缀展开（pluginRoot 自身可带前导 ./）。
+        rel = f"{_norm_rel_segments(plugin_root, raw=raw)}/{s}"
+    else:
+        raise SkillSourceError(raw, "relative plugin source must start with './' or be a bare plugin name")
+    return LocalPluginSource(rel_path=_norm_rel_segments(rel, raw=raw))
+
+
+# ── 公开 API / public API ────────────────────────────────────────────────────
+def resolve_plugin_source(raw: object, *, plugin_root: str = DEFAULT_PLUGIN_ROOT) -> ResolvedPluginSource:
+    """
+    解析 ``marketplace.json`` plugin 条目的 ``source``（5 类 disjoint union）/ Resolve a plugin entry ``source``。
+
+    协议 §5.1 五类：相对路径（``str``）/ ``url`` / ``github`` / ``git-subdir`` / ``cnb``。对象形态靠内层
+    ``source`` 字段作 union discriminator（协议 §5.3，**非**递归嵌套）。
+    Five kinds per §5.1: relative path (``str``) / ``url`` / ``github`` / ``git-subdir`` / ``cnb``; object
+    forms are discriminated by the inner ``source`` field (§5.3, not recursive nesting).
+
+    :param raw: plugin 条目的 ``source`` 值（``str`` 相对路径或 source 对象）。
+    :param plugin_root: 裸名相对路径的 ``pluginRoot`` 前缀（来自 ``metadata.pluginRoot``，默认
+        :data:`DEFAULT_PLUGIN_ROOT`）。
+    :raises SkillSourceError: 形态非法 / 缺必填字段 / discriminator 未知。
+    """
+    if isinstance(raw, str):
+        return _resolve_relative(raw, plugin_root)
+    if not isinstance(raw, Mapping):
+        raise SkillSourceError(raw, "plugin source must be a relative-path string or a source object")
+
+    kind = raw.get("source")
+    if kind == "url":
+        url = _require_str(raw, "url")
+        if not is_valid_git_url(url):
+            raise SkillSourceError(dict(raw), f"'url' is not a well-formed git url (got {url!r})")
+        ref, sha = _extract_ref_sha(raw)
+        return GitCloneSpec(url=url, ref=ref, sha=sha)
+    if kind == "github":
+        url = normalize_repo_shorthand(_require_str(raw, "repo"), GITHUB_HOST)
+        ref, sha = _extract_ref_sha(raw)
+        return GitCloneSpec(url=url, ref=ref, sha=sha)
+    if kind == "cnb":
+        url = normalize_repo_shorthand(_require_str(raw, "repo"), CNB_HOST)
+        ref, sha = _extract_ref_sha(raw)
+        return GitCloneSpec(url=url, ref=ref, sha=sha)
+    if kind == "git-subdir":
+        raw_url = _require_str(raw, "url")
+        # url 亦接受 GitHub 简写 owner/repo 或 SSH URL（协议 §5.2.3）。
+        url = raw_url if is_valid_git_url(raw_url) else normalize_repo_shorthand(raw_url, GITHUB_HOST)
+        subdir = _norm_rel_segments(_require_str(raw, "path"), raw=dict(raw))
+        ref, sha = _extract_ref_sha(raw)
+        return GitCloneSpec(url=url, ref=ref, sha=sha, subdir=subdir)
+
+    raise SkillSourceError(dict(raw), f"unknown plugin source discriminator {kind!r} (expect url|github|git-subdir|cnb)")
+
+
+def marketplace_clone_url(source: object) -> str:
+    """
+    从 marketplace source（``{type:"git", url}``）取克隆 URL / Extract the clone URL from a marketplace source。
+
+    SDK settings 的 marketplace source 仅 git url（协议 §5.3：marketplace 侧支持 url/github/git/cnb，本 SDK
+    的 :class:`~a2c_smcp.computer.settings.schema.GitSource` 收敛为 ``{type:"git", url}``；不支持 ``ref``/
+    ``sha``，与 plugin source 的 5 类**两套独立 schema**）。形态非法 → 抛 :class:`SkillSourceError`。
+    The SDK marketplace source is a plain git url (``{type:"git", url}``); no ``ref``/``sha`` and disjoint
+    from the plugin-source schema. Raises on malformed input.
+    """
+    if not isinstance(source, Mapping):
+        raise SkillSourceError(source, "marketplace source must be an object")
+    stype = source.get("type")
+    if stype != "git":
+        raise SkillSourceError(dict(source), f"marketplace source 'type' must be 'git' (got {stype!r})")
+    url = source.get("url")
+    if not isinstance(url, str) or not is_valid_git_url(url):
+        raise SkillSourceError(dict(source), f"marketplace source 'url' is not a well-formed git url (got {url!r})")
+    return url

--- a/a2c_smcp/computer/skills/staging.py
+++ b/a2c_smcp/computer/skills/staging.py
@@ -13,8 +13,27 @@ SKILL staging: mcp-source materialization + user-source in-place DropIn discover
 SDK 设计 / Design: python-sdk docs/design-0.2.1-skill-computer-management.md §5.2；
                    docs/design-0.2.1-cli-marketplace-ux.md §2.3 / §5.0（user 源 DropIn）。
 
-本模块实现 **mcp 源** 物化（#59）与 **user 源** DropIn 发现（#60）；marketplace git（#61）另见对应模块。
-This module implements **mcp-source** materialization (#59) and **user-source** DropIn discovery (#60).
+本模块实现三源 staging：**mcp 源** 物化（#59）、**user 源** DropIn 发现（#60）、**marketplace git 源**
+clone/refresh + plugin 扫描（#61，依 plugin source 5 类，见 :mod:`~a2c_smcp.computer.skills.sources`）。
+This module implements three-source staging: **mcp-source** materialization (#59), **user-source**
+DropIn discovery (#60), and **marketplace git-source** clone/refresh + plugin scan (#61).
+
+marketplace 流程 / marketplace flow（对账编排 / additive-only diff 归 reconciler #62，本模块只提供「clone 单个
+marketplace + 解析 plugin source + 扫描 skills + 注册」原语）：
+1. 按 ``{type:"git", url}`` ``git clone --depth 1``（SSH→HTTPS 回退、``GIT_TERMINAL_PROMPT=0``、超时默认
+   120s）到 ``<home>/marketplace/<mp>/``；已存在且 ``refresh`` → ``git pull`` 失败则全量重 clone；
+2. 读 ``.tfrobot-plugin/marketplace.json`` 枚举 ``plugins[]``（``metadata.pluginRoot`` 默认 ``./plugins``）；
+3. 每个 plugin：``resolve_plugin_source`` 定位 plugin 根（相对路径在 clone 内 / ``git-subdir`` sparse clone /
+   ``url``·``github``·``cnb`` 独立 clone 到 ``<home>/marketplace/.plugins/<mp>/<plugin>/``）；
+4. 扫 ``<plugin 根>/skills/<skill>/SKILL.md``，``name = <plugin>:<skill>``（``<plugin>`` = entry.name、
+   ``<skill>`` = skill 目录 basename，frontmatter 仅作显示名、不改 ID）→ 注册进 :class:`SkillRegistry`；
+5. 写 ``known_marketplaces.json`` 物化记录（installLocation / commitSha / lastUpdated / autoUpdate）。
+``installed_plugins.json`` 写入、``enabledPlugins`` 过滤、bundled MCP server 注册**不在本模块**（归 #62 /
+plugin install / #53）；``plugin_filter`` 形参供 #62 注入 ``enabledPlugins ∩ installed``。
+
+**不在本模块（显式延后，见 #80）**：marketplace 条目 / plugin.json 的 ``skills`` 组件路径**覆写**
+（protocol-v1 §4.3）与 **strict mode 冲突检测**（§4.4：``strict=false`` + plugin.json 声明组件 → 硬错误）。
+本模块只按约定扫 ``<plugin 根>/skills/<skill>/SKILL.md``（主流场景），strict 语义随组件加载层（#53）跟进。
 
 mcp 流程 / mcp flow：
 1. 经 ``manager.list_skill_resources`` 完整消费 cursor 拿到 server 全量 ``skill://`` 资源；
@@ -44,37 +63,80 @@ user 流程 / user flow（与 mcp 的关键差异）：**就地发现、不复�
 
 from __future__ import annotations
 
+import asyncio
 import base64
 import hashlib
 import io
+import json
+import os
+import re
 import shutil
 import tarfile
 import zipfile
 from collections import defaultdict
-from collections.abc import Awaitable, Callable, Iterator, Sequence
+from collections.abc import Awaitable, Callable, Iterator, Mapping, Sequence
+from datetime import UTC, datetime
 from functools import partial
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import yaml
 from mcp.types import BlobResourceContents, ReadResourceResult, Resource, TextResourceContents
 
-from a2c_smcp.computer.skills.home import SOURCE_USER, mcp_skill_dir, user_dropin_root, workdir_skill_root
+from a2c_smcp.computer.settings.schema import is_valid_marketplace_name
+from a2c_smcp.computer.skills.home import (
+    SOURCE_MARKETPLACE,
+    SOURCE_USER,
+    marketplace_skill_dir,
+    mcp_skill_dir,
+    user_dropin_root,
+    workdir_skill_root,
+)
 from a2c_smcp.computer.skills.naming import (
     SkillNameError,
     normalize_mcp_server_segment,
+    synthesize_marketplace_name,
     synthesize_mcp_name,
     synthesize_user_name,
 )
 from a2c_smcp.computer.skills.registry import SkillRegistry
+from a2c_smcp.computer.skills.sources import (
+    DEFAULT_PLUGIN_ROOT,
+    GitCloneSpec,
+    LocalPluginSource,
+    SkillSourceError,
+    marketplace_clone_url,
+    resolve_plugin_source,
+)
 from a2c_smcp.smcp import A2CSkillRef
 from a2c_smcp.utils.logger import get_logger
+
+if TYPE_CHECKING:
+    # settings.store 经 skills.home 反向依赖本包，运行时改用 _record_known_marketplace 内的惰性 import 破环；
+    # 此处仅供类型标注（本模块 from __future__ import annotations，注解全惰性求值，不在运行时触发导入）。
+    from a2c_smcp.computer.settings.store import KnownMarketplacesFile, MarketplaceRecord
 
 logger = get_logger(__name__)
 
 SKILL_MD = "SKILL.md"
 SKILL_URI_PREFIX = "skill://"
 _MCP_SOURCE_MODES = frozenset({"mounted", "archive", "resources"})
+
+# marketplace 布局常量 / marketplace layout constants（协议 marketplace-v1 §2.1 / §3.1 / §6）。
+MARKETPLACE_MANIFEST_DIR = ".tfrobot-plugin"  # marketplace.json / plugin.json 所在目录（嵌套，镜像 CC .claude-plugin）
+MARKETPLACE_MANIFEST = "marketplace.json"  # 仓库级 manifest
+PLUGIN_MANIFEST = "plugin.json"  # plugin 级 manifest
+SKILLS_SUBDIR = "skills"  # plugin 内 SKILL 子树约定目录（SKILL 协议 §2）
+# 独立 clone 的 plugin（url/github/cnb/git-subdir）落点命名空间——置于 marketplace/ 下以 "." 起首的目录，
+# 与 catalog clone（<home>/marketplace/<mp>/）物理隔离、且不与 kebab marketplace 名冲突。
+_EXTERNAL_PLUGINS_NS = ".plugins"
+
+# git clone/pull 默认超时（秒）/ Default git clone/pull timeout (design §2.2: 默认 120s)。
+DEFAULT_GIT_TIMEOUT = 120.0
+
+# scp-like / ssh:// → https 回退的解析（SSH→HTTPS fallback，design §2.2）/ ssh→https rewrite patterns。
+_SSH_SCHEME_RE = re.compile(r"^ssh://(?:[^@/]+@)?([^/:]+)(?::\d+)?/(.+)$")
+_SSH_SCP_LIKE_RE = re.compile(r"^[\w.+-]+@([\w.-]+):(.+)$")
 
 # 归档安全上界（防 tar/zip bomb OOM；可信源模型下为安全网，默认宽松，后续可配置化）。
 # Archive safety bounds (bomb guard): generous defaults under the trusted-source model.
@@ -601,4 +663,513 @@ def stage_user_skills(
         # 跨 run 既存（active 或 orphan）→ update（刷新 / 孤儿恢复）；否则 register。
         if registry.register_or_update(ref):
             registered.append(name)
+    return registered
+
+
+# ── marketplace 源 git staging（#61）/ marketplace-source git staging ──────────
+def _git_env(env: Mapping[str, str] | None) -> dict[str, str]:
+    """
+    构造非交互 git 环境 / Build a non-interactive git environment（design §2.2）。
+
+    强制 ``GIT_TERMINAL_PROMPT=0`` + ``GIT_ASKPASS=""`` 禁用凭证交互提示；``GIT_SSH_COMMAND`` 注入
+    ``-oBatchMode=yes`` 让 SSH 在缺凭证时**立即失败**（而非挂起等待密码）——失败后由 :func:`_git_clone_with_fallback`
+    走 SSH→HTTPS 回退。基于传入 ``env``（默认 ``os.environ``）派生，不污染调用方环境。
+    """
+    base = dict(os.environ if env is None else env)
+    base["GIT_TERMINAL_PROMPT"] = "0"
+    base["GIT_ASKPASS"] = ""
+    base.setdefault("GIT_SSH_COMMAND", "ssh -oBatchMode=yes")
+    return base
+
+
+async def _run_git(args: Sequence[str], *, timeout: float, env: Mapping[str, str] | None) -> str:
+    """
+    执行 ``git <args>`` 并返回 stdout / Run ``git`` capturing stdout（非零退出 / 超时 → :class:`SkillStagingError`）。
+
+    用 ``create_subprocess_exec`` 显式 argv（**不**经 shell，杜绝 url 注入）；超时 ``kill`` 并回收，
+    避免遗留僵尸进程。仿 :func:`a2c_smcp.computer.inputs.cli_io.arun_command` 的超时姿态。
+    """
+    proc = await asyncio.create_subprocess_exec(
+        "git",
+        *args,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        env=_git_env(env),
+    )
+    try:
+        stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout)
+    except TimeoutError:
+        try:
+            proc.kill()
+        except ProcessLookupError:  # pragma: no cover - 进程已退出
+            pass
+        await proc.wait()
+        raise SkillStagingError(f"git {args[0] if args else ''} timed out after {timeout}s") from None
+    if proc.returncode != 0:
+        err = stderr.decode(errors="ignore").strip()
+        raise SkillStagingError(f"git {' '.join(args)} failed (rc={proc.returncode}): {err}")
+    return stdout.decode(errors="ignore")
+
+
+def _ssh_to_https(url: str) -> str | None:
+    """
+    SSH/scp-like URL → ``https://`` 回退候选 / Rewrite an ssh URL to its ``https`` fallback。
+
+    ``ssh://[user@]host[:port]/path`` 与 scp-like ``user@host:path`` → ``https://host/path``；非 ssh 形态
+    （已是 ``https`` / ``file://`` 等）→ ``None``（无回退）。design §2.2 SSH→HTTPS 回退。
+    """
+    u = url.strip()
+    m = _SSH_SCHEME_RE.match(u)
+    if m:
+        return f"https://{m.group(1)}/{m.group(2)}"
+    m = _SSH_SCP_LIKE_RE.match(u)
+    if m:
+        return f"https://{m.group(1)}/{m.group(2)}"
+    return None
+
+
+async def _git_clone_with_fallback(
+    clone_args: Sequence[str],
+    url: str,
+    dest: Path,
+    *,
+    timeout: float,
+    env: Mapping[str, str] | None,
+) -> None:
+    """
+    ``git clone`` 到 ``dest``（clone 与 url 之间插 ``clone_args`` flag），失败 SSH→HTTPS 回退 / Clone with fallback。
+
+    ``dest`` 落盘前先 ``rmtree``（幂等、清半成品）；首次（原 url）失败且为 ssh 形态 → 改写 https 重试一次。
+    """
+    shutil.rmtree(dest, ignore_errors=True)
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        await _run_git(["clone", *clone_args, "--", url, str(dest)], timeout=timeout, env=env)
+        return
+    except SkillStagingError as first:
+        https = _ssh_to_https(url)
+        if https is None or https == url:
+            raise
+        logger.warning("git clone %s failed (%s); retrying via HTTPS %s", url, first, https)
+        shutil.rmtree(dest, ignore_errors=True)
+        await _run_git(["clone", *clone_args, "--", https, str(dest)], timeout=timeout, env=env)
+
+
+async def _git_clone_marketplace(url: str, dest: Path, *, timeout: float, env: Mapping[str, str] | None) -> None:
+    """marketplace catalog ``git clone --depth 1``（无 ref/sha，GitSource 仅 url）/ Shallow-clone the catalog。"""
+    await _git_clone_with_fallback(["--depth", "1"], url, dest, timeout=timeout, env=env)
+
+
+async def _git_refresh_marketplace(dest: Path, url: str, *, timeout: float, env: Mapping[str, str] | None) -> None:
+    """原地 ``git pull --ff-only``；失败 → 全量重 clone / In-place pull, full re-clone on failure（design §2.2）。"""
+    try:
+        await _run_git(["-C", str(dest), "pull", "--ff-only"], timeout=timeout, env=env)
+        return
+    except SkillStagingError as e:
+        logger.warning("git pull in %s failed (%s); full re-clone", dest, e)
+    await _git_clone_marketplace(url, dest, timeout=timeout, env=env)
+
+
+async def _git_clone_plugin(spec: GitCloneSpec, dest: Path, *, timeout: float, env: Mapping[str, str] | None) -> Path:
+    """
+    克隆独立 plugin 源（``url``/``github``/``cnb``/``git-subdir``）→ 返回 plugin 根 / Clone a standalone plugin source。
+
+    - ``sha`` 锁版本：``--filter=blob:none --no-checkout`` 全 refs blobless clone 后 ``checkout <sha>``（浅克隆
+      无法精确命中任意 sha）；
+    - ``git-subdir``（无 sha）：``--filter=tree:0 --sparse --depth 1``（按 design §2.2 / CC pluginLoader 链路）
+      后 ``sparse-checkout set <subdir>``，plugin 根 = ``<clone>/<subdir>``；
+    - 普通（无 sha 无 subdir）：``--depth 1 [--branch <ref>]``。
+    SSH→HTTPS 回退由 :func:`_git_clone_with_fallback` 承担。
+    """
+    if spec.sha:
+        clone_args: list[str] = ["--filter=blob:none", "--no-checkout"]
+    elif spec.subdir:
+        clone_args = ["--filter=tree:0", "--sparse", "--depth", "1"]
+        if spec.ref:
+            clone_args += ["--branch", spec.ref]
+    else:
+        clone_args = ["--depth", "1"]
+        if spec.ref:
+            clone_args += ["--branch", spec.ref]
+
+    await _git_clone_with_fallback(clone_args, spec.url, dest, timeout=timeout, env=env)
+
+    if spec.sha:
+        # blobless/no-checkout：按 sha 落实工作树（subdir 仅作 plugin 根路径，无需 sparse）。
+        await _run_git(["-C", str(dest), "checkout", spec.sha], timeout=timeout, env=env)
+    elif spec.subdir:
+        await _run_git(["-C", str(dest), "sparse-checkout", "set", spec.subdir], timeout=timeout, env=env)
+
+    return (dest / spec.subdir) if spec.subdir else dest
+
+
+async def _git_head_sha(dest: Path, *, timeout: float, env: Mapping[str, str] | None) -> str | None:
+    """``git rev-parse HEAD``（取 commitSha 物化记录用）；失败 → ``None`` / HEAD sha, ``None`` on failure。"""
+    try:
+        return (await _run_git(["-C", str(dest), "rev-parse", "HEAD"], timeout=timeout, env=env)).strip() or None
+    except SkillStagingError as e:
+        logger.warning("git rev-parse HEAD in %s failed (%s)", dest, e)
+        return None
+
+
+# ── marketplace.json / plugin.json 解析 / manifest parsing ───────────────────
+def _read_json_object(path: Path, *, what: str) -> dict[str, Any]:
+    """读 JSON 文件并要求根为对象 / Read a JSON file requiring an object root（失败 → :class:`SkillStagingError`）。"""
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as e:
+        raise SkillStagingError(f"{what} unreadable/invalid at {path}: {e}") from e
+    if not isinstance(data, dict):
+        raise SkillStagingError(f"{what} root is not an object: {path}")
+    return data
+
+
+def _read_marketplace_manifest(clone_dir: Path) -> dict[str, Any]:
+    """读 ``<clone>/.tfrobot-plugin/marketplace.json``（仓库级 manifest）/ Read the marketplace manifest。"""
+    path = clone_dir / MARKETPLACE_MANIFEST_DIR / MARKETPLACE_MANIFEST
+    if not path.is_file():
+        raise SkillStagingError(f"marketplace manifest not found: {path}")
+    return _read_json_object(path, what="marketplace manifest")
+
+
+def _read_plugin_manifest(plugin_root: Path) -> dict[str, Any]:
+    """读 ``<plugin>/.tfrobot-plugin/plugin.json``（best-effort，缺失 → ``{}``）/ Read plugin.json best-effort。"""
+    path = plugin_root / MARKETPLACE_MANIFEST_DIR / PLUGIN_MANIFEST
+    if not path.is_file():
+        return {}
+    try:
+        return _read_json_object(path, what="plugin manifest")
+    except SkillStagingError as e:
+        # plugin.json 仅供 version / 显示名兜底，损坏不致命（SKILL 由路径推导）。
+        logger.warning("plugin manifest ignored (%s)", e)
+        return {}
+
+
+def _plugin_root_base(manifest: Mapping[str, Any]) -> str:
+    """取 ``metadata.pluginRoot``（缺省 :data:`~a2c_smcp.computer.skills.sources.DEFAULT_PLUGIN_ROOT`）/ Resolve pluginRoot。"""
+    md = manifest.get("metadata")
+    if isinstance(md, Mapping):
+        pr = md.get("pluginRoot")
+        if isinstance(pr, str) and pr.strip():
+            return pr.strip()
+    return DEFAULT_PLUGIN_ROOT
+
+
+def _entry_plugin_name(entry: Mapping[str, Any]) -> str:
+    """plugin 条目 ID = entry.name（marketplace-v1 §4.1 必填；kebab 校验交 name 合成）/ The plugin entry name。"""
+    name = entry.get("name")
+    if not isinstance(name, str) or not name.strip():
+        raise SkillStagingError(f"plugin entry missing required 'name': {entry!r}")
+    return name.strip()
+
+
+def _within(child: Path, parent: Path) -> bool:
+    """``child`` 是否在 ``parent`` 内（含等于；均 ``resolve`` 后比较）/ Whether ``child`` is within ``parent``。"""
+    child = child.resolve()
+    parent = parent.resolve()
+    return child == parent or parent in child.parents
+
+
+def _external_plugin_dir(home: Path, marketplace: str, plugin: str) -> Path:
+    """独立 clone plugin 的落点 ``<home>/marketplace/.plugins/<mp>/<plugin>/`` / External plugin clone dir。"""
+    return home / SOURCE_MARKETPLACE / _EXTERNAL_PLUGINS_NS / marketplace / plugin
+
+
+def _build_marketplace_ref(name: str, marketplace: str, frontmatter: dict[str, Any], version: str | None, skill_dir: Path) -> A2CSkillRef:
+    """
+    组装 marketplace 源 A2CSkillRef / Assemble a marketplace-source A2CSkillRef。
+
+    ``source = "marketplace:<repo>"``（完整溯源，**不**进 name）；**无 ``uri``**（marketplace 源不带
+    ``skill://``）；``path`` = SKILL 包根（就地 clone 树内，不复制）；``version`` 取自 entry/plugin.json/commitSha。
+    """
+    ref: A2CSkillRef = {
+        "name": name,
+        "source": f"{SOURCE_MARKETPLACE}:{marketplace}",
+        "path": str(skill_dir.resolve()),
+        "description": str(frontmatter["description"]),
+    }
+    _apply_frontmatter_optional_fields(ref, frontmatter)
+    if version is not None:
+        ref["version"] = str(version)
+    return ref
+
+
+def _scan_and_register_plugin_skills(
+    marketplace: str,
+    plugin_name: str,
+    plugin_root: Path,
+    version: str | None,
+    registry: SkillRegistry,
+    seen: set[str],
+) -> list[str]:
+    """
+    扫 ``<plugin 根>/skills/<skill>/SKILL.md`` 并注册 / Scan a plugin's ``skills/`` and register each SKILL。
+
+    ``name = <plugin>:<skill>``（``<plugin>`` = entry.name、``<skill>`` = skill 目录 basename，frontmatter
+    仅作显示名、不改 ID，marketplace-v1 §2.1 防伪）。缺 frontmatter ``description`` / name 合成失败 / 本 run
+    重名 → 记 ERROR、跳过、不入册（失败降级，不抛）。仅扫 ``skills/`` 下**一级**（``iterdir``），不递归包内。
+
+    .. note::
+       仅扫**约定** ``skills/`` 目录；``entry.skills`` 组件路径覆写与 strict mode 冲突检测显式延后（见 #80）。
+    """
+    skills_dir = plugin_root / SKILLS_SUBDIR
+    if not skills_dir.is_dir():
+        logger.warning(
+            "marketplace %r plugin %r has no %s/ dir at %s; no SKILLs registered",
+            marketplace,
+            plugin_name,
+            SKILLS_SUBDIR,
+            skills_dir,
+        )
+        return []
+
+    registered: list[str] = []
+    for skill_dir in sorted(p for p in skills_dir.iterdir() if p.is_dir()):
+        skill_md = skill_dir / SKILL_MD
+        if not skill_md.is_file():
+            continue
+        try:
+            frontmatter = parse_skill_frontmatter(skill_md.read_text(encoding="utf-8"))
+        except OSError as e:
+            logger.error("marketplace %r plugin %r skill %r SKILL.md unreadable, skipped: %s", marketplace, plugin_name, skill_dir.name, e)
+            continue
+        if not frontmatter.get("description"):
+            logger.error(
+                "marketplace %r plugin %r skill %r missing frontmatter 'description', skipped",
+                marketplace,
+                plugin_name,
+                skill_dir.name,
+            )
+            continue
+        try:
+            name = synthesize_marketplace_name(plugin_name, skill_dir.name)
+        except SkillNameError as e:
+            logger.error(
+                "marketplace %r plugin %r skill name synthesis failed, skipped: %s (%s)",
+                marketplace,
+                plugin_name,
+                skill_dir.name,
+                e.reason,
+            )
+            continue
+        if name in seen:
+            logger.error("duplicate marketplace SKILL name within staging run, keeping first: %s (%s)", name, skill_dir)
+            continue
+        seen.add(name)
+        ref = _build_marketplace_ref(name, marketplace, frontmatter, version, skill_dir)
+        if registry.register_or_update(ref):
+            registered.append(name)
+    return registered
+
+
+async def _stage_one_plugin(
+    marketplace: str,
+    plugin_name: str,
+    entry: Mapping[str, Any],
+    catalog_dir: Path,
+    plugin_root_base: str,
+    home: Path,
+    registry: SkillRegistry,
+    seen: set[str],
+    catalog_sha: str | None,
+    *,
+    refresh: bool,
+    timeout: float,
+    env: Mapping[str, str] | None,
+) -> list[str]:
+    """解析 plugin source → 定位 plugin 根 → 扫描注册其 SKILL / Resolve source, locate root, scan & register。"""
+    raw_source = entry.get("source")
+    if raw_source is None:
+        raise SkillSourceError(dict(entry), "plugin entry missing required 'source'")
+    resolved = resolve_plugin_source(raw_source, plugin_root=plugin_root_base)
+
+    if isinstance(resolved, LocalPluginSource):
+        # 相对路径：就地在 catalog clone 内（不独立 clone）；越界保护。
+        plugin_root = (catalog_dir / resolved.rel_path).resolve()
+        if not _within(plugin_root, catalog_dir):
+            raise SkillStagingError(f"relative plugin source escapes marketplace clone: {resolved.rel_path!r}")
+        version_fallback = catalog_sha
+    else:  # GitCloneSpec：独立 clone（git-subdir sparse / sha 锁版本等）。
+        ext_dir = _external_plugin_dir(home, marketplace, plugin_name)
+        # sha 锁版本不可变：即便 refresh=True 也复用既有 clone（重 clone 无收益）。
+        if ext_dir.exists() and (not refresh or resolved.sha):
+            plugin_root = (ext_dir / resolved.subdir) if resolved.subdir else ext_dir
+        else:
+            plugin_root = await _git_clone_plugin(resolved, ext_dir, timeout=timeout, env=env)
+        version_fallback = await _git_head_sha(ext_dir, timeout=timeout, env=env)
+
+    if not plugin_root.is_dir():
+        raise SkillStagingError(f"plugin root not found after resolve: {plugin_root}")
+
+    plugin_manifest = _read_plugin_manifest(plugin_root)
+    version = _resolve_plugin_version(entry, plugin_manifest, version_fallback)
+    return _scan_and_register_plugin_skills(marketplace, plugin_name, plugin_root, version, registry, seen)
+
+
+def _resolve_plugin_version(entry: Mapping[str, Any], plugin_manifest: Mapping[str, Any], fallback_sha: str | None) -> str | None:
+    """version 优先级：entry.version > plugin.json.version > git commit SHA（marketplace-v1 §4.2）/ Resolve plugin version。"""
+    for src in (entry, plugin_manifest):
+        v = src.get("version")
+        if isinstance(v, str) and v.strip():
+            return v.strip()
+    return fallback_sha
+
+
+def _record_known_marketplace(
+    name: str,
+    source: Mapping[str, Any],
+    clone_dir: Path,
+    commit_sha: str | None,
+    auto_update: bool,
+    home: Path,
+    env: Mapping[str, str] | None,
+    *,
+    changed: bool,
+) -> None:
+    """
+    写 ``known_marketplaces.json`` 物化记录（持锁原子 RMW）/ Record into known_marketplaces.json（§6.1）。
+
+    记 ``source`` / ``installLocation``（+ 可选 ``commitSha`` / ``autoUpdate``）。``lastUpdated`` 仅在
+    ``changed``（本次实际 clone/pull）或无既有记录时刷为当下；复用既有 clone（``changed=False``）则**保留**原
+    ``lastUpdated``——使该字段语义为「最后更新时间」而非「最后扫描时间」（§6.1）。失败（锁不可得 / I/O）仅记
+    ERROR、**不**中断 staging（物化记录是诊断/对账元数据，丢失靠下次 reconcile 重建）。
+
+    settings.store 经 skills.home 反向依赖本包，故在此**惰性 import** 破除模块级环依赖（store 仅在本函数调用时
+    才被加载，彼时所有模块已初始化完毕）。
+    """
+    from a2c_smcp.computer.settings.store import update_known_marketplaces
+
+    def _mutate(current: KnownMarketplacesFile) -> None:
+        prior = current["marketplaces"].get(name)
+        record: MarketplaceRecord = {
+            "source": dict(source),  # type: ignore[typeddict-item]  # GitSource {type, url}
+            "installLocation": str(clone_dir.resolve()),
+        }
+        # lastUpdated：实际 clone/pull 或首次记录 → 刷新；纯复用 → 保留既有值。
+        prior_last = prior.get("lastUpdated") if prior else None
+        record["lastUpdated"] = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ") if (changed or not prior_last) else prior_last
+        if commit_sha:
+            record["commitSha"] = commit_sha
+        if auto_update:
+            record["autoUpdate"] = True
+        current["marketplaces"][name] = record
+        return None
+
+    try:
+        update_known_marketplaces(_mutate, home, env)
+    except Exception as e:  # 锁不可得 / I/O 失败 → 不阻断 staging
+        logger.error("failed to record known_marketplaces.json for %r: %s", name, e)
+
+
+async def stage_marketplace_skills(
+    name: str,
+    source: Mapping[str, Any],
+    registry: SkillRegistry,
+    home: Path,
+    *,
+    plugin_filter: set[str] | None = None,
+    auto_update: bool = False,
+    refresh: bool = False,
+    timeout: float = DEFAULT_GIT_TIMEOUT,
+    env: Mapping[str, str] | None = None,
+) -> list[str]:
+    """
+    clone/refresh **单个** marketplace 并物化其 plugin SKILL → 注册进 Registry / Stage one marketplace's SKILLs。
+
+    对账编排（declared∖materialized additive-only diff）、``enabledPlugins`` 过滤、孤儿清理归 reconciler（#62）；
+    本函数只「clone 一个 marketplace + 解析 plugin source + 扫描 skills + 注册」。失败降级铁律（design §2.2 /
+    工单 §8）：clone/pull/解析/物化失败 → 记 ERROR、该源 / 该 plugin 不入 Registry、**不**抛、**不**阻断其余。
+
+    :param name: marketplace 名（``known_marketplaces.json`` key + ``<home>/marketplace/<name>/`` clone 目录段）。
+    :param source: marketplace git 源 ``{type:"git", url}``（:class:`~a2c_smcp.computer.settings.schema.GitSource`）。
+    :param registry: 目标 :class:`SkillRegistry`。
+    :param home: SKILL Home 绝对根。
+    :param plugin_filter: 仅物化这些 plugin 名（``None`` = marketplace.json 全部）；#62 注入 ``enabledPlugins ∩ installed``。
+    :param auto_update: 写入物化记录的 ``autoUpdate`` 旗（仅记录，本函数不据此自动刷新）。
+    :param refresh: ``True`` → 已存在 clone 走 ``git pull``（失败重 clone）+ 独立 plugin 重 clone；``False`` →
+        缺失才 clone、已存在则就地复用（重扫）。
+    :param timeout: 单次 git 操作超时（秒）。
+    :param env: git 子进程环境（默认 ``os.environ``；便于测试注入）。
+    :return: 本次成功注册 / 刷新的 SKILL name 列表（供 reconciler / watcher diff 孤儿）。
+    """
+    registered: list[str] = []
+
+    # name 直接作 <home>/marketplace/<name>/ 路径段——本函数已进公开 API（__all__），加防御纵深：
+    # 仅接受严格 kebab marketplace 名（与 settings load 的 is_valid_marketplace_name 同契约），天然拒
+    # ``..`` / ``/`` 等路径穿越向量（上游 settings 已校验，此处兜底未来非 settings 调用方）。
+    if not is_valid_marketplace_name(name):
+        logger.error("marketplace name %r is invalid (must be strict-kebab, 1-64), skipped (not registered)", name)
+        return registered
+
+    try:
+        url = marketplace_clone_url(source)
+    except SkillSourceError as e:
+        logger.error("marketplace %r has invalid source, skipped (not registered): %s", name, e)
+        return registered
+
+    # home 由调用方保证存在（与 stage_mcp_skills / stage_user_skills 一致）；clone 目录父级由
+    # _git_clone_with_fallback 落盘前 mkdir。
+    clone_dir = marketplace_skill_dir(home, name)
+    # changed：本次是否实际发生 clone/pull——决定 known_marketplaces.json 的 lastUpdated 是否刷新
+    # （复用既有 clone 不算更新，避免 lastUpdated 退化为「最后扫描时间」）。
+    changed = False
+    try:
+        if clone_dir.exists():
+            if refresh:
+                await _git_refresh_marketplace(clone_dir, url, timeout=timeout, env=env)
+                changed = True
+        else:
+            await _git_clone_marketplace(url, clone_dir, timeout=timeout, env=env)
+            changed = True
+    except SkillStagingError as e:
+        logger.error("marketplace %r clone/refresh failed, skipped (not registered): %s", name, e)
+        return registered
+
+    commit_sha = await _git_head_sha(clone_dir, timeout=timeout, env=env)
+    _record_known_marketplace(name, source, clone_dir, commit_sha, auto_update, home, env, changed=changed)
+
+    try:
+        manifest = _read_marketplace_manifest(clone_dir)
+    except SkillStagingError as e:
+        logger.error("marketplace %r manifest invalid, skipped (clone kept): %s", name, e)
+        return registered
+
+    plugins = manifest.get("plugins")
+    if not isinstance(plugins, list):
+        logger.error("marketplace %r manifest 'plugins' is not an array, skipped: %s", name, type(plugins).__name__)
+        return registered
+
+    plugin_root_base = _plugin_root_base(manifest)
+    seen: set[str] = set()
+    for entry in plugins:
+        if not isinstance(entry, Mapping):
+            logger.error("marketplace %r has a non-object plugin entry, skipped: %r", name, entry)
+            continue
+        try:
+            plugin_name = _entry_plugin_name(entry)
+        except SkillStagingError as e:
+            logger.error("marketplace %r plugin entry invalid, skipped: %s", name, e)
+            continue
+        if plugin_filter is not None and plugin_name not in plugin_filter:
+            continue
+        try:
+            names = await _stage_one_plugin(
+                name,
+                plugin_name,
+                entry,
+                clone_dir,
+                plugin_root_base,
+                home,
+                registry,
+                seen,
+                commit_sha,
+                refresh=refresh,
+                timeout=timeout,
+                env=env,
+            )
+            registered.extend(names)
+        except (SkillSourceError, SkillStagingError) as e:
+            logger.error("marketplace %r plugin %r staging failed, skipped: %s", name, plugin_name, e)
+        except Exception as e:  # 失败降级铁律：单 plugin 任意异常不阻断其余
+            logger.error("marketplace %r plugin %r unexpected staging error, skipped: %s", name, plugin_name, e, exc_info=True)
     return registered

--- a/a2c_smcp/computer/skills/staging.py
+++ b/a2c_smcp/computer/skills/staging.py
@@ -110,6 +110,7 @@ from a2c_smcp.computer.skills.sources import (
 )
 from a2c_smcp.smcp import A2CSkillRef
 from a2c_smcp.utils.logger import get_logger
+from a2c_smcp.utils.path import is_within
 
 if TYPE_CHECKING:
     # settings.store 经 skills.home 反向依赖本包，运行时改用 _record_known_marketplace 内的惰性 import 破环；
@@ -780,6 +781,12 @@ async def _git_clone_plugin(spec: GitCloneSpec, dest: Path, *, timeout: float, e
       后 ``sparse-checkout set <subdir>``，plugin 根 = ``<clone>/<subdir>``；
     - 普通（无 sha 无 subdir）：``--depth 1 [--branch <ref>]``。
     SSH→HTTPS 回退由 :func:`_git_clone_with_fallback` 承担。
+
+    .. note::
+       ``sha``（``--filter=blob:none``）与 ``git-subdir``（``--filter=tree:0``）路径依赖远端支持 partial clone
+       （``uploadpack.allowFilter``）。不支持的自建 / 部分 CNB 服务器会 clone 失败——由上层
+       :func:`stage_marketplace_skills` 走失败降级（记 ERROR、该 plugin 不入册、不阻断其余）；**暂无**「退回
+       全量 clone」兜底（可按需后续增强）。
     """
     if spec.sha:
         clone_args: list[str] = ["--filter=blob:none", "--no-checkout"]
@@ -861,13 +868,6 @@ def _entry_plugin_name(entry: Mapping[str, Any]) -> str:
     if not isinstance(name, str) or not name.strip():
         raise SkillStagingError(f"plugin entry missing required 'name': {entry!r}")
     return name.strip()
-
-
-def _within(child: Path, parent: Path) -> bool:
-    """``child`` 是否在 ``parent`` 内（含等于；均 ``resolve`` 后比较）/ Whether ``child`` is within ``parent``。"""
-    child = child.resolve()
-    parent = parent.resolve()
-    return child == parent or parent in child.parents
 
 
 def _external_plugin_dir(home: Path, marketplace: str, plugin: str) -> Path:
@@ -984,19 +984,24 @@ async def _stage_one_plugin(
     resolved = resolve_plugin_source(raw_source, plugin_root=plugin_root_base)
 
     if isinstance(resolved, LocalPluginSource):
-        # 相对路径：就地在 catalog clone 内（不独立 clone）；越界保护。
+        # 相对路径：就地在 catalog clone 内（不独立 clone）；越界保护（is_within 词法判定，两侧均已 resolve）。
         plugin_root = (catalog_dir / resolved.rel_path).resolve()
-        if not _within(plugin_root, catalog_dir):
+        if not is_within(plugin_root, catalog_dir.resolve()):
             raise SkillStagingError(f"relative plugin source escapes marketplace clone: {resolved.rel_path!r}")
         version_fallback = catalog_sha
     else:  # GitCloneSpec：独立 clone（git-subdir sparse / sha 锁版本等）。
         ext_dir = _external_plugin_dir(home, marketplace, plugin_name)
-        # sha 锁版本不可变：即便 refresh=True 也复用既有 clone（重 clone 无收益）。
-        if ext_dir.exists() and (not refresh or resolved.sha):
-            plugin_root = (ext_dir / resolved.subdir) if resolved.subdir else ext_dir
-        else:
-            plugin_root = await _git_clone_plugin(resolved, ext_dir, timeout=timeout, env=env)
-        version_fallback = await _git_head_sha(ext_dir, timeout=timeout, env=env)
+        head = await _git_head_sha(ext_dir, timeout=timeout, env=env) if ext_dir.exists() else None
+        # 复用既有 clone 的条件（否则重 clone）：
+        #  - sha 锁版本：既有 HEAD 已等于 pin → 复用（重 clone 无收益）；pin 变更（A→B）→ 重 clone 重 pin（守住
+        #    refresh 契约，杜绝静默忽略新 sha）；
+        #  - 非 sha：仅 refresh=False 复用；refresh=True 重 clone 拉最新。
+        reuse = ext_dir.exists() and (head == resolved.sha if resolved.sha else not refresh)
+        if not reuse:
+            await _git_clone_plugin(resolved, ext_dir, timeout=timeout, env=env)
+            head = await _git_head_sha(ext_dir, timeout=timeout, env=env)
+        plugin_root = (ext_dir / resolved.subdir) if resolved.subdir else ext_dir
+        version_fallback = head
 
     if not plugin_root.is_dir():
         raise SkillStagingError(f"plugin root not found after resolve: {plugin_root}")
@@ -1086,8 +1091,15 @@ async def stage_marketplace_skills(
     :param home: SKILL Home 绝对根。
     :param plugin_filter: 仅物化这些 plugin 名（``None`` = marketplace.json 全部）；#62 注入 ``enabledPlugins ∩ installed``。
     :param auto_update: 写入物化记录的 ``autoUpdate`` 旗（仅记录，本函数不据此自动刷新）。
-    :param refresh: ``True`` → 已存在 clone 走 ``git pull``（失败重 clone）+ 独立 plugin 重 clone；``False`` →
-        缺失才 clone、已存在则就地复用（重扫）。
+    :param refresh: ``True`` → 已存在 catalog clone 走 ``git pull``（失败重 clone）+ 独立 plugin 重 clone
+        （sha 锁版本例外：仅在既有 HEAD ≠ pin 时重 clone，等于 pin 则复用）；``False`` → 缺失才 clone、
+        已存在则就地复用（重扫）。
+
+    .. note::
+       本函数经 :func:`_record_known_marketplace` 写 ``known_marketplaces.json`` 时持**同步阻塞**文件锁
+       （:func:`~a2c_smcp.computer.settings.store.file_lock`，竞争时 ``time.sleep`` 退避）。当前单 marketplace
+       串行调用无碍；若编排方（#62）以 ``asyncio.gather`` 并发 stage 多个 marketplace，须串行化或用
+       ``loop.run_in_executor`` 包裹，避免阻塞事件循环（store.py 同步设计的固有约束）。
     :param timeout: 单次 git 操作超时（秒）。
     :param env: git 子进程环境（默认 ``os.environ``；便于测试注入）。
     :return: 本次成功注册 / 刷新的 SKILL name 列表（供 reconciler / watcher diff 孤儿）。

--- a/tests/integration_tests/computer/skills/__init__.py
+++ b/tests/integration_tests/computer/skills/__init__.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+# filename: __init__.py
+# @Time    : 2026/05/26
+# @Author  : JQQ
+# @Email   : jqq1716@gmail.com
+# @Software: PyCharm
+"""Computer SKILL 子系统集成测试包 / Computer SKILL subsystem integration tests."""

--- a/tests/integration_tests/computer/skills/test_staging_marketplace.py
+++ b/tests/integration_tests/computer/skills/test_staging_marketplace.py
@@ -307,6 +307,107 @@ def test_ssh_to_https_rewrite(url: str, expected: str | None) -> None:
     assert _ssh_to_https(url) == expected
 
 
+# ── 降级/去重分支 / dedup & degrade branches ─────────────────────────────────
+@requires_git
+async def test_duplicate_synthesized_name_keeps_first(tmp_path: Path) -> None:
+    # 两个同名 plugin 条目（各含 skills/x）→ 合成同 name `dup:x`，单 run 内去重保留先到者
+    files = {
+        ".tfrobot-plugin/marketplace.json": json.dumps(
+            {
+                "name": "dupmp",
+                "owner": {"name": "x"},
+                "metadata": {"pluginRoot": "./plugins"},
+                "plugins": [
+                    {"name": "dup", "source": "alpha"},
+                    {"name": "dup", "source": "beta"},
+                ],
+            },
+        ),
+        "plugins/alpha/skills/x/SKILL.md": _skill_md("x", "from alpha"),
+        "plugins/beta/skills/x/SKILL.md": _skill_md("x", "from beta"),
+    }
+    _, bare = _make_bare(tmp_path, "dupmp", files)
+    home = _home(tmp_path)
+    reg = SkillRegistry()
+
+    names = await stage_marketplace_skills("dupmp", _src(_url(bare)), reg, home, env=_env(home))
+    assert names == ["dup:x"]  # 仅首个注册
+    assert len(reg) == 1
+    ref = reg.resolve("dup:x")
+    assert ref is not None
+    assert ref["description"] == "from alpha"  # 保留先到者
+
+
+@requires_git
+async def test_corrupt_plugin_manifest_degrades(tmp_path: Path) -> None:
+    files = {
+        ".tfrobot-plugin/marketplace.json": json.dumps(
+            {"name": "cpmp", "owner": {"name": "x"}, "metadata": {"pluginRoot": "./plugins"}, "plugins": [{"name": "cp", "source": "cp"}]},
+        ),
+        "plugins/cp/.tfrobot-plugin/plugin.json": "{ this is not valid json",  # 损坏 manifest
+        "plugins/cp/skills/s1/SKILL.md": _skill_md("s1"),
+    }
+    _, bare = _make_bare(tmp_path, "cpmp", files)
+    home = _home(tmp_path)
+    reg = SkillRegistry()
+
+    names = await stage_marketplace_skills("cpmp", _src(_url(bare)), reg, home, env=_env(home))
+    assert names == ["cp:s1"]  # 损坏 plugin.json 降级为空 manifest，不影响 SKILL 注册
+    ref = reg.resolve("cp:s1")
+    assert ref is not None
+    assert ref.get("version")  # 无 plugin.json/entry version → 回退 catalog commit sha
+
+
+# ── sha pin 变更重 pin（A2 修复回归）/ sha re-pin on change ──────────────────
+@requires_git
+async def test_sha_pin_change_repins_on_refresh(tmp_path: Path) -> None:
+    plugin_files = {
+        ".tfrobot-plugin/plugin.json": json.dumps({"name": "pin"}),
+        "skills/s/SKILL.md": _skill_md("s"),
+    }
+    work, plugin_bare = _make_bare(tmp_path, "pinplugin", plugin_files, allow_filter=True)
+    sha_a = _head_sha(work)
+    # 第二个 commit → tip = sha_b（与 sha_a 不同）
+    _write(work, {"skills/s/V2.md": "v2"})
+    _git(work, "add", "-A")
+    _git(work, "commit", "-q", "-m", "v2")
+    _git(work, "push", "-q", "origin", "main")
+    sha_b = _head_sha(work)
+    assert sha_a != sha_b
+
+    def _catalog(sha: str) -> dict[str, str]:
+        return {
+            ".tfrobot-plugin/marketplace.json": json.dumps(
+                {
+                    "name": "pin-mp",
+                    "owner": {"name": "x"},
+                    "plugins": [{"name": "pin", "source": {"source": "url", "url": _url(plugin_bare), "sha": sha}}],
+                },
+            ),
+        }
+
+    cat_work, cat_bare = _make_bare(tmp_path, "pinmp", _catalog(sha_a))
+    home = _home(tmp_path)
+    reg = SkillRegistry()
+    await stage_marketplace_skills("pin-mp", _src(_url(cat_bare)), reg, home, env=_env(home))
+
+    ext = home / "marketplace" / ".plugins" / "pin-mp" / "pin"
+    assert _head_sha(ext) == sha_a
+    ref_a = reg.resolve("pin:s")
+    assert ref_a is not None and ref_a["version"] == sha_a
+
+    # catalog 把 pin 从 sha_a 改到 sha_b 并推送；refresh=True → 重 pin（非静默复用旧 sha）
+    _write(cat_work, _catalog(sha_b))
+    _git(cat_work, "add", "-A")
+    _git(cat_work, "commit", "-q", "-m", "repin to sha_b")
+    _git(cat_work, "push", "-q", "origin", "main")
+
+    await stage_marketplace_skills("pin-mp", _src(_url(cat_bare)), reg, home, refresh=True, env=_env(home))
+    assert _head_sha(ext) == sha_b  # 重 pin 到新 sha
+    ref_b = reg.resolve("pin:s")
+    assert ref_b is not None and ref_b["version"] == sha_b
+
+
 # ── 独立 plugin clone：url plain / sha 锁版本（_git_clone_plugin 非 subdir 分支）─
 @requires_git
 async def test_url_source_standalone_clone(tmp_path: Path) -> None:

--- a/tests/integration_tests/computer/skills/test_staging_marketplace.py
+++ b/tests/integration_tests/computer/skills/test_staging_marketplace.py
@@ -1,0 +1,449 @@
+# -*- coding: utf-8 -*-
+# filename: test_staging_marketplace.py
+# @Time    : 2026/05/26
+# @Author  : JQQ
+# @Email   : jqq1716@gmail.com
+# @Software: PyCharm
+"""
+marketplace git 源 staging 本地裸仓集成测试（v0.2.1 #61）
+
+协议依据 / Protocol: tfrobot-marketplace docs/marketplace/protocol-v1.md §2/§3/§5/§6；
+SDK 设计 / Design: python-sdk docs/design-0.2.1-cli-marketplace-ux.md §3/§4.2；
+                   docs/design-0.2.1-skill-computer-management.md §2.2。
+
+测试意图 / Test intentions（用本地 ``git init --bare`` 裸仓作 file:// 源，无网络依赖）:
+- eager clone：相对路径 / 裸名 plugin 经 pluginRoot 解析 → 扫描 skills/ → 注册（含 known_marketplaces.json 物化）
+- refresh：``git pull`` 拉取新增 skill；改写历史致 ff-only 失败 → 全量重 clone 恢复
+- git-subdir：``--filter=tree:0 --sparse`` 部分克隆子目录作 plugin（cone 外目录不检出）
+- 失败降级：坏 source 不入 Registry、不抛、不阻断其余（marketplace 间 / marketplace 内 plugin 间）
+- plugin_filter（#62 注入点）：仅物化指定 plugin
+- _ssh_to_https：SSH→HTTPS 回退 URL 改写（纯函数，无需 git）
+"""
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from a2c_smcp.computer.settings.store import load_known_marketplaces
+from a2c_smcp.computer.skills.registry import SkillRegistry
+from a2c_smcp.computer.skills.staging import _ssh_to_https, stage_marketplace_skills
+
+requires_git = pytest.mark.skipif(shutil.which("git") is None, reason="requires the git binary")
+
+_GIT_IDENTITY = ["-c", "user.email=test@example.com", "-c", "user.name=Test", "-c", "commit.gpgsign=false"]
+
+
+# ── 本地裸仓 fixture 辅助 / local bare-repo helpers ──────────────────────────
+def _git(cwd: Path, *args: str) -> None:
+    subprocess.run(["git", *_GIT_IDENTITY, *args], cwd=str(cwd), check=True, capture_output=True, text=True)
+
+
+def _write(root: Path, files: dict[str, str]) -> None:
+    for rel, content in files.items():
+        p = root / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content, encoding="utf-8")
+
+
+def _skill_md(name: str, description: str = "a skill") -> str:
+    return f"---\nname: {name}\ndescription: {description}\nlicense: MIT\n---\n# {name}\nbody\n"
+
+
+def _make_bare(tmp_path: Path, name: str, files: dict[str, str], *, allow_filter: bool = False) -> tuple[Path, Path]:
+    """建一个含 ``files`` 的工作仓 + 其裸仓镜像；返回 (工作仓, 裸仓)。工作仓 origin 指向裸仓（便于 push）。"""
+    work = tmp_path / f"{name}-work"
+    work.mkdir(parents=True, exist_ok=True)
+    _git(work, "init", "-q", "-b", "main")
+    _write(work, files)
+    _git(work, "add", "-A")
+    _git(work, "commit", "-q", "-m", "init")
+    bare = tmp_path / f"{name}.git"
+    _git(tmp_path, "clone", "-q", "--bare", str(work), str(bare))
+    _git(work, "remote", "add", "origin", str(bare))
+    if allow_filter:  # file:// 部分克隆（--filter）需源仓显式允许
+        _git(bare, "config", "uploadpack.allowFilter", "true")
+        _git(bare, "config", "uploadpack.allowAnySHA1InWant", "true")
+    return work, bare
+
+
+def _head_sha(repo: Path) -> str:
+    out = subprocess.run(["git", "-C", str(repo), "rev-parse", "HEAD"], check=True, capture_output=True, text=True)
+    return out.stdout.strip()
+
+
+def _url(p: Path) -> str:
+    return f"file://{p}"
+
+
+def _src(url: str) -> dict[str, str]:
+    return {"type": "git", "url": url}
+
+
+def _env(home: Path) -> dict[str, str]:
+    return {**os.environ, "A2C_SKILL_HOME": str(home)}
+
+
+def _home(tmp_path: Path) -> Path:
+    h = tmp_path / "skill-home"
+    h.mkdir()
+    return h
+
+
+def _marketplace_files() -> dict[str, str]:
+    """标准 marketplace 布局：pluginRoot=./plugins，plugin `audit`（裸名）+ `fmt`（./ 相对路径）。"""
+    manifest = {
+        "name": "acme-skills",
+        "owner": {"name": "Acme"},
+        "metadata": {"pluginRoot": "./plugins"},
+        "plugins": [
+            {"name": "audit", "source": "audit", "version": "1.0.0"},
+            {"name": "fmt", "source": "./plugins/fmt"},
+        ],
+    }
+    return {
+        ".tfrobot-plugin/marketplace.json": json.dumps(manifest),
+        "plugins/audit/skills/audit-code/SKILL.md": _skill_md("audit-code"),
+        "plugins/audit/skills/lint/SKILL.md": _skill_md("lint"),
+        "plugins/fmt/skills/format/SKILL.md": _skill_md("format"),
+    }
+
+
+# ── eager clone ───────────────────────────────────────────────────────────────
+@requires_git
+async def test_eager_clone_registers_relative_plugins(tmp_path: Path) -> None:
+    _, bare = _make_bare(tmp_path, "acme", _marketplace_files())
+    home = _home(tmp_path)
+    reg = SkillRegistry()
+
+    names = await stage_marketplace_skills("acme-skills", _src(_url(bare)), reg, home, env=_env(home))
+
+    assert set(names) == {"audit:audit-code", "audit:lint", "fmt:format"}
+    ref = reg.resolve("audit:audit-code")
+    assert ref is not None
+    assert ref["source"] == "marketplace:acme-skills"
+    assert ref["version"] == "1.0.0"  # entry.version 优先
+    skill_path = Path(ref["path"])
+    assert skill_path.is_dir()
+    assert (skill_path / "SKILL.md").is_file()
+    # 落在 <home>/marketplace/acme-skills/ clone 树内（就地，不复制）
+    assert str(skill_path).startswith(str((home / "marketplace" / "acme-skills").resolve()))
+
+    # fmt 无 entry.version → 回退 commit SHA（非 None）
+    fmt = reg.resolve("fmt:format")
+    assert fmt is not None
+    assert fmt.get("version")
+
+    # known_marketplaces.json 物化记录
+    kmf = load_known_marketplaces(home, _env(home))
+    assert "acme-skills" in kmf["marketplaces"]
+    rec = kmf["marketplaces"]["acme-skills"]
+    assert rec["installLocation"] == str((home / "marketplace" / "acme-skills").resolve())
+    assert rec.get("commitSha")
+    assert rec["source"] == _src(_url(bare))
+
+
+# ── refresh：pull 拉新 / reclone 兜底 ────────────────────────────────────────
+@requires_git
+async def test_refresh_pull_picks_up_new_skill(tmp_path: Path) -> None:
+    work, bare = _make_bare(tmp_path, "acme", _marketplace_files())
+    home = _home(tmp_path)
+    reg = SkillRegistry()
+    await stage_marketplace_skills("acme-skills", _src(_url(bare)), reg, home, env=_env(home))
+    assert reg.resolve("audit:newskill") is None
+
+    # 工作仓新增 skill → push 到裸仓（ff 推进）
+    _write(work, {"plugins/audit/skills/newskill/SKILL.md": _skill_md("newskill")})
+    _git(work, "add", "-A")
+    _git(work, "commit", "-q", "-m", "add newskill")
+    _git(work, "push", "-q", "origin", "main")
+
+    names = await stage_marketplace_skills("acme-skills", _src(_url(bare)), reg, home, refresh=True, env=_env(home))
+    assert "audit:newskill" in names
+    assert reg.resolve("audit:newskill") is not None
+
+
+@requires_git
+async def test_refresh_reclone_when_pull_fails(tmp_path: Path) -> None:
+    work, bare = _make_bare(tmp_path, "acme", _marketplace_files())
+    home = _home(tmp_path)
+    reg = SkillRegistry()
+    await stage_marketplace_skills("acme-skills", _src(_url(bare)), reg, home, env=_env(home))
+
+    # 改写历史（amend）后强推 → 本地 clone 的 ff-only pull 失败 → 触发全量重 clone
+    _write(work, {"plugins/audit/skills/rewritten/SKILL.md": _skill_md("rewritten")})
+    _git(work, "add", "-A")
+    _git(work, "commit", "-q", "--amend", "-m", "rewritten history")
+    _git(work, "push", "-q", "-f", "origin", "main")
+
+    names = await stage_marketplace_skills("acme-skills", _src(_url(bare)), reg, home, refresh=True, env=_env(home))
+    assert "audit:rewritten" in names
+    assert reg.resolve("audit:rewritten") is not None
+
+
+# ── git-subdir sparse clone ──────────────────────────────────────────────────
+@requires_git
+async def test_git_subdir_sparse_clone(tmp_path: Path) -> None:
+    mono_files = {
+        "README.md": "monorepo root",
+        "other/junk.txt": "unrelated",
+        "pkgs/adobe/.tfrobot-plugin/plugin.json": json.dumps({"name": "adobe", "version": "2.0.0"}),
+        "pkgs/adobe/skills/photoshop/SKILL.md": _skill_md("photoshop"),
+    }
+    _, mono_bare = _make_bare(tmp_path, "mono", mono_files, allow_filter=True)
+    mp_files = {
+        ".tfrobot-plugin/marketplace.json": json.dumps(
+            {
+                "name": "curated",
+                "owner": {"name": "Curator"},
+                "plugins": [
+                    {"name": "adobe", "source": {"source": "git-subdir", "url": _url(mono_bare), "path": "pkgs/adobe"}},
+                ],
+            },
+        ),
+    }
+    _, mp_bare = _make_bare(tmp_path, "curated", mp_files)
+    home = _home(tmp_path)
+    reg = SkillRegistry()
+
+    names = await stage_marketplace_skills("curated", _src(_url(mp_bare)), reg, home, env=_env(home))
+
+    assert names == ["adobe:photoshop"]
+    ref = reg.resolve("adobe:photoshop")
+    assert ref is not None
+    assert ref["version"] == "2.0.0"  # plugin.json version（entry 无 version）
+    ext = home / "marketplace" / ".plugins" / "curated" / "adobe"
+    assert (ext / "pkgs" / "adobe" / "skills" / "photoshop" / "SKILL.md").is_file()
+    # sparse cone 外的 other/ 不应被检出
+    assert not (ext / "other").exists()
+
+
+# ── 失败降级 / failure isolation ─────────────────────────────────────────────
+@requires_git
+async def test_bad_marketplace_source_does_not_register_or_raise(tmp_path: Path) -> None:
+    home = _home(tmp_path)
+    reg = SkillRegistry()
+    # 形态合法但克隆失败（仓库不存在）→ 记 ERROR、返回 []、不抛、不入册
+    names = await stage_marketplace_skills("bad", _src(_url(tmp_path / "nonexistent.git")), reg, home, env=_env(home))
+    assert names == []
+    assert len(reg) == 0
+
+    # 不阻断其余：随后一个好 marketplace 正常注册
+    _, bare = _make_bare(tmp_path, "acme", _marketplace_files())
+    names2 = await stage_marketplace_skills("acme-skills", _src(_url(bare)), reg, home, env=_env(home))
+    assert "fmt:format" in names2
+
+
+@requires_git
+async def test_bad_plugin_does_not_block_siblings(tmp_path: Path) -> None:
+    files = {
+        ".tfrobot-plugin/marketplace.json": json.dumps(
+            {
+                "name": "mix",
+                "owner": {"name": "x"},
+                "metadata": {"pluginRoot": "./plugins"},
+                "plugins": [
+                    {"name": "good", "source": "good"},
+                    {"name": "missing", "source": "does-not-exist"},  # 指向不存在目录 → 跳过
+                    {"name": "nosrc"},  # 缺 source → 跳过
+                ],
+            },
+        ),
+        "plugins/good/skills/g1/SKILL.md": _skill_md("g1"),
+    }
+    _, bare = _make_bare(tmp_path, "mix", files)
+    home = _home(tmp_path)
+    reg = SkillRegistry()
+
+    names = await stage_marketplace_skills("mix", _src(_url(bare)), reg, home, env=_env(home))
+    assert names == ["good:g1"]
+
+
+@requires_git
+async def test_skill_missing_description_skipped(tmp_path: Path) -> None:
+    files = {
+        ".tfrobot-plugin/marketplace.json": json.dumps(
+            {"name": "p", "owner": {"name": "x"}, "metadata": {"pluginRoot": "./plugins"}, "plugins": [{"name": "a", "source": "a"}]},
+        ),
+        "plugins/a/skills/ok/SKILL.md": _skill_md("ok"),
+        "plugins/a/skills/bad/SKILL.md": "---\nname: bad\n---\nno description\n",
+    }
+    _, bare = _make_bare(tmp_path, "p", files)
+    home = _home(tmp_path)
+    reg = SkillRegistry()
+
+    names = await stage_marketplace_skills("p", _src(_url(bare)), reg, home, env=_env(home))
+    assert names == ["a:ok"]
+    assert reg.resolve("a:bad") is None
+
+
+# ── plugin_filter（#62 注入点）─────────────────────────────────────────────────
+@requires_git
+async def test_plugin_filter_restricts_registration(tmp_path: Path) -> None:
+    _, bare = _make_bare(tmp_path, "acme", _marketplace_files())
+    home = _home(tmp_path)
+    reg = SkillRegistry()
+
+    names = await stage_marketplace_skills("acme-skills", _src(_url(bare)), reg, home, plugin_filter={"audit"}, env=_env(home))
+    assert set(names) == {"audit:audit-code", "audit:lint"}
+    assert reg.resolve("fmt:format") is None
+
+
+# ── _ssh_to_https（纯函数，无需 git）/ SSH→HTTPS rewrite ──────────────────────
+@pytest.mark.parametrize(
+    ("url", "expected"),
+    [
+        ("git@github.com:owner/repo.git", "https://github.com/owner/repo.git"),
+        ("ssh://git@github.com/owner/repo.git", "https://github.com/owner/repo.git"),
+        ("ssh://git@host.example.com:2222/team/p", "https://host.example.com/team/p"),
+        ("https://github.com/owner/repo.git", None),  # 已是 https → 无回退
+        ("file:///tmp/repo.git", None),
+    ],
+)
+def test_ssh_to_https_rewrite(url: str, expected: str | None) -> None:
+    assert _ssh_to_https(url) == expected
+
+
+# ── 独立 plugin clone：url plain / sha 锁版本（_git_clone_plugin 非 subdir 分支）─
+@requires_git
+async def test_url_source_standalone_clone(tmp_path: Path) -> None:
+    plugin_files = {
+        ".tfrobot-plugin/plugin.json": json.dumps({"name": "extp", "version": "9.9.9"}),
+        "skills/remote-skill/SKILL.md": _skill_md("remote-skill"),
+    }
+    _, plugin_bare = _make_bare(tmp_path, "extplugin", plugin_files)
+    mp_files = {
+        ".tfrobot-plugin/marketplace.json": json.dumps(
+            {
+                "name": "ext-mp",
+                "owner": {"name": "x"},
+                "plugins": [{"name": "extp", "source": {"source": "url", "url": _url(plugin_bare)}}],
+            },
+        ),
+    }
+    _, mp_bare = _make_bare(tmp_path, "extmp", mp_files)
+    home = _home(tmp_path)
+    reg = SkillRegistry()
+
+    names = await stage_marketplace_skills("ext-mp", _src(_url(mp_bare)), reg, home, env=_env(home))
+
+    assert names == ["extp:remote-skill"]
+    ref = reg.resolve("extp:remote-skill")
+    assert ref is not None
+    assert ref["version"] == "9.9.9"  # plugin.json version
+    ext = home / "marketplace" / ".plugins" / "ext-mp" / "extp"
+    assert (ext / "skills" / "remote-skill" / "SKILL.md").is_file()
+
+
+@requires_git
+async def test_sha_locked_standalone_clone_pins_commit(tmp_path: Path) -> None:
+    plugin_files = {
+        ".tfrobot-plugin/plugin.json": json.dumps({"name": "lockp"}),  # 无 version → 回退 sha
+        "skills/pinned/SKILL.md": _skill_md("pinned"),
+    }
+    work, plugin_bare = _make_bare(tmp_path, "lockplugin", plugin_files, allow_filter=True)
+    pinned_sha = _head_sha(work)
+    # 追加更晚的 commit 并推送 → tip != pinned_sha
+    _write(work, {"skills/pinned/LATER.md": "later"})
+    _git(work, "add", "-A")
+    _git(work, "commit", "-q", "-m", "later commit")
+    _git(work, "push", "-q", "origin", "main")
+
+    mp_files = {
+        ".tfrobot-plugin/marketplace.json": json.dumps(
+            {
+                "name": "ext-mp",
+                "owner": {"name": "x"},
+                "plugins": [{"name": "lockp", "source": {"source": "url", "url": _url(plugin_bare), "sha": pinned_sha}}],
+            },
+        ),
+    }
+    _, mp_bare = _make_bare(tmp_path, "extmp", mp_files)
+    home = _home(tmp_path)
+    reg = SkillRegistry()
+
+    names = await stage_marketplace_skills("ext-mp", _src(_url(mp_bare)), reg, home, env=_env(home))
+
+    assert names == ["lockp:pinned"]
+    ext = home / "marketplace" / ".plugins" / "ext-mp" / "lockp"
+    assert _head_sha(ext) == pinned_sha  # 锁到指定 commit（非 tip）
+    assert not (ext / "skills" / "pinned" / "LATER.md").exists()  # 更晚 commit 的文件不在
+    ref = reg.resolve("lockp:pinned")
+    assert ref is not None
+    assert ref["version"] == pinned_sha  # 无 plugin.json version → 回退 HEAD sha
+
+
+@requires_git
+async def test_sha_locked_plugin_reused_on_refresh(tmp_path: Path) -> None:
+    plugin_files = {
+        ".tfrobot-plugin/plugin.json": json.dumps({"name": "lockp"}),
+        "skills/pinned/SKILL.md": _skill_md("pinned"),
+    }
+    work, plugin_bare = _make_bare(tmp_path, "lockplugin", plugin_files, allow_filter=True)
+    pinned_sha = _head_sha(work)
+    mp_files = {
+        ".tfrobot-plugin/marketplace.json": json.dumps(
+            {
+                "name": "ext-mp",
+                "owner": {"name": "x"},
+                "plugins": [{"name": "lockp", "source": {"source": "url", "url": _url(plugin_bare), "sha": pinned_sha}}],
+            },
+        ),
+    }
+    _, mp_bare = _make_bare(tmp_path, "extmp", mp_files)
+    home = _home(tmp_path)
+    reg = SkillRegistry()
+    await stage_marketplace_skills("ext-mp", _src(_url(mp_bare)), reg, home, env=_env(home))
+
+    # 在 ext clone 里留哨兵文件：sha 锁版本在 refresh=True 时应复用（不 rmtree 重 clone）→ 哨兵存活
+    ext = home / "marketplace" / ".plugins" / "ext-mp" / "lockp"
+    sentinel = ext / ".reuse-sentinel"
+    sentinel.write_text("keep", encoding="utf-8")
+
+    await stage_marketplace_skills("ext-mp", _src(_url(mp_bare)), reg, home, refresh=True, env=_env(home))
+    assert sentinel.exists()
+    assert reg.resolve("lockp:pinned") is not None
+
+
+# ── name 路径安全防御 / public-API name guard ────────────────────────────────
+async def test_invalid_marketplace_name_rejected(tmp_path: Path) -> None:
+    home = _home(tmp_path)
+    reg = SkillRegistry()
+    # 非法 name 在任何 git 操作前被拦截：返回 []、不入册、不在 home 外建目录
+    names = await stage_marketplace_skills("../evil", _src("file:///x.git"), reg, home, env=_env(home))
+    assert names == []
+    assert len(reg) == 0
+    assert not (home.parent / "evil").exists()
+
+
+# ── lastUpdated 语义：实际 clone/pull 才刷新，复用保留 ───────────────────────
+@requires_git
+async def test_last_updated_preserved_on_reuse_refreshed_on_pull(tmp_path: Path) -> None:
+    from a2c_smcp.computer.settings.store import update_known_marketplaces
+
+    _, bare = _make_bare(tmp_path, "acme", _marketplace_files())
+    home = _home(tmp_path)
+    reg = SkillRegistry()
+    await stage_marketplace_skills("acme-skills", _src(_url(bare)), reg, home, env=_env(home))
+
+    # 注入可辨识的旧 lastUpdated
+    old = "2000-01-01T00:00:00Z"
+
+    def _set_old(cur: dict) -> None:
+        cur["marketplaces"]["acme-skills"]["lastUpdated"] = old
+        return None
+
+    update_known_marketplaces(_set_old, home, _env(home))
+
+    # 复用既有 clone（refresh=False）→ lastUpdated 保留旧值
+    await stage_marketplace_skills("acme-skills", _src(_url(bare)), reg, home, env=_env(home))
+    rec = load_known_marketplaces(home, _env(home))["marketplaces"]["acme-skills"]
+    assert rec["lastUpdated"] == old
+    assert rec.get("commitSha")  # installLocation/commitSha 仍刷新（自愈）
+
+    # refresh=True（实际 pull）→ lastUpdated 刷新
+    await stage_marketplace_skills("acme-skills", _src(_url(bare)), reg, home, refresh=True, env=_env(home))
+    assert load_known_marketplaces(home, _env(home))["marketplaces"]["acme-skills"]["lastUpdated"] != old

--- a/tests/unit_tests/computer/skills/test_sources.py
+++ b/tests/unit_tests/computer/skills/test_sources.py
@@ -164,6 +164,17 @@ def test_bad_sha_rejected() -> None:
         resolve_plugin_source({"source": "url", "url": "https://h/r.git", "sha": "abc123"})
 
 
+def test_ref_non_string_rejected() -> None:
+    with pytest.raises(SkillSourceError):
+        resolve_plugin_source({"source": "url", "url": "https://h/r.git", "ref": 123})
+
+
+def test_relative_dot_only_empty_rejected() -> None:
+    # "./." 归一化后无有效路径段（resolves to repo root）→ 拒绝
+    with pytest.raises(SkillSourceError):
+        resolve_plugin_source("./.")
+
+
 # ── normalize_repo_shorthand 直测 / standalone ───────────────────────────────
 def test_normalize_repo_shorthand_github() -> None:
     assert normalize_repo_shorthand("owner/repo", "github.com") == "https://github.com/owner/repo.git"

--- a/tests/unit_tests/computer/skills/test_sources.py
+++ b/tests/unit_tests/computer/skills/test_sources.py
@@ -1,0 +1,198 @@
+# -*- coding: utf-8 -*-
+# filename: test_sources.py
+# @Time    : 2026/05/26
+# @Author  : JQQ
+# @Email   : jqq1716@gmail.com
+# @Software: PyCharm
+"""
+marketplace plugin source 解析单元测试（v0.2.1 #61）
+
+协议依据 / Protocol: tfrobot-marketplace docs/marketplace/protocol-v1.md §5（Plugin source 5 类
+disjoint union + github/cnb 简写糖 + git-subdir）、§3.2（pluginRoot 裸名解析）、§5.3（marketplace
+source vs plugin source 两套独立 schema）。
+
+测试意图 / Test intentions:
+- 相对路径（含裸名经 pluginRoot 解析）/ ``url`` / ``github`` / ``cnb`` / ``git-subdir`` 五类各解析正确
+- github / cnb ``owner/repo`` 简写糖归一化到对应 host 的 https url
+- 非法形态（`..` 穿越、缺必填、非简写糖、未知 discriminator、坏 sha）一律抛 SkillSourceError
+- marketplace source（{type:git,url}）提取与校验
+"""
+
+import pytest
+
+from a2c_smcp.computer.skills.sources import (
+    DEFAULT_PLUGIN_ROOT,
+    GitCloneSpec,
+    LocalPluginSource,
+    SkillSourceError,
+    marketplace_clone_url,
+    normalize_repo_shorthand,
+    resolve_plugin_source,
+)
+
+_SHA40 = "a" * 40
+
+
+# ── 相对路径 / relative-path（含裸名 pluginRoot 解析）─────────────────────────
+def test_relative_dot_slash_repo_root() -> None:
+    r = resolve_plugin_source("./my-plugin")
+    assert r == LocalPluginSource(rel_path="my-plugin")
+
+
+def test_relative_dot_slash_nested() -> None:
+    r = resolve_plugin_source("./plugins/frontend-design")
+    assert r == LocalPluginSource(rel_path="plugins/frontend-design")
+
+
+def test_relative_bare_name_uses_default_plugin_root() -> None:
+    # 裸名经 metadata.pluginRoot（默认 ./plugins）解析（协议 §3.2）
+    r = resolve_plugin_source("data-toolkit")
+    assert isinstance(r, LocalPluginSource)
+    assert r.rel_path == "plugins/data-toolkit"
+    assert DEFAULT_PLUGIN_ROOT == "./plugins"
+
+
+def test_relative_bare_name_custom_plugin_root() -> None:
+    r = resolve_plugin_source("formatter", plugin_root="./vendor/plugins")
+    assert r == LocalPluginSource(rel_path="vendor/plugins/formatter")
+
+
+def test_relative_traversal_rejected() -> None:
+    with pytest.raises(SkillSourceError):
+        resolve_plugin_source("./../escape")
+
+
+def test_relative_slashed_non_dotslash_rejected() -> None:
+    # 非 "./" 开头又含 "/"：既非合法相对路径，也非裸名 → 拒绝
+    with pytest.raises(SkillSourceError):
+        resolve_plugin_source("foo/bar")
+
+
+# ── url ───────────────────────────────────────────────────────────────────────
+def test_url_basic() -> None:
+    r = resolve_plugin_source({"source": "url", "url": "https://example.com/team/p.git"})
+    assert r == GitCloneSpec(url="https://example.com/team/p.git")
+
+
+def test_url_with_ref_and_sha() -> None:
+    r = resolve_plugin_source({"source": "url", "url": "git@gitlab.com:team/p.git", "ref": "v1.0", "sha": _SHA40})
+    assert isinstance(r, GitCloneSpec)
+    assert r.url == "git@gitlab.com:team/p.git"
+    assert r.ref == "v1.0"
+    assert r.sha == _SHA40
+
+
+def test_url_invalid_rejected() -> None:
+    with pytest.raises(SkillSourceError):
+        resolve_plugin_source({"source": "url", "url": "not a url"})
+
+
+def test_url_missing_rejected() -> None:
+    with pytest.raises(SkillSourceError):
+        resolve_plugin_source({"source": "url"})
+
+
+# ── github 简写糖 / github shorthand ─────────────────────────────────────────
+def test_github_shorthand_normalized() -> None:
+    r = resolve_plugin_source({"source": "github", "repo": "turingfocus/tfs-auth-plugin", "ref": "v0.3.1"})
+    assert r == GitCloneSpec(url="https://github.com/turingfocus/tfs-auth-plugin.git", ref="v0.3.1")
+
+
+def test_github_strips_trailing_git_suffix() -> None:
+    r = resolve_plugin_source({"source": "github", "repo": "owner/repo.git"})
+    assert isinstance(r, GitCloneSpec)
+    assert r.url == "https://github.com/owner/repo.git"
+
+
+def test_github_full_url_repo_rejected() -> None:
+    # github 的 repo 字段只接受 owner/repo 简写，不接受完整 URL
+    with pytest.raises(SkillSourceError):
+        resolve_plugin_source({"source": "github", "repo": "https://github.com/owner/repo"})
+
+
+def test_github_single_segment_rejected() -> None:
+    with pytest.raises(SkillSourceError):
+        resolve_plugin_source({"source": "github", "repo": "owner-only"})
+
+
+# ── cnb 简写糖 / cnb shorthand ───────────────────────────────────────────────
+def test_cnb_shorthand_normalized() -> None:
+    r = resolve_plugin_source({"source": "cnb", "repo": "turingfocus/tfs-auth-plugin"})
+    assert r == GitCloneSpec(url="https://cnb.cool/turingfocus/tfs-auth-plugin.git")
+
+
+# ── git-subdir ────────────────────────────────────────────────────────────────
+def test_git_subdir_basic() -> None:
+    r = resolve_plugin_source(
+        {"source": "git-subdir", "url": "https://github.com/adobe/skills.git", "path": "plugins/creative-cloud/adobe"},
+    )
+    assert r == GitCloneSpec(url="https://github.com/adobe/skills.git", subdir="plugins/creative-cloud/adobe")
+
+
+def test_git_subdir_url_shorthand_normalizes_to_github() -> None:
+    # git-subdir 的 url 亦接受 GitHub 简写 owner/repo（协议 §5.2.3）
+    r = resolve_plugin_source({"source": "git-subdir", "url": "adobe/skills", "path": "plugins/x", "sha": _SHA40})
+    assert isinstance(r, GitCloneSpec)
+    assert r.url == "https://github.com/adobe/skills.git"
+    assert r.subdir == "plugins/x"
+    assert r.sha == _SHA40
+
+
+def test_git_subdir_path_traversal_rejected() -> None:
+    with pytest.raises(SkillSourceError):
+        resolve_plugin_source({"source": "git-subdir", "url": "https://h/r.git", "path": "../escape"})
+
+
+def test_git_subdir_missing_path_rejected() -> None:
+    with pytest.raises(SkillSourceError):
+        resolve_plugin_source({"source": "git-subdir", "url": "https://h/r.git"})
+
+
+# ── 通用错误 / generic errors ────────────────────────────────────────────────
+def test_unknown_discriminator_rejected() -> None:
+    with pytest.raises(SkillSourceError):
+        resolve_plugin_source({"source": "npm", "package": "x"})
+
+
+def test_non_str_non_mapping_rejected() -> None:
+    with pytest.raises(SkillSourceError):
+        resolve_plugin_source(12345)
+
+
+def test_bad_sha_rejected() -> None:
+    with pytest.raises(SkillSourceError):
+        resolve_plugin_source({"source": "url", "url": "https://h/r.git", "sha": "abc123"})
+
+
+# ── normalize_repo_shorthand 直测 / standalone ───────────────────────────────
+def test_normalize_repo_shorthand_github() -> None:
+    assert normalize_repo_shorthand("owner/repo", "github.com") == "https://github.com/owner/repo.git"
+
+
+def test_normalize_repo_shorthand_cnb() -> None:
+    assert normalize_repo_shorthand("g/p", "cnb.cool") == "https://cnb.cool/g/p.git"
+
+
+def test_normalize_repo_shorthand_scp_like_rejected() -> None:
+    with pytest.raises(SkillSourceError):
+        normalize_repo_shorthand("git@github.com:owner/repo", "github.com")
+
+
+# ── marketplace_clone_url ─────────────────────────────────────────────────────
+def test_marketplace_clone_url_ok() -> None:
+    assert marketplace_clone_url({"type": "git", "url": "git@github.com:team/skills.git"}) == "git@github.com:team/skills.git"
+
+
+def test_marketplace_clone_url_wrong_type_rejected() -> None:
+    with pytest.raises(SkillSourceError):
+        marketplace_clone_url({"type": "github", "url": "owner/repo"})
+
+
+def test_marketplace_clone_url_invalid_url_rejected() -> None:
+    with pytest.raises(SkillSourceError):
+        marketplace_clone_url({"type": "git", "url": "bogus"})
+
+
+def test_marketplace_clone_url_non_mapping_rejected() -> None:
+    with pytest.raises(SkillSourceError):
+        marketplace_clone_url("https://h/r.git")


### PR DESCRIPTION
## 概述

实现 **#61 S8 — marketplace git 源 staging + plugin source 5 类**，补齐 Computer SKILL 三源 staging 的最后一源（mcp #59 / user #60 之后）。纯 Computer 侧本地实现，**不涉及协议变更**（消费已发布的 `a2c-smcp-protocol` skill.md lexer + `tfrobot-marketplace` protocol-v1 §5）。

Closes #61 ｜ 父任务 #39 ｜ 解锁依赖方 #62（reconciler）

## 改动

| 文件 | 内容 |
|---|---|
| `skills/sources.py`（新，纯解析） | plugin source 5 类 disjoint union（相对路径 / 裸名经 `pluginRoot` / `url` / `github` / `cnb` / `git-subdir`）+ github·cnb `owner/repo` 简写糖归一化 + `..`/越界拒绝；`marketplace_clone_url` |
| `skills/staging.py`（扩展） | git 原语（`asyncio` exec、`GIT_TERMINAL_PROMPT=0`、SSH→HTTPS 回退、120s 超时、`--depth 1` / sparse `--filter=tree:0` git-subdir / blobless-sha / pull→失败重 clone）+ `stage_marketplace_skills` 编排（clone→读 marketplace.json→解析 plugin source→扫 `skills/<skill>/SKILL.md`→注册）+ `known_marketplaces.json` 物化 + 失败降级 |
| `skills/__init__.py` | 导出 `stage_marketplace_skills` + sources 公共类型 |
| `tests/unit_tests/.../test_sources.py`（新，29 例） | 5 类解析 / 简写糖归一化 / 拒绝分支 |
| `tests/integration_tests/.../test_staging_marketplace.py`（新，18 例） | 本地裸仓集成 |

## 范围边界（与 #62 / #53 切清）

- 本 PR **只写 `known_marketplaces.json`、只铺 SKILL**；`installed_plugins.json` 写入 / `enabledPlugins` 过滤 / bundled MCP server 注册归 **#62 / plugin install / #53**。
- `plugin_filter` 形参供 **#62** 注入 `enabledPlugins ∩ installed`；对账 additive-only diff 由 #62 实现。

## 失败降级铁律

clone / pull / 解析 / 物化失败 → 记 ERROR（带 `exc_info`）、该源/该 plugin **不入 Registry**、**不抛**、**不阻断其余**、不向 Agent 硬报错。

## 验收对照（#61）

- [x] 本地裸仓集成：eager clone / refresh pull / 失败重 clone
- [x] source 5 类解析 + 简写糖归一化单测
- [x] 失败降级：该 source 不入 Registry、不阻断其余
- [x] `uv run poe lint` 净（ruff + mypy 82 文件）
- [x] `uv run poe test`：**1352 passed** / 2 skipped / 4 xfailed，零回归

## Code Review 已消化（`/fix-review discuss`）

- 🟡1 补独立 `url` clone + sha 锁版本集成测试（覆盖 `_git_clone_plugin` 非 subdir 分支）
- 🟡3 公开 API `name` 路径安全防御（`is_valid_marketplace_name`）
- 🟡4 `lastUpdated` 仅实际 clone/pull 刷新、复用保留旧值
- 🟡5 sha-locked plugin 在 `refresh=True` 复用既有 clone
- 🟡2 strict 模式 + `entry.skills` override **显式延后** → #80（已在 docstring 标注）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
