### PR TITLE
feat(computer): v0.2.1 S10 plugin install/uninstall/enable/disable（MCP 外来同名硬抛）(#63)

### DIFF
--- a/a2c_smcp/computer/settings/__init__.py
+++ b/a2c_smcp/computer/settings/__init__.py
@@ -91,12 +91,12 @@ from a2c_smcp.computer.settings.store import (
     update_known_marketplaces,
 )
 
-# 注意 / NB：:mod:`...settings.reconciler` **刻意不在此 re-export**——它依赖
+# 注意 / NB：:mod:`...settings.reconciler` 与 :mod:`...settings.installer` **刻意不在此 re-export**——它们依赖
 # :mod:`...skills.staging`，而 staging 顶层又 import :mod:`...settings.schema`（触发本 __init__）。
-# 若在此急切导入 reconciler 会与 staging 的半初始化态构成循环（`_EXTERNAL_PLUGINS_NS` 未定义）。
-# 消费方请直接 ``from a2c_smcp.computer.settings.reconciler import reconcile`` 等。
-# reconciler is intentionally NOT re-exported here to avoid a circular import with skills.staging;
-# import it directly from its submodule.
+# 若在此急切导入 reconciler/installer 会与 staging 的半初始化态构成循环（`_EXTERNAL_PLUGINS_NS` 未定义）。
+# 消费方请直接 ``from a2c_smcp.computer.settings.reconciler import reconcile`` / ``...installer import install_plugin`` 等。
+# reconciler & installer are intentionally NOT re-exported here to avoid a circular import with skills.staging;
+# import them directly from their submodules.
 
 __all__ = [
     # schema

--- a/a2c_smcp/computer/settings/installer.py
+++ b/a2c_smcp/computer/settings/installer.py
@@ -227,6 +227,23 @@ def _conflict_check(servers: list[MCPServerConfig], existing: set[str], owned: s
             )
 
 
+def _require_existing_names_guard(
+    existing_server_names: ExistingServerNames | None,
+    register_server: RegisterServer | None,
+) -> None:
+    """
+    护栏：给了 ``register_server`` 就**必须**给 ``existing_server_names`` / Guard: register implies existing-names。
+
+    否则冲突闸门以 ``existing=∅`` 运行被静默旁路——外来同名 server 会被 MCP manager **静默覆盖**（manager 对
+    同名是覆盖更新、不抛），违 §10.6「外来同名硬抛」铁律。三注入回调应「齐备或全无」，此处强制 register→existing。
+    """
+    if register_server is not None and existing_server_names is None:
+        raise PluginInstallError(
+            "existing_server_names is required when register_server is given "
+            "(else the MCP name-conflict gate is silently bypassed; design §10.6)",
+        )
+
+
 # ---------------------------------------------------------------------------
 # install / uninstall / enable / disable
 # ---------------------------------------------------------------------------
@@ -255,7 +272,8 @@ async def install_plugin(
     4. :func:`load_bundled_servers` 全量解析 ``mcp-servers/<n>.json``（任一畸形→抛，注册前）。
     5. **★冲突闸门**：外来同名→:class:`MCPServerNameConflictError`（零变更）；自有同名→幂等放行。
     6-7. 过闸后变更：注册 bundled servers → :func:`stage_marketplace_skills` 注册 skills（复用既有 clone）。
-       任一失败 → 补偿回滚（注销已注册 skills + 移除已注册 servers）→ 上抛，**不写账本**。
+       任一失败 → **精确补偿回滚**（仅注销本次新增的 skill、仅移除本次新增的 server——重装失败不误删此前已有）
+       → 上抛，**不写账本**。
     8. **★最后**写 ``installed_plugins.json``（仅全成功）：scope / installPath / version / commitSha /
        installedAt / lastUpdated / bundledMcpServers。
 
@@ -263,9 +281,11 @@ async def install_plugin(
     :param version: 记录版本覆盖（``--version``）；缺省按 entry > plugin.json > commitSha 解析。v0.2.1 git-ref
         锁版本由 entry source 的 ref 治理（version 仅作记录）。
     :param existing_server_names / register_server / remove_server: MCP 注入回调（``None`` = ledger-only）。
+        **契约**：给了 ``register_server`` 就必须给 ``existing_server_names``（否则冲突闸门被静默旁路，违 §10.6）。
     :return: 写入的 :class:`InstalledPluginRecord`。
     """
     plugin, marketplace = _split_plugin_id(plugin_id)
+    _require_existing_names_guard(existing_server_names, register_server)
     source, commit_sha = _resolve_marketplace_source(marketplace, home, env)
 
     catalog_dir = marketplace_skill_dir(home, marketplace)
@@ -298,6 +318,9 @@ async def install_plugin(
     _conflict_check(servers, existing, owned)
 
     # —— 过闸：开始变更，失败补偿回滚 ——
+    # 回滚前快照本 plugin 已活跃的 skill：使补偿只撤销**本次新增**——重装（plugin 已装、skill 已活跃、owned
+    # server 已挂）中途失败时，不误删此前就存在的 skill / 摘除原本工作的 server（精确回滚，避免 live 态破坏）。
+    skills_before = set(_plugin_skill_names(registry, marketplace, plugin))
     registered: list[str] = []
     try:
         if register_server is not None:
@@ -316,11 +339,15 @@ async def install_plugin(
             env=env,
         )
     except Exception:
-        # 回滚（逆序）：注销本 plugin 已注册的 skills + 移除已注册的 servers，再上抛（账本未写）。
+        # 精确回滚（逆序）：仅注销本次新增的 skill（不在 skills_before）、仅移除本次新增的 server（不在 owned，
+        # 即非自有/非重装前已挂）；再上抛（账本未写）。
         for name in _plugin_skill_names(registry, marketplace, plugin):
-            registry.unregister(name)
+            if name not in skills_before:
+                registry.unregister(name)
         if remove_server is not None:
             for sname in registered:
+                if sname in owned:
+                    continue  # 自有 server（重装前已挂）：保留，不误摘
                 try:
                     await remove_server(sname)
                 except Exception as e:  # 回滚 best-effort，不掩盖原异常
@@ -370,6 +397,13 @@ async def uninstall_plugin(
 
     :func:`gc_plugins` 的显式单 plugin 对应物。``--keep-servers`` 跳过 server 摘除（保留 config）。
     ``scope=None`` 删该 id 全部记录；指定 scope 仅删该 scope 记录（其余 scope 保留）。未安装 → ``False``（no-op）。
+
+    .. note::
+       **相对源 plugin**（``source`` 为相对路径）的 ``installPath`` 位于**共享 catalog clone 内**
+       （``<home>/marketplace/<mp>/plugins/<plugin>``），:func:`_safe_rmtree` 删的是该 marketplace 共享 git
+       工作树的子目录——此行为与兄弟 :func:`gc_plugins` 一致（同一 ``_safe_rmtree`` 语义、非本工单新引入）；
+       后续 ``marketplace refresh`` 遇脏树会 fallback 全量重 clone 干净恢复。「仅删外部 ``.plugins/`` 树、跳过
+       catalog 内子树」的行为收敛是 installer + gc 的**跨切 follow-up**（须两处一致，避免与 #62 的 gc 分叉）。
     """
     plugin, marketplace = _split_plugin_id(plugin_id)
     installed = load_installed_plugins(home=home, env=env)
@@ -436,6 +470,12 @@ async def disable_plugin(
     ① 写 ``enabledPlugins[id]=false``；② 停并摘除其 bundled MCP server（读物化记录的 ``bundledMcpServers``）；
     ③ 隐藏 skills（:meth:`SkillRegistry.mark_orphan`，**物化层不动**——clone 树 / installed 记录保留，
     :func:`enable_plugin` 廉价复原）。区别于 :func:`uninstall_plugin`：disable 留 installed 记录、可一键回滚。
+
+    ⚠️ **scope 契约**：``scope`` 须与该 plugin 的**安装 scope 一致**（调用方 / #69 CLI 从上下文传）——否则把
+    ``enabledPlugins[id]=false`` 写到错误层，更高优先级层意图未动 → 六层合并后可能仍 enabled、下次 reconcile 复活，
+    而 live 态已摘 server / orphan skill，造成背离。
+    ⚠️ **非原子**：先写 settings 再摘 server / orphan skill；``remove_server`` 抛错会留半态（settings 已 false 但
+    skill 未隐藏）。与 install/enable 的「预检/写在变更前」不对称——靠 reconcile 收敛兜底（#63 文档化边界）。
     """
     plugin, marketplace = _split_plugin_id(plugin_id)
     _write_enabled_plugin(plugin_id, False, scope, project_path, env)
@@ -466,8 +506,12 @@ async def enable_plugin(
     ② 写 ``enabledPlugins[id]=true``；③ 复活 skills——re-stage（:func:`stage_marketplace_skills` 的
     :meth:`register_or_update` 把孤儿同名翻 ``orphaned=False``，``refresh=False`` 复用既有 clone）；④ 重挂 servers。
     未安装 → :class:`PluginInstallError`（须先 install）。
+
+    ⚠️ **scope 契约**：同 :func:`disable_plugin`——``scope`` 须与安装 scope 一致（调用方 / #69 从上下文传），否则
+    ``enabledPlugins[id]=true`` 写错层、与 live 态背离。
     """
     plugin, marketplace = _split_plugin_id(plugin_id)
+    _require_existing_names_guard(existing_server_names, register_server)
     installed = load_installed_plugins(home=home, env=env)
     records = installed.get("plugins", {}).get(plugin_id)
     if not records:

--- a/a2c_smcp/computer/settings/installer.py
+++ b/a2c_smcp/computer/settings/installer.py
@@ -1,0 +1,506 @@
+# -*- coding: utf-8 -*-
+# filename: installer.py
+# @Time    : 2026/05/26
+# @Author  : JQQ
+# @Email   : jqq1716@gmail.com
+# @Software: PyCharm
+"""
+Plugin 显式生命周期：install / uninstall / enable / disable（v0.2.1 #63）
+Plugin explicit lifecycle: install / uninstall / enable / disable (v0.2.1 #63).
+
+SDK 设计 / Design: python-sdk docs/design-0.2.1-cli-marketplace-ux.md §3.3 / §4.3 / §6.2 / §7.2 / §10.6；
+                   父工单 #53 决策 #6（disable=整 plugin 下线）/ #18（MCP 外来同名硬抛、无逃生口）/ #19（uninstall 级联）。
+
+本模块是 :mod:`~a2c_smcp.computer.settings.reconciler` 的**兄弟**——reconciler 做 additive-only 对账 + 孤儿
+gc/prune，本模块做**显式单 plugin** 增删启停，写 ``installed_plugins.json``（正是 :func:`gc_plugins` 读取的账本，
+#62 decision A 留的接缝）。复用 :func:`~a2c_smcp.computer.skills.staging.stage_marketplace_skills`（skill 注册）
++ :func:`~a2c_smcp.computer.skills.staging.locate_plugin_root`（plugin 根定位/clone）+
+:mod:`~a2c_smcp.computer.skills.manifest`（marketplace.json / plugin.json / mcp-servers 解析）。
+
+**循环导入**：本模块 import ``skills.staging``（其顶层 import ``settings.schema``），故**刻意不在**
+``settings/__init__`` re-export（与 reconciler 同——见 #62 教训）；消费方直接
+``from a2c_smcp.computer.settings.installer import install_plugin`` 等。
+
+**MCP 注入**：与 :func:`gc_plugins` 的 ``mcp_teardown`` 同款——bundled MCP server 的存在性查询 / 注册 / 摘除经
+注入回调（:data:`ExistingServerNames` / :data:`RegisterServer` / :data:`RemoveServer`），由 #69 CLI 层用
+``Computer.aadd_or_aupdate_server`` / ``Computer.aremove_server`` / ``mcp_manager.get_server_status`` 包装；
+回调 ``None`` = ledger-only（单测 / 无 server 场景）。**install/enable 注册经 Computer 路径渲染 ``${input:}``**
+（§9.3，inputs 池消歧归 #65）。
+
+边界（文档化，非缺陷）/ Documented boundaries：
+- 本模块操作 **live session**（Computer.boot_up 当前不调 reconcile）：跨重启重挂 bundled server +
+  ``installed × enabled`` 交集归 reconcile 接线层（#68/#69）。
+- disable 的 skill orphan 为**内存态**（Registry 不落盘），同会话廉价复原；跨重启靠 reconcile 按
+  ``enabledPlugins`` 重建。uninstall 仅注销**活跃** SKILL（与 :func:`_unregister_marketplace_skills` 同限）；
+  先 disable（orphan）再 uninstall 会残留内存孤儿条目，进程重启即清。
+"""
+
+from __future__ import annotations
+
+import shutil
+from collections.abc import Awaitable, Callable, Mapping
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from a2c_smcp.computer.mcp_clients.model import MCPServerConfig
+from a2c_smcp.computer.settings.schema import SettingsScope, is_valid_enabled_plugin_key
+from a2c_smcp.computer.settings.scope import (
+    apply_write,
+    load_settings_file,
+    user_settings_path,
+    workdir_local_settings_path,
+    workdir_project_settings_path,
+)
+from a2c_smcp.computer.settings.store import (
+    InstalledPluginRecord,
+    InstalledPluginsFile,
+    atomic_write_json,
+    file_lock,
+    load_installed_plugins,
+    load_known_marketplaces,
+    update_installed_plugins,
+)
+from a2c_smcp.computer.skills.home import SOURCE_MARKETPLACE, marketplace_skill_dir
+from a2c_smcp.computer.skills.manifest import (
+    find_plugin_entry,
+    load_bundled_servers,
+    plugin_root_base,
+    read_marketplace_manifest,
+    read_plugin_metadata,
+    resolve_plugin_version,
+)
+from a2c_smcp.computer.skills.registry import SkillRegistry
+from a2c_smcp.computer.skills.staging import (
+    DEFAULT_GIT_TIMEOUT,
+    locate_plugin_root,
+    stage_marketplace_skills,
+)
+from a2c_smcp.utils.logger import get_logger
+from a2c_smcp.utils.path import is_within
+
+logger = get_logger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# 异常 / Exceptions（模块内本地异常，仿 ToolNameDuplicatedError / SkillStagingError 惯例）
+# ---------------------------------------------------------------------------
+class PluginInstallError(Exception):
+    """plugin install/enable 前置失败（marketplace 未添加 / catalog 未 clone / entry 缺失 / 非法 scope）。"""
+
+
+class MCPServerNameConflictError(Exception):
+    """
+    bundled MCP server 与**外来**同名 server 冲突（§7.2/§10.6）/ Foreign MCP server name conflict。
+
+    **硬抛、原子失败、无 rename/force 逃生口**（name 即身份）。判定排除 plugin 自有
+    （命中其 ``bundledMcpServers`` 记录）→ 幂等再物化不算冲突。
+    """
+
+
+# ---------------------------------------------------------------------------
+# MCP 注入接口 / Injected MCP interface（沿用 gc_plugins 的回调注入风格）
+# ---------------------------------------------------------------------------
+# 当前已注册 server 名集合（同步；CLI 包 ``{r[0] for r in mcp_manager.get_server_status()}``）。
+ExistingServerNames = Callable[[], set[str]]
+# 注册 / 更新一个 server（异步；CLI 包 ``Computer.aadd_or_aupdate_server``，含 ``${input:}`` 渲染）。
+RegisterServer = Callable[[MCPServerConfig], Awaitable[None]]
+# 停止并移除一个 server（异步；CLI 包 ``Computer.aremove_server``）。
+RemoveServer = Callable[[str], Awaitable[None]]
+
+
+# ---------------------------------------------------------------------------
+# 内部辅助 / Internal helpers
+# ---------------------------------------------------------------------------
+def _split_plugin_id(plugin_id: str) -> tuple[str, str]:
+    """``<plugin>@<marketplace>`` → ``(plugin, marketplace)``；非法 key → :class:`PluginInstallError`。"""
+    if not is_valid_enabled_plugin_key(plugin_id):
+        raise PluginInstallError(f"invalid plugin id {plugin_id!r} (expect '<plugin>@<marketplace>', strict kebab, each ≤64)")
+    plugin, _, marketplace = plugin_id.partition("@")
+    return plugin, marketplace
+
+
+def _safe_rmtree(path: Path, home: Path) -> None:
+    """仅当 ``path`` 词法位于 SKILL Home 内才递归删除（防越权删盘外目录）/ Guarded rmtree within SKILL Home（同 reconciler 语义）。"""
+    rp = path.resolve()
+    if not is_within(rp, home.resolve()):
+        logger.error("installer: refusing to remove %s outside SKILL Home %s", rp, home)
+        return
+    if not rp.exists():
+        return
+    try:
+        shutil.rmtree(rp)
+    except OSError as e:  # 失败降级：删除受阻不阻断后续
+        logger.warning("installer: failed to remove %s: %s", rp, e)
+
+
+def _settings_path_for_scope(scope: str, project_path: str | None, env: Mapping[str, str] | None) -> tuple[Path, SettingsScope]:
+    """
+    解析 enable/disable 写入的 settings.json 路径与 scope 枚举 / Resolve the settings.json path + scope enum to write。
+
+    可写 scope：``user``（默认）/ ``project`` / ``local``（后两者需 ``project_path`` = active workdir）。
+    ``managed`` / ``policy`` / 未知 → :class:`PluginInstallError`（policy 为只读治理层，§5.1）。
+    """
+    if scope == "user":
+        return user_settings_path(env), SettingsScope.USER
+    if scope in ("project", "local"):
+        if not project_path:
+            raise PluginInstallError(f"scope {scope!r} requires project_path (active workdir)")
+        wd = Path(project_path)
+        if scope == "project":
+            return workdir_project_settings_path(wd), SettingsScope.PROJECT
+        return workdir_local_settings_path(wd), SettingsScope.LOCAL
+    raise PluginInstallError(f"cannot write enabledPlugins to scope {scope!r} (writable: user|project|local)")
+
+
+def _write_enabled_plugin(plugin_id: str, value: bool, scope: str, project_path: str | None, env: Mapping[str, str] | None) -> None:
+    """
+    写 ``enabledPlugins[<plugin_id>] = value`` 到指定 scope 的 settings.json（持锁原子 RMW）/ Write the enabled flag。
+
+    复用 store 原语自组织：:func:`file_lock`（旁车 ``.lock``，建父目录）+ :func:`load_settings_file`（容错）+
+    :func:`apply_write`（递归进 ``enabledPlugins`` 仅改该 key、不毁兄弟）+ :func:`atomic_write_json`（``header=None``——
+    settings.json 是人编意图层，无写保护头 / version 字段，区别于物化文件）。
+    """
+    path, scope_enum = _settings_path_for_scope(scope, project_path, env)
+    with file_lock(path):
+        existing, _errors = load_settings_file(path, scope_enum)
+        updated = apply_write(existing, {"enabledPlugins": {plugin_id: value}})
+        atomic_write_json(path, updated)
+
+
+def _plugin_skill_names(registry: SkillRegistry, marketplace: str, plugin: str) -> list[str]:
+    """
+    某 plugin 当前**活跃**的 marketplace SKILL name / A plugin's currently-active marketplace SKILL names。
+
+    过滤 ``A2CSkillRef.source == "marketplace:<mp>"`` 且 ``name`` 以 ``<plugin>:`` 起（marketplace name = ``<plugin>:<skill>``）。
+    仅枚举活跃集（:meth:`SkillRegistry.active_refs` 排除孤儿）——同 :func:`_unregister_marketplace_skills`。
+    """
+    want_source = f"{SOURCE_MARKETPLACE}:{marketplace}"
+    prefix = f"{plugin}:"
+    names: list[str] = []
+    for ref in registry.active_refs():
+        if ref.get("source") != want_source:
+            continue
+        name = ref.get("name")
+        if isinstance(name, str) and name.startswith(prefix):
+            names.append(name)
+    return names
+
+
+def _bundled_servers_of(home: Path, plugin_id: str, env: Mapping[str, str] | None) -> set[str]:
+    """该 plugin 物化记录里全部 ``bundledMcpServers`` 名（跨 scope 记录并集）/ All recorded bundled server names。"""
+    installed = load_installed_plugins(home=home, env=env)
+    out: set[str] = set()
+    for rec in installed.get("plugins", {}).get(plugin_id, []):
+        servers = rec.get("bundledMcpServers")
+        if isinstance(servers, list):
+            out.update(s for s in servers if isinstance(s, str))
+    return out
+
+
+def _resolve_marketplace_source(marketplace: str, home: Path, env: Mapping[str, str] | None) -> tuple[Mapping[str, Any], str | None]:
+    """从 ``known_marketplaces.json`` 取 marketplace 的 git source + commitSha；未添加 → :class:`PluginInstallError`。"""
+    known = load_known_marketplaces(home=home, env=env)
+    record = known.get("marketplaces", {}).get(marketplace)
+    if record is None:
+        raise PluginInstallError(f"marketplace {marketplace!r} not added (run 'marketplace add' first)")
+    source = record.get("source")
+    if not isinstance(source, Mapping):
+        raise PluginInstallError(f"marketplace {marketplace!r} has no valid source record")
+    commit_sha = record.get("commitSha")
+    return source, commit_sha if isinstance(commit_sha, str) else None
+
+
+def _conflict_check(servers: list[MCPServerConfig], existing: set[str], owned: set[str]) -> None:
+    """
+    bundled server 同名冲突预检（§7.2/§10.6）/ Bundled-server name-conflict precheck。
+
+    外来同名（``cfg.name in existing`` 且 ``not in owned``）→ :class:`MCPServerNameConflictError`（硬抛、零变更）；
+    plugin 自有（命中 ``owned`` = 其 ``bundledMcpServers`` 记录）→ 幂等放行（overwrite 自有 server）。
+    """
+    for cfg in servers:
+        if cfg.name in existing and cfg.name not in owned:
+            raise MCPServerNameConflictError(
+                f"MCP server name conflict: {cfg.name!r} already exists and is not owned by this plugin. "
+                "Resolve by 'server rm' the existing server, or rename it in the plugin's own manifest "
+                "(no --rename / --force-override escape hatch: name is identity).",
+            )
+
+
+# ---------------------------------------------------------------------------
+# install / uninstall / enable / disable
+# ---------------------------------------------------------------------------
+async def install_plugin(
+    plugin_id: str,
+    registry: SkillRegistry,
+    home: Path,
+    *,
+    scope: str = "user",
+    project_path: str | None = None,
+    version: str | None = None,
+    refresh: bool = False,
+    timeout: float = DEFAULT_GIT_TIMEOUT,
+    env: Mapping[str, str] | None = None,
+    existing_server_names: ExistingServerNames | None = None,
+    register_server: RegisterServer | None = None,
+    remove_server: RemoveServer | None = None,
+) -> InstalledPluginRecord:
+    """
+    显式安装单个 plugin（**原子失败：冲突即抛、不留半装**）/ Install one plugin atomically。
+
+    顺序（§10.6「预检-先于-变更」）/ Order:
+    1. 校验 ``plugin_id`` → ``(plugin, mp)``；从 ``known_marketplaces.json`` 取 mp source（未添加→抛）。
+    2. 要求 catalog clone 已存在（``marketplace add`` 前置；缺失→抛）；读 marketplace.json 定位 entry。
+    3. :func:`locate_plugin_root` 定位 plugin 根（必要时 clone 外部 plugin；失败→抛，零变更）。
+    4. :func:`load_bundled_servers` 全量解析 ``mcp-servers/<n>.json``（任一畸形→抛，注册前）。
+    5. **★冲突闸门**：外来同名→:class:`MCPServerNameConflictError`（零变更）；自有同名→幂等放行。
+    6-7. 过闸后变更：注册 bundled servers → :func:`stage_marketplace_skills` 注册 skills（复用既有 clone）。
+       任一失败 → 补偿回滚（注销已注册 skills + 移除已注册 servers）→ 上抛，**不写账本**。
+    8. **★最后**写 ``installed_plugins.json``（仅全成功）：scope / installPath / version / commitSha /
+       installedAt / lastUpdated / bundledMcpServers。
+
+    :param scope: 物化记录 scope（``managed|user|project|local``，默认 ``user``）。
+    :param version: 记录版本覆盖（``--version``）；缺省按 entry > plugin.json > commitSha 解析。v0.2.1 git-ref
+        锁版本由 entry source 的 ref 治理（version 仅作记录）。
+    :param existing_server_names / register_server / remove_server: MCP 注入回调（``None`` = ledger-only）。
+    :return: 写入的 :class:`InstalledPluginRecord`。
+    """
+    plugin, marketplace = _split_plugin_id(plugin_id)
+    source, commit_sha = _resolve_marketplace_source(marketplace, home, env)
+
+    catalog_dir = marketplace_skill_dir(home, marketplace)
+    if not catalog_dir.is_dir():
+        raise PluginInstallError(f"marketplace {marketplace!r} catalog not cloned at {catalog_dir} (run 'marketplace add/refresh' first)")
+
+    manifest = read_marketplace_manifest(catalog_dir)
+    entry = find_plugin_entry(manifest, plugin)
+    if entry is None:
+        raise PluginInstallError(f"plugin {plugin!r} not found in marketplace {marketplace!r} manifest")
+
+    # 1-4：定位 + 解析（注册前，畸形即抛 → 原子前置）
+    plugin_root, version_fallback = await locate_plugin_root(
+        marketplace,
+        plugin,
+        entry,
+        catalog_dir,
+        plugin_root_base(manifest),
+        home,
+        commit_sha,
+        refresh=refresh,
+        timeout=timeout,
+        env=env,
+    )
+    servers = load_bundled_servers(plugin_root)
+
+    # 5：★冲突闸门（零变更）。owned = 自有同名白名单（其上次记录的 bundledMcpServers）。
+    owned = _bundled_servers_of(home, plugin_id, env)
+    existing = existing_server_names() if existing_server_names is not None else set()
+    _conflict_check(servers, existing, owned)
+
+    # —— 过闸：开始变更，失败补偿回滚 ——
+    registered: list[str] = []
+    try:
+        if register_server is not None:
+            for cfg in servers:
+                await register_server(cfg)
+                registered.append(cfg.name)
+        # skills 注册：复用 #61（catalog 已 clone、plugin 已定位 → refresh=False 不重 clone）
+        await stage_marketplace_skills(
+            marketplace,
+            source,
+            registry,
+            home,
+            plugin_filter={plugin},
+            refresh=refresh,
+            timeout=timeout,
+            env=env,
+        )
+    except Exception:
+        # 回滚（逆序）：注销本 plugin 已注册的 skills + 移除已注册的 servers，再上抛（账本未写）。
+        for name in _plugin_skill_names(registry, marketplace, plugin):
+            registry.unregister(name)
+        if remove_server is not None:
+            for sname in registered:
+                try:
+                    await remove_server(sname)
+                except Exception as e:  # 回滚 best-effort，不掩盖原异常
+                    logger.warning("install rollback: remove_server(%r) failed: %s", sname, e)
+        raise
+
+    # 8：★最后写账本（仅全成功）
+    bundled_names = [cfg.name for cfg in servers]
+    resolved_version = version if version else resolve_plugin_version(entry, read_plugin_metadata(plugin_root), version_fallback)
+    now = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+    record: InstalledPluginRecord = {"scope": scope, "installPath": str(plugin_root)}
+    if project_path:
+        record["projectPath"] = str(Path(project_path))
+    if resolved_version:
+        record["version"] = resolved_version
+    if version_fallback:
+        record["commitSha"] = version_fallback
+    record["installedAt"] = now
+    record["lastUpdated"] = now
+    if bundled_names:
+        record["bundledMcpServers"] = bundled_names
+
+    def _put(data: InstalledPluginsFile, _rec: InstalledPluginRecord = record, _pid: str = plugin_id) -> None:
+        plugins = data["plugins"]
+        # 多 scope 数组：替换同 scope 记录、保留其它 scope（v0.2.1 常见单元素）。
+        kept = [r for r in plugins.get(_pid, []) if r.get("scope") != _rec["scope"]]
+        kept.append(_rec)
+        plugins[_pid] = kept
+
+    update_installed_plugins(_put, home=home, env=env)
+    logger.info("installed plugin %r (servers=%s, skills staged)", plugin_id, bundled_names or "none")
+    return record
+
+
+async def uninstall_plugin(
+    plugin_id: str,
+    registry: SkillRegistry,
+    home: Path,
+    *,
+    scope: str | None = None,
+    keep_servers: bool = False,
+    env: Mapping[str, str] | None = None,
+    remove_server: RemoveServer | None = None,
+) -> bool:
+    """
+    卸载单个 plugin（删 installPath 树 + 注销 skills + 级联 stop+remove bundled server + 删账本记录）/ Uninstall。
+
+    :func:`gc_plugins` 的显式单 plugin 对应物。``--keep-servers`` 跳过 server 摘除（保留 config）。
+    ``scope=None`` 删该 id 全部记录；指定 scope 仅删该 scope 记录（其余 scope 保留）。未安装 → ``False``（no-op）。
+    """
+    plugin, marketplace = _split_plugin_id(plugin_id)
+    installed = load_installed_plugins(home=home, env=env)
+    records = installed.get("plugins", {}).get(plugin_id)
+    if not records:
+        logger.info("uninstall: plugin %r not installed (no-op)", plugin_id)
+        return False
+
+    targeted = [r for r in records if scope is None or r.get("scope") == scope]
+    if not targeted:
+        logger.info("uninstall: plugin %r has no record in scope %r (no-op)", plugin_id, scope)
+        return False
+
+    bundled: list[str] = []
+    for rec in targeted:
+        install_path = rec.get("installPath")
+        if isinstance(install_path, str) and install_path:
+            _safe_rmtree(Path(install_path), home)
+        servers = rec.get("bundledMcpServers")
+        if isinstance(servers, list):
+            bundled.extend(s for s in servers if isinstance(s, str))
+
+    for name in _plugin_skill_names(registry, marketplace, plugin):
+        registry.unregister(name)
+
+    if not keep_servers and remove_server is not None:
+        for sname in bundled:
+            await remove_server(sname)
+
+    def _drop(data: InstalledPluginsFile, _pid: str = plugin_id, _scope: str | None = scope) -> None:
+        plugins = data["plugins"]
+        if _scope is None:
+            plugins.pop(_pid, None)
+            return
+        remaining = [r for r in plugins.get(_pid, []) if r.get("scope") != _scope]
+        if remaining:
+            plugins[_pid] = remaining
+        else:
+            plugins.pop(_pid, None)
+
+    update_installed_plugins(_drop, home=home, env=env)
+    logger.info(
+        "uninstalled plugin %r (scope=%s, servers=%s)",
+        plugin_id,
+        scope or "all",
+        "kept" if keep_servers else (bundled or "none"),
+    )
+    return True
+
+
+async def disable_plugin(
+    plugin_id: str,
+    registry: SkillRegistry,
+    home: Path,
+    *,
+    scope: str = "user",
+    project_path: str | None = None,
+    env: Mapping[str, str] | None = None,
+    remove_server: RemoveServer | None = None,
+) -> None:
+    """
+    禁用单个 plugin = 整 plugin 下线（§4.3 决策 #6）/ Disable = take the whole plugin offline。
+
+    ① 写 ``enabledPlugins[id]=false``；② 停并摘除其 bundled MCP server（读物化记录的 ``bundledMcpServers``）；
+    ③ 隐藏 skills（:meth:`SkillRegistry.mark_orphan`，**物化层不动**——clone 树 / installed 记录保留，
+    :func:`enable_plugin` 廉价复原）。区别于 :func:`uninstall_plugin`：disable 留 installed 记录、可一键回滚。
+    """
+    plugin, marketplace = _split_plugin_id(plugin_id)
+    _write_enabled_plugin(plugin_id, False, scope, project_path, env)
+    if remove_server is not None:
+        for sname in sorted(_bundled_servers_of(home, plugin_id, env)):
+            await remove_server(sname)
+    for name in _plugin_skill_names(registry, marketplace, plugin):
+        registry.mark_orphan(name)
+    logger.info("disabled plugin %r (scope=%s, servers detached, skills orphaned)", plugin_id, scope)
+
+
+async def enable_plugin(
+    plugin_id: str,
+    registry: SkillRegistry,
+    home: Path,
+    *,
+    scope: str = "user",
+    project_path: str | None = None,
+    timeout: float = DEFAULT_GIT_TIMEOUT,
+    env: Mapping[str, str] | None = None,
+    existing_server_names: ExistingServerNames | None = None,
+    register_server: RegisterServer | None = None,
+) -> None:
+    """
+    启用单个 plugin（廉价复原，**无需重 clone/重装**）/ Enable = cheap restore (no re-clone)。
+
+    顺序：① 从物化记录的 ``installPath`` 重解析 bundled servers → **★冲突预检（先于 settings 写 → enable 原子）**；
+    ② 写 ``enabledPlugins[id]=true``；③ 复活 skills——re-stage（:func:`stage_marketplace_skills` 的
+    :meth:`register_or_update` 把孤儿同名翻 ``orphaned=False``，``refresh=False`` 复用既有 clone）；④ 重挂 servers。
+    未安装 → :class:`PluginInstallError`（须先 install）。
+    """
+    plugin, marketplace = _split_plugin_id(plugin_id)
+    installed = load_installed_plugins(home=home, env=env)
+    records = installed.get("plugins", {}).get(plugin_id)
+    if not records:
+        raise PluginInstallError(f"plugin {plugin_id!r} not installed; cannot enable (run 'plugin install' first)")
+
+    # ① 重解析 bundled servers（不重 clone，从记录 installPath 读）+ 冲突预检（零持久化变更前）
+    servers: list[MCPServerConfig] = []
+    for rec in records:
+        install_path = rec.get("installPath")
+        if isinstance(install_path, str) and install_path:
+            servers.extend(load_bundled_servers(Path(install_path)))
+    owned = _bundled_servers_of(home, plugin_id, env)
+    existing = existing_server_names() if existing_server_names is not None else set()
+    _conflict_check(servers, existing, owned)
+
+    # ② 写 enabledPlugins[id]=true（冲突预检通过后）
+    _write_enabled_plugin(plugin_id, True, scope, project_path, env)
+
+    # ③ 复活 skills（re-stage：register_or_update 翻活孤儿；复用既有 clone）
+    source, _commit_sha = _resolve_marketplace_source(marketplace, home, env)
+    await stage_marketplace_skills(
+        marketplace,
+        source,
+        registry,
+        home,
+        plugin_filter={plugin},
+        refresh=False,
+        timeout=timeout,
+        env=env,
+    )
+
+    # ④ 重挂 servers
+    if register_server is not None:
+        for cfg in servers:
+            await register_server(cfg)
+    logger.info("enabled plugin %r (scope=%s, skills recovered, servers remounted)", plugin_id, scope)

--- a/a2c_smcp/computer/skills/manifest.py
+++ b/a2c_smcp/computer/skills/manifest.py
@@ -12,13 +12,14 @@ Plugin manifest file parsing: marketplace.json + plugin.json + mcp-servers/<n>.j
                       优先级）/ §5（plugin source 5 类）；mcp-servers 协议 §1/§2（文件式、文件名=name）。
 SDK 设计 / Design: python-sdk docs/design-0.2.1-cli-marketplace-ux.md §3.2–3.5 / §3.3（bundled MCP server）。
 
-本模块是 **manifest 纯解析器**（无 git / 无 registry / 无 MCP manager 副作用），供 plugin install/enable
-（:mod:`a2c_smcp.computer.settings.installer`）消费。**刻意保持 leaf**：不 import
-:mod:`~a2c_smcp.computer.skills.staging`（staging 顶层 import ``settings.schema``——见 #62 循环导入教训；
-manifest 若反向耦合 staging 会把解析层卷入 settings/__init__ 的初始化环）。与 staging 私有 manifest 读取器
-（``_read_marketplace_manifest`` 等）存在**轻度重复**：这是为隔离循环导入风险刻意付出的代价（#63 边界决策）。
-This is a pure manifest parser (no git / registry / MCP side effects), consumed by the plugin installer.
-Kept intentionally leaf (no staging import) to avoid the settings/__init__ circular-import trap (#62).
+本模块是 **manifest 纯解析器唯一权威层**（无 git / 无 registry / 无 MCP manager 副作用），供 plugin
+install/enable（:mod:`a2c_smcp.computer.settings.installer`）与 :mod:`~a2c_smcp.computer.skills.staging`
+（marketplace git staging）**共同消费**——单向 ``staging → manifest``，无重复解析器。**刻意保持 leaf**：本模块
+**绝不** import :mod:`~a2c_smcp.computer.skills.staging`（staging 顶层 import ``settings.schema``；且 staging 现
+import 本模块，故反向耦合即构成真环）。
+This is the single authoritative manifest parser (no git / registry / MCP side effects), consumed by both the
+plugin installer and skills.staging (one-way ``staging → manifest``). Kept strictly leaf — it MUST NOT import
+skills.staging (which now imports this module, so a back-edge would be a real cycle).
 
 **显式延后 / Deferred**：
 - **bundled MCP server inputs.json 入池消歧**（§9.3 D2 前缀）归 #65——本模块**枚举 server 时排除**

--- a/a2c_smcp/computer/skills/manifest.py
+++ b/a2c_smcp/computer/skills/manifest.py
@@ -1,0 +1,171 @@
+# -*- coding: utf-8 -*-
+# filename: manifest.py
+# @Time    : 2026/05/26
+# @Author  : JQQ
+# @Email   : jqq1716@gmail.com
+# @Software: PyCharm
+"""
+Plugin manifest 文件式解析：marketplace.json + plugin.json + mcp-servers/<n>.json（v0.2.1 #63）
+Plugin manifest file parsing: marketplace.json + plugin.json + mcp-servers/<n>.json (v0.2.1 #63).
+
+协议依据 / Protocol: tfrobot-marketplace protocol-v1 §3（marketplace.json 字段）/ §4（plugin entry / version
+                      优先级）/ §5（plugin source 5 类）；mcp-servers 协议 §1/§2（文件式、文件名=name）。
+SDK 设计 / Design: python-sdk docs/design-0.2.1-cli-marketplace-ux.md §3.2–3.5 / §3.3（bundled MCP server）。
+
+本模块是 **manifest 纯解析器**（无 git / 无 registry / 无 MCP manager 副作用），供 plugin install/enable
+（:mod:`a2c_smcp.computer.settings.installer`）消费。**刻意保持 leaf**：不 import
+:mod:`~a2c_smcp.computer.skills.staging`（staging 顶层 import ``settings.schema``——见 #62 循环导入教训；
+manifest 若反向耦合 staging 会把解析层卷入 settings/__init__ 的初始化环）。与 staging 私有 manifest 读取器
+（``_read_marketplace_manifest`` 等）存在**轻度重复**：这是为隔离循环导入风险刻意付出的代价（#63 边界决策）。
+This is a pure manifest parser (no git / registry / MCP side effects), consumed by the plugin installer.
+Kept intentionally leaf (no staging import) to avoid the settings/__init__ circular-import trap (#62).
+
+**显式延后 / Deferred**：
+- **bundled MCP server inputs.json 入池消歧**（§9.3 D2 前缀）归 #65——本模块**枚举 server 时排除**
+  ``inputs.json``，不解析 inputs 池。
+- **strict mode 组件路径覆写 / 冲突检测**（§3.4/§3.5）归 #80——本模块按约定路径解析，不做 strict 校验。
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+from pydantic import TypeAdapter, ValidationError
+
+from a2c_smcp.computer.mcp_clients.model import MCPServerConfig
+from a2c_smcp.computer.skills.sources import DEFAULT_PLUGIN_ROOT
+from a2c_smcp.utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+# manifest 布局常量（协议 marketplace-v1 §2.1/§3.1 + mcp-servers §1）/ manifest layout constants。
+MARKETPLACE_MANIFEST_DIR = ".tfrobot-plugin"  # marketplace.json / plugin.json 所在目录（镜像 CC .claude-plugin）
+MARKETPLACE_MANIFEST = "marketplace.json"  # 仓库级 manifest
+PLUGIN_MANIFEST = "plugin.json"  # plugin 级 manifest（仅元数据）
+MCP_SERVERS_SUBDIR = "mcp-servers"  # plugin 携带 MCP server 的文件式子树（§3.3）
+MCP_INPUTS_FILENAME = "inputs.json"  # plugin 范围 inputs 池定义（枚举 server 时排除；入池归 #65）
+
+# 单点构造校验入口：dict → MCPServerConfig union（按 type 分型，pydantic v2）/ Single dict→config adapter.
+_MCP_SERVER_ADAPTER: TypeAdapter[MCPServerConfig] = TypeAdapter(MCPServerConfig)
+
+
+class PluginManifestError(Exception):
+    """manifest / mcp-servers 文件解析或校验失败（致命，§3.3：JSON 解析失败不降级）/ Manifest parse/validate failure (fatal)."""
+
+
+# ── JSON 读取（leaf-local；与 staging 同语义，刻意不复用以保持 leaf）/ leaf-local JSON read ──────────
+def _read_json_object(path: Path, *, what: str) -> dict[str, Any]:
+    """读 JSON 文件并要求根为对象 / Read a JSON file requiring an object root（失败 → :class:`PluginManifestError`）。"""
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as e:
+        raise PluginManifestError(f"{what} unreadable/invalid at {path}: {e}") from e
+    if not isinstance(data, dict):
+        raise PluginManifestError(f"{what} root is not an object: {path}")
+    return data
+
+
+# ── marketplace.json（仓库级）/ marketplace-level manifest ────────────────────
+def read_marketplace_manifest(catalog_dir: Path) -> dict[str, Any]:
+    """读 ``<catalog>/.tfrobot-plugin/marketplace.json``（缺失/损坏 → 抛）/ Read the marketplace manifest (raise if absent)。"""
+    path = catalog_dir / MARKETPLACE_MANIFEST_DIR / MARKETPLACE_MANIFEST
+    if not path.is_file():
+        raise PluginManifestError(f"marketplace manifest not found: {path}")
+    return _read_json_object(path, what="marketplace manifest")
+
+
+def iter_plugin_entries(manifest: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+    """取 ``manifest.plugins`` 中的对象条目（非数组 → []，非对象条目跳过）/ Object entries under ``manifest.plugins``。"""
+    plugins = manifest.get("plugins")
+    if not isinstance(plugins, Sequence) or isinstance(plugins, str | bytes):
+        return []
+    return [e for e in plugins if isinstance(e, Mapping)]
+
+
+def find_plugin_entry(manifest: Mapping[str, Any], plugin_name: str) -> Mapping[str, Any] | None:
+    """按 ``entry.name == plugin_name`` 定位 plugin 条目（marketplace-v1 §4.1）/ Locate a plugin entry by name。"""
+    for entry in iter_plugin_entries(manifest):
+        name = entry.get("name")
+        if isinstance(name, str) and name.strip() == plugin_name:
+            return entry
+    return None
+
+
+def plugin_root_base(manifest: Mapping[str, Any]) -> str:
+    """取 ``metadata.pluginRoot``（缺省 :data:`DEFAULT_PLUGIN_ROOT`）/ Resolve the pluginRoot base prefix。"""
+    md = manifest.get("metadata")
+    if isinstance(md, Mapping):
+        pr = md.get("pluginRoot")
+        if isinstance(pr, str) and pr.strip():
+            return pr.strip()
+    return DEFAULT_PLUGIN_ROOT
+
+
+# ── plugin.json（plugin 级，仅元数据）/ plugin-level metadata ──────────────────
+def read_plugin_metadata(plugin_root: Path) -> dict[str, Any]:
+    """读 ``<plugin>/.tfrobot-plugin/plugin.json``（best-effort，缺失/损坏 → ``{}``）/ Read plugin.json metadata best-effort。"""
+    path = plugin_root / MARKETPLACE_MANIFEST_DIR / PLUGIN_MANIFEST
+    if not path.is_file():
+        return {}
+    try:
+        return _read_json_object(path, what="plugin manifest")
+    except PluginManifestError as e:
+        # plugin.json 仅供 version / 显示名兜底，损坏不致命（SKILL/server 由路径推导）。
+        logger.warning("plugin manifest ignored (%s)", e)
+        return {}
+
+
+def resolve_plugin_version(entry: Mapping[str, Any], plugin_metadata: Mapping[str, Any], fallback_sha: str | None) -> str | None:
+    """version 优先级：entry.version > plugin.json.version > git commit SHA（marketplace-v1 §4.2）/ Resolve plugin version。"""
+    for src in (entry, plugin_metadata):
+        v = src.get("version")
+        if isinstance(v, str) and v.strip():
+            return v.strip()
+    return fallback_sha
+
+
+# ── mcp-servers/<n>.json（plugin 携带 MCP server，文件式）/ bundled MCP server files ──────────
+def enumerate_bundled_server_files(plugin_root: Path) -> list[Path]:
+    """
+    列 ``<plugin>/mcp-servers/*.json``（根下**一级**，排除 ``inputs.json``，``sorted`` 确定序）/ List bundled server files。
+
+    无 ``mcp-servers/`` 目录 → ``[]``（plugin 不携带 MCP server，合法）。``inputs.json`` 是 plugin inputs 池
+    定义、非 server 配置，枚举时排除（入池归 #65）。
+    """
+    d = plugin_root / MCP_SERVERS_SUBDIR
+    if not d.is_dir():
+        return []
+    return sorted(p for p in d.iterdir() if p.is_file() and p.suffix == ".json" and p.name != MCP_INPUTS_FILENAME)
+
+
+def parse_bundled_server(path: Path) -> MCPServerConfig:
+    """
+    解析单个 ``mcp-servers/<name>.json`` → 校验后的 :class:`MCPServerConfig` / Parse one bundled server file。
+
+    强制**文件名（去 ``.json``）== 配置内 ``name``**（mcp-servers 协议 §1：文件名即 server 身份）；不一致 / 校验
+    失败 → :class:`PluginManifestError`（致命，install 原子前置条件）。
+    """
+    data = _read_json_object(path, what="bundled MCP server")
+    try:
+        cfg = _MCP_SERVER_ADAPTER.validate_python(data)
+    except ValidationError as e:
+        raise PluginManifestError(f"invalid MCP server config at {path}: {e}") from e
+    if cfg.name != path.stem:
+        raise PluginManifestError(
+            f"bundled MCP server filename stem {path.stem!r} != config name {cfg.name!r} at {path} "
+            "(mcp-servers protocol §1: filename = server identity)",
+        )
+    return cfg
+
+
+def load_bundled_servers(plugin_root: Path) -> list[MCPServerConfig]:
+    """
+    枚举并解析一个 plugin 的全部 bundled MCP server 配置 / Enumerate + parse all bundled MCP server configs。
+
+    **任一文件解析/校验失败即抛** :class:`PluginManifestError`——这是 plugin install「冲突预检前先全量解析、
+    畸形则原子失败」的承重前置（§10.6：不留半装）。无 server → ``[]``。
+    """
+    return [parse_bundled_server(p) for p in enumerate_bundled_server_files(plugin_root)]

--- a/a2c_smcp/computer/skills/staging.py
+++ b/a2c_smcp/computer/skills/staging.py
@@ -67,7 +67,6 @@ import asyncio
 import base64
 import hashlib
 import io
-import json
 import os
 import re
 import shutil
@@ -92,6 +91,15 @@ from a2c_smcp.computer.skills.home import (
     user_dropin_root,
     workdir_skill_root,
 )
+from a2c_smcp.computer.skills.manifest import (
+    PluginManifestError,
+    read_marketplace_manifest,
+    read_plugin_metadata,
+    resolve_plugin_version,
+)
+from a2c_smcp.computer.skills.manifest import (
+    plugin_root_base as resolve_plugin_root_base,
+)
 from a2c_smcp.computer.skills.naming import (
     SkillNameError,
     normalize_mcp_server_segment,
@@ -101,7 +109,6 @@ from a2c_smcp.computer.skills.naming import (
 )
 from a2c_smcp.computer.skills.registry import SkillRegistry
 from a2c_smcp.computer.skills.sources import (
-    DEFAULT_PLUGIN_ROOT,
     GitCloneSpec,
     LocalPluginSource,
     SkillSourceError,
@@ -123,10 +130,7 @@ SKILL_MD = "SKILL.md"
 SKILL_URI_PREFIX = "skill://"
 _MCP_SOURCE_MODES = frozenset({"mounted", "archive", "resources"})
 
-# marketplace 布局常量 / marketplace layout constants（协议 marketplace-v1 §2.1 / §3.1 / §6）。
-MARKETPLACE_MANIFEST_DIR = ".tfrobot-plugin"  # marketplace.json / plugin.json 所在目录（嵌套，镜像 CC .claude-plugin）
-MARKETPLACE_MANIFEST = "marketplace.json"  # 仓库级 manifest
-PLUGIN_MANIFEST = "plugin.json"  # plugin 级 manifest
+# marketplace 布局常量 / marketplace layout constants（marketplace.json/plugin.json 解析见 :mod:`skills.manifest`）。
 SKILLS_SUBDIR = "skills"  # plugin 内 SKILL 子树约定目录（SKILL 协议 §2）
 # 独立 clone 的 plugin（url/github/cnb/git-subdir）落点命名空间——置于 marketplace/ 下以 "." 起首的目录，
 # 与 catalog clone（<home>/marketplace/<mp>/）物理隔离、且不与 kebab marketplace 名冲突。
@@ -819,49 +823,7 @@ async def _git_head_sha(dest: Path, *, timeout: float, env: Mapping[str, str] | 
         return None
 
 
-# ── marketplace.json / plugin.json 解析 / manifest parsing ───────────────────
-def _read_json_object(path: Path, *, what: str) -> dict[str, Any]:
-    """读 JSON 文件并要求根为对象 / Read a JSON file requiring an object root（失败 → :class:`SkillStagingError`）。"""
-    try:
-        data = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as e:
-        raise SkillStagingError(f"{what} unreadable/invalid at {path}: {e}") from e
-    if not isinstance(data, dict):
-        raise SkillStagingError(f"{what} root is not an object: {path}")
-    return data
-
-
-def _read_marketplace_manifest(clone_dir: Path) -> dict[str, Any]:
-    """读 ``<clone>/.tfrobot-plugin/marketplace.json``（仓库级 manifest）/ Read the marketplace manifest。"""
-    path = clone_dir / MARKETPLACE_MANIFEST_DIR / MARKETPLACE_MANIFEST
-    if not path.is_file():
-        raise SkillStagingError(f"marketplace manifest not found: {path}")
-    return _read_json_object(path, what="marketplace manifest")
-
-
-def _read_plugin_manifest(plugin_root: Path) -> dict[str, Any]:
-    """读 ``<plugin>/.tfrobot-plugin/plugin.json``（best-effort，缺失 → ``{}``）/ Read plugin.json best-effort。"""
-    path = plugin_root / MARKETPLACE_MANIFEST_DIR / PLUGIN_MANIFEST
-    if not path.is_file():
-        return {}
-    try:
-        return _read_json_object(path, what="plugin manifest")
-    except SkillStagingError as e:
-        # plugin.json 仅供 version / 显示名兜底，损坏不致命（SKILL 由路径推导）。
-        logger.warning("plugin manifest ignored (%s)", e)
-        return {}
-
-
-def _plugin_root_base(manifest: Mapping[str, Any]) -> str:
-    """取 ``metadata.pluginRoot``（缺省 :data:`~a2c_smcp.computer.skills.sources.DEFAULT_PLUGIN_ROOT`）/ Resolve pluginRoot。"""
-    md = manifest.get("metadata")
-    if isinstance(md, Mapping):
-        pr = md.get("pluginRoot")
-        if isinstance(pr, str) and pr.strip():
-            return pr.strip()
-    return DEFAULT_PLUGIN_ROOT
-
-
+# ── plugin entry 解析 / plugin-entry parsing（marketplace.json/plugin.json/version 解析见 :mod:`skills.manifest`）──
 def _entry_plugin_name(entry: Mapping[str, Any]) -> str:
     """plugin 条目 ID = entry.name（marketplace-v1 §4.1 必填；kebab 校验交 name 合成）/ The plugin entry name。"""
     name = entry.get("name")
@@ -1049,18 +1011,9 @@ async def _stage_one_plugin(
         timeout=timeout,
         env=env,
     )
-    plugin_manifest = _read_plugin_manifest(plugin_root)
-    version = _resolve_plugin_version(entry, plugin_manifest, version_fallback)
+    plugin_manifest = read_plugin_metadata(plugin_root)
+    version = resolve_plugin_version(entry, plugin_manifest, version_fallback)
     return _scan_and_register_plugin_skills(marketplace, plugin_name, plugin_root, version, registry, seen)
-
-
-def _resolve_plugin_version(entry: Mapping[str, Any], plugin_manifest: Mapping[str, Any], fallback_sha: str | None) -> str | None:
-    """version 优先级：entry.version > plugin.json.version > git commit SHA（marketplace-v1 §4.2）/ Resolve plugin version。"""
-    for src in (entry, plugin_manifest):
-        v = src.get("version")
-        if isinstance(v, str) and v.strip():
-            return v.strip()
-    return fallback_sha
 
 
 def _record_known_marketplace(
@@ -1184,8 +1137,8 @@ async def stage_marketplace_skills(
     _record_known_marketplace(name, source, clone_dir, commit_sha, auto_update, home, env, changed=changed)
 
     try:
-        manifest = _read_marketplace_manifest(clone_dir)
-    except SkillStagingError as e:
+        manifest = read_marketplace_manifest(clone_dir)
+    except PluginManifestError as e:
         logger.error("marketplace %r manifest invalid, skipped (clone kept): %s", name, e)
         return registered
 
@@ -1194,7 +1147,7 @@ async def stage_marketplace_skills(
         logger.error("marketplace %r manifest 'plugins' is not an array, skipped: %s", name, type(plugins).__name__)
         return registered
 
-    plugin_root_base = _plugin_root_base(manifest)
+    plugin_root_base = resolve_plugin_root_base(manifest)
     seen: set[str] = set()
     for entry in plugins:
         if not isinstance(entry, Mapping):

--- a/a2c_smcp/computer/skills/staging.py
+++ b/a2c_smcp/computer/skills/staging.py
@@ -962,22 +962,35 @@ def _scan_and_register_plugin_skills(
     return registered
 
 
-async def _stage_one_plugin(
+async def locate_plugin_root(
     marketplace: str,
     plugin_name: str,
     entry: Mapping[str, Any],
     catalog_dir: Path,
     plugin_root_base: str,
     home: Path,
-    registry: SkillRegistry,
-    seen: set[str],
     catalog_sha: str | None,
     *,
-    refresh: bool,
-    timeout: float,
-    env: Mapping[str, str] | None,
-) -> list[str]:
-    """解析 plugin source → 定位 plugin 根 → 扫描注册其 SKILL / Resolve source, locate root, scan & register。"""
+    refresh: bool = False,
+    timeout: float = DEFAULT_GIT_TIMEOUT,
+    env: Mapping[str, str] | None = None,
+) -> tuple[Path, str | None]:
+    """
+    解析 plugin source 并 clone/定位其根，返回 ``(plugin_root, version_fallback_sha)`` / Resolve & clone/locate a plugin's root。
+
+    plugin install（:mod:`a2c_smcp.computer.settings.installer`）与 :func:`_stage_one_plugin` 共用本原语，
+    避免 plugin source 5 类解析（相对路径就地 / ``git-subdir`` sparse / ``url``·``github``·``cnb`` 独立 clone）
+    重复实现。**不**扫描 / 注册 SKILL、**不**读 plugin.json——纯定位（install 需先拿 plugin 根再读
+    ``mcp-servers/`` 做冲突预检，故定位须与 skill 扫描解耦）。
+
+    - 相对路径（:class:`LocalPluginSource`）：就地在 catalog clone 内，越界保护（``is_within`` 词法判定）；
+      ``version_fallback = catalog_sha``。
+    - 独立 clone（:class:`GitCloneSpec`）：落 ``<home>/marketplace/.plugins/<mp>/<plugin>/``；复用条件——
+      sha 锁版本既有 HEAD==pin 则复用、pin 变更则重 clone；非 sha 仅 ``refresh=False`` 复用。
+      ``version_fallback = HEAD``。
+
+    clone / source 解析失败 → :class:`SkillStagingError` / :class:`SkillSourceError`（上抛，调用方据失败降级）。
+    """
     raw_source = entry.get("source")
     if raw_source is None:
         raise SkillSourceError(dict(entry), "plugin entry missing required 'source'")
@@ -1005,7 +1018,37 @@ async def _stage_one_plugin(
 
     if not plugin_root.is_dir():
         raise SkillStagingError(f"plugin root not found after resolve: {plugin_root}")
+    return plugin_root, version_fallback
 
+
+async def _stage_one_plugin(
+    marketplace: str,
+    plugin_name: str,
+    entry: Mapping[str, Any],
+    catalog_dir: Path,
+    plugin_root_base: str,
+    home: Path,
+    registry: SkillRegistry,
+    seen: set[str],
+    catalog_sha: str | None,
+    *,
+    refresh: bool,
+    timeout: float,
+    env: Mapping[str, str] | None,
+) -> list[str]:
+    """解析 plugin source → 定位 plugin 根 → 扫描注册其 SKILL / Resolve source, locate root, scan & register。"""
+    plugin_root, version_fallback = await locate_plugin_root(
+        marketplace,
+        plugin_name,
+        entry,
+        catalog_dir,
+        plugin_root_base,
+        home,
+        catalog_sha,
+        refresh=refresh,
+        timeout=timeout,
+        env=env,
+    )
     plugin_manifest = _read_plugin_manifest(plugin_root)
     version = _resolve_plugin_version(entry, plugin_manifest, version_fallback)
     return _scan_and_register_plugin_skills(marketplace, plugin_name, plugin_root, version, registry, seen)

--- a/tests/integration_tests/computer/settings/test_installer.py
+++ b/tests/integration_tests/computer/settings/test_installer.py
@@ -1,0 +1,193 @@
+# -*- coding: utf-8 -*-
+# filename: test_installer.py
+# @Time    : 2026/05/26
+# @Author  : JQQ
+# @Email   : jqq1716@gmail.com
+# @Software: PyCharm
+"""
+Plugin installer 本地裸仓集成测试（v0.2.1 #63）—— 真 git clone + 真 skill 注册 + bundled MCP 解析
+Plugin installer local bare-repo integration tests: real git clone + real skill registration + bundled MCP parse.
+
+SDK 设计 / Design: python-sdk docs/design-0.2.1-cli-marketplace-ux.md §4.3 / §6.2 / §10.6。
+
+测试意图 / Test intentions（本地 ``git init --bare`` 裸仓作 file:// 源，无网络；plugin 同时含
+``skills/<s>/SKILL.md`` + ``mcp-servers/<n>.json``；MCP 注入用录制式替身捕获校验后的 MCPServerConfig）:
+- install 端到端：真 clone catalog → 注册 plugin skills + 解析 bundled server + 写 installed_plugins.json。
+- uninstall 端到端：删 installPath 树 + 注销 skills + 级联 remove server + 删账本记录。
+- install→disable→enable：**不重 clone**（哨兵保留）+ skill 复活 + server 重挂。
+"""
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from a2c_smcp.computer.settings.installer import disable_plugin, enable_plugin, install_plugin, uninstall_plugin
+from a2c_smcp.computer.settings.store import load_installed_plugins
+from a2c_smcp.computer.skills.home import marketplace_skill_dir
+from a2c_smcp.computer.skills.registry import SkillRegistry
+from a2c_smcp.computer.skills.staging import stage_marketplace_skills
+
+requires_git = pytest.mark.skipif(shutil.which("git") is None, reason="requires the git binary")
+
+_GIT_IDENTITY = ["-c", "user.email=test@example.com", "-c", "user.name=Test", "-c", "commit.gpgsign=false"]
+
+
+# ── 本地裸仓 fixture 辅助 / local bare-repo helpers ──────────────────────────
+def _git(cwd: Path, *args: str) -> None:
+    subprocess.run(["git", *_GIT_IDENTITY, *args], cwd=str(cwd), check=True, capture_output=True, text=True)
+
+
+def _write(root: Path, files: dict[str, str]) -> None:
+    for rel, content in files.items():
+        p = root / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content, encoding="utf-8")
+
+
+def _skill_md(name: str, description: str = "a skill") -> str:
+    return f"---\nname: {name}\ndescription: {description}\nlicense: MIT\n---\n# {name}\nbody\n"
+
+
+def _make_bare(tmp_path: Path, name: str, files: dict[str, str]) -> Path:
+    work = tmp_path / f"{name}-work"
+    work.mkdir(parents=True, exist_ok=True)
+    _git(work, "init", "-q", "-b", "main")
+    _write(work, files)
+    _git(work, "add", "-A")
+    _git(work, "commit", "-q", "-m", "init")
+    bare = tmp_path / f"{name}.git"
+    _git(tmp_path, "clone", "-q", "--bare", str(work), str(bare))
+    return bare
+
+
+def _url(p: Path) -> str:
+    return f"file://{p}"
+
+
+def _src(url: str) -> dict[str, str]:
+    return {"type": "git", "url": url}
+
+
+def _env(home: Path) -> dict[str, str]:
+    # A2C_SKILL_HOME 供物化路径；XDG_CONFIG_HOME 重定向 settings.json（隔离 disable/enable 写真实 ~/.config）。
+    return {**os.environ, "A2C_SKILL_HOME": str(home), "XDG_CONFIG_HOME": str(home / "cfg")}
+
+
+def _home(tmp_path: Path) -> Path:
+    h = tmp_path / "skill-home"
+    h.mkdir()
+    return h
+
+
+def _plugin_files() -> dict[str, str]:
+    """单 plugin（audit）含 1 skill（lint）+ 1 bundled MCP server（figma）的标准 marketplace 布局。"""
+    manifest = {
+        "name": "acme-skills",
+        "owner": {"name": "Acme"},
+        "metadata": {"pluginRoot": "./plugins"},
+        "plugins": [{"name": "audit", "source": "audit", "version": "1.2.0"}],
+    }
+    server = {"name": "figma", "type": "stdio", "server_parameters": {"command": "echo"}}
+    return {
+        ".tfrobot-plugin/marketplace.json": json.dumps(manifest),
+        "plugins/audit/skills/lint/SKILL.md": _skill_md("lint"),
+        "plugins/audit/mcp-servers/figma.json": json.dumps(server),
+    }
+
+
+async def _add_marketplace(home: Path, bare: Path, env: dict[str, str]) -> None:
+    """模拟 ``marketplace add``：clone catalog + 写 known_marketplaces.json（plugin_filter=空 → 不注册 skill）。"""
+    await stage_marketplace_skills("acme-skills", _src(_url(bare)), SkillRegistry(), home, plugin_filter=set(), env=env)
+
+
+# ── install 端到端 / end-to-end ──────────────────────────────────────────────
+@requires_git
+async def test_install_end_to_end(tmp_path: Path) -> None:
+    bare = _make_bare(tmp_path, "acme", _plugin_files())
+    home = _home(tmp_path)
+    env = _env(home)
+    await _add_marketplace(home, bare, env)
+    reg = SkillRegistry()
+    captured: list[str] = []
+
+    async def _register(cfg) -> None:
+        captured.append(cfg.name)
+
+    record = await install_plugin(
+        "audit@acme-skills", reg, home, env=env, existing_server_names=lambda: set(), register_server=_register,
+    )
+
+    assert record["bundledMcpServers"] == ["figma"]
+    assert record["version"] == "1.2.0"
+    assert reg.resolve("audit:lint") is not None  # 真 skill 注册
+    assert captured == ["figma"]  # bundled server 解析+注册
+    assert "audit@acme-skills" in load_installed_plugins(home=home)["plugins"]
+
+
+@requires_git
+async def test_uninstall_end_to_end(tmp_path: Path) -> None:
+    bare = _make_bare(tmp_path, "acme", _plugin_files())
+    home = _home(tmp_path)
+    env = _env(home)
+    await _add_marketplace(home, bare, env)
+    reg = SkillRegistry()
+    removed: list[str] = []
+
+    async def _register(cfg) -> None:
+        pass
+
+    async def _remove(name: str) -> None:
+        removed.append(name)
+
+    await install_plugin("audit@acme-skills", reg, home, env=env, existing_server_names=lambda: set(), register_server=_register)
+    install_path = Path(load_installed_plugins(home=home)["plugins"]["audit@acme-skills"][0]["installPath"])
+    assert install_path.exists() and reg.resolve("audit:lint") is not None
+
+    ok = await uninstall_plugin("audit@acme-skills", reg, home, env=env, remove_server=_remove)
+
+    assert ok is True
+    assert removed == ["figma"]  # 级联 stop+remove
+    assert not install_path.exists()  # installPath 树清除
+    assert reg.resolve("audit:lint") is None  # skills 注销
+    assert "audit@acme-skills" not in load_installed_plugins(home=home)["plugins"]  # 账本记录删除
+
+
+@requires_git
+async def test_install_disable_enable_no_reclone(tmp_path: Path) -> None:
+    bare = _make_bare(tmp_path, "acme", _plugin_files())
+    home = _home(tmp_path)
+    env = _env(home)
+    await _add_marketplace(home, bare, env)
+    reg = SkillRegistry()
+    captured: list[str] = []
+    removed: list[str] = []
+
+    async def _register(cfg) -> None:
+        captured.append(cfg.name)
+
+    async def _remove(name: str) -> None:
+        removed.append(name)
+
+    await install_plugin("audit@acme-skills", reg, home, env=env, existing_server_names=lambda: set(), register_server=_register)
+    assert reg.resolve("audit:lint") is not None
+    # 哨兵：植入 catalog clone 内 plugin 根，用于检测 enable 是否误重 clone（重 clone 会 wipe）。
+    sentinel = marketplace_skill_dir(home, "acme-skills") / "plugins" / "audit" / "SENTINEL"
+    sentinel.write_text("x", encoding="utf-8")
+
+    # disable：摘 server + orphan skill
+    await disable_plugin("audit@acme-skills", reg, home, env=env, remove_server=_remove)
+    assert reg.is_orphan("audit:lint") and removed == ["figma"]
+    captured.clear()
+
+    # enable：复活 skill + 重挂 server，且不重 clone
+    await enable_plugin("audit@acme-skills", reg, home, env=env, existing_server_names=lambda: set(), register_server=_register)
+
+    assert sentinel.exists()  # 未重 clone（哨兵保留 → 复用既有 clone 树）
+    assert reg.resolve("audit:lint") is not None  # 孤儿复活
+    assert captured == ["figma"]  # server 重挂
+    settings = json.loads((home / "cfg" / "a2c" / "settings.json").read_text(encoding="utf-8"))
+    assert settings["enabledPlugins"]["audit@acme-skills"] is True

--- a/tests/unit_tests/computer/settings/test_installer.py
+++ b/tests/unit_tests/computer/settings/test_installer.py
@@ -1,0 +1,404 @@
+# -*- coding: utf-8 -*-
+# filename: test_installer.py
+# @Time    : 2026/05/26
+# @Author  : JQQ
+# @Email   : jqq1716@gmail.com
+# @Software: PyCharm
+"""
+Plugin installer 单元测试（v0.2.1 #63）—— install/uninstall/enable/disable 编排（mock git staging + 注入 MCP）
+Plugin installer unit tests: install/uninstall/enable/disable orchestration (stage mocked, MCP injected).
+
+SDK 设计 / Design: python-sdk docs/design-0.2.1-cli-marketplace-ux.md §3.3/§4.3/§6.2/§7.2/§10.6。
+
+测试意图 / Test intentions（不依赖 git——用相对路径 plugin（locate_plugin_root 无 git）+ monkeypatch
+``stage_marketplace_skills`` + 注入回调记录 MCP 调用；settings 写经 ``XDG_CONFIG_HOME`` 重定向隔离）:
+- install：外来同名硬抛+原子（零变更）/ 自有同名幂等 / happy 写账本+注册 / 过闸后失败补偿回滚
+  （register 失败 / stage 失败两路）/ ledger-only（无注入）/ 未添加 mp / catalog 未 clone / 非法 id。
+- uninstall：级联 stop+remove + 注销 + 删记录 + 删 installPath 树 / --keep-servers / 未安装 no-op。
+- disable：写 enabledPlugins=false + 摘 server + orphan skill（可复原）/ scope 路由 / 非法 scope。
+- enable：写 true + 复活 skill + 重挂 server / 未安装抛 / 外来同名冲突且 settings 未写（原子）。
+"""
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from a2c_smcp.computer.settings.installer import (
+    MCPServerNameConflictError,
+    PluginInstallError,
+    disable_plugin,
+    enable_plugin,
+    install_plugin,
+    uninstall_plugin,
+)
+from a2c_smcp.computer.settings.scope import user_settings_path, workdir_project_settings_path
+from a2c_smcp.computer.settings.store import load_installed_plugins, save_installed_plugins, save_known_marketplaces
+from a2c_smcp.computer.skills.home import SOURCE_MARKETPLACE, marketplace_skill_dir
+from a2c_smcp.computer.skills.registry import SkillRegistry
+
+_SRC = {"type": "git", "url": "https://example.com/acme.git"}
+_STAGE = "a2c_smcp.computer.settings.installer.stage_marketplace_skills"
+
+
+# ── 辅助 / helpers ───────────────────────────────────────────────────────────
+def _home(tmp_path: Path) -> Path:
+    h = tmp_path / "skill-home"
+    h.mkdir()
+    return h
+
+
+def _env(tmp_path: Path) -> dict[str, str]:
+    """重定向 XDG_CONFIG_HOME → tmp，隔离 user settings.json 写（防写真实 ~/.config）。"""
+    return {**os.environ, "XDG_CONFIG_HOME": str(tmp_path / "cfg")}
+
+
+def _write_json(path: Path, obj: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(obj), encoding="utf-8")
+
+
+def _stdio(name: str, command: str = "node") -> dict:
+    return {"name": name, "type": "stdio", "server_parameters": {"command": command}}
+
+
+def _setup_catalog(home: Path, mp: str, plugin: str, *, servers: list[str], commit: str = "abc123") -> Path:
+    """
+    造真实 catalog 树（相对源 plugin，locate_plugin_root 无 git）+ marketplace.json + plugin mcp-servers/，
+    并 seed known_marketplaces。返回 plugin 根 ``<catalog>/plugins/<plugin>``。
+    """
+    catalog = marketplace_skill_dir(home, mp)
+    manifest = {
+        "name": mp,
+        "owner": {"name": "X"},
+        "metadata": {"pluginRoot": "./plugins"},
+        "plugins": [{"name": plugin, "source": plugin, "version": "1.2.0"}],
+    }
+    _write_json(catalog / ".tfrobot-plugin" / "marketplace.json", manifest)
+    plugin_root = catalog / "plugins" / plugin
+    plugin_root.mkdir(parents=True, exist_ok=True)
+    for sname in servers:
+        _write_json(plugin_root / "mcp-servers" / f"{sname}.json", _stdio(sname))
+    save_known_marketplaces(
+        {"version": 1, "marketplaces": {mp: {"source": _SRC, "installLocation": str(catalog.resolve()), "commitSha": commit}}},
+        home=home,
+    )
+    return plugin_root
+
+
+def _seed_installed(home: Path, plugins: dict[str, list[dict]]) -> None:
+    save_installed_plugins({"version": 1, "plugins": plugins}, home=home)
+
+
+def _fake_stage(calls: list[dict], *, fail: bool = False, register_skill: bool = True):
+    """替身 stage：记录入参；可选注册 ``<plugin>:lint`` SKILL（供 orphan/recover/rollback 断言）；可选抛错。"""
+
+    async def _stage(name, source, registry, home, *, plugin_filter=None, auto_update=False, refresh=False, timeout=0.0, env=None):
+        calls.append({"name": name, "plugin_filter": set(plugin_filter or ()), "refresh": refresh})
+        if register_skill:
+            for plugin in plugin_filter or set():
+                registry.register_or_update(
+                    {
+                        "name": f"{plugin}:lint",
+                        "source": f"{SOURCE_MARKETPLACE}:{name}",
+                        "path": str(marketplace_skill_dir(home, name).resolve()),
+                    },
+                )
+        if fail:
+            raise RuntimeError("stage boom")
+        return [f"{p}:lint" for p in plugin_filter or set()]
+
+    return _stage
+
+
+class _FakeMCP:
+    """记录 MCP 注入回调调用 / Records injected MCP callback invocations。"""
+
+    def __init__(self, existing: set[str] | None = None) -> None:
+        self.existing: set[str] = set(existing or ())
+        self.registered: list[str] = []
+        self.removed: list[str] = []
+        self.fail_on: str | None = None  # 该 server 注册时抛错
+
+    def existing_names(self) -> set[str]:
+        return set(self.existing)
+
+    async def register(self, cfg) -> None:
+        if self.fail_on is not None and cfg.name == self.fail_on:
+            raise RuntimeError(f"register {cfg.name} boom")
+        self.registered.append(cfg.name)
+        self.existing.add(cfg.name)
+
+    async def remove(self, name: str) -> None:
+        self.removed.append(name)
+        self.existing.discard(name)
+
+
+# ── install ──────────────────────────────────────────────────────────────────
+async def test_install_happy_writes_ledger_and_registers(tmp_path: Path, monkeypatch) -> None:
+    home = _home(tmp_path)
+    _setup_catalog(home, "acme", "audit", servers=["figma"])
+    calls: list[dict] = []
+    monkeypatch.setattr(_STAGE, _fake_stage(calls))
+    mcp = _FakeMCP()
+    reg = SkillRegistry()
+
+    record = await install_plugin(
+        "audit@acme", reg, home, env=_env(tmp_path),
+        existing_server_names=mcp.existing_names, register_server=mcp.register, remove_server=mcp.remove,
+    )
+
+    assert record["scope"] == "user"
+    assert record["version"] == "1.2.0"  # entry.version 胜
+    assert record["commitSha"] == "abc123"
+    assert record["bundledMcpServers"] == ["figma"]
+    assert record["installPath"].replace("\\", "/").endswith("marketplace/acme/plugins/audit")
+    assert mcp.registered == ["figma"]
+    assert calls[0]["plugin_filter"] == {"audit"} and calls[0]["refresh"] is False
+    assert reg.resolve("audit:lint") is not None
+    ipf = load_installed_plugins(home=home)["plugins"]
+    assert ipf["audit@acme"][0]["bundledMcpServers"] == ["figma"]
+
+
+async def test_install_foreign_conflict_is_atomic(tmp_path: Path, monkeypatch) -> None:
+    home = _home(tmp_path)
+    _setup_catalog(home, "acme", "audit", servers=["figma"])
+    calls: list[dict] = []
+    monkeypatch.setattr(_STAGE, _fake_stage(calls))
+    mcp = _FakeMCP(existing={"figma"})  # 外来 figma 已存在
+    reg = SkillRegistry()
+
+    with pytest.raises(MCPServerNameConflictError, match="figma"):
+        await install_plugin(
+            "audit@acme", reg, home, env=_env(tmp_path),
+            existing_server_names=mcp.existing_names, register_server=mcp.register, remove_server=mcp.remove,
+        )
+
+    assert mcp.registered == []  # 零注册
+    assert calls == []  # stage 未调用（冲突闸门在变更前）
+    assert reg.resolve("audit:lint") is None
+    assert "audit@acme" not in load_installed_plugins(home=home)["plugins"]  # 不写账本
+
+
+async def test_install_own_same_name_is_idempotent(tmp_path: Path, monkeypatch) -> None:
+    home = _home(tmp_path)
+    install_path = _setup_catalog(home, "acme", "audit", servers=["figma"])
+    _seed_installed(home, {"audit@acme": [{"scope": "user", "installPath": str(install_path), "bundledMcpServers": ["figma"]}]})
+    monkeypatch.setattr(_STAGE, _fake_stage([]))
+    mcp = _FakeMCP(existing={"figma"})  # figma 存在但归本 plugin 自有 → 不冲突
+    reg = SkillRegistry()
+
+    record = await install_plugin(
+        "audit@acme", reg, home, env=_env(tmp_path),
+        existing_server_names=mcp.existing_names, register_server=mcp.register, remove_server=mcp.remove,
+    )
+
+    assert mcp.registered == ["figma"]  # 幂等再注册（overwrite 自有）
+    assert record["bundledMcpServers"] == ["figma"]
+
+
+async def test_install_rolls_back_on_server_register_failure(tmp_path: Path, monkeypatch) -> None:
+    home = _home(tmp_path)
+    _setup_catalog(home, "acme", "audit", servers=["alpha", "beta"])
+    calls: list[dict] = []
+    monkeypatch.setattr(_STAGE, _fake_stage(calls))
+    mcp = _FakeMCP()
+    mcp.fail_on = "beta"  # 第二个 server 注册失败
+    reg = SkillRegistry()
+
+    with pytest.raises(RuntimeError, match="beta"):
+        await install_plugin(
+            "audit@acme", reg, home, env=_env(tmp_path),
+            existing_server_names=mcp.existing_names, register_server=mcp.register, remove_server=mcp.remove,
+        )
+
+    assert mcp.removed == ["alpha"]  # 已注册的 alpha 被回滚移除
+    assert calls == []  # stage 在 server 循环之后 → 未到达
+    assert "audit@acme" not in load_installed_plugins(home=home)["plugins"]  # 账本未写
+
+
+async def test_install_rolls_back_on_stage_failure(tmp_path: Path, monkeypatch) -> None:
+    home = _home(tmp_path)
+    _setup_catalog(home, "acme", "audit", servers=["figma"])
+    monkeypatch.setattr(_STAGE, _fake_stage([], fail=True))  # stage 先注册 skill 再抛
+    mcp = _FakeMCP()
+    reg = SkillRegistry()
+
+    with pytest.raises(RuntimeError, match="stage boom"):
+        await install_plugin(
+            "audit@acme", reg, home, env=_env(tmp_path),
+            existing_server_names=mcp.existing_names, register_server=mcp.register, remove_server=mcp.remove,
+        )
+
+    assert mcp.registered == ["figma"] and mcp.removed == ["figma"]  # 注册后回滚移除
+    assert reg.resolve("audit:lint") is None  # 已注册 skill 回滚注销
+    assert "audit@acme" not in load_installed_plugins(home=home)["plugins"]
+
+
+async def test_install_ledger_only_without_injection(tmp_path: Path, monkeypatch) -> None:
+    home = _home(tmp_path)
+    _setup_catalog(home, "acme", "audit", servers=["figma"])
+    monkeypatch.setattr(_STAGE, _fake_stage([]))
+    reg = SkillRegistry()
+
+    record = await install_plugin("audit@acme", reg, home, env=_env(tmp_path))  # 无注入
+
+    assert record["bundledMcpServers"] == ["figma"]  # 解析+记录（即使未注册 server）
+    assert "audit@acme" in load_installed_plugins(home=home)["plugins"]
+
+
+async def test_install_invalid_plugin_id_raises(tmp_path: Path) -> None:
+    with pytest.raises(PluginInstallError, match="invalid plugin id"):
+        await install_plugin("no-at-sign", SkillRegistry(), _home(tmp_path))
+
+
+async def test_install_unknown_marketplace_raises(tmp_path: Path) -> None:
+    with pytest.raises(PluginInstallError, match="not added"):
+        await install_plugin("audit@acme", SkillRegistry(), _home(tmp_path))
+
+
+async def test_install_catalog_not_cloned_raises(tmp_path: Path) -> None:
+    home = _home(tmp_path)
+    save_known_marketplaces({"version": 1, "marketplaces": {"acme": {"source": _SRC, "installLocation": "x"}}}, home=home)
+    with pytest.raises(PluginInstallError, match="catalog not cloned"):
+        await install_plugin("audit@acme", SkillRegistry(), home)
+
+
+# ── uninstall ─────────────────────────────────────────────────────────────────
+async def _install(home: Path, tmp_path: Path, monkeypatch, mcp: _FakeMCP, reg: SkillRegistry, *, servers: list[str]) -> Path:
+    """安装一个 plugin（happy）作为 uninstall/disable/enable 的前置；返回 installPath。"""
+    install_path = _setup_catalog(home, "acme", "audit", servers=servers)
+    monkeypatch.setattr(_STAGE, _fake_stage([]))
+    await install_plugin(
+        "audit@acme", reg, home, env=_env(tmp_path),
+        existing_server_names=mcp.existing_names, register_server=mcp.register, remove_server=mcp.remove,
+    )
+    return install_path
+
+
+async def test_uninstall_default_cascades(tmp_path: Path, monkeypatch) -> None:
+    home = _home(tmp_path)
+    mcp = _FakeMCP()
+    reg = SkillRegistry()
+    install_path = await _install(home, tmp_path, monkeypatch, mcp, reg, servers=["figma"])
+    assert install_path.exists()
+    mcp.removed.clear()
+
+    ok = await uninstall_plugin("audit@acme", reg, home, remove_server=mcp.remove)
+
+    assert ok is True
+    assert mcp.removed == ["figma"]  # 级联 stop+remove
+    assert reg.resolve("audit:lint") is None  # skills 注销
+    assert "audit@acme" not in load_installed_plugins(home=home)["plugins"]  # 记录删除
+    assert not install_path.exists()  # installPath 树清除
+
+
+async def test_uninstall_keep_servers_skips_teardown(tmp_path: Path, monkeypatch) -> None:
+    home = _home(tmp_path)
+    mcp = _FakeMCP()
+    reg = SkillRegistry()
+    await _install(home, tmp_path, monkeypatch, mcp, reg, servers=["figma"])
+    mcp.removed.clear()
+
+    ok = await uninstall_plugin("audit@acme", reg, home, keep_servers=True, remove_server=mcp.remove)
+
+    assert ok is True
+    assert mcp.removed == []  # 保留 server
+    assert reg.resolve("audit:lint") is None
+    assert "audit@acme" not in load_installed_plugins(home=home)["plugins"]
+
+
+async def test_uninstall_not_installed_is_noop(tmp_path: Path) -> None:
+    assert await uninstall_plugin("ghost@acme", SkillRegistry(), _home(tmp_path)) is False
+
+
+# ── disable ───────────────────────────────────────────────────────────────────
+async def test_disable_writes_flag_detaches_servers_orphans_skills(tmp_path: Path, monkeypatch) -> None:
+    home = _home(tmp_path)
+    env = _env(tmp_path)
+    mcp = _FakeMCP()
+    reg = SkillRegistry()
+    await _install(home, tmp_path, monkeypatch, mcp, reg, servers=["figma"])
+    mcp.removed.clear()
+
+    await disable_plugin("audit@acme", reg, home, env=env, remove_server=mcp.remove)
+
+    settings = json.loads(user_settings_path(env).read_text(encoding="utf-8"))
+    assert settings["enabledPlugins"]["audit@acme"] is False
+    assert mcp.removed == ["figma"]  # 停+摘 bundled server
+    assert reg.is_orphan("audit:lint") is True  # 隐藏（孤儿）
+    assert reg.resolve("audit:lint") is None  # 活跃集排除
+    assert "audit:lint" in reg  # 物化层保留（仍注册、可复原）
+
+
+async def test_disable_project_scope_writes_workdir_settings(tmp_path: Path, monkeypatch) -> None:
+    home = _home(tmp_path)
+    env = _env(tmp_path)
+    workdir = tmp_path / "proj"
+    workdir.mkdir()
+    _setup_catalog(home, "acme", "audit", servers=[])
+    audit_path = str(marketplace_skill_dir(home, "acme") / "plugins" / "audit")
+    _seed_installed(home, {"audit@acme": [{"scope": "project", "installPath": audit_path}]})
+    monkeypatch.setattr(_STAGE, _fake_stage([]))
+
+    await disable_plugin("audit@acme", SkillRegistry(), home, scope="project", project_path=str(workdir), env=env)
+
+    settings = json.loads(workdir_project_settings_path(workdir).read_text(encoding="utf-8"))
+    assert settings["enabledPlugins"]["audit@acme"] is False
+
+
+async def test_disable_project_scope_requires_project_path(tmp_path: Path) -> None:
+    with pytest.raises(PluginInstallError, match="project_path"):
+        await disable_plugin("audit@acme", SkillRegistry(), _home(tmp_path), scope="project", env=_env(tmp_path))
+
+
+async def test_disable_managed_scope_rejected(tmp_path: Path) -> None:
+    with pytest.raises(PluginInstallError, match="writable"):
+        await disable_plugin("audit@acme", SkillRegistry(), _home(tmp_path), scope="managed", env=_env(tmp_path))
+
+
+# ── enable ────────────────────────────────────────────────────────────────────
+async def test_enable_recovers_skills_and_remounts_servers(tmp_path: Path, monkeypatch) -> None:
+    home = _home(tmp_path)
+    env = _env(tmp_path)
+    mcp = _FakeMCP()
+    reg = SkillRegistry()
+    await _install(home, tmp_path, monkeypatch, mcp, reg, servers=["figma"])
+    await disable_plugin("audit@acme", reg, home, env=env, remove_server=mcp.remove)
+    assert reg.is_orphan("audit:lint")
+    mcp.registered.clear()
+
+    await enable_plugin(
+        "audit@acme", reg, home, env=env,
+        existing_server_names=mcp.existing_names, register_server=mcp.register,
+    )
+
+    settings = json.loads(user_settings_path(env).read_text(encoding="utf-8"))
+    assert settings["enabledPlugins"]["audit@acme"] is True
+    assert reg.resolve("audit:lint") is not None  # 孤儿复活
+    assert mcp.registered == ["figma"]  # server 重挂
+
+
+async def test_enable_not_installed_raises(tmp_path: Path) -> None:
+    with pytest.raises(PluginInstallError, match="not installed"):
+        await enable_plugin("ghost@acme", SkillRegistry(), _home(tmp_path), env=_env(tmp_path))
+
+
+async def test_enable_foreign_conflict_leaves_settings_untouched(tmp_path: Path, monkeypatch) -> None:
+    home = _home(tmp_path)
+    env = _env(tmp_path)
+    install_path = marketplace_skill_dir(home, "acme") / "plugins" / "audit"
+    _write_json(install_path / "mcp-servers" / "figma.json", _stdio("figma"))
+    # 记录无 bundledMcpServers → owned 空；外来 figma 占名 → enable 应硬抛
+    _seed_installed(home, {"audit@acme": [{"scope": "user", "installPath": str(install_path)}]})
+    monkeypatch.setattr(_STAGE, _fake_stage([]))
+    mcp = _FakeMCP(existing={"figma"})
+
+    with pytest.raises(MCPServerNameConflictError, match="figma"):
+        await enable_plugin(
+            "audit@acme", SkillRegistry(), home, env=env,
+            existing_server_names=mcp.existing_names, register_server=mcp.register,
+        )
+
+    assert not user_settings_path(env).exists()  # 冲突先于 settings 写 → 原子（未写）

--- a/tests/unit_tests/computer/settings/test_installer.py
+++ b/tests/unit_tests/computer/settings/test_installer.py
@@ -265,6 +265,45 @@ async def test_install_catalog_not_cloned_raises(tmp_path: Path) -> None:
         await install_plugin("audit@acme", SkillRegistry(), home)
 
 
+async def test_install_register_without_existing_names_raises(tmp_path: Path, monkeypatch) -> None:
+    """护栏：给了 register_server 但缺 existing_server_names → 抛（防冲突闸门被静默旁路）。"""
+    home = _home(tmp_path)
+    _setup_catalog(home, "acme", "audit", servers=["figma"])
+    monkeypatch.setattr(_STAGE, _fake_stage([]))
+    mcp = _FakeMCP()
+
+    with pytest.raises(PluginInstallError, match="existing_server_names is required"):
+        await install_plugin("audit@acme", SkillRegistry(), home, env=_env(tmp_path), register_server=mcp.register)
+
+
+async def test_install_reinstall_failure_preserves_existing(tmp_path: Path, monkeypatch) -> None:
+    """精确回滚：重装中途失败时，不误删此前已有的 skill / 不误摘自有 server（仅撤销本次新增）。"""
+    home = _home(tmp_path)
+    mcp = _FakeMCP()
+    reg = SkillRegistry()
+    await _install(home, tmp_path, monkeypatch, mcp, reg, servers=["figma"])  # 首装 figma + audit:lint
+    assert reg.resolve("audit:lint") is not None and mcp.registered == ["figma"]
+
+    # 重装：plugin 新增一个会注册失败的 server（zeta）；owned={figma}、既有 skill audit:lint 活跃
+    plugin_root = marketplace_skill_dir(home, "acme") / "plugins" / "audit"
+    _write_json(plugin_root / "mcp-servers" / "zeta.json", _stdio("zeta"))
+    mcp.registered.clear()
+    mcp.removed.clear()
+    mcp.fail_on = "zeta"
+
+    with pytest.raises(RuntimeError, match="zeta"):
+        await install_plugin(
+            "audit@acme", reg, home, env=_env(tmp_path),
+            existing_server_names=mcp.existing_names, register_server=mcp.register, remove_server=mcp.remove,
+        )
+
+    assert reg.resolve("audit:lint") is not None  # 既有 skill 未被误注销
+    assert mcp.removed == []  # 自有 figma 未被误摘（zeta 注册失败本就没进）
+    assert "figma" in mcp.existing  # figma 仍挂在 manager
+    rec = load_installed_plugins(home=home)["plugins"]["audit@acme"][0]
+    assert rec["bundledMcpServers"] == ["figma"]  # 账本仍为首装记录（本次失败未改写）
+
+
 # ── uninstall ─────────────────────────────────────────────────────────────────
 async def _install(home: Path, tmp_path: Path, monkeypatch, mcp: _FakeMCP, reg: SkillRegistry, *, servers: list[str]) -> Path:
     """安装一个 plugin（happy）作为 uninstall/disable/enable 的前置；返回 installPath。"""
@@ -402,3 +441,11 @@ async def test_enable_foreign_conflict_leaves_settings_untouched(tmp_path: Path,
         )
 
     assert not user_settings_path(env).exists()  # 冲突先于 settings 写 → 原子（未写）
+
+
+async def test_enable_register_without_existing_names_raises(tmp_path: Path) -> None:
+    """护栏：enable 给了 register_server 但缺 existing_server_names → 抛（先于读记录/写 settings）。"""
+    home = _home(tmp_path)
+    mcp = _FakeMCP()
+    with pytest.raises(PluginInstallError, match="existing_server_names is required"):
+        await enable_plugin("audit@acme", SkillRegistry(), home, env=_env(tmp_path), register_server=mcp.register)

--- a/tests/unit_tests/computer/skills/test_manifest.py
+++ b/tests/unit_tests/computer/skills/test_manifest.py
@@ -1,0 +1,196 @@
+# -*- coding: utf-8 -*-
+# filename: test_manifest.py
+# @Time    : 2026/05/26
+# @Author  : JQQ
+# @Email   : jqq1716@gmail.com
+# @Software: PyCharm
+"""
+Plugin manifest 解析单元测试（v0.2.1 #63）—— marketplace.json / plugin.json / mcp-servers/<n>.json
+Plugin manifest parsing unit tests: marketplace.json / plugin.json / mcp-servers/<n>.json.
+
+SDK 设计 / Design: python-sdk docs/design-0.2.1-cli-marketplace-ux.md §3.2–3.5 / §3.3。
+
+测试意图 / Test intentions（纯解析，无 git / manager）:
+- marketplace.json：present/缺失抛/非对象抛；iter/find entry；pluginRoot 默认。
+- plugin.json：present/缺失→{}/损坏→{}（best-effort）。
+- version 优先级 entry > plugin.json > commitSha。
+- mcp-servers：枚举一级、排除 inputs.json、sorted、缺目录→[]；stdio/sse/streamable round-trip；
+  文件名≠name 抛；畸形 JSON 抛；非法 config 抛；load 任一失败即抛、空→[]。
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from a2c_smcp.computer.mcp_clients.model import SseServerConfig, StdioServerConfig, StreamableHttpServerConfig
+from a2c_smcp.computer.skills.manifest import (
+    PluginManifestError,
+    enumerate_bundled_server_files,
+    find_plugin_entry,
+    iter_plugin_entries,
+    load_bundled_servers,
+    parse_bundled_server,
+    plugin_root_base,
+    read_marketplace_manifest,
+    read_plugin_metadata,
+    resolve_plugin_version,
+)
+
+
+def _write_json(path: Path, obj: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(obj), encoding="utf-8")
+
+
+def _stdio(name: str, command: str = "node") -> dict:
+    return {"name": name, "type": "stdio", "server_parameters": {"command": command}}
+
+
+# ── marketplace.json ─────────────────────────────────────────────────────────
+def test_read_marketplace_manifest_ok(tmp_path: Path) -> None:
+    manifest = {
+        "name": "acme",
+        "owner": {"name": "X"},
+        "metadata": {"pluginRoot": "./plugins"},
+        "plugins": [{"name": "audit", "source": "audit", "version": "1.2.0"}],
+    }
+    _write_json(tmp_path / ".tfrobot-plugin" / "marketplace.json", manifest)
+
+    out = read_marketplace_manifest(tmp_path)
+    assert out["name"] == "acme"
+    assert plugin_root_base(out) == "./plugins"
+    assert [e["name"] for e in iter_plugin_entries(out)] == ["audit"]
+    entry = find_plugin_entry(out, "audit")
+    assert entry is not None and entry["source"] == "audit"
+    assert find_plugin_entry(out, "missing") is None
+
+
+def test_read_marketplace_manifest_absent_raises(tmp_path: Path) -> None:
+    with pytest.raises(PluginManifestError):
+        read_marketplace_manifest(tmp_path)
+
+
+def test_read_marketplace_manifest_non_object_raises(tmp_path: Path) -> None:
+    _write_json(tmp_path / ".tfrobot-plugin" / "marketplace.json", ["not", "an", "object"])
+    with pytest.raises(PluginManifestError):
+        read_marketplace_manifest(tmp_path)
+
+
+def test_plugin_root_base_defaults() -> None:
+    assert plugin_root_base({}) == "./plugins"
+    assert plugin_root_base({"metadata": {"pluginRoot": "  "}}) == "./plugins"  # 空白回退默认
+
+
+def test_iter_plugin_entries_non_array_or_missing() -> None:
+    assert iter_plugin_entries({"plugins": "oops"}) == []
+    assert iter_plugin_entries({}) == []
+    # 非对象条目被跳过
+    assert iter_plugin_entries({"plugins": [{"name": "a"}, "junk", 42]}) == [{"name": "a"}]
+
+
+# ── plugin.json ──────────────────────────────────────────────────────────────
+def test_read_plugin_metadata_ok(tmp_path: Path) -> None:
+    _write_json(tmp_path / ".tfrobot-plugin" / "plugin.json", {"name": "audit", "version": "1.2.0"})
+    assert read_plugin_metadata(tmp_path)["version"] == "1.2.0"
+
+
+def test_read_plugin_metadata_absent(tmp_path: Path) -> None:
+    assert read_plugin_metadata(tmp_path) == {}
+
+
+def test_read_plugin_metadata_corrupt_degrades(tmp_path: Path) -> None:
+    p = tmp_path / ".tfrobot-plugin" / "plugin.json"
+    p.parent.mkdir(parents=True)
+    p.write_text("{not json", encoding="utf-8")
+    assert read_plugin_metadata(tmp_path) == {}  # best-effort → {}
+
+
+# ── version 优先级 ───────────────────────────────────────────────────────────
+def test_resolve_plugin_version_priority() -> None:
+    assert resolve_plugin_version({"version": "9.9"}, {"version": "1.0"}, "sha") == "9.9"  # entry 胜
+    assert resolve_plugin_version({}, {"version": "1.0"}, "sha") == "1.0"  # plugin.json 次之
+    assert resolve_plugin_version({}, {}, "sha") == "sha"  # commitSha 兜底
+    assert resolve_plugin_version({}, {}, None) is None
+
+
+# ── mcp-servers/ ─────────────────────────────────────────────────────────────
+def test_enumerate_excludes_inputs_and_non_json_and_sorts(tmp_path: Path) -> None:
+    d = tmp_path / "mcp-servers"
+    d.mkdir()
+    for n in ("b", "a"):
+        _write_json(d / f"{n}.json", _stdio(n))
+    _write_json(d / "inputs.json", {"inputs": []})  # 排除（入池归 #65）
+    (d / "notes.txt").write_text("x", encoding="utf-8")  # 非 .json 排除
+
+    files = enumerate_bundled_server_files(tmp_path)
+    assert [f.name for f in files] == ["a.json", "b.json"]  # sorted、排除 inputs.json + 非 json
+
+
+def test_enumerate_missing_dir(tmp_path: Path) -> None:
+    assert enumerate_bundled_server_files(tmp_path) == []
+
+
+def test_parse_bundled_server_stdio(tmp_path: Path) -> None:
+    p = tmp_path / "mcp-servers" / "figma.json"
+    _write_json(p, _stdio("figma"))
+    cfg = parse_bundled_server(p)
+    assert isinstance(cfg, StdioServerConfig) and cfg.name == "figma"
+
+
+def test_parse_bundled_server_sse(tmp_path: Path) -> None:
+    p = tmp_path / "mcp-servers" / "remote.json"
+    _write_json(p, {"name": "remote", "type": "sse", "server_parameters": {"url": "https://x/sse"}})
+    cfg = parse_bundled_server(p)
+    assert isinstance(cfg, SseServerConfig) and cfg.name == "remote"
+
+
+def test_parse_bundled_server_streamable(tmp_path: Path) -> None:
+    p = tmp_path / "mcp-servers" / "http.json"
+    _write_json(p, {"name": "http", "type": "streamable", "server_parameters": {"url": "https://x/mcp"}})
+    cfg = parse_bundled_server(p)
+    assert isinstance(cfg, StreamableHttpServerConfig) and cfg.name == "http"
+
+
+def test_parse_bundled_server_stem_mismatch_raises(tmp_path: Path) -> None:
+    p = tmp_path / "mcp-servers" / "wrongname.json"
+    _write_json(p, _stdio("figma"))  # stem 'wrongname' != name 'figma'
+    with pytest.raises(PluginManifestError, match="filename stem"):
+        parse_bundled_server(p)
+
+
+def test_parse_bundled_server_malformed_json_raises(tmp_path: Path) -> None:
+    p = tmp_path / "mcp-servers" / "x.json"
+    p.parent.mkdir(parents=True)
+    p.write_text("{bad", encoding="utf-8")
+    with pytest.raises(PluginManifestError):
+        parse_bundled_server(p)
+
+
+def test_parse_bundled_server_invalid_config_raises(tmp_path: Path) -> None:
+    p = tmp_path / "mcp-servers" / "bad.json"
+    _write_json(p, {"name": "bad", "type": "stdio"})  # stdio 缺 server_parameters → ValidationError → 抛
+    with pytest.raises(PluginManifestError):
+        parse_bundled_server(p)
+
+
+def test_load_bundled_servers_all(tmp_path: Path) -> None:
+    d = tmp_path / "mcp-servers"
+    d.mkdir()
+    _write_json(d / "figma.json", _stdio("figma"))
+    _write_json(d / "blender.json", _stdio("blender"))
+    servers = load_bundled_servers(tmp_path)
+    assert sorted(s.name for s in servers) == ["blender", "figma"]
+
+
+def test_load_bundled_servers_any_malformed_raises(tmp_path: Path) -> None:
+    d = tmp_path / "mcp-servers"
+    d.mkdir()
+    _write_json(d / "ok.json", _stdio("ok"))
+    (d / "broken.json").write_text("{bad", encoding="utf-8")
+    with pytest.raises(PluginManifestError):
+        load_bundled_servers(tmp_path)
+
+
+def test_load_bundled_servers_empty(tmp_path: Path) -> None:
+    assert load_bundled_servers(tmp_path) == []


### PR DESCRIPTION
## 概述

实现 #63（S10）：plugin 显式生命周期 **install / uninstall / enable / disable**，填 #62 `decision A` 留的 `installed_plugins.json` 账本接缝（即 `gc_plugins` 读取的账本的写入方）。纯 Computer 侧、**无 A2C 协议变更**——消费已发布的 tfrobot-marketplace protocol-v1 §3/§5 + mcp-servers 协议 §1/§2；冲突走本地异常，复用既有 `server:update_tool_list` / `notify:update_skills`。依赖 `#58`（物化 store）+ `#61`（marketplace staging）。

## 改动

| 文件 | 性质 |
|---|---|
| `skills/manifest.py` | **新** · canonical manifest 解析器（marketplace.json + plugin.json + `mcp-servers/<n>.json` + version/entry helpers），leaf 模块**不 import staging**（避循环导入） |
| `skills/staging.py` | 提取 public `locate_plugin_root`，`_stage_one_plugin` 复用（**同代码路径**，#61 行为不变） |
| `settings/installer.py` | **新** · 四操作 + `MCPServerNameConflictError` / `PluginInstallError` + 注入式 MCP 接口 |
| `settings/__init__.py` | installer 同 reconciler **刻意不 re-export**（循环导入：staging 顶层 import settings.schema） |

## 核心语义

- **install**：原子序「**冲突预检-先于-变更** + 过闸后补偿回滚」——外来同名 bundled MCP server → 硬抛 `MCPServerNameConflictError`、**零变更不写账本**（§10.6，无 rename/force 逃生口）；自有同名（命中记录 `bundledMcpServers`）幂等放行。要求 catalog 已 clone（`marketplace add` 前置）。
- **uninstall**：镜像兄弟 `gc_plugins`——删 `installPath` 树 + 注销 skills + 级联 stop+remove bundled server（`--keep-servers` 跳过）+ 删账本记录。
- **disable**：写 `enabledPlugins[id]=false` + 停摘 bundled server + `mark_orphan` 隐藏 skills（**物化层保留**，可廉价复原）。
- **enable**：冲突预检（先于 settings 写 → 原子）+ 写 `true` + re-stage 复活孤儿 skill（`register_or_update` 翻 `orphaned=False`，**不重 clone**）+ 重挂 server。
- **MCP 注入**：`existing_server_names` / `register_server` / `remove_server` 回调（沿用 `gc_plugins` 的 `mcp_teardown` 风格）；#69 CLI 层用 `Computer.aadd_or_aupdate_server` / `aremove_server` / `mcp_manager.get_server_status()` 包装。

## 文档化边界（非缺陷）

- 跨重启重挂 bundled server + `installed × enabled` 交集 → **reconcile 接线层（#68/#69）**（`boot_up` 当前不调 reconcile，#63 操作 live session；disable 的 skill orphan 为内存态）。
- plugin `inputs.json` 入池消歧（§9.3 D2 前缀）→ **#65**；strict mode 组件路径覆写/冲突（§3.4/§3.5）→ **#80**。

## 验收

- [x] install 外来同名硬抛 + 原子失败（不写 installed_plugins.json）；自有同名幂等
- [x] uninstall 级联 stop+remove；`--keep-servers` 跳过
- [x] disable 停摘 server + 隐藏 skills；enable 廉价复原（不重 clone）
- [x] `uv run poe lint` 净（ruff All checks passed + mypy 85 文件 0 issue）

## 测试

- unit `test_manifest.py`(20) + unit `test_installer.py`(19) + integration `test_installer.py`(3，本地裸仓真 git clone)。
- 全量套件 **1421 passed, 2 skipped, 4 xfailed**（含 #61/#62 回归，验证 `locate_plugin_root` 提取无回归）。

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)
