### PR TITLE
feat(computer): v0.2.1 S9 SKILL reconciler（additive-only 四分支 + gc/prune）(#62)

### DIFF
--- a/a2c_smcp/computer/settings/__init__.py
+++ b/a2c_smcp/computer/settings/__init__.py
@@ -7,10 +7,10 @@
 """
 Computer 意图 / 治理层 settings 子系统 / Computer intent & governance settings subsystem（v0.2.1）
 
-承载 settings.json 的结构、五级 scope 合并、policy 子源选取与物化层文件 store——CLI
-marketplace/plugin/skill 管理 UX 的"意图层 + 物化层"。reconciler / MCP 定义层为后续工单（#62 / #64）。
-The intent + materialized layers of the CLI marketplace/plugin/skill management UX. Reconciler /
-MCP-definition layer land in follow-up tickets.
+承载 settings.json 的结构、五级 scope 合并、policy 子源选取、物化层文件 store 与启动对账
+reconciler——CLI marketplace/plugin/skill 管理 UX 的"意图层 + 物化层 + 对账层"。MCP 定义层为后续工单（#64）。
+The intent + materialized + reconcile layers of the CLI marketplace/plugin/skill management UX.
+MCP-definition layer lands in a follow-up ticket.
 
 已落地模块 / Landed modules：
 - :mod:`a2c_smcp.computer.settings.schema` —— settings.json TypedDict + 字段级容错校验
@@ -21,8 +21,10 @@ MCP-definition layer land in follow-up tickets.
   managed-settings[+.d] + HKCU）（S4，#56）
 - :mod:`a2c_smcp.computer.settings.store`  —— 物化文件（known_marketplaces / installed_plugins）原子写 +
   文件锁 + ``.corrupt-<ts>.bak`` 损坏恢复 + 写保护头（带 version）（S5，#58）
+- :mod:`a2c_smcp.computer.settings.reconciler` —— 启动对账（additive-only 四分支）+ 孤儿清理
+  （marketplace prune / plugin gc）（S9，#62）
 
-SDK 设计 / Design: python-sdk docs/design-0.2.1-cli-marketplace-ux.md §5。
+SDK 设计 / Design: python-sdk docs/design-0.2.1-cli-marketplace-ux.md §5 / §7。
 """
 
 from __future__ import annotations
@@ -88,6 +90,13 @@ from a2c_smcp.computer.settings.store import (
     update_installed_plugins,
     update_known_marketplaces,
 )
+
+# 注意 / NB：:mod:`...settings.reconciler` **刻意不在此 re-export**——它依赖
+# :mod:`...skills.staging`，而 staging 顶层又 import :mod:`...settings.schema`（触发本 __init__）。
+# 若在此急切导入 reconciler 会与 staging 的半初始化态构成循环（`_EXTERNAL_PLUGINS_NS` 未定义）。
+# 消费方请直接 ``from a2c_smcp.computer.settings.reconciler import reconcile`` 等。
+# reconciler is intentionally NOT re-exported here to avoid a circular import with skills.staging;
+# import it directly from its submodule.
 
 __all__ = [
     # schema

--- a/a2c_smcp/computer/settings/reconciler.py
+++ b/a2c_smcp/computer/settings/reconciler.py
@@ -1,0 +1,405 @@
+# -*- coding: utf-8 -*-
+# filename: reconciler.py
+# @Time    : 2026/05/26
+# @Author  : JQQ
+# @Email   : jqq1716@gmail.com
+# @Software: PyCharm
+"""
+Reconciler：启动对账（additive-only 只增不删）+ 孤儿清理（marketplace prune / plugin gc）（v0.2.1 #62）
+Reconciler: startup reconcile (additive-only) + orphan cleanup (v0.2.1 #62).
+
+SDK 设计 / Design: python-sdk docs/design-0.2.1-cli-marketplace-ux.md §7.1（启动流程）/ §7.2（失败降级）/
+                   §7.3（显式 sync 与孤儿清理）；父工单 #53「reconciler additive-only」决策。
+
+核心契约 / Core contract（§7.1 校正自 CC 问询）：
+- **先合并单一声明视图再对账**（不是逐 scope）：调用方经
+  :func:`a2c_smcp.computer.settings.scope.resolve_settings` 把所有 scope 合成单一视图后传入
+  :func:`reconcile` 的 ``declared``（``enabledPlugins`` / ``extraKnownMarketplaces`` 两键即对账输入）。
+- **additive-only 只增不删**：CC 的 reconcile 返回只有 ``{installed, updated, upToDate, failed, skipped}``、
+  **无 removed**。"声明没、物化有"的条目**完全不动**（绝不自动清理）；孤儿留待 §7.3 显式
+  :func:`prune_marketplaces` / :func:`gc_plugins` 清。
+- **失败降级铁律**（§7.2）：git clone/pull 失败 → 记 ERROR、不阻断其余、对 Agent 不可见（不入
+  Registry）；本模块**不**向调用方抛 git/IO 异常（沿用 :func:`stage_marketplace_skills` 的吞错降级）。
+
+边界（#62 / #63 接缝）/ Boundary:
+- 本模块**只**维护 ``known_marketplaces.json``（经 :func:`stage_marketplace_skills`）并按
+  ``enabledPlugins`` 注册启用 plugin 的 SKILL；**不写** ``installed_plugins.json``——plugin install /
+  uninstall / enable / disable 账本归 #63。:func:`gc_plugins` **读** ``installed_plugins.json`` 找孤儿
+  （生产由 #63 写入、本工单测试直接 seed）。
+- bundled MCP server 的起停经 :func:`gc_plugins` 的 ``mcp_teardown`` 回调注入；真正接线（MCP manager）
+  由 computer.py 集成承担，不在 #62。
+
+并发 / Concurrency：:func:`reconcile` **串行** stage 各 marketplace（不 ``asyncio.gather``），遵守
+:func:`stage_marketplace_skills` 文档化的同步 ``file_lock`` 阻塞约束（store.py 同步设计的固有约束）。
+"""
+
+from __future__ import annotations
+
+import shutil
+from collections.abc import Awaitable, Callable, Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from a2c_smcp.computer.settings.schema import is_valid_enabled_plugin_key, is_valid_marketplace_name
+from a2c_smcp.computer.settings.store import (
+    InstalledPluginsFile,
+    KnownMarketplacesFile,
+    load_installed_plugins,
+    load_known_marketplaces,
+    update_installed_plugins,
+    update_known_marketplaces,
+)
+from a2c_smcp.computer.skills.home import SOURCE_MARKETPLACE, marketplace_skill_dir
+from a2c_smcp.computer.skills.registry import SkillRegistry
+from a2c_smcp.computer.skills.staging import (
+    _EXTERNAL_PLUGINS_NS,
+    DEFAULT_GIT_TIMEOUT,
+    stage_marketplace_skills,
+)
+from a2c_smcp.utils.logger import get_logger
+from a2c_smcp.utils.path import is_within
+
+logger = get_logger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# 对账报告 / Reconcile report
+# ---------------------------------------------------------------------------
+@dataclass(frozen=True, slots=True)
+class ReconcileReport:
+    """
+    一次 :func:`reconcile` 的结果（镜像 CC reconcile 返回值；**无 removed** —— additive-only）。
+    The result of one :func:`reconcile` run (mirrors CC's return shape; **no removed** — additive-only)。
+
+    各 marketplace 名互斥地归入 installed / updated / up_to_date / failed / skipped 之一；
+    ``registered_skills`` 汇总本次成功注册 / 刷新的全部 SKILL 名（供 watcher / emit diff）。
+    """
+
+    installed: list[str] = field(default_factory=list)  # 本次新 clone 的 marketplace
+    updated: list[str] = field(default_factory=list)  # autoUpdate pull / sourceChanged 重 clone
+    up_to_date: list[str] = field(default_factory=list)  # 声明且已在、未刷新
+    failed: list[str] = field(default_factory=list)  # 声明但 stage 后 clone 树仍缺失（clone 失败，已降级）
+    skipped: list[str] = field(default_factory=list)  # 预留（trust 门控落 #68 / strict 延后 #80）
+    registered_skills: list[str] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# 声明视图提取 / Declared-view extraction
+# ---------------------------------------------------------------------------
+def _declared_marketplaces(declared: Mapping[str, object]) -> dict[str, Mapping[str, object]]:
+    """
+    从单一声明视图取合法 marketplace 声明 / Extract valid marketplace declarations。
+
+    跳过非法名（非 strict-kebab）/ 非对象条目（记 WARN）；返回 ``name → {source, autoUpdate?}``。
+    """
+    raw = declared.get("extraKnownMarketplaces")
+    if not isinstance(raw, Mapping):
+        return {}
+    out: dict[str, Mapping[str, object]] = {}
+    for name, decl in raw.items():
+        if not is_valid_marketplace_name(name):
+            logger.warning("reconcile: invalid marketplace name %r in extraKnownMarketplaces, skipped", name)
+            continue
+        if not isinstance(decl, Mapping):
+            logger.warning("reconcile: marketplace %r declaration is not an object, skipped: %r", name, decl)
+            continue
+        out[name] = decl
+    return out
+
+
+def declared_marketplace_names(declared: Mapping[str, object]) -> set[str]:
+    """单一声明视图里全部合法 marketplace 名 / All valid declared marketplace names（供孤儿判定）。"""
+    return set(_declared_marketplaces(declared))
+
+
+def declared_plugin_ids(declared: Mapping[str, object]) -> set[str]:
+    """
+    所有**声明过**的 plugin id（``<plugin>@<mp>``，含 ``false`` 禁用项）/ All declared plugin ids。
+
+    用于 :func:`list_orphan_plugins` 的孤儿判定——``false`` = 声明禁用（**非**孤儿），仅 key 完全缺失才算孤儿。
+    """
+    raw = declared.get("enabledPlugins")
+    if not isinstance(raw, Mapping):
+        return set()
+    return {k for k in raw if is_valid_enabled_plugin_key(k)}
+
+
+def _enabled_plugin_names_for(marketplace: str, declared: Mapping[str, object]) -> set[str]:
+    """
+    某 marketplace 下**启用**（``true``）的 plugin 名集合 / Enabled (``true``) plugin names for a marketplace。
+
+    ``enabledPlugins`` key 形如 ``<plugin>@<mp>``；返回去掉 ``@<mp>`` 后缀的 ``<plugin>`` 集合，作
+    :func:`stage_marketplace_skills` 的 ``plugin_filter``（缺启用项 → 空集 → 仅 clone catalog、不注册 SKILL）。
+    """
+    raw = declared.get("enabledPlugins")
+    if not isinstance(raw, Mapping):
+        return set()
+    suffix = f"@{marketplace}"
+    names: set[str] = set()
+    for key, enabled in raw.items():
+        if enabled is True and is_valid_enabled_plugin_key(key) and key.endswith(suffix):
+            names.add(key[: -len(suffix)])
+    return names
+
+
+# ---------------------------------------------------------------------------
+# 安全删除 / Guarded removal
+# ---------------------------------------------------------------------------
+def _safe_rmtree(path: Path, home: Path) -> None:
+    """
+    仅当 ``path`` 词法位于 SKILL Home 内才递归删除（防越权删盘外目录）/ rmtree only within SKILL Home。
+
+    ``path`` 不存在 → no-op；越界 → 记 ERROR + 拒删（不抛）。删除失败 → 记 WARN（不阻断后续清理）。
+    """
+    rp = path.resolve()
+    if not is_within(rp, home.resolve()):
+        logger.error("reconcile: refusing to remove %s outside SKILL Home %s", rp, home)
+        return
+    if not rp.exists():
+        return
+    try:
+        shutil.rmtree(rp)
+    except OSError as e:  # 失败降级：删除受阻不阻断其余清理
+        logger.warning("reconcile: failed to remove %s: %s", rp, e)
+
+
+def _unregister_marketplace_skills(registry: SkillRegistry, marketplace: str, *, plugin: str | None = None) -> None:
+    """
+    从 Registry 注销某 marketplace（可选限定单 plugin）的 SKILL / Unregister a marketplace's SKILLs。
+
+    按 ``A2CSkillRef.source == "marketplace:<mp>"`` 反查（marketplace SKILL name 形如 ``<plugin>:<skill>``，
+    ``plugin`` 给定时再按 ``<plugin>:`` 前缀过滤）。additive-only 模型下 marketplace clone 树不上 watcher，
+    其 SKILL 在 prune/gc 前恒活跃，故经 :meth:`SkillRegistry.active_refs` 枚举即可。
+    """
+    want_source = f"{SOURCE_MARKETPLACE}:{marketplace}"
+    prefix = f"{plugin}:" if plugin is not None else None
+    for ref in registry.active_refs():
+        if ref.get("source") != want_source:
+            continue
+        name = ref.get("name")
+        if not name:
+            continue
+        if prefix is not None and not name.startswith(prefix):
+            continue
+        registry.unregister(name)
+
+
+# ---------------------------------------------------------------------------
+# 启动对账（additive-only）/ Startup reconcile (additive-only)
+# ---------------------------------------------------------------------------
+async def reconcile(
+    registry: SkillRegistry,
+    home: Path,
+    declared: Mapping[str, object],
+    *,
+    env: Mapping[str, str] | None = None,
+    refresh: bool = False,
+    timeout: float = DEFAULT_GIT_TIMEOUT,
+) -> ReconcileReport:
+    """
+    对账声明的 marketplace 与物化 clone 树（additive-only）/ Reconcile declared marketplaces vs materialized clones。
+
+    四分支（§7.1 step 3）/ Four branches:
+    - **missing**（declared∖materialized）→ clone（``stage_marketplace_skills`` 缺失即 clone）。
+    - **sourceChanged**（``record.source != decl.source``）→ 先 ``rmtree`` 旧 clone 树（含外部 plugin 树）
+      再重 clone（**reconciler 兜底**：:func:`stage_marketplace_skills` 仅 pull 不换库）。
+    - **autoUpdate**（``decl.autoUpdate==True`` 或显式 ``refresh=True``）→ ``git pull``。
+    - **orphan**（materialized∖declared）→ **完全不动**（不进循环；靠 :func:`prune_marketplaces` 显式清）。
+
+    每个 declared marketplace 物化其 ``enabledPlugins`` 中**启用**的 plugin 的 SKILL（``plugin_filter``）；
+    禁用 / 未声明 plugin 不注册。失败降级：stage 吞错返回空 → 本函数据 clone 树是否存在判 ``failed``。
+
+    :param registry: 目标 :class:`SkillRegistry`。
+    :param home: SKILL Home 绝对根（调用方保证存在）。
+    :param declared: 单一声明视图（:func:`...scope.resolve_settings` 的 ``.settings``），取
+        ``extraKnownMarketplaces`` / ``enabledPlugins`` 两键。
+    :param env: git 子进程 / 物化文件路径解析环境（默认 ``os.environ``）。
+    :param refresh: ``True`` = 显式 sync（``/plugin sync`` / ``/marketplace refresh``）：对**全部**已存在
+        clone 走 pull（不止 ``autoUpdate`` 项）；仍 additive-only。
+    :param timeout: 单次 git 操作超时（秒），透传 :func:`stage_marketplace_skills`。
+    :return: :class:`ReconcileReport`。
+    """
+    declared_mps = _declared_marketplaces(declared)
+    # 对账前快照物化状态（stage 会在循环内回写 known_marketplaces.json，故先取基线分类）。
+    known = load_known_marketplaces(home=home, env=env)
+    materialized = known.get("marketplaces", {})
+
+    installed: list[str] = []
+    updated: list[str] = []
+    up_to_date: list[str] = []
+    failed: list[str] = []
+    registered_skills: list[str] = []
+
+    ext_root = home / SOURCE_MARKETPLACE / _EXTERNAL_PLUGINS_NS
+    for name, decl in declared_mps.items():
+        source = decl.get("source")
+        record = materialized.get(name)
+        source_changed = record is not None and record.get("source") != source
+        clone_dir = marketplace_skill_dir(home, name)
+
+        if source_changed:
+            # 源已变更：旧 clone 是「别的仓库」，必须 wipe 后重 clone（stage 只 pull 不换库）。
+            logger.info("reconcile: marketplace %r source changed, wiping stale clone for re-clone", name)
+            _unregister_marketplace_skills(registry, name)
+            _safe_rmtree(clone_dir, home)
+            _safe_rmtree(ext_root / name, home)
+
+        present_before = clone_dir.exists()
+        do_refresh = bool(decl.get("autoUpdate")) or refresh
+        plugin_filter = _enabled_plugin_names_for(name, declared)
+
+        names = await stage_marketplace_skills(
+            name,
+            source if isinstance(source, Mapping) else {},
+            registry,
+            home,
+            plugin_filter=plugin_filter,
+            auto_update=bool(decl.get("autoUpdate")),
+            refresh=do_refresh,
+            timeout=timeout,
+            env=env,
+        )
+        registered_skills.extend(names)
+
+        if not clone_dir.exists():
+            failed.append(name)
+        elif source_changed:
+            updated.append(name)
+        elif not present_before:
+            installed.append(name)
+        elif do_refresh:
+            updated.append(name)
+        else:
+            up_to_date.append(name)
+
+    return ReconcileReport(
+        installed=installed,
+        updated=updated,
+        up_to_date=up_to_date,
+        failed=failed,
+        registered_skills=registered_skills,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 孤儿清理 / Orphan cleanup（§7.3，additive-only 唯一删除入口）
+# ---------------------------------------------------------------------------
+def list_orphan_marketplaces(
+    home: Path,
+    declared: Mapping[str, object],
+    *,
+    env: Mapping[str, str] | None = None,
+) -> list[str]:
+    """
+    列出"所有 scope 都不再声明"的孤儿 marketplace（物化有、声明无）/ List orphan marketplaces。
+
+    :param declared: 单一声明视图（取 ``extraKnownMarketplaces`` key 作"仍声明"集）。
+    :return: ``known_marketplaces.json`` 中 key ∉ 声明集 的 marketplace 名（保持物化顺序）。
+    """
+    declared_names = declared_marketplace_names(declared)
+    known = load_known_marketplaces(home=home, env=env)
+    return [name for name in known.get("marketplaces", {}) if name not in declared_names]
+
+
+def prune_marketplaces(
+    names: list[str],
+    registry: SkillRegistry,
+    home: Path,
+    *,
+    env: Mapping[str, str] | None = None,
+) -> list[str]:
+    """
+    清理孤儿 marketplace（clone 树 + 外部 plugin 树 + known_marketplaces.json 条目 + Registry SKILL）/ Prune。
+
+    y/N 确认交 CLI 层（#68）；本函数只**执行**清理（``names`` 应为 :func:`list_orphan_marketplaces` 的子集，
+    经用户确认后传入）。非法名跳过；删除越界守卫见 :func:`_safe_rmtree`。**不**触碰 ``installed_plugins.json``
+    （plugin 账本归 #63 / :func:`gc_plugins`）。
+
+    :return: 实际清理的 marketplace 名列表。
+    """
+    ext_root = home / SOURCE_MARKETPLACE / _EXTERNAL_PLUGINS_NS
+    removed: list[str] = []
+    for name in names:
+        if not is_valid_marketplace_name(name):
+            logger.warning("prune: invalid marketplace name %r, skipped", name)
+            continue
+        _unregister_marketplace_skills(registry, name)
+        _safe_rmtree(marketplace_skill_dir(home, name), home)
+        _safe_rmtree(ext_root / name, home)
+
+        def _drop(data: KnownMarketplacesFile, _n: str = name) -> None:
+            data.get("marketplaces", {}).pop(_n, None)
+
+        update_known_marketplaces(_drop, home=home, env=env)
+        removed.append(name)
+        logger.info("prune: removed orphan marketplace %r", name)
+    return removed
+
+
+def list_orphan_plugins(
+    home: Path,
+    declared: Mapping[str, object],
+    *,
+    env: Mapping[str, str] | None = None,
+) -> list[str]:
+    """
+    列出"所有 scope 都不再声明"的孤儿 plugin（installed 有、enabledPlugins 无此 key）/ List orphan plugins。
+
+    ``false`` = 声明禁用（key 仍在）→ **非**孤儿；仅 key 完全缺失才算孤儿（见 :func:`declared_plugin_ids`）。
+
+    :param declared: 单一声明视图（取 ``enabledPlugins`` 全部 key——含 ``false``——作"仍声明"集）。
+    :return: ``installed_plugins.json`` 中 plugin id ∉ 声明集 的列表（保持物化顺序）。
+    """
+    declared_ids = declared_plugin_ids(declared)
+    installed = load_installed_plugins(home=home, env=env)
+    return [pid for pid in installed.get("plugins", {}) if pid not in declared_ids]
+
+
+async def gc_plugins(
+    plugin_ids: list[str],
+    registry: SkillRegistry,
+    home: Path,
+    *,
+    env: Mapping[str, str] | None = None,
+    mcp_teardown: Callable[[list[str]], Awaitable[None]] | None = None,
+) -> list[str]:
+    """
+    清理孤儿 plugin（installPath 树 + installed_plugins.json 条目 + Registry SKILL + bundled MCP）/ GC plugins。
+
+    y/N 确认交 CLI 层（#68）；``plugin_ids`` 应为 :func:`list_orphan_plugins` 的子集（用户确认后传入）。
+    每条记录的 ``installPath`` 仅在词法位于 SKILL Home 内才删（:func:`_safe_rmtree`）；``bundledMcpServers``
+    汇总后经 ``mcp_teardown`` 回调停/摘（真正接线由 computer.py 集成承担，#62 只触发回调）。
+
+    :param mcp_teardown: 可选异步回调，入参为本次清理涉及的全部 bundled MCP server name；``None`` = 不处理。
+    :return: 实际清理的 plugin id 列表。
+    """
+    installed = load_installed_plugins(home=home, env=env)
+    plugins = installed.get("plugins", {})
+    removed: list[str] = []
+    for pid in plugin_ids:
+        records = plugins.get(pid)
+        if records is None:
+            continue
+        bundled: list[str] = []
+        for rec in records:
+            install_path = rec.get("installPath")
+            if isinstance(install_path, str) and install_path:
+                _safe_rmtree(Path(install_path), home)
+            servers = rec.get("bundledMcpServers")
+            if isinstance(servers, list):
+                bundled.extend(s for s in servers if isinstance(s, str))
+
+        plugin, _, marketplace = pid.partition("@")
+        if marketplace:
+            _unregister_marketplace_skills(registry, marketplace, plugin=plugin)
+
+        if mcp_teardown is not None and bundled:
+            await mcp_teardown(bundled)
+
+        def _drop(data: InstalledPluginsFile, _p: str = pid) -> None:
+            data.get("plugins", {}).pop(_p, None)
+
+        update_installed_plugins(_drop, home=home, env=env)
+        removed.append(pid)
+        logger.info("gc: removed orphan plugin %r (bundled MCP: %s)", pid, bundled or "none")
+    return removed

--- a/tests/integration_tests/computer/settings/__init__.py
+++ b/tests/integration_tests/computer/settings/__init__.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+# filename: __init__.py
+# @Time    : 2026/05/26
+# @Author  : JQQ
+# @Email   : jqq1716@gmail.com
+# @Software: PyCharm
+"""Computer settings 子系统集成测试包 / Computer settings subsystem integration tests."""

--- a/tests/integration_tests/computer/settings/test_reconciler.py
+++ b/tests/integration_tests/computer/settings/test_reconciler.py
@@ -1,0 +1,181 @@
+# -*- coding: utf-8 -*-
+# filename: test_reconciler.py
+# @Time    : 2026/05/26
+# @Author  : JQQ
+# @Email   : jqq1716@gmail.com
+# @Software: PyCharm
+"""
+Reconciler 本地裸仓集成测试（v0.2.1 #62）—— 端到端真实 git clone/reclone/prune
+Reconciler local bare-repo integration tests: end-to-end real git clone/reclone/prune.
+
+SDK 设计 / Design: python-sdk docs/design-0.2.1-cli-marketplace-ux.md §7.1/§7.3。
+
+测试意图 / Test intentions（用本地 ``git init --bare`` 裸仓作 file:// 源，无网络依赖）:
+- reconcile 端到端：声明 marketplace → clone → 按 ``enabledPlugins`` 仅注册启用 plugin 的 SKILL
+  （未启用 plugin 不入册）+ 写 known_marketplaces.json。
+- sourceChanged：声明源换库 → wipe 旧 clone + 重 clone → 注册新库 SKILL、旧库 SKILL 注销。
+- prune：声明移除 marketplace → list 孤儿 + 清 clone 树 + 删物化条目 + 注销 SKILL。
+"""
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from a2c_smcp.computer.settings.reconciler import list_orphan_marketplaces, prune_marketplaces, reconcile
+from a2c_smcp.computer.settings.store import load_known_marketplaces
+from a2c_smcp.computer.skills.home import marketplace_skill_dir
+from a2c_smcp.computer.skills.registry import SkillRegistry
+
+requires_git = pytest.mark.skipif(shutil.which("git") is None, reason="requires the git binary")
+
+_GIT_IDENTITY = ["-c", "user.email=test@example.com", "-c", "user.name=Test", "-c", "commit.gpgsign=false"]
+
+
+# ── 本地裸仓 fixture 辅助 / local bare-repo helpers ──────────────────────────
+def _git(cwd: Path, *args: str) -> None:
+    subprocess.run(["git", *_GIT_IDENTITY, *args], cwd=str(cwd), check=True, capture_output=True, text=True)
+
+
+def _write(root: Path, files: dict[str, str]) -> None:
+    for rel, content in files.items():
+        p = root / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content, encoding="utf-8")
+
+
+def _skill_md(name: str, description: str = "a skill") -> str:
+    return f"---\nname: {name}\ndescription: {description}\nlicense: MIT\n---\n# {name}\nbody\n"
+
+
+def _make_bare(tmp_path: Path, name: str, files: dict[str, str]) -> Path:
+    """建一个含 ``files`` 的工作仓 + 其裸仓镜像；返回裸仓路径（作 file:// 源）。"""
+    work = tmp_path / f"{name}-work"
+    work.mkdir(parents=True, exist_ok=True)
+    _git(work, "init", "-q", "-b", "main")
+    _write(work, files)
+    _git(work, "add", "-A")
+    _git(work, "commit", "-q", "-m", "init")
+    bare = tmp_path / f"{name}.git"
+    _git(tmp_path, "clone", "-q", "--bare", str(work), str(bare))
+    return bare
+
+
+def _url(p: Path) -> str:
+    return f"file://{p}"
+
+
+def _src(url: str) -> dict[str, str]:
+    return {"type": "git", "url": url}
+
+
+def _env(home: Path) -> dict[str, str]:
+    return {**os.environ, "A2C_SKILL_HOME": str(home)}
+
+
+def _home(tmp_path: Path) -> Path:
+    h = tmp_path / "skill-home"
+    h.mkdir()
+    return h
+
+
+def _one_plugin_files(plugin: str, skill: str) -> dict[str, str]:
+    """单 plugin（裸名经 pluginRoot 解析）单 skill 的标准 marketplace 布局。"""
+    manifest = {
+        "name": "acme-skills",
+        "owner": {"name": "Acme"},
+        "metadata": {"pluginRoot": "./plugins"},
+        "plugins": [{"name": plugin, "source": plugin}],
+    }
+    return {
+        ".tfrobot-plugin/marketplace.json": json.dumps(manifest),
+        f"plugins/{plugin}/skills/{skill}/SKILL.md": _skill_md(skill),
+    }
+
+
+def _marketplace_two_plugins() -> dict[str, str]:
+    """两 plugin（audit / fmt）；用于验证 enabledPlugins 过滤。"""
+    manifest = {
+        "name": "acme-skills",
+        "metadata": {"pluginRoot": "./plugins"},
+        "plugins": [{"name": "audit", "source": "audit"}, {"name": "fmt", "source": "fmt"}],
+    }
+    return {
+        ".tfrobot-plugin/marketplace.json": json.dumps(manifest),
+        "plugins/audit/skills/lint/SKILL.md": _skill_md("lint"),
+        "plugins/fmt/skills/format/SKILL.md": _skill_md("format"),
+    }
+
+
+# ── reconcile 端到端 / end-to-end ────────────────────────────────────────────
+@requires_git
+async def test_reconcile_clones_and_registers_only_enabled_plugin(tmp_path: Path) -> None:
+    bare = _make_bare(tmp_path, "acme", _marketplace_two_plugins())
+    home = _home(tmp_path)
+    reg = SkillRegistry()
+    declared = {
+        "extraKnownMarketplaces": {"acme-skills": {"source": _src(_url(bare))}},
+        "enabledPlugins": {"audit@acme-skills": True},  # 仅启用 audit；fmt 不启用
+    }
+
+    report = await reconcile(reg, home, declared, env=_env(home))
+
+    assert report.installed == ["acme-skills"]
+    assert "audit:lint" in report.registered_skills
+    assert reg.resolve("audit:lint") is not None
+    assert reg.resolve("fmt:format") is None  # 未启用 plugin 不入册
+    # known_marketplaces.json 物化
+    kmf = load_known_marketplaces(home=home)["marketplaces"]
+    assert "acme-skills" in kmf
+    assert kmf["acme-skills"]["source"] == _src(_url(bare))
+
+
+@requires_git
+async def test_reconcile_source_changed_switches_repo(tmp_path: Path) -> None:
+    bare1 = _make_bare(tmp_path, "repo1", _one_plugin_files("p", "old-skill"))
+    bare2 = _make_bare(tmp_path, "repo2", _one_plugin_files("p", "new-skill"))
+    home = _home(tmp_path)
+    reg = SkillRegistry()
+    enabled = {"enabledPlugins": {"p@acme-skills": True}}
+
+    await reconcile(reg, home, {"extraKnownMarketplaces": {"acme-skills": {"source": _src(_url(bare1))}}, **enabled}, env=_env(home))
+    assert reg.resolve("p:old-skill") is not None
+
+    # 声明换源 → sourceChanged 重 clone
+    report = await reconcile(
+        reg, home, {"extraKnownMarketplaces": {"acme-skills": {"source": _src(_url(bare2))}}, **enabled}, env=_env(home)
+    )
+
+    assert report.updated == ["acme-skills"]
+    assert reg.resolve("p:new-skill") is not None  # 新库 SKILL 注册
+    assert reg.resolve("p:old-skill") is None  # 旧库 SKILL 注销
+    assert load_known_marketplaces(home=home)["marketplaces"]["acme-skills"]["source"] == _src(_url(bare2))
+
+
+@requires_git
+async def test_prune_removes_clone_tree_and_record(tmp_path: Path) -> None:
+    bare = _make_bare(tmp_path, "acme", _one_plugin_files("p", "s1"))
+    home = _home(tmp_path)
+    reg = SkillRegistry()
+    await reconcile(
+        reg,
+        home,
+        {"extraKnownMarketplaces": {"acme-skills": {"source": _src(_url(bare))}}, "enabledPlugins": {"p@acme-skills": True}},
+        env=_env(home),
+    )
+    clone = marketplace_skill_dir(home, "acme-skills")
+    assert clone.exists() and reg.resolve("p:s1") is not None
+
+    # 不再声明 → 孤儿 → prune
+    declared_empty = {"extraKnownMarketplaces": {}}
+    assert list_orphan_marketplaces(home, declared_empty, env=_env(home)) == ["acme-skills"]
+
+    removed = prune_marketplaces(["acme-skills"], reg, home, env=_env(home))
+
+    assert removed == ["acme-skills"]
+    assert not clone.exists()  # clone 树清除
+    assert "acme-skills" not in load_known_marketplaces(home=home)["marketplaces"]  # 物化条目删除
+    assert reg.resolve("p:s1") is None  # SKILL 注销

--- a/tests/unit_tests/computer/settings/test_reconciler.py
+++ b/tests/unit_tests/computer/settings/test_reconciler.py
@@ -1,0 +1,416 @@
+# -*- coding: utf-8 -*-
+# filename: test_reconciler.py
+# @Time    : 2026/05/26
+# @Author  : JQQ
+# @Email   : jqq1716@gmail.com
+# @Software: PyCharm
+"""
+Reconciler 单元测试（v0.2.1 #62）—— additive-only 四分支 + gc/prune 决策逻辑（mock 掉 git staging）
+Reconciler unit tests: additive-only four branches + gc/prune (stage_marketplace_skills mocked).
+
+SDK 设计 / Design: python-sdk docs/design-0.2.1-cli-marketplace-ux.md §7.1/§7.2/§7.3。
+
+测试意图 / Test intentions（不依赖 git——monkeypatch ``stage_marketplace_skills``，只验 reconciler 编排决策）:
+- 四分支：missing→clone(refresh=False) / sourceChanged→wipe+reclone / autoUpdate→pull(refresh=True) /
+  orphan(materialized∖declared)→**完全不动**（stage 不被调用、物化记录不变）；附 up_to_date / failed。
+- plugin_filter 由 ``enabledPlugins`` 推导（仅 ``true`` 且属本 marketplace 的 plugin）。
+- 声明视图提取过滤非法 marketplace 名 / 非对象条目 / 非法 plugin key。
+- 孤儿清理：list/prune marketplace（clone 树 + 外部 plugin 树 + 物化条目 + Registry SKILL）；
+  list/gc plugin（installPath + 物化条目 + Registry SKILL + bundled MCP 回调）；installPath 越界守卫。
+"""
+
+from collections.abc import Awaitable, Callable, Mapping
+from pathlib import Path
+from typing import Any
+
+from a2c_smcp.computer.settings.reconciler import (
+    ReconcileReport,
+    declared_marketplace_names,
+    declared_plugin_ids,
+    gc_plugins,
+    list_orphan_marketplaces,
+    list_orphan_plugins,
+    prune_marketplaces,
+    reconcile,
+)
+from a2c_smcp.computer.settings.store import (
+    load_installed_plugins,
+    load_known_marketplaces,
+    save_installed_plugins,
+    save_known_marketplaces,
+)
+from a2c_smcp.computer.skills.home import SOURCE_MARKETPLACE, marketplace_skill_dir
+from a2c_smcp.computer.skills.registry import SkillRegistry
+
+_SRC_A = {"type": "git", "url": "https://example.com/team/a.git"}
+_SRC_B = {"type": "git", "url": "https://example.com/team/b.git"}
+_RECONCILER = "a2c_smcp.computer.settings.reconciler.stage_marketplace_skills"
+
+
+# ── 辅助 / helpers ───────────────────────────────────────────────────────────
+def _home(tmp_path: Path) -> Path:
+    h = tmp_path / "skill-home"
+    h.mkdir()
+    return h
+
+
+def _ext_dir(home: Path, mp: str) -> Path:
+    return home / SOURCE_MARKETPLACE / ".plugins" / mp
+
+
+def _make_clone(home: Path, mp: str, *, sentinel: bool = True) -> Path:
+    """造一个假 clone 树（含 sentinel 文件用于断言 wipe/保留）/ Fake clone tree with a sentinel file."""
+    d = marketplace_skill_dir(home, mp)
+    d.mkdir(parents=True, exist_ok=True)
+    if sentinel:
+        (d / "SENTINEL").write_text("x", encoding="utf-8")
+    return d
+
+
+def _seed_known(home: Path, records: dict[str, dict]) -> None:
+    data = {
+        "version": 1,
+        "marketplaces": {
+            mp: {"source": src, "installLocation": str(marketplace_skill_dir(home, mp).resolve())} for mp, src in records.items()
+        },
+    }
+    save_known_marketplaces(data, home=home)
+
+
+def _reg_skill(reg: SkillRegistry, name: str, marketplace: str, path: Path) -> None:
+    reg.register({"name": name, "source": f"{SOURCE_MARKETPLACE}:{marketplace}", "path": str(path.resolve())})
+
+
+def _fake_stage(
+    calls: list[dict[str, Any]],
+    *,
+    succeed: bool = True,
+    skills: list[str] | None = None,
+) -> Callable[..., Awaitable[list[str]]]:
+    """替身：记录入参；``succeed`` 时 mkdir clone 树（模拟 clone 成功）并返回 ``skills``，否则返回空。"""
+
+    async def _stage(
+        name: str,
+        source: Mapping[str, Any],
+        registry: SkillRegistry,
+        home: Path,
+        *,
+        plugin_filter: set[str] | None = None,
+        auto_update: bool = False,
+        refresh: bool = False,
+        timeout: float = 0.0,
+        env: Mapping[str, str] | None = None,
+    ) -> list[str]:
+        calls.append(
+            {"name": name, "source": source, "plugin_filter": plugin_filter, "auto_update": auto_update, "refresh": refresh}
+        )
+        if succeed:
+            marketplace_skill_dir(home, name).mkdir(parents=True, exist_ok=True)
+            return list(skills or [])
+        return []
+
+    return _stage
+
+
+# ── 四分支 / four branches ───────────────────────────────────────────────────
+async def test_reconcile_missing_clones(tmp_path: Path, monkeypatch) -> None:
+    home = _home(tmp_path)
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(_RECONCILER, _fake_stage(calls, skills=["audit:lint"]))
+    declared = {"extraKnownMarketplaces": {"acme": {"source": _SRC_A}}, "enabledPlugins": {"audit@acme": True}}
+
+    report = await reconcile(SkillRegistry(), home, declared)
+
+    assert isinstance(report, ReconcileReport)
+    assert report.installed == ["acme"]
+    assert report.updated == [] and report.up_to_date == [] and report.failed == []
+    assert report.registered_skills == ["audit:lint"]
+    assert calls[0]["refresh"] is False
+    assert calls[0]["plugin_filter"] == {"audit"}
+
+
+async def test_reconcile_source_changed_wipes_and_reclones(tmp_path: Path, monkeypatch) -> None:
+    home = _home(tmp_path)
+    _seed_known(home, {"acme": _SRC_A})
+    clone = _make_clone(home, "acme")  # 旧 clone + sentinel
+    ext = _ext_dir(home, "acme")  # 外部 plugin 树（git-subdir / standalone url plugin 落点）
+    ext.mkdir(parents=True)
+    (ext / "plug").mkdir()
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(_RECONCILER, _fake_stage(calls))
+    declared = {"extraKnownMarketplaces": {"acme": {"source": _SRC_B}}}  # 源已变更
+
+    report = await reconcile(SkillRegistry(), home, declared)
+
+    assert report.updated == ["acme"]
+    assert not (clone / "SENTINEL").exists()  # 旧 catalog clone 被 wipe
+    assert not ext.exists()  # 外部 plugin 树同样被 wipe（sourceChanged 清两处）
+    assert clone.exists()  # mock 重新 clone
+    assert calls[0]["source"] == _SRC_B
+
+
+async def test_reconcile_autoupdate_pulls_without_wipe(tmp_path: Path, monkeypatch) -> None:
+    home = _home(tmp_path)
+    _seed_known(home, {"acme": _SRC_A})
+    clone = _make_clone(home, "acme")
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(_RECONCILER, _fake_stage(calls))
+    declared = {"extraKnownMarketplaces": {"acme": {"source": _SRC_A, "autoUpdate": True}}}
+
+    report = await reconcile(SkillRegistry(), home, declared)
+
+    assert report.updated == ["acme"]
+    assert calls[0]["refresh"] is True
+    assert calls[0]["auto_update"] is True
+    assert (clone / "SENTINEL").exists()  # 未 wipe（autoUpdate 走 pull）
+
+
+async def test_reconcile_up_to_date_no_refresh(tmp_path: Path, monkeypatch) -> None:
+    home = _home(tmp_path)
+    _seed_known(home, {"acme": _SRC_A})
+    _make_clone(home, "acme")
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(_RECONCILER, _fake_stage(calls))
+    declared = {"extraKnownMarketplaces": {"acme": {"source": _SRC_A}}}
+
+    report = await reconcile(SkillRegistry(), home, declared)
+
+    assert report.up_to_date == ["acme"]
+    assert calls[0]["refresh"] is False
+
+
+async def test_reconcile_explicit_refresh_pulls_existing(tmp_path: Path, monkeypatch) -> None:
+    home = _home(tmp_path)
+    _seed_known(home, {"acme": _SRC_A})
+    _make_clone(home, "acme")
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(_RECONCILER, _fake_stage(calls))
+    declared = {"extraKnownMarketplaces": {"acme": {"source": _SRC_A}}}
+
+    report = await reconcile(SkillRegistry(), home, declared, refresh=True)
+
+    assert report.updated == ["acme"]
+    assert calls[0]["refresh"] is True
+
+
+async def test_reconcile_orphan_left_untouched(tmp_path: Path, monkeypatch) -> None:
+    """materialized∖declared：不进循环、stage 不被调用、物化记录 + clone 树 + Registry 全不动。"""
+    home = _home(tmp_path)
+    _seed_known(home, {"legacy": _SRC_A})
+    clone = _make_clone(home, "legacy")
+    reg = SkillRegistry()
+    _reg_skill(reg, "leg:tool", "legacy", clone)
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(_RECONCILER, _fake_stage(calls))
+
+    report = await reconcile(reg, home, {"extraKnownMarketplaces": {}})  # 不再声明 legacy
+
+    assert calls == []  # stage 完全未被调用
+    assert report.installed == [] and report.updated == [] and report.failed == []
+    assert (clone / "SENTINEL").exists()  # clone 树不动
+    assert "legacy" in load_known_marketplaces(home=home)["marketplaces"]  # 物化记录不动
+    assert reg.resolve("leg:tool") is not None  # Registry 不动
+
+
+async def test_reconcile_failed_when_clone_absent_after_stage(tmp_path: Path, monkeypatch) -> None:
+    home = _home(tmp_path)
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(_RECONCILER, _fake_stage(calls, succeed=False))  # 模拟 clone 失败（不建目录）
+    declared = {"extraKnownMarketplaces": {"acme": {"source": _SRC_A}}}
+
+    report = await reconcile(SkillRegistry(), home, declared)
+
+    assert report.failed == ["acme"]
+    assert report.installed == [] and report.updated == []
+
+
+async def test_reconcile_plugin_filter_only_true_and_same_marketplace(tmp_path: Path, monkeypatch) -> None:
+    home = _home(tmp_path)
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(_RECONCILER, _fake_stage(calls))
+    declared = {
+        "extraKnownMarketplaces": {"acme": {"source": _SRC_A}},
+        "enabledPlugins": {
+            "audit@acme": True,  # 启用、本 mp → 入
+            "fmt@acme": False,  # 禁用 → 不入
+            "x@other": True,  # 启用但别的 mp → 不入
+            "bad-key-no-at": True,  # 非法 key → 忽略
+        },
+    }
+
+    await reconcile(SkillRegistry(), home, declared)
+
+    assert calls[0]["plugin_filter"] == {"audit"}
+
+
+# ── 声明视图提取 / declared-view extraction ──────────────────────────────────
+def test_declared_marketplace_names_filters_invalid() -> None:
+    declared = {
+        "extraKnownMarketplaces": {
+            "good-mp": {"source": _SRC_A},
+            "bad/name": {"source": _SRC_A},  # 非 kebab → 滤掉
+            "not-object": "oops",  # 非对象 → 滤掉
+        }
+    }
+    assert declared_marketplace_names(declared) == {"good-mp"}
+
+
+def test_declared_plugin_ids_filters_invalid() -> None:
+    declared = {"enabledPlugins": {"audit@acme": True, "disabled@acme": False, "no-at-sign": True}}
+    # 含 false（声明禁用，仍是"已声明"）；滤掉非法 key
+    assert declared_plugin_ids(declared) == {"audit@acme", "disabled@acme"}
+
+
+def test_declared_helpers_handle_missing_keys() -> None:
+    assert declared_marketplace_names({}) == set()
+    assert declared_plugin_ids({}) == set()
+
+
+# ── marketplace prune ───────────────────────────────────────────────────────
+def test_list_and_prune_marketplaces(tmp_path: Path) -> None:
+    home = _home(tmp_path)
+    _seed_known(home, {"acme": _SRC_A, "legacy": _SRC_B})
+    acme_clone = _make_clone(home, "acme")
+    legacy_clone = _make_clone(home, "legacy")
+    _ext_dir(home, "legacy").mkdir(parents=True, exist_ok=True)
+    (_ext_dir(home, "legacy") / "plug").mkdir()
+    reg = SkillRegistry()
+    _reg_skill(reg, "audit:lint", "acme", acme_clone)
+    _reg_skill(reg, "leg:tool", "legacy", legacy_clone)
+    declared = {"extraKnownMarketplaces": {"acme": {"source": _SRC_A}}}  # legacy 不再声明
+
+    assert list_orphan_marketplaces(home, declared) == ["legacy"]
+
+    removed = prune_marketplaces(["legacy"], reg, home)
+
+    assert removed == ["legacy"]
+    assert not legacy_clone.exists()  # clone 树清除
+    assert not _ext_dir(home, "legacy").exists()  # 外部 plugin 树清除
+    kmf = load_known_marketplaces(home=home)["marketplaces"]
+    assert "legacy" not in kmf and "acme" in kmf  # 物化条目删除、acme 保留
+    assert reg.resolve("leg:tool") is None  # 孤儿 SKILL 注销
+    assert reg.resolve("audit:lint") is not None  # acme SKILL 保留
+    assert acme_clone.exists()  # acme clone 树不动
+
+
+def test_prune_skips_invalid_marketplace_name(tmp_path: Path) -> None:
+    home = _home(tmp_path)
+    _seed_known(home, {"acme": _SRC_A})
+    removed = prune_marketplaces(["../escape"], SkillRegistry(), home)
+    assert removed == []
+    assert "acme" in load_known_marketplaces(home=home)["marketplaces"]
+
+
+# ── plugin gc ────────────────────────────────────────────────────────────────
+def _seed_installed(home: Path, plugins: dict[str, list[dict]]) -> None:
+    save_installed_plugins({"version": 1, "plugins": plugins}, home=home)
+
+
+async def test_list_and_gc_plugins(tmp_path: Path) -> None:
+    home = _home(tmp_path)
+    audit_path = marketplace_skill_dir(home, "acme") / "audit"
+    keep_path = marketplace_skill_dir(home, "acme") / "keep"
+    audit_path.mkdir(parents=True)
+    keep_path.mkdir(parents=True)
+    _seed_installed(
+        home,
+        {
+            "audit@acme": [{"scope": "user", "installPath": str(audit_path), "bundledMcpServers": ["figma", "blender"]}],
+            "keep@acme": [{"scope": "user", "installPath": str(keep_path)}],
+        },
+    )
+    reg = SkillRegistry()
+    _reg_skill(reg, "audit:lint", "acme", audit_path)
+    _reg_skill(reg, "keep:do", "acme", keep_path)
+    declared = {"enabledPlugins": {"keep@acme": True}}  # audit 不再声明 → 孤儿
+
+    assert list_orphan_plugins(home, declared) == ["audit@acme"]
+
+    teardown: list[list[str]] = []
+
+    async def _cb(servers: list[str]) -> None:
+        teardown.append(servers)
+
+    removed = await gc_plugins(["audit@acme"], reg, home, mcp_teardown=_cb)
+
+    assert removed == ["audit@acme"]
+    assert not audit_path.exists()  # installPath 树清除
+    assert keep_path.exists()  # 保留
+    ipf = load_installed_plugins(home=home)["plugins"]
+    assert "audit@acme" not in ipf and "keep@acme" in ipf
+    assert reg.resolve("audit:lint") is None  # 孤儿 plugin 的 SKILL 注销
+    assert reg.resolve("keep:do") is not None  # 保留 plugin 的 SKILL 不动
+    assert teardown == [["figma", "blender"]]  # bundled MCP 经回调下线
+
+
+async def test_gc_guards_installpath_outside_home(tmp_path: Path) -> None:
+    home = _home(tmp_path)
+    outside = tmp_path / "outside-home"  # 故意落在 SKILL Home 之外
+    outside.mkdir()
+    (outside / "keepme").write_text("x", encoding="utf-8")
+    _seed_installed(home, {"evil@acme": [{"scope": "user", "installPath": str(outside)}]})
+
+    removed = await gc_plugins(["evil@acme"], SkillRegistry(), home)
+
+    assert removed == ["evil@acme"]
+    assert outside.exists() and (outside / "keepme").exists()  # 越界守卫：拒删盘外目录
+    assert "evil@acme" not in load_installed_plugins(home=home)["plugins"]  # 物化条目仍清除
+
+
+async def test_gc_without_teardown_callback(tmp_path: Path) -> None:
+    """无 mcp_teardown 回调时不报错、照常清理 / No callback → still cleans, no error。"""
+    home = _home(tmp_path)
+    p = marketplace_skill_dir(home, "acme") / "audit"
+    p.mkdir(parents=True)
+    _seed_installed(home, {"audit@acme": [{"scope": "user", "installPath": str(p), "bundledMcpServers": ["x"]}]})
+
+    removed = await gc_plugins(["audit@acme"], SkillRegistry(), home, mcp_teardown=None)
+
+    assert removed == ["audit@acme"]
+    assert not p.exists()
+
+
+# ── 失败降级 / 防御兜底分支 / failure-degradation & defensive branches ────────
+def test_safe_rmtree_oserror_does_not_abort_prune(tmp_path: Path, monkeypatch) -> None:
+    """``_safe_rmtree`` 删除受阻（OSError）→ 记 WARN 降级、prune 不中断（「失败不阻断」铁律）。"""
+    import a2c_smcp.computer.settings.reconciler as rec_mod
+
+    home = _home(tmp_path)
+    _seed_known(home, {"acme": _SRC_A})
+    _make_clone(home, "acme")
+
+    def _boom(*_a: object, **_k: object) -> None:
+        raise OSError("disk busy")
+
+    monkeypatch.setattr(rec_mod.shutil, "rmtree", _boom)
+
+    removed = prune_marketplaces(["acme"], SkillRegistry(), home)
+
+    # rmtree 抛错被降级吞掉，prune 仍走完：物化条目照常删除、不向上抛
+    assert removed == ["acme"]
+    assert "acme" not in load_known_marketplaces(home=home)["marketplaces"]
+
+
+async def test_gc_skips_unknown_plugin_id(tmp_path: Path) -> None:
+    """gc 入参含 installed_plugins.json 里不存在的 pid → 跳过（``records is None`` 守卫），不计入 removed。"""
+    home = _home(tmp_path)
+    _seed_installed(home, {"real@acme": [{"scope": "user", "installPath": str(marketplace_skill_dir(home, "acme"))}]})
+
+    removed = await gc_plugins(["ghost@acme"], SkillRegistry(), home)
+
+    assert removed == []
+    assert "real@acme" in load_installed_plugins(home=home)["plugins"]  # 已存在项不受影响
+
+
+async def test_gc_plugin_id_without_at_sign(tmp_path: Path) -> None:
+    """畸形 pid（无 ``@``）→ 不做 SKILL 注销（``if marketplace:`` 假分支）、仍清 installPath + 账本，不崩。"""
+    home = _home(tmp_path)
+    p = marketplace_skill_dir(home, "x") / "noat"
+    p.mkdir(parents=True)
+    _seed_installed(home, {"noatsign": [{"scope": "user", "installPath": str(p)}]})
+
+    removed = await gc_plugins(["noatsign"], SkillRegistry(), home)
+
+    assert removed == ["noatsign"]
+    assert not p.exists()
+    assert "noatsign" not in load_installed_plugins(home=home)["plugins"]


### PR DESCRIPTION
## 概述

实现 #62 S9 reconciler：新增 `a2c_smcp/computer/settings/reconciler.py`——启动对账（先合并单一声明视图再对账）+ 孤儿清理。纯 Computer 侧，消费已发布的 v0.2.1 SKILL 协议 + tfrobot-marketplace protocol-v1，**无协议变更**。

设计依据：`docs/design-0.2.1-cli-marketplace-ux.md` §7.1（启动流程）/ §7.2（失败降级）/ §7.3（显式 sync 与孤儿清理）；父工单 #53「reconciler additive-only」决策。

## 核心实现

- **`reconcile()` additive-only 四分支**（§7.1）：
  - `missing`（declared∖materialized）→ clone
  - `sourceChanged`（`record.source != decl.source`）→ wipe 旧 clone 树（含 `.plugins/<mp>` 外部树）+ 注销旧 SKILL → 重 clone（兜底：`stage_marketplace_skills` 只 pull 不换库）
  - `autoUpdate`（或显式 `refresh=True`）→ pull
  - `orphan`（materialized∖declared）→ **完全不动**（不进循环）
  - `plugin_filter` 由 `enabledPlugins` 推导（仅 `true` 且属本 marketplace）；**串行** stage 守同步 `file_lock` 约束（不 `gather`）
  - 返回 `ReconcileReport{installed, updated, up_to_date, failed, skipped, registered_skills}`（镜像 CC，**无 removed**）
- **孤儿清理**（§7.3，additive-only 唯一删除入口；y/N 确认交 CLI #68，本模块给纯函数）：
  - `prune_marketplaces`：clone 树 + `.plugins/<mp>` + `known_marketplaces.json` 条目 + Registry SKILL
  - `gc_plugins`：`installPath` + `installed_plugins.json` 条目 + Registry SKILL + bundled MCP（经 `mcp_teardown` 回调）
- **`_safe_rmtree` 越权守卫**：仅删 SKILL Home 内目录（`installPath` 来自 json，越界拒删 + 仍清账本条目；删除 OSError 降级记 WARN 不阻断）

## 边界决策（已与维护者确认）

- **#62/#63 接缝**：reconcile 只维护 `known_marketplaces.json`（经 stage）+ 注册启用 SKILL，**不写** `installed_plugins.json`（install/uninstall/enable/disable 账本归 #63）→ 依赖恰为 {#58, #61}，零 #63 耦合。`gc_plugins` 读该账本找孤儿。
- **trust 门控不做**：守住四分支范围；`skipped` 字段占位，trust 落 `marketplace add` CLI（#68）/ strict 延后（#80）。
- **bundled-MCP teardown** 经可选回调注入；真正接线（MCP manager）留 computer.py 集成。
- **reconciler 刻意不从 `settings/__init__` re-export**：它依赖 `skills.staging`，而 staging 顶层 import `settings.schema`（触发 `settings/__init__`），急切导入会构成循环（`_EXTERNAL_PLUGINS_NS` 未定义）。消费方直接 `from ...settings.reconciler import ...`，已在 `__init__` 注释固化原因。

## 验收对照（#62）

- [x] 对账四分支（missing/sourceChanged/autoUpdate/orphan-不动）单测
- [x] additive-only：声明没/物化有 → 不自动清理
- [x] gc/prune 列全 scope 不再声明的孤儿 + 确认后清理
- [x] `uv run poe lint` 净

## 测试

- **新增 22 例**（19 unit + 3 集成）：四分支 + plugin_filter 推导 + 声明视图提取 + gc/prune + 越权守卫 + **失败降级铁律**（`_safe_rmtree` OSError 不阻断）+ gc 守卫分支（未知 pid / 畸形 pid）。集成测试用本地 `git init --bare` + `file://`，无网络依赖。
- **lint gate 净**：ruff All checks passed + mypy 83 文件 0 issue。
- **全量套件 1376 passed / 0 失败**（= 此前 1357 + 19；含本轮 fix-review 补测后 22）。

## fix-review

经 `/fix-review discuss`（5 🟡，0 🔴）：🟡2 已补防御分支测试（OSError 降级 + gc 守卫 + sourceChanged ext 树 wipe 断言）；🟡4（`failed` 判定）/ 🟡5（集成对称）经共识保持现状；🟡1（覆盖率 vrl_python PyO3）/ 🟡3（`skipped` 预留）属环境/有意为之，无动作。

🤖 Generated with [Claude Code](https://claude.com/claude-code)