### PR TITLE
feat(computer): v0.2.1 S11 .tfrobot/mcp.json 定义层 + MCP 批准门控（#64）

### DIFF
--- a/a2c_smcp/computer/settings/__init__.py
+++ b/a2c_smcp/computer/settings/__init__.py
@@ -7,10 +7,11 @@
 """
 Computer 意图 / 治理层 settings 子系统 / Computer intent & governance settings subsystem（v0.2.1）
 
-承载 settings.json 的结构、五级 scope 合并、policy 子源选取、物化层文件 store 与启动对账
-reconciler——CLI marketplace/plugin/skill 管理 UX 的"意图层 + 物化层 + 对账层"。MCP 定义层为后续工单（#64）。
-The intent + materialized + reconcile layers of the CLI marketplace/plugin/skill management UX.
-MCP-definition layer lands in a follow-up ticket.
+承载 settings.json 的结构、五级 scope 合并、policy 子源选取、物化层文件 store、启动对账 reconciler 与
+``.tfrobot/mcp.json`` MCP 定义层/批准门控——CLI marketplace/plugin/skill 管理 UX 的"意图层 + 物化层 + 对账层
++ MCP 定义/门控层"。
+The intent + materialized + reconcile + MCP-definition/gating layers of the CLI marketplace/plugin/skill
+management UX.
 
 已落地模块 / Landed modules：
 - :mod:`a2c_smcp.computer.settings.schema` —— settings.json TypedDict + 字段级容错校验
@@ -94,9 +95,11 @@ from a2c_smcp.computer.settings.store import (
 # 注意 / NB：:mod:`...settings.reconciler` 与 :mod:`...settings.installer` **刻意不在此 re-export**——它们依赖
 # :mod:`...skills.staging`，而 staging 顶层又 import :mod:`...settings.schema`（触发本 __init__）。
 # 若在此急切导入 reconciler/installer 会与 staging 的半初始化态构成循环（`_EXTERNAL_PLUGINS_NS` 未定义）。
-# 消费方请直接 ``from a2c_smcp.computer.settings.reconciler import reconcile`` / ``...installer import install_plugin`` 等。
-# reconciler & installer are intentionally NOT re-exported here to avoid a circular import with skills.staging;
-# import them directly from their submodules.
+# 同理 :mod:`...settings.mcp_config` 亦**不 re-export**——它 import :mod:`...mcp_clients.model`（→ vrl 传递依赖），
+# 在此急切导入会无谓加重 ``import ...settings``（与 installer/manifest 同姿态，不成环但不必拉重）。
+# 消费方请直接 ``from a2c_smcp.computer.settings.reconciler import reconcile`` /
+# ``...installer import install_plugin`` / ``...mcp_config import resolve_mcp_config`` 等。
+# reconciler / installer / mcp_config are intentionally NOT re-exported here; import them directly from submodules.
 
 __all__ = [
     # schema

--- a/a2c_smcp/computer/settings/mcp_config.py
+++ b/a2c_smcp/computer/settings/mcp_config.py
@@ -1,0 +1,451 @@
+# -*- coding: utf-8 -*-
+# filename: mcp_config.py
+# @Time    : 2026/05/26
+# @Author  : JQQ
+# @Email   : jqq1716@gmail.com
+# @Software: PyCharm
+"""
+``.tfrobot/mcp.json`` MCP server 定义层（A2C 原生 schema）多 scope 加载 + 批准门控（v0.2.1 #64）
+``.tfrobot/mcp.json`` MCP server definition layer (A2C-native schema) multi-scope load + approval gate.
+
+SDK 设计 / Design: python-sdk docs/design-0.2.1-cli-marketplace-ux.md §9.1（A2C 原生 schema、为何不复用标准
+``.mcp.json``）/ §9.2（全套 CC 批准门控）/ §5.1（active-workdir 单根）/ §5.5（MCP 定义合并顺序）。
+
+本模块是 **MCP 定义/门控的纯逻辑层**（无 git / 无 MCP manager / 无网络）。职责三件：
+1. **多 scope 加载合并** ``mcp.json`` —— 顺序 ``policy > active-local > active-project > user > flag``，
+   **无能力层并集**（敏感面隔离，区别于 settings.json 的能力发现层 §5.1 (A)）；server 按 name **整体替换**
+   （配置是原子单元、非深合并），记录最高定义 scope 为 ``origin``。
+2. **批准门控判定**（:func:`mcp_server_status`）—— 据 resolved settings（#56 已落地的 MCP 门控字段）+
+   plugin-bundled 账本（#63 ``installed_plugins.json``）算 ``enabled/disabled/pending``。
+3. **批准写助手** —— 批准/拒绝写 **local scope**（§9.2，个人决定不污染共享层），镜像
+   :func:`a2c_smcp.computer.settings.installer._write_enabled_plugin` 的持锁原子 RMW。
+
+This is the pure logic layer for MCP definitions/gating (no git / MCP manager / network).
+
+**显式划界 / Deferred boundaries**：
+- **取值渲染**（``envFile`` 加载 / ``${env:}`` / ``${workspaceFolder}`` / inputs 解析链 / keyring / 明文
+  state）归 **#65**：本模块产出**带占位符**的定义，``ResolvedMcpServer.ext``（``envFile`` 等 VS Code 扩展）
+  + 未渲染占位符是交给 #65 的 handoff。**绝不在此渲染**（§9.1 安全铁律：值不离 Computer）。
+- **批准框 TTY 交互**（``[a]/[y]/[n]``）/ ``--approve-all-mcp`` flag / 非交互 pending→skip+WARN 接线归
+  **#69**：本模块只提供 :class:`McpApprovalStatus` 判定 + 三个写助手原语。
+- ``allowManagedMcpServersOnly``（§9.2）#56 schema 未引入，v0.2.1 范围外；本模块只用
+  ``allowedMcpServers`` / ``deniedMcpServers``。
+- ``managed-mcp.json`` v0.2.1 仅读 layer-3 文件（per-platform managed dir），remote/MDM stub，对齐
+  :mod:`a2c_smcp.computer.settings.policy` 的 settings 姿态。
+
+**容错姿态**：``mcp.json`` 是**人/团队编辑文件**，故**字段级容错**（单 server / input 畸形 → drop + 记
+:class:`~a2c_smcp.computer.settings.schema.SettingsValidationError`，**不 abort**）——刻意区别于 #63
+``manifest.py`` 对 plugin-bundled server 的**硬抛**（那是 install 原子前置条件）。照 §5.6 人编文件容错。
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from enum import StrEnum
+from pathlib import Path
+from typing import Any
+
+from pydantic import TypeAdapter, ValidationError
+
+from a2c_smcp.computer.mcp_clients.model import MCPServerConfig, MCPServerInput
+from a2c_smcp.computer.settings.policy import LINUX_MANAGED_DIR, MACOS_MANAGED_DIR, WINDOWS_MANAGED_DIR
+from a2c_smcp.computer.settings.schema import (
+    FIELD_ALLOWED_MCP_SERVERS,
+    FIELD_DENIED_MCP_SERVERS,
+    FIELD_DISABLED_MCPJSON_SERVERS,
+    FIELD_ENABLE_ALL_PROJECT_MCP,
+    FIELD_ENABLED_MCPJSON_SERVERS,
+    SettingsScope,
+    SettingsValidationError,
+)
+from a2c_smcp.computer.settings.scope import (
+    apply_write,
+    load_settings_file,
+    resolve_user_config_dir,
+    workdir_local_settings_path,
+    workdir_settings_dir,
+)
+from a2c_smcp.computer.settings.store import atomic_write_json, file_lock, load_installed_plugins
+from a2c_smcp.utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+# ---------------------------------------------------------------------------
+# 常量 / Constants
+# ---------------------------------------------------------------------------
+MCP_CONFIG_FILENAME = "mcp.json"  # user / project scope（§9.1）
+MCP_LOCAL_CONFIG_FILENAME = "mcp.local.json"  # active workdir local scope（不入 git）
+MANAGED_MCP_FILENAME = "managed-mcp.json"  # policy scope（企业下发）
+
+# server 定义里的 VS Code 风格扩展字段：非 A2C ``MCPServerConfig`` 字段（其 ``extra="forbid"``），校验前
+# 剥离、原样保留交 #65 渲染消费 / VS Code-style extension keys, stripped before validation, kept for #65.
+_VSCODE_EXT_KEYS: frozenset[str] = frozenset({"envFile"})
+
+# 预信任 origin scope（用户/老 flag/企业自己加的 server，不弹批准框，§9.2）；project/local = 工作区共享、
+# 受门控 / Pre-trusted origin scopes (no approval prompt); project/local = workspace-shared, gated.
+_TRUSTED_ORIGINS: frozenset[SettingsScope] = frozenset({SettingsScope.USER, SettingsScope.FLAG, SettingsScope.POLICY})
+
+# 单点构造校验入口（照 manifest.py 范式）/ Single dict→model adapters.
+_MCP_SERVER_ADAPTER: TypeAdapter[MCPServerConfig] = TypeAdapter(MCPServerConfig)
+_MCP_INPUT_ADAPTER: TypeAdapter[MCPServerInput] = TypeAdapter(MCPServerInput)
+
+
+class McpConfigError(Exception):
+    """MCP 定义/批准写助手的契约违例（如批准写缺 active workdir）/ Contract violation in MCP config helpers."""
+
+
+class McpApprovalStatus(StrEnum):
+    """单个 MCP server 的批准门控状态（§9.2）/ Approval-gate status of one MCP server。"""
+
+    ENABLED = "enabled"  # 已批准 / 预信任 / bundled 免批准 → 可连接
+    DISABLED = "disabled"  # 显式拒绝 / 企业拒绝名单 / 不在白名单 → 不连接
+    PENDING = "pending"  # 工作区共享且未决 → 启动时弹批准框（#69）
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedMcpServer:
+    """
+    合并解析后的单个 MCP server 定义 / A merged-and-resolved single MCP server definition。
+
+    ``config`` 是校验后的 A2C :class:`MCPServerConfig`（**含占位符、未渲染**）；``ext`` 是剥离出的 VS Code
+    扩展字段（如 ``envFile``，交 #65 渲染消费）；``origin`` 为最高定义 scope；``trusted_origin`` 决定是否免
+    批准门控（user/flag/policy 免，project/local 受门控）。
+    """
+
+    name: str
+    config: MCPServerConfig
+    ext: dict[str, Any]
+    origin: SettingsScope
+    trusted_origin: bool
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedMcpConfig:
+    """
+    多 scope 合并后的 MCP 定义视图 / The multi-scope merged MCP definition view。
+
+    ``servers`` 按 name 索引；``inputs`` 为去重后的 input **定义**（取值/渲染归 #65）；``errors`` 汇总字段级
+    校验错误（不阻断、供诊断呈现，照 §5.6）。
+    """
+
+    servers: dict[str, ResolvedMcpServer]
+    inputs: list[MCPServerInput] = field(default_factory=list)
+    errors: list[SettingsValidationError] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# 路径解析（复用 scope.py 的路径根）/ Path resolution (reuses scope.py roots)
+# ---------------------------------------------------------------------------
+def user_mcp_config_path(env: Mapping[str, str] | None = None) -> Path:
+    """user scope ``$XDG_CONFIG_HOME/a2c/mcp.json`` 路径 / Path to the user-scope mcp.json。"""
+    return resolve_user_config_dir(env) / MCP_CONFIG_FILENAME
+
+
+def workdir_mcp_config_path(workdir: Path) -> Path:
+    """project scope ``<workdir>/.tfrobot/mcp.json`` 路径（入 git、团队共享）/ project-scope mcp.json path。"""
+    return workdir_settings_dir(workdir) / MCP_CONFIG_FILENAME
+
+
+def workdir_mcp_local_config_path(workdir: Path) -> Path:
+    """local scope ``<workdir>/.tfrobot/mcp.local.json`` 路径（不入 git）/ local-scope mcp.local.json path。"""
+    return workdir_settings_dir(workdir) / MCP_LOCAL_CONFIG_FILENAME
+
+
+def _default_managed_dir(platform: str) -> Path:
+    """按平台选 managed 目录（镜像 :func:`policy.default_policy_sources` 的分支）/ Per-platform managed dir。"""
+    if platform == "darwin":
+        return MACOS_MANAGED_DIR
+    if platform == "win32":
+        return WINDOWS_MANAGED_DIR
+    return LINUX_MANAGED_DIR
+
+
+def managed_mcp_config_path(platform: str | None = None) -> Path:
+    """policy scope ``<managed-dir>/managed-mcp.json`` 路径 / Path to the policy-scope managed-mcp.json。"""
+    return _default_managed_dir(platform or sys.platform) / MANAGED_MCP_FILENAME
+
+
+# ---------------------------------------------------------------------------
+# 单文件加载（容错）/ Single-file load (tolerant)
+# ---------------------------------------------------------------------------
+def _err(scope: SettingsScope, fld: str, reason: str, source: str | None) -> SettingsValidationError:
+    """构造一条字段级校验错误（缩短重复构造 + 控行宽）/ Build one field-level validation error."""
+    return SettingsValidationError(scope=scope, field=fld, reason=reason, source_path=source)
+
+
+def load_mcp_config_file(path: Path, scope: SettingsScope) -> tuple[dict[str, Any], list[SettingsValidationError]]:
+    """
+    读取并容错规整单个 ``mcp.json`` 文件为 ``{servers:{}, inputs:[]}`` / Load + tolerantly coerce one mcp.json。
+
+    缺失 → ``({servers:{}, inputs:[]}, [])``；JSON 损坏 / 根非对象 → 空 + 一条错误（**不**备份、**不**清盘，
+    照 §5.6 人编文件姿态）；``servers`` 非对象 / ``inputs`` 非数组 → 该字段判空 + 记错（其余仍用）。
+    Missing → empty; corrupt / non-object root → empty + one error (file untouched); wrong-typed
+    ``servers`` / ``inputs`` → that field emptied + error.
+    """
+    empty: dict[str, Any] = {"servers": {}, "inputs": []}
+    p = Path(path)
+    src = str(p)
+    if not p.exists():
+        return dict(empty), []
+    try:
+        raw = json.loads(p.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.warning("MCP config %s unreadable/corrupt, ignored (kept on disk): %s", p, exc)
+        return dict(empty), [_err(scope, "<file>", f"unreadable or corrupt JSON: {exc}", src)]
+    if not isinstance(raw, dict):
+        return dict(empty), [_err(scope, "<root>", "mcp config root must be an object", src)]
+
+    errors: list[SettingsValidationError] = []
+    servers = raw.get("servers")
+    if not isinstance(servers, dict):
+        if servers is not None:
+            errors.append(_err(scope, "servers", "'servers' must be an object", src))
+        servers = {}
+    inputs = raw.get("inputs")
+    if not isinstance(inputs, list):
+        if inputs is not None:
+            errors.append(_err(scope, "inputs", "'inputs' must be an array", src))
+        inputs = []
+    return {"servers": servers, "inputs": inputs}, errors
+
+
+# ---------------------------------------------------------------------------
+# 校验单元（字段级容错）/ Validation units (field-level tolerant)
+# ---------------------------------------------------------------------------
+def _validate_server(
+    name: str,
+    sdef: Any,
+    scope: SettingsScope,
+    source: str | None,
+) -> tuple[ResolvedMcpServer | None, list[SettingsValidationError]]:
+    """
+    校验单个 server 定义 → :class:`ResolvedMcpServer`（畸形 → ``None`` + 错误，**不抛**）/ Validate one server。
+
+    map **key 即 server 身份**（VS Code/CC 风格）：注入 ``name=<key>``；若 ``sdef`` 内显式 ``name`` 与 key
+    冲突 → 判废。剥离 :data:`_VSCODE_EXT_KEYS` 入 ``ext``（交 #65），其余校验为 ``MCPServerConfig``。
+    """
+    fld = f"servers.{name}"
+    if not isinstance(sdef, Mapping):
+        return None, [_err(scope, fld, "server definition must be an object", source)]
+    ext = {k: v for k, v in sdef.items() if k in _VSCODE_EXT_KEYS}
+    body = {k: v for k, v in sdef.items() if k not in _VSCODE_EXT_KEYS}
+    if "name" in body and body["name"] != name:
+        reason = f"server 'name' field {body['name']!r} != map key {name!r} (the map key is the canonical identity)"
+        return None, [_err(scope, fld, reason, source)]
+    body["name"] = name  # key 即身份 / the map key is the identity.
+    try:
+        cfg = _MCP_SERVER_ADAPTER.validate_python(body)
+    except ValidationError as exc:
+        return None, [_err(scope, fld, f"invalid MCP server config: {exc}", source)]
+    return ResolvedMcpServer(name=name, config=cfg, ext=ext, origin=scope, trusted_origin=scope in _TRUSTED_ORIGINS), []
+
+
+def _validate_input(idef: Any, scope: SettingsScope, source: str | None) -> tuple[MCPServerInput | None, list[SettingsValidationError]]:
+    """校验单个 input 定义 → :class:`MCPServerInput`（畸形 → ``None`` + 错误，**不抛**）/ Validate one input def。"""
+    raw_id = idef.get("id") if isinstance(idef, Mapping) else None
+    fld = f"inputs.{raw_id}" if isinstance(raw_id, str) else "inputs.<unknown>"
+    try:
+        inp = _MCP_INPUT_ADAPTER.validate_python(idef)
+    except ValidationError as exc:
+        return None, [_err(scope, fld, f"invalid input definition: {exc}", source)]
+    return inp, []
+
+
+# ---------------------------------------------------------------------------
+# 多 scope 解析 / Multi-scope resolution
+# ---------------------------------------------------------------------------
+def resolve_mcp_config(
+    *,
+    active_workdir: Path | None = None,
+    env: Mapping[str, str] | None = None,
+    flag_config_path: Path | None = None,
+    managed_mcp_path: Path | None = None,
+    platform: str | None = None,
+) -> ResolvedMcpConfig:
+    """
+    多 scope 加载合并 ``.tfrobot/mcp.json`` + 字段级校验 / Multi-scope load + merge + validate mcp.json。
+
+    合并顺序 low → high = ``[flag, user, active-project, active-local, policy]``（即优先级
+    ``policy > local > project > user > flag``，§9.1/§5.5）；**无能力层并集**（敏感面隔离，区别于
+    settings.json）。``active_workdir is None`` → project/local 全空，仅 user + flag + policy + 默认。
+
+    - **servers**：按 name **整体替换**（高 scope 同名整体覆盖；server config 是原子单元、**非**深合并），
+      ``origin`` = 最高定义 scope，``trusted_origin`` = origin ∈ {user, flag, policy}。
+    - **inputs**：按 ``id`` 去重、高 scope 胜（缺 ``id`` 的条目各自保留以便逐条报错）。
+    - 单 server / input 畸形 → drop + :class:`SettingsValidationError`，**不 abort**（§5.6 人编文件容错）。
+
+    :param active_workdir: 当前绑定任务的单根（project/local 来源）；``None`` = 空闲。
+    :param env: 环境映射（解析 user config dir），默认 ``os.environ``。
+    :param flag_config_path: ``--config @file`` 老接口文件（最低优先级，§5.5）。
+    :param managed_mcp_path: policy scope ``managed-mcp.json`` 覆盖路径（缺省按平台推导；便于测试）。
+    :param platform: 平台标识（缺省 ``sys.platform``）；仅在 ``managed_mcp_path`` 未给时用于推导 managed 目录。
+    """
+    managed_path = managed_mcp_path if managed_mcp_path is not None else managed_mcp_config_path(platform)
+
+    # (scope, path) 层，低优先级在前 / layers, lowest priority first.
+    layers: list[tuple[SettingsScope, Path]] = []
+    if flag_config_path is not None:
+        layers.append((SettingsScope.FLAG, Path(flag_config_path)))
+    layers.append((SettingsScope.USER, user_mcp_config_path(env)))
+    if active_workdir is not None:
+        layers.append((SettingsScope.PROJECT, workdir_mcp_config_path(active_workdir)))
+        layers.append((SettingsScope.LOCAL, workdir_mcp_local_config_path(active_workdir)))
+    layers.append((SettingsScope.POLICY, managed_path))
+
+    errors: list[SettingsValidationError] = []
+    # 累积原始定义（低→高，后者覆盖前者）；server 整体替换 + 记 origin / source / Raw accumulation.
+    raw_servers: dict[str, tuple[Any, SettingsScope, str]] = {}
+    raw_inputs: dict[str, tuple[Any, SettingsScope, str]] = {}
+    noid = 0
+
+    for scope, path in layers:
+        data, errs = load_mcp_config_file(path, scope)
+        errors.extend(errs)
+        src = str(path)
+        for srv_name, sdef in data["servers"].items():
+            raw_servers[srv_name] = (sdef, scope, src)  # 高 scope 整体覆盖 → origin = 最高 / high wins.
+        for idef in data["inputs"]:
+            iid = idef.get("id") if isinstance(idef, Mapping) and isinstance(idef.get("id"), str) else None
+            key = iid if iid is not None else f"<noid-{noid}>"
+            if iid is None:
+                noid += 1
+            raw_inputs[key] = (idef, scope, src)  # 同 id 高 scope 胜 / same id, high wins.
+
+    servers: dict[str, ResolvedMcpServer] = {}
+    for srv_name, (sdef, scope, src) in raw_servers.items():
+        resolved, errs = _validate_server(srv_name, sdef, scope, src)
+        errors.extend(errs)
+        if resolved is not None:
+            servers[srv_name] = resolved
+
+    inputs: list[MCPServerInput] = []
+    for _key, (idef, scope, src) in raw_inputs.items():
+        resolved_input, errs = _validate_input(idef, scope, src)
+        errors.extend(errs)
+        if resolved_input is not None:
+            inputs.append(resolved_input)
+
+    return ResolvedMcpConfig(servers=servers, inputs=inputs, errors=errors)
+
+
+# ---------------------------------------------------------------------------
+# 批准门控判定 / Approval-gate decision（§9.2）
+# ---------------------------------------------------------------------------
+def _str_list(settings: Mapping[str, Any], key: str) -> list[str]:
+    """从 resolved settings 取字符串数组字段（非 list → ``[]``）/ Read a string-array field (non-list → [])."""
+    value = settings.get(key)
+    return [v for v in value if isinstance(v, str)] if isinstance(value, list) else []
+
+
+def mcp_server_status(name: str, *, settings: Mapping[str, Any], bundled: set[str], trusted_origin: bool) -> McpApprovalStatus:
+    """
+    判定单个 MCP server 的批准状态（§9.2，**顺序即优先级**）/ Decide one server's approval status。
+
+    优先级（先到先决）/ Priority (first match wins):
+    1. ``deniedMcpServers``（企业拒绝名单，policy）→ ``DISABLED``。
+    2. ``allowedMcpServers`` 非空（企业白名单，policy）且不在其中 → ``DISABLED``。
+    3. ``disabledMcpjsonServers`` → ``DISABLED``（**disabled 优先** over enabled）。
+    4. plugin-bundled（``bundled`` 并集，#63 显式 install = trusted）→ ``ENABLED``（免批准）。
+    5. ``trusted_origin``（user/flag/policy scope 自定义 server）→ ``ENABLED``（用户自己加的，不弹框）。
+    6. ``enabledMcpjsonServers`` → ``ENABLED``。
+    7. ``enableAllProjectMcpServers is True`` → ``ENABLED``。
+    8. 否则（工作区共享且未决）→ ``PENDING``。
+
+    :param settings: 六层合并后的 resolved settings（含 #56 落地的 MCP 门控字段）。
+    :param bundled: 已安装 plugin 携带的 bundled MCP server name 并集（见 :func:`bundled_mcp_server_names`）。
+    :param trusted_origin: 该 server 是否来自预信任 scope（见 :attr:`ResolvedMcpServer.trusted_origin`）。
+    """
+    if name in _str_list(settings, FIELD_DENIED_MCP_SERVERS):
+        return McpApprovalStatus.DISABLED
+    allowed = _str_list(settings, FIELD_ALLOWED_MCP_SERVERS)
+    if allowed and name not in allowed:
+        return McpApprovalStatus.DISABLED
+    if name in _str_list(settings, FIELD_DISABLED_MCPJSON_SERVERS):
+        return McpApprovalStatus.DISABLED
+    if name in bundled:
+        return McpApprovalStatus.ENABLED
+    if trusted_origin:
+        return McpApprovalStatus.ENABLED
+    if name in _str_list(settings, FIELD_ENABLED_MCPJSON_SERVERS):
+        return McpApprovalStatus.ENABLED
+    if settings.get(FIELD_ENABLE_ALL_PROJECT_MCP) is True:
+        return McpApprovalStatus.ENABLED
+    return McpApprovalStatus.PENDING
+
+
+def gate_mcp_servers(
+    resolved: ResolvedMcpConfig,
+    settings: Mapping[str, Any],
+    bundled: set[str],
+) -> dict[str, McpApprovalStatus]:
+    """对全部已解析 server 套 :func:`mcp_server_status` / Apply the gate to all resolved servers。"""
+    return {
+        name: mcp_server_status(name, settings=settings, bundled=bundled, trusted_origin=srv.trusted_origin)
+        for name, srv in resolved.servers.items()
+    }
+
+
+def bundled_mcp_server_names(home: Path | None = None, env: Mapping[str, str] | None = None) -> set[str]:
+    """
+    已安装 plugin 携带的 bundled MCP server name 并集（#64↔#63 账本接缝）/ Union of installed plugins' bundled servers。
+
+    读 ``installed_plugins.json``（#63 物化账本）全记录的 ``bundledMcpServers`` 字段——这些 server 因用户**显式
+    install plugin**而 trusted、门控免批准（§9.2 ``mcp_server_status`` 第 4 档）。
+    """
+    out: set[str] = set()
+    for records in load_installed_plugins(home=home, env=env)["plugins"].values():
+        for record in records:
+            out.update(record.get("bundledMcpServers", []) or [])
+    return out
+
+
+# ---------------------------------------------------------------------------
+# 批准写助手（写 local scope）/ Approval write helpers (write to local scope)（§9.2）
+# ---------------------------------------------------------------------------
+def _require_active_workdir(active_workdir: Path | None) -> Path:
+    """批准写须落 local scope = active workdir；缺则 fail-fast（镜像 installer scope 守卫）/ local-scope guard。"""
+    if not active_workdir:
+        raise McpConfigError("MCP approval write requires an active workdir (local scope); none provided")
+    return Path(active_workdir)
+
+
+def _append_local_mcp_array(active_workdir: Path | None, field_name: str, name: str) -> None:
+    """
+    把 ``name`` 追加进 local ``settings.local.json`` 的某 MCP 数组字段（持锁原子 RMW + dedup）/ Append to a local array。
+
+    复用 store 原语：:func:`file_lock`（旁车 ``.lock``）+ :func:`load_settings_file`（容错）+ :func:`apply_write`
+    （数组**整体替换**写语义，§5.4）+ :func:`atomic_write_json`（``header=None``——人编意图层无写保护头/version）。
+    锁内读-改-写杜绝并发丢更新。
+    """
+    wd = _require_active_workdir(active_workdir)
+    path = workdir_local_settings_path(wd)
+    with file_lock(path):
+        existing, _errors = load_settings_file(path, SettingsScope.LOCAL)
+        current = [v for v in existing.get(field_name, []) if isinstance(v, str)]
+        if name not in current:
+            current.append(name)
+        updated = apply_write(existing, {field_name: current})
+        atomic_write_json(path, updated)
+
+
+def approve_mcp_server(name: str, *, active_workdir: Path | None) -> None:
+    """批准框 ``[y]es``：追加 ``enabledMcpjsonServers`` 到 local scope（§9.2）/ Approve: append to enabled list (local)。"""
+    _append_local_mcp_array(active_workdir, FIELD_ENABLED_MCPJSON_SERVERS, name)
+
+
+def deny_mcp_server(name: str, *, active_workdir: Path | None) -> None:
+    """批准框 ``[n]o``：追加 ``disabledMcpjsonServers`` 到 local scope（§9.2）/ Deny: append to disabled list (local)。"""
+    _append_local_mcp_array(active_workdir, FIELD_DISABLED_MCPJSON_SERVERS, name)
+
+
+def approve_all_project_mcp(*, active_workdir: Path | None) -> None:
+    """批准框 ``[a]ll``：``enableAllProjectMcpServers=true`` 写 local scope（§9.2）/ Approve-all: set the bool (local)。"""
+    wd = _require_active_workdir(active_workdir)
+    path = workdir_local_settings_path(wd)
+    with file_lock(path):
+        existing, _errors = load_settings_file(path, SettingsScope.LOCAL)
+        updated = apply_write(existing, {FIELD_ENABLE_ALL_PROJECT_MCP: True})
+        atomic_write_json(path, updated)

--- a/a2c_smcp/computer/settings/mcp_config.py
+++ b/a2c_smcp/computer/settings/mcp_config.py
@@ -27,7 +27,9 @@ This is the pure logic layer for MCP definitions/gating (no git / MCP manager / 
   state）归 **#65**：本模块产出**带占位符**的定义，``ResolvedMcpServer.ext``（``envFile`` 等 VS Code 扩展）
   + 未渲染占位符是交给 #65 的 handoff。**绝不在此渲染**（§9.1 安全铁律：值不离 Computer）。
 - **批准框 TTY 交互**（``[a]/[y]/[n]``）/ ``--approve-all-mcp`` flag / 非交互 pending→skip+WARN 接线归
-  **#69**：本模块只提供 :class:`McpApprovalStatus` 判定 + 三个写助手原语。
+  **#69**：本模块只提供 :class:`McpApprovalStatus` 判定 + 三个写助手原语。#69 接线另须把
+  :attr:`ResolvedMcpConfig.errors`（含畸形 server/input 被 drop —— 如非 ``envFile`` 的 VS Code 扩展撞
+  ``MCPServerConfig`` 的 ``extra="forbid"``）**纳入启动 WARN 输出**，否则被 drop 的 server 对用户静默不可见。
 - ``allowManagedMcpServersOnly``（§9.2）#56 schema 未引入，v0.2.1 范围外；本模块只用
   ``allowedMcpServers`` / ``deniedMcpServers``。
 - ``managed-mcp.json`` v0.2.1 仅读 layer-3 文件（per-platform managed dir），remote/MDM stub，对齐
@@ -46,6 +48,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass, field
 from enum import StrEnum
 from pathlib import Path
+from types import MappingProxyType
 from typing import Any
 
 from pydantic import TypeAdapter, ValidationError
@@ -111,13 +114,14 @@ class ResolvedMcpServer:
     合并解析后的单个 MCP server 定义 / A merged-and-resolved single MCP server definition。
 
     ``config`` 是校验后的 A2C :class:`MCPServerConfig`（**含占位符、未渲染**）；``ext`` 是剥离出的 VS Code
-    扩展字段（如 ``envFile``，交 #65 渲染消费）；``origin`` 为最高定义 scope；``trusted_origin`` 决定是否免
-    批准门控（user/flag/policy 免，project/local 受门控）。
+    扩展字段（如 ``envFile``，交 #65 渲染消费），以 :class:`~types.MappingProxyType` **只读视图**承载——
+    frozen dataclass 只防字段重绑定、不冻 dict 内容，故下沉只读视图杜绝下游原地改污染；``origin`` 为最高定义
+    scope；``trusted_origin`` 决定是否免批准门控（user/flag/policy 免，project/local 受门控）。
     """
 
     name: str
     config: MCPServerConfig
-    ext: dict[str, Any]
+    ext: Mapping[str, Any]
     origin: SettingsScope
     trusted_origin: bool
 
@@ -240,7 +244,9 @@ def _validate_server(
         cfg = _MCP_SERVER_ADAPTER.validate_python(body)
     except ValidationError as exc:
         return None, [_err(scope, fld, f"invalid MCP server config: {exc}", source)]
-    return ResolvedMcpServer(name=name, config=cfg, ext=ext, origin=scope, trusted_origin=scope in _TRUSTED_ORIGINS), []
+    # ext 以只读视图承载（frozen dataclass 不冻 dict 内容；下游 #65 只读消费）/ ext as a read-only view.
+    server = ResolvedMcpServer(name=name, config=cfg, ext=MappingProxyType(ext), origin=scope, trusted_origin=scope in _TRUSTED_ORIGINS)
+    return server, []
 
 
 def _validate_input(idef: Any, scope: SettingsScope, source: str | None) -> tuple[MCPServerInput | None, list[SettingsValidationError]]:

--- a/tests/integration_tests/computer/settings/test_mcp_config.py
+++ b/tests/integration_tests/computer/settings/test_mcp_config.py
@@ -1,0 +1,130 @@
+# -*- coding: utf-8 -*-
+# filename: test_mcp_config.py
+# @Time    : 2026/05/26
+# @Author  : JQQ
+# @Email   : jqq1716@gmail.com
+# @Software: PyCharm
+"""
+``.tfrobot/mcp.json`` 定义层 + 批准门控集成测试（v0.2.1 #64）—— 全栈跨 scope 真文件 + 真 settings 解析
+``.tfrobot/mcp.json`` definition layer + approval-gate integration tests: full cross-scope real files.
+
+SDK 设计 / Design: python-sdk docs/design-0.2.1-cli-marketplace-ux.md §9.1 / §9.2 / §5.1 / §5.5。
+
+测试意图 / Test intentions（无 git；真实跨 user(XDG) + active project/local(.tfrobot) + managed 目录铺 mcp.json，
+真实 installed_plugins.json 供 bundled 接缝；批准 roundtrip 经真实 ``resolve_settings`` 六层合并读回）:
+- resolve + gate 全栈：user→enabled(trusted) / project→pending(workspace) / bundled→enabled(免批准) /
+  policy deny→disabled。
+- approve roundtrip：pending project server → ``approve_mcp_server`` 写 local → ``resolve_settings`` 读回 →
+  重门控 → enabled（接缝验证、不重复造判定）。
+- scope 覆盖全栈：同名 server user+local 双定义，local 胜（origin=local、workspace 受门控）。
+"""
+
+import json
+import os
+from pathlib import Path
+
+from a2c_smcp.computer.settings.mcp_config import (
+    McpApprovalStatus,
+    approve_mcp_server,
+    bundled_mcp_server_names,
+    gate_mcp_servers,
+    resolve_mcp_config,
+)
+from a2c_smcp.computer.settings.scope import resolve_settings
+from a2c_smcp.computer.settings.store import save_installed_plugins
+
+
+# ── 辅助 / helpers ───────────────────────────────────────────────────────────
+def _env(tmp_path: Path) -> dict[str, str]:
+    """XDG_CONFIG_HOME → user mcp.json/settings.json；A2C_SKILL_HOME → installed_plugins.json（bundled 接缝）。"""
+    return {**os.environ, "XDG_CONFIG_HOME": str(tmp_path / "cfg"), "A2C_SKILL_HOME": str(tmp_path / "home")}
+
+
+def _write_json(path: Path, obj: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(obj), encoding="utf-8")
+
+
+def _stdio() -> dict:
+    return {"type": "stdio", "server_parameters": {"command": "node"}}
+
+
+def _mcp(servers: dict) -> dict:
+    return {"servers": servers, "inputs": []}
+
+
+def _home(tmp_path: Path) -> Path:
+    h = tmp_path / "home"
+    h.mkdir(parents=True, exist_ok=True)
+    return h
+
+
+# ── resolve + gate 全栈 ───────────────────────────────────────────────────────
+def test_resolve_and_gate_full_stack(tmp_path: Path) -> None:
+    env = _env(tmp_path)
+    wd = tmp_path / "wd"
+    managed_mcp = tmp_path / "managed-mcp.json"
+
+    # 跨 scope 铺 server 定义：user(trusted) / project(workspace) / policy(trusted)。
+    _write_json(tmp_path / "cfg" / "a2c" / "mcp.json", _mcp({"user-srv": _stdio()}))
+    _write_json(wd / ".tfrobot" / "mcp.json", _mcp({"proj-srv": _stdio(), "blender": _stdio()}))
+    _write_json(managed_mcp, _mcp({"policy-srv": _stdio()}))
+
+    # bundled 账本：plugin 携带 "blender" → 即使在 workspace mcp.json 出现，也免批准。
+    save_installed_plugins(
+        {"plugins": {"3d@mp": [{"scope": "user", "installPath": "/x", "bundledMcpServers": ["blender"]}]}},
+        home=_home(tmp_path),
+    )
+
+    # policy denies "policy-srv"（企业拒绝名单，policy scope）。
+    policy = {"deniedMcpServers": ["policy-srv"]}
+
+    resolved = resolve_mcp_config(env=env, active_workdir=wd, managed_mcp_path=managed_mcp)
+    assert set(resolved.servers) == {"user-srv", "proj-srv", "blender", "policy-srv"}
+
+    settings = resolve_settings(active_workdir=wd, env=env, policy_settings=policy).settings
+    bundled = bundled_mcp_server_names(env=env)
+    statuses = gate_mcp_servers(resolved, settings, bundled)
+
+    assert statuses == {
+        "user-srv": McpApprovalStatus.ENABLED,  # trusted origin（用户自己加）
+        "proj-srv": McpApprovalStatus.PENDING,  # workspace 共享、未决 → 弹框（#69）
+        "blender": McpApprovalStatus.ENABLED,  # plugin-bundled 免批准（即便 workspace 声明）
+        "policy-srv": McpApprovalStatus.DISABLED,  # 企业拒绝名单
+    }
+
+
+def test_approve_roundtrip_flips_pending_to_enabled(tmp_path: Path) -> None:
+    """pending workspace server → approve 写 local → resolve_settings 六层读回 → 重门控 enabled。"""
+    env = _env(tmp_path)
+    wd = tmp_path / "wd"
+    managed_mcp = tmp_path / "absent-managed-mcp.json"
+    _write_json(wd / ".tfrobot" / "mcp.json", _mcp({"figma": _stdio()}))
+
+    resolved = resolve_mcp_config(env=env, active_workdir=wd, managed_mcp_path=managed_mcp)
+    bundled = bundled_mcp_server_names(env=env)
+
+    before = gate_mcp_servers(resolved, resolve_settings(active_workdir=wd, env=env).settings, bundled)
+    assert before == {"figma": McpApprovalStatus.PENDING}
+
+    # 批准框 [y]es：写 active-workdir local settings.local.json。
+    approve_mcp_server("figma", active_workdir=wd)
+
+    after = gate_mcp_servers(resolved, resolve_settings(active_workdir=wd, env=env).settings, bundled)
+    assert after == {"figma": McpApprovalStatus.ENABLED}
+
+
+def test_scope_override_full_stack(tmp_path: Path) -> None:
+    """同名 server user(低) + local(高)：local 整体覆盖、origin=local、workspace 受门控（pending）。"""
+    env = _env(tmp_path)
+    wd = tmp_path / "wd"
+    _write_json(tmp_path / "cfg" / "a2c" / "mcp.json", _mcp({"shared": {"type": "stdio", "server_parameters": {"command": "user-cmd"}}}))
+    _write_json(wd / ".tfrobot" / "mcp.local.json", _mcp({"shared": {"type": "stdio", "server_parameters": {"command": "local-cmd"}}}))
+
+    resolved = resolve_mcp_config(env=env, active_workdir=wd, managed_mcp_path=tmp_path / "absent.json")
+    srv = resolved.servers["shared"]
+    assert srv.config.server_parameters.command == "local-cmd"  # 高 scope 整体覆盖
+    assert srv.trusted_origin is False  # origin=local → workspace 共享、受门控
+
+    statuses = gate_mcp_servers(resolved, resolve_settings(active_workdir=wd, env=env).settings, set())
+    assert statuses == {"shared": McpApprovalStatus.PENDING}

--- a/tests/unit_tests/computer/settings/test_mcp_config.py
+++ b/tests/unit_tests/computer/settings/test_mcp_config.py
@@ -1,0 +1,348 @@
+# -*- coding: utf-8 -*-
+# filename: test_mcp_config.py
+# @Time    : 2026/05/26
+# @Author  : JQQ
+# @Email   : jqq1716@gmail.com
+# @Software: PyCharm
+"""
+``.tfrobot/mcp.json`` 定义层 + MCP 批准门控单元测试（v0.2.1 #64）
+``.tfrobot/mcp.json`` definition layer + MCP approval-gate unit tests.
+
+SDK 设计 / Design: python-sdk docs/design-0.2.1-cli-marketplace-ux.md §9.1 / §9.2 / §5.1 / §5.5。
+
+测试意图 / Test intentions（纯文件系统、无 git / manager；env 重定向 XDG_CONFIG_HOME 隔离 user mcp.json）:
+- load：缺失→空；损坏/根非对象→空+err；servers 非对象/inputs 非数组→该字段空+err。
+- merge：scope 优先级 policy>local>project>user>flag；同名 server 高 scope 整体覆盖 + origin；无 active →
+  仅 user+flag+policy；inputs 按 id 去重高胜。
+- ext 剥离：envFile 入 ext + 配置校验通过；含真未知 key 的 server → drop + err（字段容错、不 abort）。
+- gate：未知→pending；enabled/disabled（disabled 优先）；enableAll；plugin-bundled 免批准；user-origin 自动
+  enabled；policy deny→disabled；policy allow 白名单。
+- 写助手：approve/deny/approveAll 写 active-workdir local（dedup、无 version/header）；缺 active → 抛。
+- bundled 接缝：bundled_mcp_server_names 跨多记录并集。
+"""
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from a2c_smcp.computer.mcp_clients.model import StdioServerConfig
+from a2c_smcp.computer.settings.mcp_config import (
+    McpApprovalStatus,
+    McpConfigError,
+    ResolvedMcpConfig,
+    approve_all_project_mcp,
+    approve_mcp_server,
+    bundled_mcp_server_names,
+    deny_mcp_server,
+    gate_mcp_servers,
+    load_mcp_config_file,
+    mcp_server_status,
+    resolve_mcp_config,
+)
+from a2c_smcp.computer.settings.schema import SettingsScope
+from a2c_smcp.computer.settings.scope import workdir_local_settings_path
+from a2c_smcp.computer.settings.store import save_installed_plugins
+
+
+# ── 辅助 / helpers ───────────────────────────────────────────────────────────
+def _env(tmp_path: Path) -> dict[str, str]:
+    """重定向 XDG_CONFIG_HOME → tmp，隔离 user mcp.json / settings.json 写。"""
+    return {**os.environ, "XDG_CONFIG_HOME": str(tmp_path / "cfg")}
+
+
+def _write_json(path: Path, obj: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(obj), encoding="utf-8")
+
+
+def _stdio(command: str = "node") -> dict:
+    """无 name 的 stdio server 定义体（name 由 mcp.json map key 注入）。"""
+    return {"type": "stdio", "server_parameters": {"command": command}}
+
+
+def _user_mcp(tmp_path: Path) -> Path:
+    return tmp_path / "cfg" / "a2c" / "mcp.json"
+
+
+def _mcp_doc(servers: dict | None = None, inputs: list | None = None) -> dict:
+    return {"servers": servers or {}, "inputs": inputs or []}
+
+
+# ── load_mcp_config_file ──────────────────────────────────────────────────────
+def test_load_missing_returns_empty(tmp_path: Path) -> None:
+    data, errors = load_mcp_config_file(tmp_path / "nope.json", SettingsScope.USER)
+    assert data == {"servers": {}, "inputs": []}
+    assert errors == []
+
+
+def test_load_corrupt_json_returns_empty_plus_error(tmp_path: Path) -> None:
+    p = tmp_path / "mcp.json"
+    p.write_text("{bad json", encoding="utf-8")
+    data, errors = load_mcp_config_file(p, SettingsScope.USER)
+    assert data == {"servers": {}, "inputs": []}
+    assert len(errors) == 1 and errors[0].field == "<file>"
+
+
+def test_load_non_object_root_returns_empty_plus_error(tmp_path: Path) -> None:
+    p = tmp_path / "mcp.json"
+    _write_json(p, ["not", "an", "object"])
+    data, errors = load_mcp_config_file(p, SettingsScope.USER)
+    assert data == {"servers": {}, "inputs": []}
+    assert len(errors) == 1 and errors[0].field == "<root>"
+
+
+def test_load_wrong_typed_fields_emptied_with_errors(tmp_path: Path) -> None:
+    p = tmp_path / "mcp.json"
+    _write_json(p, {"servers": ["oops"], "inputs": {"oops": 1}})
+    data, errors = load_mcp_config_file(p, SettingsScope.USER)
+    assert data == {"servers": {}, "inputs": []}
+    assert {e.field for e in errors} == {"servers", "inputs"}
+
+
+def test_load_ok(tmp_path: Path) -> None:
+    p = tmp_path / "mcp.json"
+    _write_json(p, _mcp_doc(servers={"figma": _stdio()}, inputs=[{"id": "tok", "type": "promptString", "description": "d"}]))
+    data, errors = load_mcp_config_file(p, SettingsScope.USER)
+    assert list(data["servers"]) == ["figma"] and len(data["inputs"]) == 1
+    assert errors == []
+
+
+# ── resolve_mcp_config：merge / scope ─────────────────────────────────────────
+def test_resolve_user_only_no_active(tmp_path: Path) -> None:
+    env = _env(tmp_path)
+    _write_json(_user_mcp(tmp_path), _mcp_doc(servers={"figma": _stdio()}))
+    out = resolve_mcp_config(env=env, managed_mcp_path=tmp_path / "absent-managed.json")
+    assert set(out.servers) == {"figma"}
+    srv = out.servers["figma"]
+    assert isinstance(srv.config, StdioServerConfig) and srv.config.name == "figma"
+    assert srv.origin == SettingsScope.USER and srv.trusted_origin is True
+
+
+def test_resolve_no_active_ignores_workdir(tmp_path: Path) -> None:
+    """active_workdir=None → project/local 全不读（即使磁盘上有 .tfrobot/mcp.json 也不进）。"""
+    env = _env(tmp_path)
+    wd = tmp_path / "wd"
+    _write_json(wd / ".tfrobot" / "mcp.json", _mcp_doc(servers={"proj-srv": _stdio()}))
+    out = resolve_mcp_config(env=env, active_workdir=None, managed_mcp_path=tmp_path / "absent.json")
+    assert "proj-srv" not in out.servers
+
+
+def test_resolve_scope_priority_high_overrides(tmp_path: Path) -> None:
+    """同名 server：local(高) 整体覆盖 user(低)，origin 记最高 scope。"""
+    env = _env(tmp_path)
+    wd = tmp_path / "wd"
+    _write_json(_user_mcp(tmp_path), _mcp_doc(servers={"figma": _stdio("user-cmd")}))
+    _write_json(wd / ".tfrobot" / "mcp.local.json", _mcp_doc(servers={"figma": _stdio("local-cmd")}))
+    out = resolve_mcp_config(env=env, active_workdir=wd, managed_mcp_path=tmp_path / "absent.json")
+    srv = out.servers["figma"]
+    assert srv.origin == SettingsScope.LOCAL and srv.trusted_origin is False  # workspace-shared、受门控
+    assert isinstance(srv.config, StdioServerConfig)
+    assert srv.config.server_parameters.command == "local-cmd"  # 整体覆盖（高胜）
+
+
+def test_resolve_origins_partition_trust(tmp_path: Path) -> None:
+    """user/flag/policy → trusted；project/local → 受门控。"""
+    env = _env(tmp_path)
+    wd = tmp_path / "wd"
+    flag = tmp_path / "flag-mcp.json"
+    managed = tmp_path / "managed-mcp.json"
+    _write_json(flag, _mcp_doc(servers={"flag-srv": _stdio()}))
+    _write_json(_user_mcp(tmp_path), _mcp_doc(servers={"user-srv": _stdio()}))
+    _write_json(wd / ".tfrobot" / "mcp.json", _mcp_doc(servers={"proj-srv": _stdio()}))
+    _write_json(managed, _mcp_doc(servers={"policy-srv": _stdio()}))
+    out = resolve_mcp_config(env=env, active_workdir=wd, flag_config_path=flag, managed_mcp_path=managed)
+    trust = {n: s.trusted_origin for n, s in out.servers.items()}
+    assert trust == {"flag-srv": True, "user-srv": True, "proj-srv": False, "policy-srv": True}
+
+
+def test_resolve_inputs_dedup_by_id_high_wins(tmp_path: Path) -> None:
+    env = _env(tmp_path)
+    wd = tmp_path / "wd"
+    _write_json(_user_mcp(tmp_path), _mcp_doc(inputs=[{"id": "tok", "type": "promptString", "description": "user"}]))
+    local_inputs = [
+        {"id": "tok", "type": "promptString", "description": "local"},
+        {"id": "other", "type": "promptString", "description": "x"},
+    ]
+    _write_json(wd / ".tfrobot" / "mcp.local.json", _mcp_doc(inputs=local_inputs))
+    out = resolve_mcp_config(env=env, active_workdir=wd, managed_mcp_path=tmp_path / "absent.json")
+    by_id = {i.id: i for i in out.inputs}
+    assert set(by_id) == {"tok", "other"}
+    assert by_id["tok"].description == "local"  # 高 scope 胜
+
+
+# ── ext 剥离 + 字段级容错 ──────────────────────────────────────────────────────
+def test_resolve_envfile_stripped_to_ext(tmp_path: Path) -> None:
+    """envFile 是 VS Code 扩展（非 MCPServerConfig 字段）→ 剥离入 ext，配置仍校验通过。"""
+    env = _env(tmp_path)
+    sdef = {**_stdio(), "envFile": "${workspaceFolder}/.env"}
+    _write_json(_user_mcp(tmp_path), _mcp_doc(servers={"figma": sdef}))
+    out = resolve_mcp_config(env=env, managed_mcp_path=tmp_path / "absent.json")
+    srv = out.servers["figma"]
+    assert srv.ext == {"envFile": "${workspaceFolder}/.env"}
+    assert out.errors == []
+
+
+def test_resolve_placeholders_preserved_unrendered(tmp_path: Path) -> None:
+    """${input:}/${env:} 占位符是字符串、校验无碍，且原样保留（不渲染 → 值不离 Computer）。"""
+    env = _env(tmp_path)
+    sdef = {"type": "stdio", "server_parameters": {"command": "node", "env": {"TOK": "${input:figma_token}"}}}
+    _write_json(_user_mcp(tmp_path), _mcp_doc(servers={"figma": sdef}))
+    out = resolve_mcp_config(env=env, managed_mcp_path=tmp_path / "absent.json")
+    assert isinstance(out.servers["figma"].config, StdioServerConfig)
+    assert out.servers["figma"].config.server_parameters.env == {"TOK": "${input:figma_token}"}
+
+
+def test_resolve_malformed_server_dropped_not_abort(tmp_path: Path) -> None:
+    """单 server 含真未知 key（extra=forbid）→ drop + 记错；其余 server 存活（不 abort）。"""
+    env = _env(tmp_path)
+    servers = {"good": _stdio(), "bad": {**_stdio(), "bogus_field": 1}}
+    _write_json(_user_mcp(tmp_path), _mcp_doc(servers=servers))
+    out = resolve_mcp_config(env=env, managed_mcp_path=tmp_path / "absent.json")
+    assert set(out.servers) == {"good"}  # bad 被 drop
+    assert any(e.field == "servers.bad" for e in out.errors)
+
+
+def test_resolve_server_name_key_mismatch_dropped(tmp_path: Path) -> None:
+    env = _env(tmp_path)
+    sdef = {**_stdio(), "name": "different"}  # 内嵌 name 与 map key 冲突
+    _write_json(_user_mcp(tmp_path), _mcp_doc(servers={"figma": sdef}))
+    out = resolve_mcp_config(env=env, managed_mcp_path=tmp_path / "absent.json")
+    assert out.servers == {}
+    assert any("!= map key" in e.reason for e in out.errors)
+
+
+def test_resolve_malformed_input_dropped(tmp_path: Path) -> None:
+    env = _env(tmp_path)
+    _write_json(_user_mcp(tmp_path), _mcp_doc(inputs=[{"id": "ok", "type": "promptString", "description": "d"}, {"id": "bad"}]))
+    out = resolve_mcp_config(env=env, managed_mcp_path=tmp_path / "absent.json")
+    assert {i.id for i in out.inputs} == {"ok"}  # 缺 description 的 bad 被 drop
+    assert any(e.field == "inputs.bad" for e in out.errors)
+
+
+# ── gate：mcp_server_status / gate_mcp_servers ────────────────────────────────
+def test_status_pending_when_unknown_workspace(tmp_path: Path) -> None:
+    assert mcp_server_status("x", settings={}, bundled=set(), trusted_origin=False) == McpApprovalStatus.PENDING
+
+
+def test_status_enabled_via_enabled_list() -> None:
+    s = {"enabledMcpjsonServers": ["x"]}
+    assert mcp_server_status("x", settings=s, bundled=set(), trusted_origin=False) == McpApprovalStatus.ENABLED
+
+
+def test_status_disabled_takes_priority_over_enabled() -> None:
+    s = {"enabledMcpjsonServers": ["x"], "disabledMcpjsonServers": ["x"]}
+    assert mcp_server_status("x", settings=s, bundled=set(), trusted_origin=False) == McpApprovalStatus.DISABLED
+
+
+def test_status_enable_all() -> None:
+    s = {"enableAllProjectMcpServers": True}
+    assert mcp_server_status("x", settings=s, bundled=set(), trusted_origin=False) == McpApprovalStatus.ENABLED
+
+
+def test_status_bundled_auto_enabled_even_if_not_listed() -> None:
+    assert mcp_server_status("x", settings={}, bundled={"x"}, trusted_origin=False) == McpApprovalStatus.ENABLED
+
+
+def test_status_disabled_overrides_bundled() -> None:
+    """disabled（显式拒绝）优先于 bundled 免批准。"""
+    s = {"disabledMcpjsonServers": ["x"]}
+    assert mcp_server_status("x", settings=s, bundled={"x"}, trusted_origin=False) == McpApprovalStatus.DISABLED
+
+
+def test_status_trusted_origin_auto_enabled() -> None:
+    assert mcp_server_status("x", settings={}, bundled=set(), trusted_origin=True) == McpApprovalStatus.ENABLED
+
+
+def test_status_policy_deny() -> None:
+    s = {"deniedMcpServers": ["x"], "enabledMcpjsonServers": ["x"]}
+    assert mcp_server_status("x", settings=s, bundled={"x"}, trusted_origin=True) == McpApprovalStatus.DISABLED
+
+
+def test_status_policy_allow_whitelist() -> None:
+    s = {"allowedMcpServers": ["other"]}  # 非空白名单且 x 不在内 → disabled
+    assert mcp_server_status("x", settings=s, bundled=set(), trusted_origin=True) == McpApprovalStatus.DISABLED
+    s2 = {"allowedMcpServers": ["x"]}
+    assert mcp_server_status("x", settings=s2, bundled=set(), trusted_origin=False) == McpApprovalStatus.PENDING
+
+
+def test_gate_mcp_servers_maps_all(tmp_path: Path) -> None:
+    env = _env(tmp_path)
+    wd = tmp_path / "wd"
+    _write_json(_user_mcp(tmp_path), _mcp_doc(servers={"user-srv": _stdio()}))
+    _write_json(wd / ".tfrobot" / "mcp.json", _mcp_doc(servers={"proj-srv": _stdio()}))
+    out = resolve_mcp_config(env=env, active_workdir=wd, managed_mcp_path=tmp_path / "absent.json")
+    statuses = gate_mcp_servers(out, settings={}, bundled=set())
+    assert statuses == {"user-srv": McpApprovalStatus.ENABLED, "proj-srv": McpApprovalStatus.PENDING}
+
+
+# ── bundled 接缝 ──────────────────────────────────────────────────────────────
+def test_bundled_mcp_server_names_union(tmp_path: Path) -> None:
+    save_installed_plugins(
+        {
+            "plugins": {
+                "a@mp": [{"scope": "user", "installPath": "/x", "bundledMcpServers": ["figma", "blender"]}],
+                "b@mp": [{"scope": "user", "installPath": "/y", "bundledMcpServers": ["blender", "godot"]}],
+            }
+        },
+        home=tmp_path,
+    )
+    assert bundled_mcp_server_names(home=tmp_path) == {"figma", "blender", "godot"}
+
+
+def test_bundled_mcp_server_names_empty(tmp_path: Path) -> None:
+    assert bundled_mcp_server_names(home=tmp_path) == set()
+
+
+# ── 批准写助手（local scope）─────────────────────────────────────────────────
+def _read_local_settings(wd: Path) -> dict:
+    return json.loads(workdir_local_settings_path(wd).read_text(encoding="utf-8"))
+
+
+def test_approve_writes_enabled_to_local(tmp_path: Path) -> None:
+    wd = tmp_path / "wd"
+    approve_mcp_server("figma", active_workdir=wd)
+    approve_mcp_server("figma", active_workdir=wd)  # dedup
+    settings = _read_local_settings(wd)
+    assert settings["enabledMcpjsonServers"] == ["figma"]
+    assert "version" not in settings  # 人编层无 version
+    # 无写保护头：首行即 JSON
+    assert workdir_local_settings_path(wd).read_text(encoding="utf-8").lstrip().startswith("{")
+
+
+def test_deny_writes_disabled_to_local(tmp_path: Path) -> None:
+    wd = tmp_path / "wd"
+    deny_mcp_server("sketchy", active_workdir=wd)
+    assert _read_local_settings(wd)["disabledMcpjsonServers"] == ["sketchy"]
+
+
+def test_approve_all_sets_bool_local(tmp_path: Path) -> None:
+    wd = tmp_path / "wd"
+    approve_all_project_mcp(active_workdir=wd)
+    assert _read_local_settings(wd)["enableAllProjectMcpServers"] is True
+
+
+def test_approve_then_resolve_settings_flips_status(tmp_path: Path) -> None:
+    """approve roundtrip：写 local enabled → 再判定 status 由 pending→enabled（接缝验证）。"""
+    wd = tmp_path / "wd"
+    assert mcp_server_status("figma", settings={}, bundled=set(), trusted_origin=False) == McpApprovalStatus.PENDING
+    approve_mcp_server("figma", active_workdir=wd)
+    enabled = _read_local_settings(wd)["enabledMcpjsonServers"]
+    after = mcp_server_status("figma", settings={"enabledMcpjsonServers": enabled}, bundled=set(), trusted_origin=False)
+    assert after == McpApprovalStatus.ENABLED
+
+
+def test_approval_write_without_active_workdir_raises() -> None:
+    with pytest.raises(McpConfigError):
+        approve_mcp_server("x", active_workdir=None)
+    with pytest.raises(McpConfigError):
+        deny_mcp_server("x", active_workdir=None)
+    with pytest.raises(McpConfigError):
+        approve_all_project_mcp(active_workdir=None)
+
+
+def test_resolved_mcp_config_dataclass_defaults() -> None:
+    """ResolvedMcpConfig inputs/errors 默认空（无 server 场景）。"""
+    rc = ResolvedMcpConfig(servers={})
+    assert rc.inputs == [] and rc.errors == []

--- a/tests/unit_tests/computer/settings/test_mcp_config.py
+++ b/tests/unit_tests/computer/settings/test_mcp_config.py
@@ -29,6 +29,7 @@ import pytest
 
 from a2c_smcp.computer.mcp_clients.model import StdioServerConfig
 from a2c_smcp.computer.settings.mcp_config import (
+    MANAGED_MCP_FILENAME,
     McpApprovalStatus,
     McpConfigError,
     ResolvedMcpConfig,
@@ -38,9 +39,11 @@ from a2c_smcp.computer.settings.mcp_config import (
     deny_mcp_server,
     gate_mcp_servers,
     load_mcp_config_file,
+    managed_mcp_config_path,
     mcp_server_status,
     resolve_mcp_config,
 )
+from a2c_smcp.computer.settings.policy import LINUX_MANAGED_DIR, MACOS_MANAGED_DIR, WINDOWS_MANAGED_DIR
 from a2c_smcp.computer.settings.schema import SettingsScope
 from a2c_smcp.computer.settings.scope import workdir_local_settings_path
 from a2c_smcp.computer.settings.store import save_installed_plugins
@@ -346,3 +349,23 @@ def test_resolved_mcp_config_dataclass_defaults() -> None:
     """ResolvedMcpConfig inputs/errors 默认空（无 server 场景）。"""
     rc = ResolvedMcpConfig(servers={})
     assert rc.inputs == [] and rc.errors == []
+
+
+# ── managed-mcp.json 平台派生 / 无 id input 覆盖盲区（fix-review #84）────────────
+def test_managed_mcp_config_path_platform_branches() -> None:
+    """平台派生三分支 + 文件名拼接（resolve_* 测试均注入 managed_mcp_path，此处直测兜底派生路径）。"""
+    assert managed_mcp_config_path("darwin") == MACOS_MANAGED_DIR / MANAGED_MCP_FILENAME
+    assert managed_mcp_config_path("win32") == WINDOWS_MANAGED_DIR / MANAGED_MCP_FILENAME
+    assert managed_mcp_config_path("linux") == LINUX_MANAGED_DIR / MANAGED_MCP_FILENAME
+    assert managed_mcp_config_path("freebsd") == LINUX_MANAGED_DIR / MANAGED_MCP_FILENAME  # 非 darwin/win32 → linux 兜底
+
+
+def test_resolve_idless_and_non_object_inputs_dropped(tmp_path: Path) -> None:
+    """无 id 对象 input + 非对象 input：各走 <noid-N> key + inputs.<unknown>，皆 drop、不崩、去重 key 不冲突。"""
+    env = _env(tmp_path)
+    inputs = [{"type": "promptString", "description": "no-id"}, "junk-string"]
+    _write_json(_user_mcp(tmp_path), _mcp_doc(inputs=inputs))
+    out = resolve_mcp_config(env=env, managed_mcp_path=tmp_path / "absent.json")
+    assert out.inputs == []  # 两者皆 drop、不崩
+    unknown_errs = [e for e in out.errors if e.field == "inputs.<unknown>"]
+    assert len(unknown_errs) == 2  # 各自独立报错 → <noid-N> key 不冲突（非互相覆盖）


### PR DESCRIPTION
## 概述

实现 **#64 S11 `.tfrobot/mcp.json` 定义层 + MCP 批准门控**。纯 Computer 侧、**无 A2C 协议变更**（消费已发布的 `MCPServerConfig`/`MCPServerInput`，`.tfrobot/mcp.json` 本地读取不过线，`smcp.py` 不变）。依赖 **#56（已合）**。

设计依据：`docs/design-0.2.1-cli-marketplace-ux.md` §9.1（A2C 原生 schema、为何不复用标准 `.mcp.json`）/ §9.2（全套 CC 批准门控）/ §5.1（active-workdir 单根）/ §5.5（MCP 定义合并顺序）。落点 §12.1 = 新增单模块 `settings/mcp_config.py`。

## 改动

**`settings/mcp_config.py`（新增）**
- **多 scope 加载合并** `.tfrobot/mcp.json`：优先级 `policy > local > project > user > flag`，**无能力层并集**（敏感面隔离，区别于 settings.json 的能力发现层）；无 active workdir 时仅 user+flag+policy。
- **servers 按 name 整体替换**（server config 是原子单元、非深合并）；`origin` = 最高定义 scope，`trusted_origin` = origin∈{user,flag,policy}（免门控）vs {project,local}（workspace 共享、受门控）。
- **字段级容错**：单 server/input 畸形 → drop + `SettingsValidationError`、**不 abort**（人编文件姿态，§5.6；刻意区别于 #63 `manifest.py` 对 bundled server 的硬抛）。
- `envFile` 等 VS Code 扩展字段（非 `MCPServerConfig` 字段、`extra=forbid`）→ 校验前剥离入 `ResolvedMcpServer.ext`（交 #65）；`${input:}`/`${env:}` 占位符原样保留、**不渲染**（§9.1 值不离 Computer）。
- **门控判定** `mcp_server_status` / `gate_mcp_servers`（顺序即优先级）：deny → allow 白名单 → disabled（**优先**）→ bundled（免批准）→ trusted_origin → enabled → enableAll → 否则 pending。
- **bundled 免批准接缝** `bundled_mcp_server_names`：读 #63 `installed_plugins.json` 的 `bundledMcpServers` 并集。
- **批准写助手** `approve_mcp_server` / `deny_mcp_server` / `approve_all_project_mcp`：写 **local scope**（镜像 installer `_write_enabled_plugin` 持锁原子 RMW）。

**`settings/__init__.py`**：NB 注释纳入 `mcp_config` 为 direct-import-only（import `mcp_clients.model`→vrl，不 re-export 以免无谓加重 `import settings`）。

## 下游接缝（handoff，避免遗漏）

- **#65 S12**（取值/渲染）：消费 `ResolvedMcpServer.ext`（envFile）+ `.config`（带占位符）+ `ResolvedMcpConfig.inputs`（`MCPServerInput` 池）→ envFile 加载 + `${env:}`/`${workspaceFolder}`/`${input:}` 展开 + 解析链 env→keyring→明文 state→prompt→default + secret/value_store + plugin inputs 前缀消歧。#65 正文已满覆盖。
- **#69 S16**（CLI 接线）：消费 `gate_mcp_servers` 判定 + 三写助手原语 → 接线 TTY 批准框 `[a]/[y]/[n]`、全局 `--approve-all-mcp`，**以及非交互/`--json` 下 pending→skip 该 server + WARN（§9.2 末项，#69 验收清单原未单列，特此登记）**。
- 范围外：`allowManagedMcpServersOnly`（#56 schema 未引入）；`managed-mcp.json` 仅读 layer-3 文件（remote/MDM stub）。

## 验收（对齐 #64 四项）

- ✅ 多 scope 优先级（policy>local>project>user>flag；无 active 仅 user+flag+默认）
- ✅ 门控判定（未知→pending；enabled/disabled[disabled 优先]；enableAll；plugin-bundled 免批准）
- ✅ 不跨目录并集（敏感面隔离）
- ✅ `uv run poe lint` 净（ruff All checks passed + mypy 86 文件 0 issue）

测试：unit **33** + integration **3**；settings/skills **441 passed**；全量 **1460 passed, 2 skipped, 4 xfailed**。

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)
