### PR TITLE
feat(computer): v0.2.1 S15 CLI marketplace + skill 命令（+ trust/completer/progress/banner/help）(#68)

### DIFF
--- a/a2c_smcp/computer/cli/banner.py
+++ b/a2c_smcp/computer/cli/banner.py
@@ -22,6 +22,9 @@ from rich.panel import Panel
 
 from a2c_smcp.computer.cli.utils import console
 from a2c_smcp.computer.settings.store import load_installed_plugins
+from a2c_smcp.utils.logger import get_logger
+
+logger = get_logger(__name__)
 
 
 def _installed_plugin_count(home: Path | None, env: Mapping[str, str] | None) -> int:
@@ -29,7 +32,8 @@ def _installed_plugin_count(home: Path | None, env: Mapping[str, str] | None) ->
         return 0
     try:
         return len(load_installed_plugins(home, env).get("plugins") or {})
-    except Exception:  # banner 不应因物化读失败而打断启动 / never break boot on store read failure
+    except Exception as e:  # banner 不应因物化读失败而打断启动；记 DEBUG 便于排障（含编程错）/ never break boot
+        logger.debug("banner: installed-plugin count failed (%s), treating as 0", e)
         return 0
 
 

--- a/a2c_smcp/computer/cli/banner.py
+++ b/a2c_smcp/computer/cli/banner.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+# filename: banner.py
+# @Time    : 2026/05/27
+# @Author  : JQQ
+# @Email   : jqq1716@gmail.com
+# @Software: PyCharm
+"""
+REPL 启动 banner（zero-state 引导）/ REPL startup banner with zero-state guidance（S15，#68）。
+
+设计依据 / Design: python-sdk docs/design-0.2.1-cli-marketplace-ux.md §10.1。
+
+触发条件：``installed plugins == 0 AND servers == 0``（marketplace 数量不计入）→ 引导框；否则一行摘要。
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from rich.panel import Panel
+
+from a2c_smcp.computer.cli.utils import console
+from a2c_smcp.computer.settings.store import load_installed_plugins
+
+
+def _installed_plugin_count(home: Path | None, env: Mapping[str, str] | None) -> int:
+    if home is None:
+        return 0
+    try:
+        return len(load_installed_plugins(home, env).get("plugins") or {})
+    except Exception:  # banner 不应因物化读失败而打断启动 / never break boot on store read failure
+        return 0
+
+
+def render_banner(comp: Any, home: Path | None, env: Mapping[str, str] | None) -> None:
+    """zero-state（0 plugins AND 0 servers）→ 引导框；否则一行摘要 / Zero-state box or one-line summary。"""
+    plugins = _installed_plugin_count(home, env)
+    servers = len(getattr(comp, "mcp_servers", ()) or ())
+
+    if plugins == 0 and servers == 0:
+        body = (
+            "[bold]A2C Computer[/bold] — ready (0 plugins, 0 servers)\n\n"
+            "[bold]Next steps:[/bold]\n"
+            "  • [cyan]marketplace add <git-url>[/cyan]   add a SKILL marketplace\n"
+            "  • [cyan]server add @<file>[/cyan]          add an MCP server\n"
+            "  • [cyan]help[/cyan]                        full command list"
+        )
+        console.print(Panel(body, expand=False, border_style="cyan"))
+        return
+    console.print(f"[bold]A2C Computer[/bold]  ·  {plugins} plugins  ·  {servers} servers")

--- a/a2c_smcp/computer/cli/commands/__init__.py
+++ b/a2c_smcp/computer/cli/commands/__init__.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+# filename: __init__.py
+# @Time    : 2026/05/27
+# @Author  : JQQ
+# @Email   : jqq1716@gmail.com
+# @Software: PyCharm
+"""
+CLI 命令核心（REPL 与 Typer 非交互共用）/ CLI command core shared by the REPL and non-interactive Typer surfaces。
+
+设计依据 / Design: python-sdk docs/design-0.2.1-cli-marketplace-ux.md §4.2 / §4.4 / §12（S15，#68）。
+
+本包把 marketplace / skill 命令的业务逻辑（包裹 staging / reconciler / store / installer / registry 既有后端）
+抽成纯函数式 handler，签名取**显式资源**（``registry`` / ``home`` / ``env`` + flags）而非整个 Computer，便于
+隔离单测；REPL 经各模块的 ``repl_dispatch`` 适配器把 ``Computer`` 的活跃 registry / home / session 绑定进去，
+Typer 子命令则构造轻量上下文（不 boot Computer、不连 socket）。
+
+本模块只放 **跨命令共享的接缝**：:func:`build_mcp_callbacks`——从 ``Computer`` 装配 installer / 卸载级联所需的
+MCP 注入回调（``existing_server_names`` / ``register_server`` / ``remove_server``）。plugin / settings 命令（#69）
+将复用本接缝。
+This package holds the command business logic as pure-ish handlers (explicit resources, not the whole Computer)
+so they unit-test in isolation. Only the cross-command seam lives here: :func:`build_mcp_callbacks`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # 仅类型，避免运行时循环导入 / type-only to dodge runtime import cycle
+    from a2c_smcp.computer.computer import Computer
+    from a2c_smcp.computer.mcp_clients.model import MCPServerConfig
+    from a2c_smcp.computer.settings.installer import ExistingServerNames, RegisterServer, RemoveServer
+
+
+@dataclass(frozen=True, slots=True)
+class McpCallbacks:
+    """installer / 卸载级联所需的三个 MCP 注入回调 / The three MCP injection callbacks installer/cascade needs。"""
+
+    existing_server_names: ExistingServerNames
+    register_server: RegisterServer
+    remove_server: RemoveServer
+
+
+def build_mcp_callbacks(comp: Computer) -> McpCallbacks:
+    """
+    从 ``Computer`` 装配 installer / uninstall 级联所需的 MCP 注入回调 / Wire MCP callbacks from a live Computer。
+
+    - ``existing_server_names``：当前已注册 MCP server 名集合（冲突预检用）；
+    - ``register_server``：注册 / 更新一个 ``MCPServerConfig``（enable / install remount 用）；
+    - ``remove_server``：按 name 停并摘除 server（disable / uninstall teardown 用）。
+
+    设计 §12.2：marketplace remove 的级联卸载（→ :func:`installer.uninstall_plugin`）与 #69 的 plugin
+    enable/disable/install/uninstall 共用此接缝，避免各处重复装配。
+    """
+
+    def _existing() -> set[str]:
+        return {cfg.name for cfg in comp.mcp_servers}
+
+    async def _register(cfg: MCPServerConfig) -> None:
+        await comp.aadd_or_aupdate_server(cfg)
+
+    async def _remove(name: str) -> None:
+        await comp.aremove_server(name)
+
+    return McpCallbacks(existing_server_names=_existing, register_server=_register, remove_server=_remove)

--- a/a2c_smcp/computer/cli/commands/marketplace.py
+++ b/a2c_smcp/computer/cli/commands/marketplace.py
@@ -9,8 +9,9 @@
 
 设计依据 / Design: python-sdk docs/design-0.2.1-cli-marketplace-ux.md §4.2 / §10.4 / §10.5（S15，#68）。
 
-handler 取**显式资源**（``registry`` / ``home`` / ``env``）+ flags，返回退出码（0 成功 / 1 用户错 / 2 网络错 /
-3 内部错，§4.6），便于隔离单测。包裹既有后端：克隆/对账 :func:`stage_marketplace_skills`、物化读写
+handler 取**显式资源**（``registry`` / ``home`` / ``env``）+ flags，返回退出码（0 成功 / 1 用户错 / 2 网络错；
+§4.6 另定义 3=内部错，本层暂不显式产出——内部异常由 Typer 顶层处理），便于隔离单测。包裹既有后端：克隆/对账
+:func:`stage_marketplace_skills`、物化读写
 :func:`load_known_marketplaces` 等、卸载级联 :func:`uninstall_plugin` + :func:`prune_marketplaces`。
 Trust（§10.5）首见经 ``confirm`` 回调（REPL=session y/N；Typer 非交互无 confirm 且无 ``--trust`` → 退出码 1），
 批准后持久化到 user scope ``trustedMarketplaces``（CC 模型，§16：``known_marketplaces.json`` **不**带 trusted 字段）。
@@ -106,19 +107,31 @@ def default_marketplace_name(url: str) -> str | None:
 
 
 # ── trust 持久化（user scope settings.json）/ trust persistence ────────────────
+# 键空间 = marketplace **name**（设计 §5.3.1 规范表：trustedMarketplaces 元素=name，与 blockedMarketplaces
+# 同键空间、line 458 blocked 优先可比；#80 strict/白名单按 name 读）。**不**用 URL，避免 #80 落地时键型不一致 +
+# 已写入 user settings 的迁移成本。
 def _load_trusted(env: Mapping[str, str] | None) -> set[str]:
     existing, _errors = load_settings_file(user_settings_path(env), SettingsScope.USER)
-    return {u for u in existing.get(FIELD_TRUSTED_MARKETPLACES, []) if isinstance(u, str)}
+    return {n for n in existing.get(FIELD_TRUSTED_MARKETPLACES, []) if isinstance(n, str)}
 
 
-def _record_trust(url: str, env: Mapping[str, str] | None) -> None:
-    """把 ``url`` 追加进 user ``settings.json`` 的 ``trustedMarketplaces``（持锁原子 RMW + dedup）/ Record trust。"""
+def _record_trust(name: str, env: Mapping[str, str] | None) -> None:
+    """把 marketplace ``name`` 追加进 user ``settings.json`` 的 ``trustedMarketplaces``（持锁原子 RMW + dedup）。"""
     path = user_settings_path(env)
     with file_lock(path):
         existing, _errors = load_settings_file(path, SettingsScope.USER)
-        current = [u for u in existing.get(FIELD_TRUSTED_MARKETPLACES, []) if isinstance(u, str)]
-        if url not in current:
-            current.append(url)
+        current = [n for n in existing.get(FIELD_TRUSTED_MARKETPLACES, []) if isinstance(n, str)]
+        if name not in current:
+            current.append(name)
+        atomic_write_json(path, apply_write(existing, {FIELD_TRUSTED_MARKETPLACES: current}))
+
+
+def _revoke_trust(name: str, env: Mapping[str, str] | None) -> None:
+    """从 user ``settings.json`` 的 ``trustedMarketplaces`` 移除 marketplace ``name``（remove 时调，避免只增不减）。"""
+    path = user_settings_path(env)
+    with file_lock(path):
+        existing, _errors = load_settings_file(path, SettingsScope.USER)
+        current = [n for n in existing.get(FIELD_TRUSTED_MARKETPLACES, []) if isinstance(n, str) and n != name]
         atomic_write_json(path, apply_write(existing, {FIELD_TRUSTED_MARKETPLACES: current}))
 
 
@@ -147,13 +160,14 @@ async def marketplace_add(
     if mp_name in _marketplaces(home, env):
         return _err(f"marketplace name conflict: {mp_name!r} already exists", json_output=json_output)
 
-    # trust 门：已信任 / --trust → 直通；否则 confirm 回调（缺回调=非交互且无 --trust）→ 报错退出。
-    if not trust and url not in _load_trusted(env):
+    # trust 门：name 已信任 / --trust → 直通；否则 confirm 回调（缺回调=非交互且无 --trust）→ 报错退出。
+    # 门控/落盘按 **name**（§5.3.1），prompt 仍展示 url 供用户判断来源。
+    if not trust and mp_name not in _load_trusted(env):
         if confirm is None:
-            return _err(f"untrusted marketplace {url!r}; pass --trust to confirm non-interactively", json_output=json_output)
+            return _err(f"untrusted marketplace {mp_name!r} ({url}); pass --trust to confirm non-interactively", json_output=json_output)
         if not await confirm(url):
             return _err("aborted by user (untrusted)", json_output=json_output)
-    _record_trust(url, env)
+    _record_trust(mp_name, env)
 
     if no_clone:
         # 仅注册意图（不推荐，§4.2 debug 用）：记 known_marketplaces 但不 clone/stage。
@@ -192,7 +206,7 @@ def marketplace_list(home: Path, env: Mapping[str, str] | None, *, json_output: 
                 {
                     "name": nm,
                     "url": _source_url(rec),
-                    "trusted": _source_url(rec) in trusted,
+                    "trusted": nm in trusted,  # 信任按 name 判定（§5.3.1）
                     "autoUpdate": bool(rec.get("autoUpdate", False)),
                     "lastUpdated": rec.get("lastUpdated"),
                     "commitSha": rec.get("commitSha"),
@@ -214,7 +228,7 @@ def marketplace_list(home: Path, env: Mapping[str, str] | None, *, json_output: 
         table.add_row(
             nm,
             url,
-            "✓" if url in trusted else "—",
+            "✓" if nm in trusted else "—",
             "on" if rec.get("autoUpdate") else "off",
             str(rec.get("lastUpdated") or "—"),
             sha[:10] if sha else "—",
@@ -238,7 +252,7 @@ def marketplace_info(home: Path, env: Mapping[str, str] | None, name: str, *, js
         "installLocation": rec.get("installLocation"),
         "commitSha": rec.get("commitSha"),
         "autoUpdate": bool(rec.get("autoUpdate", False)),
-        "trusted": url in _load_trusted(env),
+        "trusted": name in _load_trusted(env),  # 信任按 name 判定（§5.3.1）
         "lastUpdated": rec.get("lastUpdated"),
         "installedPlugins": plugins,
     }
@@ -283,6 +297,7 @@ async def marketplace_remove(
                 uninstalled.append(pid)
 
     pruned = prune_marketplaces([name], registry, home, env=env)
+    _revoke_trust(name, env)  # 撤销信任，避免 trustedMarketplaces 只增不减（user scope）
     if json_output:
         console.print_json(data={"removed": name, "pruned": pruned, "uninstalledPlugins": uninstalled, "keptPlugins": keep_plugins})
         return EXIT_OK
@@ -370,12 +385,13 @@ async def repl_dispatch(comp: Any, parts: list[str], *, session: Any) -> None:
             console.print("[yellow]usage: marketplace add <git-url> [--name N] [--trust] [--auto-update] [--no-clone][/yellow]")
             return
         name = _flag_value(args, "--name")
-        await marketplace_add(
+        code = await marketplace_add(
             registry, home, env, pos[0],
             name=name, trust="--trust" in args, auto_update="--auto-update" in args,
             no_clone="--no-clone" in args, confirm=_confirm, json_output=json_output,
         )
-        comp.mark_skills_dirty()
+        if code == EXIT_OK:  # 仅成功才标脏，避免失败/拒绝触发无意义 emit
+            comp.mark_skills_dirty()
     elif sub == "list":
         marketplace_list(home, env, json_output=json_output)
     elif sub == "info":
@@ -389,16 +405,18 @@ async def repl_dispatch(comp: Any, parts: list[str], *, session: Any) -> None:
             return
         from a2c_smcp.computer.cli.commands import build_mcp_callbacks
 
-        await marketplace_remove(
+        code = await marketplace_remove(
             registry, home, env, pos[0],
             keep_plugins="--keep-plugins" in args, confirm=_confirm,
             mcp_cbs=build_mcp_callbacks(comp), json_output=json_output,
         )
-        comp.mark_skills_dirty()
+        if code == EXIT_OK:
+            comp.mark_skills_dirty()
     elif sub == "refresh":
         target = pos[0] if pos else "all"
-        await marketplace_refresh(registry, home, env, target, json_output=json_output)
-        comp.mark_skills_dirty()
+        code = await marketplace_refresh(registry, home, env, target, json_output=json_output)
+        if code == EXIT_OK:
+            comp.mark_skills_dirty()
     elif sub == "set":
         # marketplace set <name> auto-update=<bool>
         if len(pos) < 2 or "=" not in pos[1]:

--- a/a2c_smcp/computer/cli/commands/marketplace.py
+++ b/a2c_smcp/computer/cli/commands/marketplace.py
@@ -1,0 +1,419 @@
+# -*- coding: utf-8 -*-
+# filename: marketplace.py
+# @Time    : 2026/05/27
+# @Author  : JQQ
+# @Email   : jqq1716@gmail.com
+# @Software: PyCharm
+"""
+``marketplace`` 命令 handler（add / list / info / remove / refresh / set）/ Marketplace command handlers。
+
+设计依据 / Design: python-sdk docs/design-0.2.1-cli-marketplace-ux.md §4.2 / §10.4 / §10.5（S15，#68）。
+
+handler 取**显式资源**（``registry`` / ``home`` / ``env``）+ flags，返回退出码（0 成功 / 1 用户错 / 2 网络错 /
+3 内部错，§4.6），便于隔离单测。包裹既有后端：克隆/对账 :func:`stage_marketplace_skills`、物化读写
+:func:`load_known_marketplaces` 等、卸载级联 :func:`uninstall_plugin` + :func:`prune_marketplaces`。
+Trust（§10.5）首见经 ``confirm`` 回调（REPL=session y/N；Typer 非交互无 confirm 且无 ``--trust`` → 退出码 1），
+批准后持久化到 user scope ``trustedMarketplaces``（CC 模型，§16：``known_marketplaces.json`` **不**带 trusted 字段）。
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from collections.abc import Awaitable, Callable, Mapping
+from pathlib import Path
+from typing import Any
+
+from rich.table import Table
+
+from a2c_smcp.computer.cli.commands import McpCallbacks
+from a2c_smcp.computer.cli.progress import clone_spinner, refresh_summary_table
+from a2c_smcp.computer.cli.utils import console
+from a2c_smcp.computer.settings.installer import uninstall_plugin
+from a2c_smcp.computer.settings.reconciler import prune_marketplaces
+from a2c_smcp.computer.settings.schema import (
+    FIELD_TRUSTED_MARKETPLACES,
+    SettingsScope,
+    is_valid_git_url,
+    is_valid_marketplace_name,
+)
+from a2c_smcp.computer.settings.scope import apply_write, load_settings_file, user_settings_path
+from a2c_smcp.computer.settings.store import (
+    atomic_write_json,
+    file_lock,
+    load_installed_plugins,
+    load_known_marketplaces,
+    update_known_marketplaces,
+)
+from a2c_smcp.computer.skills.registry import SkillRegistry
+from a2c_smcp.computer.skills.sources import GITHUB_HOST, SkillSourceError, normalize_repo_shorthand
+from a2c_smcp.computer.skills.staging import stage_marketplace_skills
+
+# trust 确认回调：接收待信任源（url/name）→ 返回是否继续 / Trust confirm callback。
+ConfirmFn = Callable[[str], Awaitable[bool]]
+
+# 退出码语义（§4.6）/ Exit code semantics。
+EXIT_OK = 0
+EXIT_USER_ERROR = 1
+EXIT_NETWORK_ERROR = 2
+
+
+# ── 输出辅助 / output helpers ─────────────────────────────────────────────────
+def _err(msg: str, *, json_output: bool, code: int = EXIT_USER_ERROR) -> int:
+    if json_output:
+        console.print_json(data={"error": msg})
+    else:
+        console.print(f"[red]✗ {msg}[/red]")
+    return code
+
+
+def _ok(msg: str) -> int:
+    console.print(f"[green]✓ {msg}[/green]")
+    return EXIT_OK
+
+
+def _marketplaces(home: Path, env: Mapping[str, str] | None) -> dict[str, Any]:
+    """known_marketplaces 的 marketplaces 映射（plain dict，规避 TypedDict 严格性）/ marketplaces map as a plain dict。"""
+    return dict(load_known_marketplaces(home, env).get("marketplaces") or {})
+
+
+def _source_url(rec: Mapping[str, Any]) -> str | None:
+    """从 marketplace 记录取 git url / Extract the git url from a marketplace record。"""
+    src = rec.get("source")
+    return src.get("url") if isinstance(src, Mapping) else None
+
+
+# ── URL / name 归一 / normalization ───────────────────────────────────────────
+def normalize_marketplace_url(raw: str) -> str | None:
+    """归一 marketplace git URL：完整 URL 原样；裸 ``owner/repo`` 简写按 GitHub 糖展开 / Normalize a marketplace git URL。"""
+    raw = raw.strip()
+    if is_valid_git_url(raw):
+        return raw
+    try:
+        return normalize_repo_shorthand(raw, GITHUB_HOST)
+    except SkillSourceError:
+        return None
+
+
+def default_marketplace_name(url: str) -> str | None:
+    """从 git URL 末段派生严格-kebab marketplace 名（去 ``.git``、非字母数字折叠为 ``-``）/ Derive a kebab name from URL。"""
+    tail = url.rstrip("/")
+    seg = re.split(r"[/:]", tail)[-1]
+    if seg.endswith(".git"):
+        seg = seg[:-4]
+    slug = re.sub(r"[^a-z0-9]+", "-", seg.lower()).strip("-")
+    return slug if slug and is_valid_marketplace_name(slug) else None
+
+
+# ── trust 持久化（user scope settings.json）/ trust persistence ────────────────
+def _load_trusted(env: Mapping[str, str] | None) -> set[str]:
+    existing, _errors = load_settings_file(user_settings_path(env), SettingsScope.USER)
+    return {u for u in existing.get(FIELD_TRUSTED_MARKETPLACES, []) if isinstance(u, str)}
+
+
+def _record_trust(url: str, env: Mapping[str, str] | None) -> None:
+    """把 ``url`` 追加进 user ``settings.json`` 的 ``trustedMarketplaces``（持锁原子 RMW + dedup）/ Record trust。"""
+    path = user_settings_path(env)
+    with file_lock(path):
+        existing, _errors = load_settings_file(path, SettingsScope.USER)
+        current = [u for u in existing.get(FIELD_TRUSTED_MARKETPLACES, []) if isinstance(u, str)]
+        if url not in current:
+            current.append(url)
+        atomic_write_json(path, apply_write(existing, {FIELD_TRUSTED_MARKETPLACES: current}))
+
+
+# ── handlers ──────────────────────────────────────────────────────────────────
+async def marketplace_add(
+    registry: SkillRegistry,
+    home: Path,
+    env: Mapping[str, str] | None,
+    git_url: str,
+    *,
+    name: str | None = None,
+    trust: bool = False,
+    auto_update: bool = False,
+    no_clone: bool = False,
+    confirm: ConfirmFn | None = None,
+    json_output: bool = False,
+) -> int:
+    """添加新 marketplace（首次 trust y/N，默认 eager clone）/ Add a marketplace (trust on first add, eager clone)。"""
+    url = normalize_marketplace_url(git_url)
+    if url is None:
+        return _err(f"not a well-formed git url or owner/repo shorthand: {git_url!r}", json_output=json_output)
+    mp_name = name or default_marketplace_name(url)
+    if not mp_name or not is_valid_marketplace_name(mp_name):
+        return _err(f"cannot derive a valid marketplace name from {git_url!r}; pass --name", json_output=json_output)
+
+    if mp_name in _marketplaces(home, env):
+        return _err(f"marketplace name conflict: {mp_name!r} already exists", json_output=json_output)
+
+    # trust 门：已信任 / --trust → 直通；否则 confirm 回调（缺回调=非交互且无 --trust）→ 报错退出。
+    if not trust and url not in _load_trusted(env):
+        if confirm is None:
+            return _err(f"untrusted marketplace {url!r}; pass --trust to confirm non-interactively", json_output=json_output)
+        if not await confirm(url):
+            return _err("aborted by user (untrusted)", json_output=json_output)
+    _record_trust(url, env)
+
+    if no_clone:
+        # 仅注册意图（不推荐，§4.2 debug 用）：记 known_marketplaces 但不 clone/stage。
+        update_known_marketplaces(
+            lambda f: f["marketplaces"].__setitem__(  # type: ignore[func-returns-value]
+                mp_name, {"source": {"type": "git", "url": url}, "installLocation": "", "autoUpdate": auto_update}
+            )
+            or f,
+            home,
+            env,
+        )
+        return _ok(f"registered marketplace intent {mp_name!r} (no clone)")
+
+    source = {"type": "git", "url": url}
+    with clone_spinner(f"Cloning {mp_name}...", enabled=not json_output):
+        registered = await stage_marketplace_skills(mp_name, source, registry, home, auto_update=auto_update, env=env)
+
+    # 成功判定：stage 失败降级（不抛、返回空 + 不写 known_marketplaces）；据物化记录是否落盘判定。
+    if mp_name not in _marketplaces(home, env):
+        return _err(f"clone/refresh failed for {url!r} (see logs)", json_output=json_output, code=EXIT_NETWORK_ERROR)
+
+    if json_output:
+        console.print_json(data={"added": mp_name, "url": url, "skills": len(registered)})
+        return EXIT_OK
+    return _ok(f"added {mp_name!r} — cloned, {len(registered)} skill(s) found")
+
+
+def marketplace_list(home: Path, env: Mapping[str, str] | None, *, json_output: bool = False) -> int:
+    """列出所有已知 marketplace（trusted / clone 状态 / 上次刷新 / auto_update）/ List known marketplaces。"""
+    mps = _marketplaces(home, env)
+    trusted = _load_trusted(env)
+
+    if json_output:
+        console.print_json(
+            data=[
+                {
+                    "name": nm,
+                    "url": _source_url(rec),
+                    "trusted": _source_url(rec) in trusted,
+                    "autoUpdate": bool(rec.get("autoUpdate", False)),
+                    "lastUpdated": rec.get("lastUpdated"),
+                    "commitSha": rec.get("commitSha"),
+                }
+                for nm, rec in mps.items()
+            ]
+        )
+        return EXIT_OK
+
+    if not mps:
+        console.print("[dim]No marketplaces. Add one: marketplace add <git-url>[/dim]")
+        return EXIT_OK
+    table = Table(title="Marketplaces", header_style="bold magenta")
+    for col in ("Name", "URL", "Trusted", "Auto-update", "Last updated", "Commit"):
+        table.add_column(col)
+    for nm, rec in mps.items():
+        url = _source_url(rec) or ""
+        sha = rec.get("commitSha") or ""
+        table.add_row(
+            nm,
+            url,
+            "✓" if url in trusted else "—",
+            "on" if rec.get("autoUpdate") else "off",
+            str(rec.get("lastUpdated") or "—"),
+            sha[:10] if sha else "—",
+        )
+    console.print(table)
+    return EXIT_OK
+
+
+def marketplace_info(home: Path, env: Mapping[str, str] | None, name: str, *, json_output: bool = False) -> int:
+    """marketplace 详情：URL / clone 路径 / commit / plugins[]（含 installed 状态）/ auto_update / trusted。"""
+    rec = _marketplaces(home, env).get(name)
+    if rec is None:
+        return _err(f"unknown marketplace: {name!r}", json_output=json_output)
+
+    installed = load_installed_plugins(home, env).get("plugins") or {}
+    plugins = [pid for pid in installed if pid.endswith(f"@{name}")]
+    url = _source_url(rec)
+    info: dict[str, Any] = {
+        "name": name,
+        "url": url,
+        "installLocation": rec.get("installLocation"),
+        "commitSha": rec.get("commitSha"),
+        "autoUpdate": bool(rec.get("autoUpdate", False)),
+        "trusted": url in _load_trusted(env),
+        "lastUpdated": rec.get("lastUpdated"),
+        "installedPlugins": plugins,
+    }
+    if json_output:
+        console.print_json(data=info)
+        return EXIT_OK
+    table = Table(title=f"Marketplace · {name}", show_header=False)
+    table.add_column("Field", style="bold cyan")
+    table.add_column("Value")
+    for k in ("url", "installLocation", "commitSha", "autoUpdate", "trusted", "lastUpdated"):
+        table.add_row(k, str(info[k]))
+    table.add_row("installedPlugins", ", ".join(plugins) if plugins else "—")
+    console.print(table)
+    return EXIT_OK
+
+
+async def marketplace_remove(
+    registry: SkillRegistry,
+    home: Path,
+    env: Mapping[str, str] | None,
+    name: str,
+    *,
+    keep_plugins: bool = False,
+    confirm: ConfirmFn | None = None,
+    mcp_cbs: McpCallbacks | None = None,
+    json_output: bool = False,
+) -> int:
+    """移除 marketplace。默认级联卸载其下 installed plugin（含 MCP server）；``--keep-plugins`` 仅 prune clone（记录留存=孤儿）。"""
+    if name not in _marketplaces(home, env):
+        return _err(f"unknown marketplace: {name!r}", json_output=json_output)
+
+    if confirm is not None and not await confirm(name):
+        return _err("aborted by user", json_output=json_output)
+
+    uninstalled: list[str] = []
+    if not keep_plugins:
+        installed = load_installed_plugins(home, env).get("plugins") or {}
+        victims = [pid for pid in installed if pid.endswith(f"@{name}")]
+        remove_cb = mcp_cbs.remove_server if mcp_cbs is not None else None
+        for pid in victims:
+            if await uninstall_plugin(pid, registry, home, env=env, remove_server=remove_cb):
+                uninstalled.append(pid)
+
+    pruned = prune_marketplaces([name], registry, home, env=env)
+    if json_output:
+        console.print_json(data={"removed": name, "pruned": pruned, "uninstalledPlugins": uninstalled, "keptPlugins": keep_plugins})
+        return EXIT_OK
+    detail = f" (uninstalled {len(uninstalled)} plugin(s))" if uninstalled else (" (plugins kept as orphans)" if keep_plugins else "")
+    return _ok(f"removed marketplace {name!r}{detail}")
+
+
+async def marketplace_refresh(
+    registry: SkillRegistry,
+    home: Path,
+    env: Mapping[str, str] | None,
+    target: str = "all",
+    *,
+    json_output: bool = False,
+) -> int:
+    """``git pull`` 失败则全量重 clone；与缓存 plugin 集合对账 + 失败汇总（§10.4）/ Refresh marketplaces。"""
+    mps = _marketplaces(home, env)
+    names = list(mps) if target == "all" else [target]
+
+    rows: list[dict[str, Any]] = []
+    for nm in names:
+        rec = mps.get(nm)
+        if rec is None:
+            rows.append({"name": nm, "status": "missing"})
+            continue
+        before = rec.get("commitSha")
+        with clone_spinner(f"Refreshing {nm}...", enabled=not json_output):
+            registered = await stage_marketplace_skills(
+                nm, rec.get("source") or {}, registry, home, auto_update=bool(rec.get("autoUpdate", False)), refresh=True, env=env
+            )
+        after = _marketplaces(home, env).get(nm) or {}
+        status = "updated" if after.get("commitSha") != before else "unchanged"
+        rows.append({"name": nm, "status": status, "skills": len(registered)})
+
+    if json_output:
+        console.print_json(data=rows)
+        return EXIT_OK
+    console.print(refresh_summary_table(rows))
+    updated = sum(1 for r in rows if r["status"] == "updated")
+    failed = sum(1 for r in rows if r["status"] == "missing")
+    console.print(f"[dim]{len(rows)} marketplace(s) · {updated} updated · {failed} failed[/dim]")
+    return EXIT_OK
+
+
+def marketplace_set(
+    home: Path, env: Mapping[str, str] | None, name: str, key: str, value: str, *, json_output: bool = False
+) -> int:
+    """设置 per-source 旗，目前仅 ``auto-update=<bool>`` / Set a per-source flag (auto-update only for v0.2.1)。"""
+    if key != "auto-update":
+        return _err(f"unknown key {key!r} (only 'auto-update' supported)", json_output=json_output)
+    val = value.strip().lower() in {"true", "1", "yes", "on"}
+    if name not in _marketplaces(home, env):
+        return _err(f"unknown marketplace: {name!r}", json_output=json_output)
+
+    def _mutate(f: Any) -> Any:
+        f["marketplaces"][name]["autoUpdate"] = val
+        return f
+
+    update_known_marketplaces(_mutate, home, env)
+    if json_output:
+        console.print_json(data={"name": name, "autoUpdate": val})
+        return EXIT_OK
+    return _ok(f"{name!r} auto-update set to {val}")
+
+
+# ── REPL dispatcher（绑定 Computer 的活跃 registry / home / session）/ REPL adapter ──
+async def repl_dispatch(comp: Any, parts: list[str], *, session: Any) -> None:
+    """把 ``marketplace ...`` REPL 行解析为 flags → 调 handler；变更后触发去抖 emit / Parse a REPL line and dispatch。"""
+    sub = parts[1].lower()
+    args = parts[2:]
+    registry = comp.skill_registry
+    home = comp.skill_home
+    env = os.environ
+
+    async def _confirm(target: str) -> bool:
+        prompt = f"⚠ Untrusted source: {target}\n  Trust this source and continue? [y/N]: "
+        ans = (await session.prompt_async(prompt)).strip().lower()
+        return ans in {"y", "yes"}
+
+    json_output = "--json" in args
+    pos = [a for a in args if not a.startswith("--")]
+
+    if sub == "add":
+        if not pos:
+            console.print("[yellow]usage: marketplace add <git-url> [--name N] [--trust] [--auto-update] [--no-clone][/yellow]")
+            return
+        name = _flag_value(args, "--name")
+        await marketplace_add(
+            registry, home, env, pos[0],
+            name=name, trust="--trust" in args, auto_update="--auto-update" in args,
+            no_clone="--no-clone" in args, confirm=_confirm, json_output=json_output,
+        )
+        comp.mark_skills_dirty()
+    elif sub == "list":
+        marketplace_list(home, env, json_output=json_output)
+    elif sub == "info":
+        if not pos:
+            console.print("[yellow]usage: marketplace info <name>[/yellow]")
+            return
+        marketplace_info(home, env, pos[0], json_output=json_output)
+    elif sub in {"remove", "rm"}:
+        if not pos:
+            console.print("[yellow]usage: marketplace remove <name> [--keep-plugins][/yellow]")
+            return
+        from a2c_smcp.computer.cli.commands import build_mcp_callbacks
+
+        await marketplace_remove(
+            registry, home, env, pos[0],
+            keep_plugins="--keep-plugins" in args, confirm=_confirm,
+            mcp_cbs=build_mcp_callbacks(comp), json_output=json_output,
+        )
+        comp.mark_skills_dirty()
+    elif sub == "refresh":
+        target = pos[0] if pos else "all"
+        await marketplace_refresh(registry, home, env, target, json_output=json_output)
+        comp.mark_skills_dirty()
+    elif sub == "set":
+        # marketplace set <name> auto-update=<bool>
+        if len(pos) < 2 or "=" not in pos[1]:
+            console.print("[yellow]usage: marketplace set <name> auto-update=<bool>[/yellow]")
+            return
+        key, _, value = pos[1].partition("=")
+        marketplace_set(home, env, pos[0], key, value, json_output=json_output)
+    else:
+        console.print(f"[yellow]unknown marketplace subcommand: {sub}[/yellow]")
+
+
+def _flag_value(args: list[str], flag: str) -> str | None:
+    """取 ``--flag value`` 形态的值（不支持 ``--flag=value``，REPL 简化）/ Extract a ``--flag value`` pair。"""
+    if flag in args:
+        idx = args.index(flag)
+        if idx + 1 < len(args) and not args[idx + 1].startswith("--"):
+            return args[idx + 1]
+    return None

--- a/a2c_smcp/computer/cli/commands/skill.py
+++ b/a2c_smcp/computer/cli/commands/skill.py
@@ -1,0 +1,145 @@
+# -*- coding: utf-8 -*-
+# filename: skill.py
+# @Time    : 2026/05/27
+# @Author  : JQQ
+# @Email   : jqq1716@gmail.com
+# @Software: PyCharm
+"""
+``skill`` 命令 handler（跨源扁平视图：list / info 两个只读动词）/ Skill command handlers (read-only list/info)。
+
+设计依据 / Design: python-sdk docs/design-0.2.1-cli-marketplace-ux.md §4.4（S15，#68）。
+
+skill **没有** install/uninstall/enable/disable —— 这些经 plugin 层（marketplace 源）/ server add-rm（mcp 源）/
+文件操作（user 源）完成。CLI 只暴露 list / info（§4.4）。list 跨三源扁平展示 name / source / enabled / orphan，
+``--source mp|mcp|user`` 过滤。REPL 直读 ``Computer`` 活跃 registry；Typer 非交互在新进程重建 registry
+（从 ``known_marketplaces.json`` 离线重扫 marketplace + user DropIn；mcp 源需 live 服务器 → 非交互不列、需 REPL）。
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from a2c_smcp.computer.cli.utils import console
+from a2c_smcp.computer.skills.home import SOURCE_MARKETPLACE, SOURCE_MCP, SOURCE_USER
+from a2c_smcp.computer.skills.registry import SkillRegistry
+
+# CLI --source 短名 → A2CSkillRef.source 前缀段 / CLI short name → source prefix segment。
+_SOURCE_ALIAS: dict[str, str] = {"mp": SOURCE_MARKETPLACE, "mcp": SOURCE_MCP, "user": SOURCE_USER}
+
+
+def _source_segment(src: str) -> str:
+    """取 ``A2CSkillRef.source`` 的来源段（``marketplace:<mp>`` → ``marketplace``）/ Source kind segment。"""
+    return src.split(":", 1)[0]
+
+
+def skill_list(registry: SkillRegistry, *, source: str | None = None, json_output: bool = False) -> int:
+    """跨源列出当前可见 SKILL（name / source / enabled / orphan），``source`` ∈ {mp,mcp,user} 过滤 / List skills。"""
+    want = _SOURCE_ALIAS.get(source) if source else None
+    if source and want is None:
+        console.print(f"[yellow]unknown --source {source!r} (expected mp|mcp|user)[/yellow]")
+        return 1
+
+    rows: list[dict[str, Any]] = []
+    for ref, orphaned in registry.all_refs():
+        src = str(ref.get("source", ""))
+        if want is not None and _source_segment(src) != want:
+            continue
+        rows.append({"name": ref.get("name"), "source": src, "enabled": not orphaned, "orphan": orphaned})
+    rows.sort(key=lambda r: str(r["name"]))
+
+    if json_output:
+        console.print_json(data=rows)
+        return 0
+    if not rows:
+        console.print("[dim]No skills visible.[/dim]")
+        return 0
+    from rich.table import Table
+
+    table = Table(title="Skills", header_style="bold magenta")
+    for col in ("Name", "Source", "Enabled", "Orphan"):
+        table.add_column(col)
+    for r in rows:
+        table.add_row(str(r["name"]), r["source"], "✓" if r["enabled"] else "—", "⚠" if r["orphan"] else "—")
+    console.print(table)
+    return 0
+
+
+def skill_info(registry: SkillRegistry, name: str, *, json_output: bool = False) -> int:
+    """SKILL 详情：source / 归属 / version / frontmatter / SKILL.md 路径（含孤儿）/ Skill detail (incl. orphan)。"""
+    found: dict[str, Any] | None = None
+    orphaned = False
+    for ref, is_orphan in registry.all_refs():
+        if ref.get("name") == name:
+            found, orphaned = dict(ref), is_orphan
+            break
+    if found is None:
+        if json_output:
+            console.print_json(data={"error": f"unknown skill: {name}"})
+        else:
+            console.print(f"[red]✗ unknown skill: {name!r}[/red]")
+        return 1
+    found["orphan"] = orphaned
+    found["enabled"] = not orphaned
+    if json_output:
+        console.print_json(data=found)
+        return 0
+    from rich.table import Table
+
+    table = Table(title=f"Skill · {name}", show_header=False)
+    table.add_column("Field", style="bold cyan")
+    table.add_column("Value")
+    for key in ("source", "version", "description", "path", "license", "compatibility", "enabled", "orphan"):
+        if key in found:
+            table.add_row(key, str(found[key]))
+    console.print(table)
+    return 0
+
+
+async def rebuild_registry(home: Path, env: Mapping[str, str] | None) -> SkillRegistry:
+    """
+    非交互重建 registry：从 ``known_marketplaces.json`` 离线重扫 marketplace clone + user DropIn / Offline rebuild。
+
+    新进程的 registry 是空的；据已物化的 marketplace clone（``refresh=False`` 复用本地树、不触网）+ user 源
+    就地发现重新注册。**mcp 源不在此**（需运行中 MCP 服务器，仅 REPL 可见）。
+    """
+    from a2c_smcp.computer.settings.store import load_known_marketplaces
+    from a2c_smcp.computer.skills.staging import stage_marketplace_skills, stage_user_skills
+
+    reg = SkillRegistry()
+    mps = load_known_marketplaces(home, env).get("marketplaces") or {}
+    for nm, rec in mps.items():
+        await stage_marketplace_skills(
+            nm, rec.get("source") or {}, reg, home, auto_update=bool(rec.get("autoUpdate", False)), refresh=False, env=env
+        )
+    stage_user_skills(reg, home)
+    return reg
+
+
+# ── REPL dispatcher / REPL adapter ────────────────────────────────────────────
+def repl_dispatch(comp: Any, parts: list[str]) -> None:
+    """``skill list|info ...`` REPL 行解析 → 调 handler（直读 Computer 活跃 registry）/ Parse a REPL skill line。"""
+    sub = parts[1].lower()
+    args = parts[2:]
+    json_output = "--json" in args
+    pos = [a for a in args if not a.startswith("--")]
+    registry: SkillRegistry = comp.skill_registry
+
+    if sub == "list":
+        skill_list(registry, source=_flag_value(args, "--source"), json_output=json_output)
+    elif sub == "info":
+        if not pos:
+            console.print("[yellow]usage: skill info <name>[/yellow]")
+            return
+        skill_info(registry, pos[0], json_output=json_output)
+    else:
+        console.print(f"[yellow]unknown skill subcommand: {sub}[/yellow]")
+
+
+def _flag_value(args: list[str], flag: str) -> str | None:
+    if flag in args:
+        idx = args.index(flag)
+        if idx + 1 < len(args) and not args[idx + 1].startswith("--"):
+            return args[idx + 1]
+    return None

--- a/a2c_smcp/computer/cli/completer.py
+++ b/a2c_smcp/computer/cli/completer.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+# filename: completer.py
+# @Time    : 2026/05/27
+# @Author  : JQQ
+# @Email   : jqq1716@gmail.com
+# @Software: PyCharm
+"""
+prompt_toolkit Tab 补全 / prompt_toolkit Tab completion（S15，#68）。
+
+设计依据 / Design: python-sdk docs/design-0.2.1-cli-marketplace-ux.md §10.3。
+
+按上下文补全：行首 namespace / 顶层命令词；namespace 后子命令词；命令后动态名（marketplace 名取
+``known_marketplaces.json``、skill 名取 ``Computer.get_skills``）；``--flag`` 位置补 flag 集。命令分类法是
+:mod:`help` 的单一事实源。plugin / settings 子命令作骨架先行补全，其**动态名**（available plugins 等）由 #69 填。
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterable, Iterator
+from typing import Any
+
+from prompt_toolkit.completion import Completer, Completion
+from prompt_toolkit.document import Document
+
+from a2c_smcp.computer.cli.help import FLAGS, ROOT_WORDS, SUBCOMMANDS
+
+# 触发动态名补全的 (namespace, subcommand) / commands whose positional arg is a dynamic name。
+_DYNAMIC_MARKETPLACE = {("marketplace", s) for s in ("info", "remove", "refresh", "set")}
+_DYNAMIC_SKILL = {("skill", "info")}
+
+
+class A2CCompleter(Completer):
+    """REPL Tab 补全器，持 ``Computer`` 引用以取动态名 / REPL completer holding a Computer for dynamic names。"""
+
+    def __init__(self, comp: Any) -> None:
+        self._comp = comp
+
+    def get_completions(self, document: Document, complete_event: Any) -> Iterator[Completion]:
+        text = document.text_before_cursor
+        words = text.split()
+        trailing_space = text == "" or text.endswith(" ")
+        completing = "" if trailing_space else (words[-1] if words else "")
+        prev = words if trailing_space else words[:-1]
+        n = len(prev)
+
+        if n == 0:  # 行首：namespace + 顶层命令 / root words
+            yield from self._match(ROOT_WORDS, completing)
+            return
+
+        ns = prev[0].lower()
+        if n == 1:  # namespace 后：子命令词 / subcommand words
+            yield from self._match(SUBCOMMANDS.get(ns, []), completing)
+            return
+
+        sub = prev[1].lower()
+        if completing.startswith("--"):  # flag 位置 / flag position
+            yield from self._match(FLAGS.get((ns, sub), []), completing)
+            return
+
+        # 位置参数：动态名 / positional dynamic name
+        yield from self._match(self._dynamic_names(ns, sub), completing)
+
+    def _dynamic_names(self, ns: str, sub: str) -> list[str]:
+        try:
+            if (ns, sub) in _DYNAMIC_MARKETPLACE:
+                from a2c_smcp.computer.settings.store import load_known_marketplaces
+
+                return list((load_known_marketplaces(self._comp.skill_home, os.environ).get("marketplaces") or {}).keys())
+            if (ns, sub) in _DYNAMIC_SKILL:
+                return [str(r.get("name")) for r in self._comp.get_skills() if r.get("name")]
+        except Exception:  # 动态取名失败不应打断补全 / never break completion on lookup failure
+            return []
+        return []  # plugin / settings 动态名 → #69
+
+    @staticmethod
+    def _match(candidates: Iterable[str], prefix: str) -> Iterator[Completion]:
+        for cand in candidates:
+            if cand.startswith(prefix):
+                yield Completion(cand, start_position=-len(prefix))

--- a/a2c_smcp/computer/cli/completer.py
+++ b/a2c_smcp/computer/cli/completer.py
@@ -24,6 +24,9 @@ from prompt_toolkit.completion import Completer, Completion
 from prompt_toolkit.document import Document
 
 from a2c_smcp.computer.cli.help import FLAGS, ROOT_WORDS, SUBCOMMANDS
+from a2c_smcp.utils.logger import get_logger
+
+logger = get_logger(__name__)
 
 # 触发动态名补全的 (namespace, subcommand) / commands whose positional arg is a dynamic name。
 _DYNAMIC_MARKETPLACE = {("marketplace", s) for s in ("info", "remove", "refresh", "set")}
@@ -69,7 +72,8 @@ class A2CCompleter(Completer):
                 return list((load_known_marketplaces(self._comp.skill_home, os.environ).get("marketplaces") or {}).keys())
             if (ns, sub) in _DYNAMIC_SKILL:
                 return [str(r.get("name")) for r in self._comp.get_skills() if r.get("name")]
-        except Exception:  # 动态取名失败不应打断补全 / never break completion on lookup failure
+        except Exception as e:  # 动态取名失败不应打断补全；记 DEBUG 便于排障（含编程错）/ never break completion
+            logger.debug("completer: dynamic-name lookup for (%s %s) failed (%s)", ns, sub, e)
             return []
         return []  # plugin / settings 动态名 → #69
 

--- a/a2c_smcp/computer/cli/help.py
+++ b/a2c_smcp/computer/cli/help.py
@@ -1,0 +1,137 @@
+# -*- coding: utf-8 -*-
+# filename: help.py
+# @Time    : 2026/05/27
+# @Author  : JQQ
+# @Email   : jqq1716@gmail.com
+# @Software: PyCharm
+"""
+分组 help 渲染 + 命令分类法（REPL help / completer 共用单一事实源）/ Grouped help + command taxonomy。
+
+设计依据 / Design: python-sdk docs/design-0.2.1-cli-marketplace-ux.md §4.1 / §10.2（S15，#68）。
+
+``render_help`` 默认列 namespace（折叠），``help <ns>`` 列该 namespace 命令。命令分类法（:data:`NAMESPACES` /
+:data:`NAMESPACE_COMMANDS` / :data:`SUBCOMMANDS` / :data:`FLAGS`）是 REPL help 与 :mod:`completer` 的**单一事实源**。
+plugin / settings namespace 作多 namespace 可扩展骨架先行登记（命令体由 #69 落地）。
+"""
+
+from __future__ import annotations
+
+from a2c_smcp.computer.cli.utils import console
+
+# namespace → 一行描述（折叠 help 用，顺序即展示序）/ namespace → one-line description (ordered)。
+NAMESPACES: dict[str, str] = {
+    "server": "MCP server lifecycle (add / rm / start / stop)",
+    "inputs": "Input definitions and values",
+    "marketplace": "SKILL marketplaces (git sources)",
+    "plugin": "Plugins — skill+mcp bundles (see #69)",
+    "skill": "Skills cross-source query (list / info)",
+    "socket": "Socket.IO connection control",
+    "notify": "Send notifications to Agent",
+    "settings": "Edit settings.json files (see #69)",
+    "utility": "status / tools / mcp / desktop / render / tc / history",
+}
+
+# namespace → [(命令样式, 描述)] 完整 help 行 / namespace → full help rows。
+NAMESPACE_COMMANDS: dict[str, list[tuple[str, str]]] = {
+    "server": [
+        ("server add <json|@file>", "添加或更新 MCP 配置 / add or update config"),
+        ("server rm <name>", "移除 MCP 配置 / remove config"),
+        ("start <name>|all", "启动客户端 / start client(s)"),
+        ("stop <name>|all", "停止客户端 / stop client(s)"),
+    ],
+    "inputs": [
+        ("inputs load <@file>", "从文件加载 inputs 定义 / load inputs"),
+        ("inputs list", "查看当前 inputs 定义 / show inputs"),
+        ("inputs value list|get|set|rm|clear", "inputs 缓存值增删改查 / CRUD cached input values"),
+    ],
+    "marketplace": [
+        ("marketplace add <git-url> [--name N] [--trust] [--auto-update] [--no-clone]", "添加 marketplace（首次 y/N trust）/ add"),
+        ("marketplace list [--json]", "列出已知 marketplace / list known marketplaces"),
+        ("marketplace info <name> [--json]", "marketplace 详情 / marketplace detail"),
+        ("marketplace remove <name> [--keep-plugins]", "移除（默认级联卸载 plugin）/ remove (cascade)"),
+        ("marketplace refresh [<name>|all]", "git pull / 重 clone + 对账 / refresh"),
+        ("marketplace set <name> auto-update=<bool>", "设置 per-source auto-update / set flag"),
+    ],
+    "plugin": [
+        ("plugin install|uninstall|enable|disable|list|info", "（#69 落地）/ implemented in #69"),
+    ],
+    "skill": [
+        ("skill list [--source mp|mcp|user] [--json]", "跨源列出可见 SKILL / list skills"),
+        ("skill info <name> [--json]", "SKILL 详情 / skill detail"),
+    ],
+    "socket": [
+        ("socket connect [<url>]", "连接 Socket.IO / connect"),
+        ("socket join <office_id> <computer_name>", "加入房间 / join office"),
+        ("socket leave", "离开房间 / leave office"),
+    ],
+    "notify": [("notify update", "触发配置更新通知 / emit config updated notification")],
+    "settings": [("settings show|edit|get|set", "（#69 落地）/ implemented in #69")],
+    "utility": [
+        ("status", "查看服务器状态 / show server status"),
+        ("tools", "列出可用工具 / list tools"),
+        ("mcp", "显示当前 MCP 配置 / show current MCP config"),
+        ("desktop [size] [window_uri]", "获取当前桌面窗口组合 / get desktop"),
+        ("render <json|@file>", "测试渲染（占位符解析）/ test rendering"),
+        ("tc <json|@file>", "调试工具调用 / debug tool call"),
+        ("history [n]", "最近工具调用历史 / recent tool call history"),
+        ("help [<namespace>]", "查看命令 / show commands"),
+        ("quit | exit", "退出 / quit"),
+    ],
+}
+
+# completer 用：namespace → 子命令词 / subcommand words per namespace (for completion)。
+SUBCOMMANDS: dict[str, list[str]] = {
+    "server": ["add", "rm", "remove"],
+    "inputs": ["load", "add", "update", "rm", "remove", "get", "list", "value"],
+    "marketplace": ["add", "list", "info", "remove", "refresh", "set"],
+    "plugin": ["install", "uninstall", "enable", "disable", "list", "info"],
+    "skill": ["list", "info"],
+    "socket": ["connect", "join", "leave"],
+    "notify": ["update"],
+    "settings": ["show", "edit", "get", "set"],
+}
+
+# 行首可补全词：namespace + 顶层命令 / root completions: namespaces + top-level commands。
+ROOT_WORDS: list[str] = [
+    *SUBCOMMANDS.keys(),
+    "start", "stop", "status", "tools", "mcp", "desktop", "render", "tc", "history", "help", "quit", "exit",
+]
+
+# (namespace, subcommand) → flag 集 / flags per command (for completion)。
+FLAGS: dict[tuple[str, str], list[str]] = {
+    ("marketplace", "add"): ["--name", "--trust", "--auto-update", "--no-clone", "--json"],
+    ("marketplace", "list"): ["--json"],
+    ("marketplace", "info"): ["--json"],
+    ("marketplace", "remove"): ["--keep-plugins", "--json"],
+    ("marketplace", "refresh"): ["--json"],
+    ("marketplace", "set"): ["--json"],
+    ("skill", "list"): ["--source", "--json"],
+    ("skill", "info"): ["--json"],
+}
+
+
+def render_help(namespace: str | None = None) -> None:
+    """折叠 namespace 列表（``namespace=None``）或某 namespace 命令详情（§10.2）/ Render grouped help。"""
+    from rich.table import Table
+
+    if namespace is None:
+        table = Table(title="Namespaces (type 'help <name>' for details)", header_style="bold magenta")
+        table.add_column("Namespace", style="bold cyan", no_wrap=True)
+        table.add_column("Description")
+        for name, desc in NAMESPACES.items():
+            table.add_row(name, desc)
+        console.print(table)
+        console.print("[dim]提示: help <namespace> 查看该组命令；? 重看本表。[/dim]")
+        return
+
+    ns = namespace.lower()
+    rows = NAMESPACE_COMMANDS.get(ns)
+    if rows is None:
+        console.print(f"[yellow]unknown namespace: {namespace!r} (try 'help')[/yellow]")
+        return
+    table = Table(title=f"{ns} commands", header_style="bold magenta")
+    table.add_column("Command", style="bold cyan", no_wrap=True)
+    table.add_column("Description")
+    for cmd, desc in rows:
+        table.add_row(cmd, desc)
+    console.print(table)

--- a/a2c_smcp/computer/cli/interactive_impl.py
+++ b/a2c_smcp/computer/cli/interactive_impl.py
@@ -70,7 +70,9 @@ async def interactive_loop(
             "[yellow]检测到控制台可能不支持 ANSI 颜色。若在 PyCharm 中运行，请在 Run/Debug 配置中启用 'Emulate terminal in "
             "output console'；或者使用 --no-color 关闭彩色输出。[/yellow]",
         )
-    # zero-state 引导 banner（§10.1）；未启动时 _skill_home 为 None → 物化计数按 0 处理 / startup banner。
+    # zero-state 引导 banner（§10.1）。刻意读裸 ``_skill_home``（可能为 None）而非公开 ``skill_home`` property：
+    # 后者会 ensure_skill_home() 强制解析并创建目录，而 banner 仅需"未启动=None→物化计数按 0"语义，不应在
+    # 此处产生副作用（尤其未经 boot_up 的单测路径）。/ read raw _skill_home to avoid forcing resolution.
     render_banner(comp, comp._skill_home, os.environ)
 
     while True:

--- a/a2c_smcp/computer/cli/interactive_impl.py
+++ b/a2c_smcp/computer/cli/interactive_impl.py
@@ -13,14 +13,19 @@
 from __future__ import annotations
 
 import json
+import os
 from contextlib import AbstractContextManager
 from pathlib import Path
 from typing import Any, Protocol
 
 from prompt_toolkit import PromptSession
+from prompt_toolkit.completion import Completer
 from pydantic import TypeAdapter
-from rich.table import Table
 
+from a2c_smcp.computer.cli.banner import render_banner
+from a2c_smcp.computer.cli.commands import marketplace as mp_cmd
+from a2c_smcp.computer.cli.commands import skill as skill_cmd
+from a2c_smcp.computer.cli.help import render_help
 from a2c_smcp.computer.cli.utils import console, parse_kv_pairs, print_mcp_config, print_status, print_tools
 from a2c_smcp.computer.computer import Computer
 from a2c_smcp.computer.mcp_clients.model import MCPServerInput as MCPServerInputModel
@@ -48,10 +53,13 @@ async def interactive_loop(
     patch_stdout_ctx: PatchStdoutCtx,
     smcp_client_cls: type[Any],
     init_client: Any | None = None,
+    completer: Completer | None = None,
 ) -> None:
     """
     中文: 交互循环的可注入实现；从 main.py 传入 PromptSession 工厂、patch_stdout 上下文与 SMCP 客户端类。
     English: DI-friendly interactive loop; main.py passes PromptSession factory, patch_stdout ctx and SMCP client class.
+
+    completer: 可选 Tab 补全器（逐次传入 ``prompt_async``，trust y/N 等子提示不带补全）/ optional Tab completer.
     """
     session = session_factory()
     smcp_client = init_client
@@ -62,11 +70,13 @@ async def interactive_loop(
             "[yellow]检测到控制台可能不支持 ANSI 颜色。若在 PyCharm 中运行，请在 Run/Debug 配置中启用 'Emulate terminal in "
             "output console'；或者使用 --no-color 关闭彩色输出。[/yellow]",
         )
+    # zero-state 引导 banner（§10.1）；未启动时 _skill_home 为 None → 物化计数按 0 处理 / startup banner。
+    render_banner(comp, comp._skill_home, os.environ)
 
     while True:
         try:
             with patch_stdout_ctx(raw=True):
-                raw = (await session.prompt_async("a2c> ")).strip()
+                raw = (await session.prompt_async("a2c> ", completer=completer)).strip()
         except (EOFError, KeyboardInterrupt):
             console.print("\n[cyan]Bye[/cyan]")
             break
@@ -74,52 +84,11 @@ async def interactive_loop(
         if raw == "":
             continue
 
-        if raw.lower() in {"help", "?"}:
-            help_table = Table(
-                title="可用命令 / Commands",
-                header_style="bold magenta",
-                show_lines=False,
-                expand=False,
-            )
-            help_table.add_column("Command", style="bold cyan", no_wrap=True)
-            help_table.add_column("Description", style="white")
-
-            help_table.add_row("status", "查看服务器状态 / show server status")
-            help_table.add_row("tools", "列出可用工具 / list tools")
-            help_table.add_row("mcp", "显示当前 MCP 配置 / show current MCP config")
-            help_table.add_row("server add <json|@file>", "添加或更新 MCP 配置 / add or update config")
-            help_table.add_row("server rm <name>", "移除 MCP 配置 / remove config")
-            help_table.add_row("start <name>|all", "启动客户端 / start client(s)")
-            help_table.add_row("stop <name>|all", "停止客户端 / stop client(s)")
-            help_table.add_row("inputs load <@file>", "从文件加载 inputs 定义 / load inputs")
-            help_table.add_row("inputs list", "查看当前inputs的定义 / show inputs")
-            # 中文: 新增当前 inputs 值的增删改查命令
-            # English: Add CRUD commands for current inputs values
-            help_table.add_row("inputs value list", "列出当前 inputs 的缓存值 / list current cached input values")
-            help_table.add_row("inputs value get <id>", "获取指定 id 的值 / get cached value by id")
-            help_table.add_row(
-                "inputs value set <id> [<json|text>]", "设置指定 id 的值（省略值则用 default）/ set cached value (omit to use default)"
-            )
-            help_table.add_row("inputs value rm <id>", "删除指定 id 的值 / remove cached value by id")
-            help_table.add_row("inputs value clear [<id>]", "清空全部或指定 id 的缓存 / clear all or one cached value")
-            help_table.add_row("tc <json|@file>", "使用与 Socket.IO 一致的 JSON 结构调试工具 / debug tool with Socket.IO-compatible JSON")
-            help_table.add_row(
-                "desktop [size] [window_uri]",
-                "获取当前桌面窗口组合（可选限制条数与指定URI） / get current desktop (optional size and URI)",
-            )
-            help_table.add_row("history [n]", "显示最近的工具调用历史（默认最多10条）/ show recent tool call history (default up to 10)")
-            help_table.add_row(
-                "socket connect [<url>]",
-                "连接 Socket.IO（省略 URL 将进入引导式输入） / connect to Socket.IO (guided if URL omitted)",
-            )
-            help_table.add_row("socket join <office_id> <computer_name>", "加入房间 / join office")
-            help_table.add_row("socket leave", "离开房间 / leave office")
-            help_table.add_row("notify update", "触发配置更新通知 / emit config updated notification")
-            help_table.add_row("render <json|@file>", "测试渲染（占位符解析） / test rendering (placeholders)")
-            help_table.add_row("quit | exit", "退出 / quit")
-
-            console.print(help_table)
-            console.print("[dim]提示: 输入命令后按回车执行；输入 'help' 或 '?' 重新查看命令列表。[/dim]")
+        low = raw.lower()
+        if low in {"help", "?"} or low.startswith("help "):
+            # 分组 help（§10.2）：help 列 namespace，help <ns> 列该组命令 / grouped help, migrated to help.py
+            help_parts = raw.split()
+            render_help(help_parts[1] if len(help_parts) > 1 else None)
             continue
 
         parts = raw.split()
@@ -518,6 +487,14 @@ async def interactive_loop(
                     console.print_json(data=tc_items)
                 except Exception as e:  # pragma: no cover
                     console.print(f"[red]❌ 读取历史失败 / Failed to read history: {e}[/red]")
+
+            elif cmd == "marketplace" and len(parts) >= 2:
+                # v0.2.1 SKILL marketplace 管理（S15，#68）；委托 commands/marketplace.py，变更后触发去抖 emit。
+                await mp_cmd.repl_dispatch(comp, parts, session=session)
+
+            elif cmd == "skill" and len(parts) >= 2:
+                # v0.2.1 跨源 SKILL 只读查询（list / info，§4.4）；直读 Computer 活跃 registry。
+                skill_cmd.repl_dispatch(comp, parts)
 
             else:
                 console.print("[yellow]未知命令 / Unknown command[/yellow]")

--- a/a2c_smcp/computer/cli/main.py
+++ b/a2c_smcp/computer/cli/main.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
@@ -23,6 +24,9 @@ from prompt_toolkit import PromptSession
 from prompt_toolkit.patch_stdout import patch_stdout
 from pydantic import TypeAdapter
 
+from a2c_smcp.computer.cli.commands import marketplace as mp_cmd
+from a2c_smcp.computer.cli.commands import skill as skill_cmd
+from a2c_smcp.computer.cli.completer import A2CCompleter
 from a2c_smcp.computer.cli.interactive_impl import interactive_loop as _interactive_loop_impl
 from a2c_smcp.computer.cli.utils import (
     parse_kv_pairs,
@@ -33,6 +37,8 @@ from a2c_smcp.computer.inputs.resolver import InputResolver
 from a2c_smcp.computer.mcp_clients.model import (
     MCPServerInput as MCPServerInputModel,
 )
+from a2c_smcp.computer.skills.home import ensure_skill_home
+from a2c_smcp.computer.skills.registry import SkillRegistry
 from a2c_smcp.computer.socketio.client import SMCPComputerClient
 from a2c_smcp.computer.utils import console as console_util
 from a2c_smcp.smcp import SMCP_NAMESPACE
@@ -132,6 +138,7 @@ async def _interactive_loop(comp: Computer, init_client: SMCPComputerClient | No
         patch_stdout_ctx=patch_stdout,
         smcp_client_cls=SMCPComputerClient,
         init_client=init_client,
+        completer=A2CCompleter(comp),
     )
 
 
@@ -284,6 +291,106 @@ def run(
         config=config,
         inputs=inputs,
     )
+
+
+# ---------------------------------------------------------------------------
+# 非交互 Typer 子命令（marketplace / skill，S15 #68）/ Non-interactive Typer subcommands
+# ---------------------------------------------------------------------------
+# 非交互形态不 boot Computer、不连 socket：以 env 解析 SKILL Home + 新建 registry，直接读写物化层 / staging。
+# trust 缺 confirm（confirm=None）→ marketplace add 须显式 --trust，否则退出码 1（§4.6 / §11）。
+marketplace_app = typer.Typer(help="SKILL marketplaces (git sources)")
+skill_app = typer.Typer(help="Skills cross-source query (list / info)")
+
+
+@marketplace_app.command("add")
+def _mp_add(
+    git_url: str = typer.Argument(..., help="git URL 或 owner/repo 简写 / git URL or owner/repo shorthand"),
+    name: str | None = typer.Option(None, "--name", help="marketplace 名（默认从 URL 派生）/ name (derived from URL by default)"),
+    trust: bool = typer.Option(False, "--trust", help="跳过 trust 确认（非交互必需）/ skip trust prompt (required non-interactively)"),
+    auto_update: bool = typer.Option(False, "--auto-update", help="启用 per-source 自动更新 / enable per-source auto-update"),
+    no_clone: bool = typer.Option(False, "--no-clone", help="仅注册意图、不 clone（debug）/ register intent only (debug)"),
+    json_output: bool = typer.Option(False, "--json", help="JSON 输出 / JSON output"),
+) -> None:
+    """添加 marketplace（非交互须 --trust）/ Add a marketplace (requires --trust non-interactively)."""
+    code = asyncio.run(
+        mp_cmd.marketplace_add(
+            SkillRegistry(), ensure_skill_home(), os.environ, git_url,
+            name=name, trust=trust, auto_update=auto_update, no_clone=no_clone, confirm=None, json_output=json_output,
+        ),
+    )
+    raise typer.Exit(code)
+
+
+@marketplace_app.command("list")
+def _mp_list(json_output: bool = typer.Option(False, "--json", help="JSON 输出 / JSON output")) -> None:
+    """列出已知 marketplace / List known marketplaces."""
+    raise typer.Exit(mp_cmd.marketplace_list(ensure_skill_home(), os.environ, json_output=json_output))
+
+
+@marketplace_app.command("info")
+def _mp_info(name: str = typer.Argument(...), json_output: bool = typer.Option(False, "--json")) -> None:
+    """marketplace 详情 / Marketplace detail."""
+    raise typer.Exit(mp_cmd.marketplace_info(ensure_skill_home(), os.environ, name, json_output=json_output))
+
+
+@marketplace_app.command("remove")
+def _mp_remove(
+    name: str = typer.Argument(...),
+    keep_plugins: bool = typer.Option(False, "--keep-plugins", help="保留 installed plugin（标记孤儿）/ keep installed plugins (orphaned)"),
+    json_output: bool = typer.Option(False, "--json"),
+) -> None:
+    """移除 marketplace（默认级联卸载其下 plugin）/ Remove a marketplace (cascade by default)."""
+    code = asyncio.run(
+        mp_cmd.marketplace_remove(
+            SkillRegistry(), ensure_skill_home(), os.environ, name,
+            keep_plugins=keep_plugins, confirm=None, mcp_cbs=None, json_output=json_output,
+        ),
+    )
+    raise typer.Exit(code)
+
+
+@marketplace_app.command("refresh")
+def _mp_refresh(
+    target: str = typer.Argument("all", help="marketplace 名或 all / a name or 'all'"),
+    json_output: bool = typer.Option(False, "--json"),
+) -> None:
+    """刷新 marketplace（git pull / 重 clone + 对账）/ Refresh marketplaces."""
+    code = asyncio.run(
+        mp_cmd.marketplace_refresh(SkillRegistry(), ensure_skill_home(), os.environ, target, json_output=json_output),
+    )
+    raise typer.Exit(code)
+
+
+@marketplace_app.command("set")
+def _mp_set(
+    name: str = typer.Argument(...),
+    assignment: str = typer.Argument(..., help="auto-update=<bool>"),
+    json_output: bool = typer.Option(False, "--json"),
+) -> None:
+    """设置 per-source 旗（仅 auto-update=<bool>）/ Set a per-source flag (auto-update only)."""
+    key, _, value = assignment.partition("=")
+    raise typer.Exit(mp_cmd.marketplace_set(ensure_skill_home(), os.environ, name, key, value, json_output=json_output))
+
+
+@skill_app.command("list")
+def _skill_list(
+    source: str | None = typer.Option(None, "--source", help="过滤来源 mp|mcp|user / filter by source"),
+    json_output: bool = typer.Option(False, "--json"),
+) -> None:
+    """跨源列出可见 SKILL（非交互重建 registry；mcp 源需 live 服务器 → REPL）/ List skills (registry rebuilt offline)."""
+    reg = asyncio.run(skill_cmd.rebuild_registry(ensure_skill_home(), os.environ))
+    raise typer.Exit(skill_cmd.skill_list(reg, source=source, json_output=json_output))
+
+
+@skill_app.command("info")
+def _skill_info(name: str = typer.Argument(...), json_output: bool = typer.Option(False, "--json")) -> None:
+    """SKILL 详情 / Skill detail."""
+    reg = asyncio.run(skill_cmd.rebuild_registry(ensure_skill_home(), os.environ))
+    raise typer.Exit(skill_cmd.skill_info(reg, name, json_output=json_output))
+
+
+app.add_typer(marketplace_app, name="marketplace")
+app.add_typer(skill_app, name="skill")
 
 
 # 为 console_scripts 兼容提供入口

--- a/a2c_smcp/computer/cli/progress.py
+++ b/a2c_smcp/computer/cli/progress.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+# filename: progress.py
+# @Time    : 2026/05/27
+# @Author  : JQQ
+# @Email   : jqq1716@gmail.com
+# @Software: PyCharm
+"""
+Rich 进度反馈（git clone/pull spinner）+ 刷新汇总表 / Rich progress feedback + refresh summary（S15，#68）。
+
+设计依据 / Design: python-sdk docs/design-0.2.1-cli-marketplace-ux.md §10.4。
+
+:func:`clone_spinner` 在 clone/pull await 期间显示 spinner（json / 非终端下自动退化为 no-op）；
+:func:`refresh_summary_table` 渲染多 marketplace 刷新汇总。
+.. note::
+   byte-级进度百分比（``45% (2.3/5.1 MiB)``）需 staging 暴露 git ``--progress`` stderr 行解析 hook
+   （属 staging 改动、出本 PR cli/ 范围）；v0.2.1 先 spinner + 汇总满足可视进度，%-解析记为后续增强。
+"""
+
+from __future__ import annotations
+
+import contextlib
+from collections.abc import Iterator
+from typing import Any
+
+from rich.progress import Progress, SpinnerColumn, TextColumn
+from rich.table import Table
+
+from a2c_smcp.computer.cli.utils import console
+
+
+@contextlib.contextmanager
+def _spinner(description: str) -> Iterator[None]:
+    with Progress(SpinnerColumn(), TextColumn("[progress.description]{task.description}"), transient=True, console=console) as p:
+        p.add_task(description, total=None)
+        yield
+
+
+def clone_spinner(description: str, *, enabled: bool = True) -> contextlib.AbstractContextManager[None]:
+    """clone/pull 期 spinner；``enabled=False`` 或非终端（json / 管道）→ no-op / Spinner, no-op when disabled。"""
+    if not enabled or not console.is_terminal:
+        return contextlib.nullcontext()
+    return _spinner(description)
+
+
+def refresh_summary_table(rows: list[dict[str, Any]]) -> Table:
+    """多 marketplace 刷新汇总表（updated / unchanged / missing）/ Build the refresh summary table。"""
+    table = Table(title="Refresh summary", header_style="bold magenta")
+    for col in ("Marketplace", "Status", "Skills"):
+        table.add_column(col)
+    marks = {"updated": "✓", "unchanged": "·", "missing": "✗"}
+    for r in rows:
+        status = str(r.get("status", "?"))
+        table.add_row(str(r.get("name", "")), f"{marks.get(status, '?')} {status}", str(r.get("skills", "—")))
+    return table

--- a/a2c_smcp/computer/computer.py
+++ b/a2c_smcp/computer/computer.py
@@ -1106,6 +1106,24 @@ class Computer(BaseComputer[PromptSession]):
         """
         return self._skill_registry
 
+    @property
+    def skill_home(self) -> Path:
+        """SKILL Home 绝对根（``boot_up`` 解析；未启动时按 env 解析链兜底并缓存）/ SKILL Home root。
+
+        CLI marketplace / skill 命令经此取物化根（``known_marketplaces.json`` / ``installed_plugins.json`` /
+        ``marketplace/<name>/`` clone 树所在）。
+        """
+        if self._skill_home is None:
+            self._skill_home = self._resolve_skill_home()
+        return self._skill_home
+
+    def mark_skills_dirty(self) -> None:
+        """标记 SKILL 集合变更 → 去抖器在窗口内合并触发单次 ``emit_update_skills``（CLI marketplace 变更后调）。
+
+        Mark the SKILL set dirty so the debouncer coalesces a single emit (called after CLI marketplace mutations).
+        """
+        self._skill_debouncer.mark_dirty()
+
     def get_skills(self) -> list[A2CSkillRef]:
         """当前已安装且可用 SKILL（排除孤儿；不排序、不去重）—— ``client:get_skills`` 数据源。
 

--- a/a2c_smcp/computer/skills/registry.py
+++ b/a2c_smcp/computer/skills/registry.py
@@ -187,6 +187,15 @@ class SkillRegistry:
         """
         return [copy.deepcopy(entry.ref) for entry in self._entries.values() if not entry.orphaned]
 
+    def all_refs(self) -> list[tuple[A2CSkillRef, bool]]:
+        """
+        全部条目的 ``(ref 深拷贝, orphaned)``（含孤儿）/ Deep-copied ``(ref, orphaned)`` for every entry。
+
+        供 CLI ``skill list``（§4.4）跨源扁平视图——需展示 orphan 标志，故 active 集（:meth:`active_refs`）
+        不够。仅读、深拷贝，调用方就地改写不污染 Registry。
+        """
+        return [(copy.deepcopy(entry.ref), entry.orphaned) for entry in self._entries.values()]
+
     def is_orphan(self, name: str) -> bool:
         """name 是否为已注册的孤儿条目 / Whether name is a registered-but-orphaned entry。"""
         entry = self._entries.get(name)

--- a/tests/e2e/computer/test_cli_interactive.py
+++ b/tests/e2e/computer/test_cli_interactive.py
@@ -23,7 +23,8 @@ pexpect = pytest.importorskip("pexpect", reason="e2e tests require pexpect; inst
 # 中文: 帮助标题的匹配，沿用 ANSI 感知的模式以避免误匹配 re.S(或re.DOTALL) 模式下 . 将匹配包括换行模式符在内的任意字符。因此必须强制关闭
 # re.S 否则会拦截正常输出
 # English: Help title regex using ANSI-aware pattern to avoid mismatches
-HELP_TITLE_RE = re.compile(ANSI + r".*可用命令 / Commands.*")
+# v0.2.1 #68：help 改为分组 namespace 视图（§10.2），标题为 "Namespaces (...)" / grouped help title
+HELP_TITLE_RE = re.compile(ANSI + r".*Namespaces.*")
 
 
 @pytest.mark.e2e
@@ -58,12 +59,18 @@ def test_help_shows_table(cli_proc: pexpect.spawn) -> None:
     child.expect(PROMPT_RE, timeout=5)
     output = strip_ansi((child.before or "").strip())
 
-    assert "server add <json|@file>" in output
-    assert "socket connect" in output
+    # v0.2.1 #68：根 help 改为分组 namespace 视图（§10.2），详情移至 help <ns> / grouped namespace list
+    assert "server" in output and "marketplace" in output and "socket" in output
 
     # 再用 ? 验证一次 / verify with ? again
     child.sendline("?")
     child.expect(HELP_TITLE_RE)
     child.expect(PROMPT_RE, timeout=5)
     output2 = strip_ansi((child.before or "").strip())
-    assert "server add <json|@file>" in output2
+    assert "marketplace" in output2 and "skill" in output2
+
+    # help <namespace> 展开该组详细命令 / help <ns> expands the group's commands
+    child.sendline("help server")
+    child.expect(PROMPT_RE, timeout=5)
+    output3 = strip_ansi((child.before or "").strip())
+    assert "server add" in output3

--- a/tests/e2e/computer/test_cli_marketplace_e2e.py
+++ b/tests/e2e/computer/test_cli_marketplace_e2e.py
@@ -1,0 +1,100 @@
+# -*- coding: utf-8 -*-
+# filename: test_cli_marketplace_e2e.py
+# @Time    : 2026/05/27
+# @Author  : JQQ
+# @Email   : jqq1716@gmail.com
+# @Software: PyCharm
+"""
+``marketplace`` REPL E2E（pexpect 真进程，v0.2.1 #68）/ Marketplace REPL E2E via pexpect。
+
+设计依据 / Design: python-sdk docs/design-0.2.1-cli-marketplace-ux.md §4.2 / §10.5 验收。
+
+测试意图 / Test intentions（本地 ``git init --bare`` 裸仓作 file:// 源，无网络；A2C_SKILL_HOME → tmp）:
+- ``marketplace add <file://bare> --name acme`` → trust ``[y/N]`` 提示 → 送 ``y`` → clone →
+  ``marketplace list`` 见 ``acme``。
+
+说明：因启用 A2C_SKILL_HOME 后文件 watcher 常驻，pty 不再静默，故用直接 ``expect(PROMPT_RE)`` 锚定提示符，
+不走 ``expect_prompt_stable`` 的静默窗口检测（后者在常驻输出下不稳）。
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+pexpect = pytest.importorskip("pexpect", reason="e2e tests require pexpect; install with `pip install pexpect`.")
+
+from tests.e2e.computer.conftest import _spawn_cli  # noqa: E402
+from tests.e2e.computer.utils import PROMPT_RE  # noqa: E402
+
+requires_git = pytest.mark.skipif(shutil.which("git") is None, reason="requires the git binary")
+
+_GIT_IDENTITY = ["-c", "user.email=test@example.com", "-c", "user.name=Test", "-c", "commit.gpgsign=false"]
+
+
+def _git(cwd: Path, *args: str) -> None:
+    subprocess.run(["git", *_GIT_IDENTITY, *args], cwd=str(cwd), check=True, capture_output=True, text=True)
+
+
+def _make_bare(tmp_path: Path) -> Path:
+    manifest = {
+        "name": "acme-skills",
+        "owner": {"name": "Acme"},
+        "metadata": {"pluginRoot": "./plugins"},
+        "plugins": [{"name": "audit", "source": "audit", "version": "1.0.0"}],
+    }
+    work = tmp_path / "acme-work"
+    (work / ".tfrobot-plugin").mkdir(parents=True, exist_ok=True)
+    (work / ".tfrobot-plugin" / "marketplace.json").write_text(json.dumps(manifest), encoding="utf-8")
+    skill = work / "plugins" / "audit" / "skills" / "audit-code" / "SKILL.md"
+    skill.parent.mkdir(parents=True, exist_ok=True)
+    skill.write_text("---\nname: audit-code\ndescription: a skill\nlicense: MIT\n---\n# audit-code\nbody\n", encoding="utf-8")
+    _git(work, "init", "-q", "-b", "main")
+    _git(work, "add", "-A")
+    _git(work, "commit", "-q", "-m", "init")
+    bare = tmp_path / "acme.git"
+    _git(tmp_path, "clone", "-q", "--bare", str(work), str(bare))
+    return bare
+
+
+@pytest.fixture()
+def _cli_with_home(tmp_path: Path) -> Iterator[tuple]:
+    """A2C_SKILL_HOME / XDG_CONFIG_HOME 重定向到 tmp 后启动 CLI（_spawn_cli 复制 os.environ）。"""
+    home = tmp_path / "home"
+    home.mkdir(parents=True, exist_ok=True)
+    saved = {k: os.environ.get(k) for k in ("A2C_SKILL_HOME", "XDG_CONFIG_HOME")}
+    os.environ["A2C_SKILL_HOME"] = str(home)
+    os.environ["XDG_CONFIG_HOME"] = str(tmp_path / "cfg")
+    try:
+        with _spawn_cli() as child:
+            child.expect(PROMPT_RE, timeout=60)  # 启动横幅后首个提示符 / first prompt after banner
+            yield child, tmp_path
+    finally:
+        for k, v in saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+
+@pytest.mark.e2e
+@requires_git
+def test_marketplace_add_trust_clone_list(_cli_with_home: tuple) -> None:
+    child, tmp_path = _cli_with_home
+    bare = _make_bare(tmp_path)
+
+    child.sendline(f"marketplace add file://{bare} --name acme")
+    child.expect([r"y/N", r"Trust this source"], timeout=30)  # trust 提示
+    child.sendline("y")
+    child.expect(r"acme", timeout=30)  # 成功行 "✓ added 'acme' — cloned, N skill(s)"
+    child.expect(PROMPT_RE, timeout=30)
+
+    child.sendline("marketplace list")
+    idx = child.expect([r"acme", r"No marketplaces"], timeout=20)
+    assert idx == 0  # acme 出现在列表

--- a/tests/integration_tests/computer/cli/test_marketplace.py
+++ b/tests/integration_tests/computer/cli/test_marketplace.py
@@ -1,0 +1,153 @@
+# -*- coding: utf-8 -*-
+# filename: test_marketplace.py
+# @Time    : 2026/05/27
+# @Author  : JQQ
+# @Email   : jqq1716@gmail.com
+# @Software: PyCharm
+"""
+``marketplace`` / ``skill`` CLI 集成测试（v0.2.1 #68）/ Marketplace + skill CLI integration tests。
+
+设计依据 / Design: python-sdk docs/design-0.2.1-cli-marketplace-ux.md §4.2 / §4.4 / §4.6 / §10.5。
+
+测试意图 / Test intentions（本地裸仓 file:// 源，无网络；tmp home + XDG 重定向；走真实 Typer/ REPL 全栈）:
+- Typer 非交互：``marketplace add --trust`` → ``list`` → ``info`` → ``remove`` 退出码 + 物化落盘；
+  非交互缺 ``--trust`` → 退出码 1（§4.6 / §11）；``skill list --source mp --json`` 跨进程重建 registry 列出。
+- REPL：``marketplace add`` 触发 trust ``[y/N]`` → ``y`` → clone → ``skill list`` 见 marketplace 源 skill。
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any
+
+import pytest
+from typer.testing import CliRunner
+
+import a2c_smcp.computer.cli.main as cli_main
+from a2c_smcp.computer.cli.main import _interactive_loop
+from a2c_smcp.computer.computer import Computer
+from a2c_smcp.computer.settings.store import load_known_marketplaces
+
+requires_git = pytest.mark.skipif(shutil.which("git") is None, reason="requires the git binary")
+
+_GIT_IDENTITY = ["-c", "user.email=test@example.com", "-c", "user.name=Test", "-c", "commit.gpgsign=false"]
+
+
+def _git(cwd: Path, *args: str) -> None:
+    subprocess.run(["git", *_GIT_IDENTITY, *args], cwd=str(cwd), check=True, capture_output=True, text=True)
+
+
+def _skill_md(name: str) -> str:
+    return f"---\nname: {name}\ndescription: a skill\nlicense: MIT\n---\n# {name}\nbody\n"
+
+
+def _make_bare(tmp_path: Path) -> Path:
+    manifest = {
+        "name": "acme-skills",
+        "owner": {"name": "Acme"},
+        "metadata": {"pluginRoot": "./plugins"},
+        "plugins": [{"name": "audit", "source": "audit", "version": "1.0.0"}],
+    }
+    files = {
+        ".tfrobot-plugin/marketplace.json": json.dumps(manifest),
+        "plugins/audit/skills/audit-code/SKILL.md": _skill_md("audit-code"),
+    }
+    work = tmp_path / "acme-work"
+    work.mkdir(parents=True, exist_ok=True)
+    _git(work, "init", "-q", "-b", "main")
+    for rel, content in files.items():
+        p = work / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content, encoding="utf-8")
+    _git(work, "add", "-A")
+    _git(work, "commit", "-q", "-m", "init")
+    bare = tmp_path / "acme.git"
+    _git(tmp_path, "clone", "-q", "--bare", str(work), str(bare))
+    return bare
+
+
+def _set_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    (tmp_path / "home").mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("A2C_SKILL_HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "cfg"))
+
+
+# ── Typer 非交互全栈 / Typer non-interactive full stack ───────────────────────
+@requires_git
+def test_typer_add_list_info_remove(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_env(monkeypatch, tmp_path)
+    url = f"file://{_make_bare(tmp_path)}"
+    runner = CliRunner()
+
+    r = runner.invoke(cli_main.app, ["marketplace", "add", url, "--name", "acme", "--trust"])
+    assert r.exit_code == 0, r.output
+    assert "acme" in (load_known_marketplaces(tmp_path / "home").get("marketplaces") or {})
+
+    assert runner.invoke(cli_main.app, ["marketplace", "list", "--json"]).exit_code == 0
+    assert runner.invoke(cli_main.app, ["marketplace", "info", "acme"]).exit_code == 0
+    assert runner.invoke(cli_main.app, ["marketplace", "remove", "acme"]).exit_code == 0
+    assert "acme" not in (load_known_marketplaces(tmp_path / "home").get("marketplaces") or {})
+
+
+@requires_git
+def test_typer_add_missing_trust_exits_1(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """非交互缺 --trust → 退出码 1、不落盘（§4.6 / §11）/ missing --trust exits 1, nothing recorded。"""
+    _set_env(monkeypatch, tmp_path)
+    url = f"file://{_make_bare(tmp_path)}"
+    r = CliRunner().invoke(cli_main.app, ["marketplace", "add", url, "--name", "acme"])
+    assert r.exit_code == 1
+    assert "acme" not in (load_known_marketplaces(tmp_path / "home").get("marketplaces") or {})
+
+
+@requires_git
+def test_typer_skill_list_rebuilds_registry(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """新进程 registry 为空 → skill list 离线重扫已物化 marketplace clone 列出 marketplace 源 skill。"""
+    _set_env(monkeypatch, tmp_path)
+    url = f"file://{_make_bare(tmp_path)}"
+    runner = CliRunner()
+    assert runner.invoke(cli_main.app, ["marketplace", "add", url, "--name", "acme", "--trust"]).exit_code == 0
+
+    r = runner.invoke(cli_main.app, ["skill", "list", "--source", "mp", "--json"])
+    assert r.exit_code == 0, r.output
+    names = {row["name"] for row in json.loads(r.output)}
+    assert "audit:audit-code" in names
+
+
+# ── REPL trust 流程 / REPL trust flow ─────────────────────────────────────────
+class _FakePromptSession:
+    def __init__(self, commands: list[str]) -> None:
+        self._commands = commands
+
+    async def prompt_async(self, *_: str, **__: Any) -> str:
+        if not self._commands:
+            raise EOFError
+        return self._commands.pop(0)
+
+
+@contextmanager
+def _no_patch_stdout():  # type: ignore[no-untyped-def]
+    yield
+
+
+@requires_git
+@pytest.mark.asyncio
+async def test_repl_add_trust_yes_then_skill_list(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_env(monkeypatch, tmp_path)
+    url = f"file://{_make_bare(tmp_path)}"
+    # 脚本：add 触发 trust [y/N] → "y" 被 confirm 消费 → list → skill list → exit
+    commands = [f"marketplace add {url} --name acme", "y", "marketplace list", "skill list", "exit"]
+    monkeypatch.setattr(cli_main, "PromptSession", lambda: _FakePromptSession(commands))
+    monkeypatch.setattr(cli_main, "patch_stdout", lambda raw: _no_patch_stdout())
+
+    comp = Computer(name="repl-mp", inputs=set(), mcp_servers=set(), auto_connect=False, auto_reconnect=False)
+    try:
+        await _interactive_loop(comp)
+        assert "acme" in (load_known_marketplaces(tmp_path / "home").get("marketplaces") or {})
+        names = {str(r.get("name")) for r in comp.skill_registry.active_refs()}
+        assert "audit:audit-code" in names
+    finally:
+        await comp._skill_debouncer.aclose()  # 排空 mark_skills_dirty 触发的去抖任务

--- a/tests/unit_tests/computer/cli/test_banner.py
+++ b/tests/unit_tests/computer/cli/test_banner.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+# filename: test_banner.py
+# @Time    : 2026/05/27
+# @Author  : JQQ
+# @Email   : jqq1716@gmail.com
+# @Software: PyCharm
+"""
+启动 banner 单元测试（v0.2.1 #68）/ Startup banner unit tests（§10.1）。
+
+zero-state（0 plugins AND 0 servers）→ 引导框；否则一行摘要。
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from a2c_smcp.computer.cli.banner import render_banner
+
+
+class _Comp:
+    def __init__(self, servers: int) -> None:
+        self.mcp_servers = {object() for _ in range(servers)}
+
+
+def test_zero_state(capsys: pytest.CaptureFixture[str]) -> None:
+    render_banner(_Comp(0), None, None)
+    out = capsys.readouterr().out
+    assert "0 plugins" in out and "marketplace add" in out  # 引导框含 next steps
+
+
+def test_non_zero_one_liner(capsys: pytest.CaptureFixture[str]) -> None:
+    render_banner(_Comp(2), None, None)
+    out = capsys.readouterr().out
+    assert "2 servers" in out and "Next steps" not in out

--- a/tests/unit_tests/computer/cli/test_completer.py
+++ b/tests/unit_tests/computer/cli/test_completer.py
@@ -1,0 +1,77 @@
+# -*- coding: utf-8 -*-
+# filename: test_completer.py
+# @Time    : 2026/05/27
+# @Author  : JQQ
+# @Email   : jqq1716@gmail.com
+# @Software: PyCharm
+"""
+``A2CCompleter`` Tab 补全单元测试（v0.2.1 #68）/ Completer unit tests。
+
+设计依据 / Design: python-sdk docs/design-0.2.1-cli-marketplace-ux.md §10.3。
+
+测试意图 / Test intentions:
+- 行首 → namespace + 顶层命令词（含 plugin/settings 骨架）；
+- namespace 后 → 子命令词；命令后 ``--`` → flag 集；
+- 动态名：marketplace info → known_marketplaces 名；skill info → 当前 skill 名。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from prompt_toolkit.document import Document
+
+from a2c_smcp.computer.cli.completer import A2CCompleter
+from a2c_smcp.computer.settings.store import save_known_marketplaces
+
+
+class _FakeComp:
+    def __init__(self, home: Path) -> None:
+        self.skill_home = home
+
+    def get_skills(self) -> list[dict]:
+        return [{"name": "audit:lint"}, {"name": "mcp:blender:render"}]
+
+
+def _complete(completer: A2CCompleter, text: str) -> list[str]:
+    return [c.text for c in completer.get_completions(Document(text, len(text)), None)]
+
+
+def _comp(tmp_path: Path) -> A2CCompleter:
+    save_known_marketplaces({"marketplaces": {"acme": {"source": {"type": "git", "url": "u"}, "installLocation": "x"}}}, home=tmp_path)
+    return A2CCompleter(_FakeComp(tmp_path))
+
+
+def test_root_namespaces(tmp_path: Path) -> None:
+    out = _complete(_comp(tmp_path), "")
+    for ns in ("marketplace", "skill", "plugin", "settings", "server"):
+        assert ns in out
+
+
+def test_root_prefix(tmp_path: Path) -> None:
+    assert _complete(_comp(tmp_path), "mar") == ["marketplace"]
+
+
+def test_subcommands(tmp_path: Path) -> None:
+    out = _complete(_comp(tmp_path), "marketplace ")
+    assert {"add", "list", "info", "remove", "refresh", "set"} <= set(out)
+    assert _complete(_comp(tmp_path), "marketplace ad") == ["add"]
+
+
+def test_flags(tmp_path: Path) -> None:
+    out = _complete(_comp(tmp_path), "marketplace add --")
+    assert {"--name", "--trust", "--auto-update", "--no-clone", "--json"} <= set(out)
+
+
+def test_dynamic_marketplace_name(tmp_path: Path) -> None:
+    assert "acme" in _complete(_comp(tmp_path), "marketplace info ")
+
+
+def test_dynamic_skill_name(tmp_path: Path) -> None:
+    out = _complete(_comp(tmp_path), "skill info ")
+    assert "audit:lint" in out and "mcp:blender:render" in out
+
+
+def test_plugin_subcommands_scaffold(tmp_path: Path) -> None:
+    # plugin namespace 子命令词作骨架先行补全（命令体由 #69 落地）
+    assert {"install", "enable", "disable"} <= set(_complete(_comp(tmp_path), "plugin "))

--- a/tests/unit_tests/computer/cli/test_help.py
+++ b/tests/unit_tests/computer/cli/test_help.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+# filename: test_help.py
+# @Time    : 2026/05/27
+# @Author  : JQQ
+# @Email   : jqq1716@gmail.com
+# @Software: PyCharm
+"""
+分组 help 渲染单元测试（v0.2.1 #68）/ Grouped help rendering unit tests（§10.2）。
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from a2c_smcp.computer.cli.help import render_help
+
+
+def test_help_lists_namespaces(capsys: pytest.CaptureFixture[str]) -> None:
+    render_help()
+    out = capsys.readouterr().out
+    for ns in ("server", "marketplace", "plugin", "skill", "settings"):
+        assert ns in out
+
+
+def test_help_namespace_detail(capsys: pytest.CaptureFixture[str]) -> None:
+    render_help("marketplace")
+    out = capsys.readouterr().out
+    assert "marketplace" in out  # 标题 "marketplace commands"
+
+
+def test_help_unknown_namespace(capsys: pytest.CaptureFixture[str]) -> None:
+    render_help("bogus")
+    assert "unknown" in capsys.readouterr().out.lower()

--- a/tests/unit_tests/computer/cli/test_marketplace.py
+++ b/tests/unit_tests/computer/cli/test_marketplace.py
@@ -1,0 +1,226 @@
+# -*- coding: utf-8 -*-
+# filename: test_marketplace.py
+# @Time    : 2026/05/27
+# @Author  : JQQ
+# @Email   : jqq1716@gmail.com
+# @Software: PyCharm
+"""
+``marketplace`` 命令 handler 单元测试（v0.2.1 #68）/ Marketplace command handler unit tests。
+
+设计依据 / Design: python-sdk docs/design-0.2.1-cli-marketplace-ux.md §4.2 / §10.5。
+
+测试意图 / Test intentions（本地 ``git init --bare`` 裸仓作 file:// 源，无网络；tmp home + XDG 重定向隔离）:
+- URL / name 归一（纯函数，无需 git）；
+- add：trust 缺 flag 且无 confirm → 退出码 1、不落盘；confirm=yes → clone + 注册 + 落 known_marketplaces；
+  confirm=no → 退出码 1；同名冲突 → 退出码 1；--trust 直通；
+- list / info / set(auto-update) / remove（级联 prune）；
+- ``--json`` 输出形态。
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from a2c_smcp.computer.cli.commands.marketplace import (
+    default_marketplace_name,
+    marketplace_add,
+    marketplace_info,
+    marketplace_list,
+    marketplace_remove,
+    marketplace_set,
+    normalize_marketplace_url,
+)
+from a2c_smcp.computer.settings.store import load_known_marketplaces
+from a2c_smcp.computer.skills.registry import SkillRegistry
+
+requires_git = pytest.mark.skipif(shutil.which("git") is None, reason="requires the git binary")
+
+_GIT_IDENTITY = ["-c", "user.email=test@example.com", "-c", "user.name=Test", "-c", "commit.gpgsign=false"]
+
+
+# ── 本地裸仓 + 环境隔离辅助 / local bare-repo + env-isolation helpers ──────────
+def _git(cwd: Path, *args: str) -> None:
+    subprocess.run(["git", *_GIT_IDENTITY, *args], cwd=str(cwd), check=True, capture_output=True, text=True)
+
+
+def _write(root: Path, files: dict[str, str]) -> None:
+    for rel, content in files.items():
+        p = root / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content, encoding="utf-8")
+
+
+def _skill_md(name: str) -> str:
+    return f"---\nname: {name}\ndescription: a skill\nlicense: MIT\n---\n# {name}\nbody\n"
+
+
+def _marketplace_files() -> dict[str, str]:
+    manifest = {
+        "name": "acme-skills",
+        "owner": {"name": "Acme"},
+        "metadata": {"pluginRoot": "./plugins"},
+        "plugins": [{"name": "audit", "source": "audit", "version": "1.0.0"}],
+    }
+    return {
+        ".tfrobot-plugin/marketplace.json": json.dumps(manifest),
+        "plugins/audit/skills/audit-code/SKILL.md": _skill_md("audit-code"),
+        "plugins/audit/skills/lint/SKILL.md": _skill_md("lint"),
+    }
+
+
+def _make_bare(tmp_path: Path, name: str, files: dict[str, str]) -> Path:
+    work = tmp_path / f"{name}-work"
+    work.mkdir(parents=True, exist_ok=True)
+    _git(work, "init", "-q", "-b", "main")
+    _write(work, files)
+    _git(work, "add", "-A")
+    _git(work, "commit", "-q", "-m", "init")
+    bare = tmp_path / f"{name}.git"
+    _git(tmp_path, "clone", "-q", "--bare", str(work), str(bare))
+    return bare
+
+
+def _env(tmp_path: Path) -> dict[str, str]:
+    """A2C_SKILL_HOME → 物化根；XDG_CONFIG_HOME → user settings（trust 落盘）/ isolate home + user settings。"""
+    return {**os.environ, "A2C_SKILL_HOME": str(tmp_path / "home"), "XDG_CONFIG_HOME": str(tmp_path / "cfg")}
+
+
+def _home(tmp_path: Path) -> Path:
+    h = tmp_path / "home"
+    h.mkdir(parents=True, exist_ok=True)
+    return h
+
+
+async def _yes(_target: str) -> bool:
+    return True
+
+
+async def _no(_target: str) -> bool:
+    return False
+
+
+# ── 纯函数：URL / name 归一 / pure normalization ──────────────────────────────
+def test_normalize_marketplace_url() -> None:
+    assert normalize_marketplace_url("https://github.com/team/skills.git") == "https://github.com/team/skills.git"
+    assert normalize_marketplace_url("git@github.com:team/skills.git") == "git@github.com:team/skills.git"
+    # owner/repo 简写 → GitHub https 糖
+    assert normalize_marketplace_url("team/skills") == "https://github.com/team/skills.git"
+    # 非法 → None
+    assert normalize_marketplace_url("not a url at all !!") is None
+
+
+def test_default_marketplace_name() -> None:
+    assert default_marketplace_name("https://github.com/team/My_Skills.git") == "my-skills"
+    assert default_marketplace_name("git@github.com:team/acme-skills.git") == "acme-skills"
+    assert default_marketplace_name("file:///tmp/foo.git") == "foo"
+
+
+# ── add：trust 门 / add: trust gate ───────────────────────────────────────────
+@requires_git
+@pytest.mark.asyncio
+async def test_add_untrusted_no_confirm_no_flag_errors(tmp_path: Path) -> None:
+    """非交互（confirm=None）且无 --trust → 退出码 1、不落盘 / refuse + no record。"""
+    bare = _make_bare(tmp_path, "acme", _marketplace_files())
+    env, home, reg = _env(tmp_path), _home(tmp_path), SkillRegistry()
+    code = await marketplace_add(reg, home, env, f"file://{bare}", name="acme", trust=False, confirm=None)
+    assert code == 1
+    assert "acme" not in (load_known_marketplaces(home, env).get("marketplaces") or {})
+
+
+@requires_git
+@pytest.mark.asyncio
+async def test_add_confirm_yes_clones_and_records(tmp_path: Path) -> None:
+    bare = _make_bare(tmp_path, "acme", _marketplace_files())
+    env, home, reg = _env(tmp_path), _home(tmp_path), SkillRegistry()
+    code = await marketplace_add(reg, home, env, f"file://{bare}", name="acme", trust=False, confirm=_yes)
+    assert code == 0
+    assert "acme" in (load_known_marketplaces(home, env).get("marketplaces") or {})
+    # plugin audit 的 skills 已注册（marketplace 2 段名 <plugin>:<skill>）
+    names = {str(r.get("name")) for r in reg.active_refs()}
+    assert "audit:audit-code" in names and "audit:lint" in names
+
+
+@requires_git
+@pytest.mark.asyncio
+async def test_add_confirm_no_aborts(tmp_path: Path) -> None:
+    bare = _make_bare(tmp_path, "acme", _marketplace_files())
+    env, home, reg = _env(tmp_path), _home(tmp_path), SkillRegistry()
+    code = await marketplace_add(reg, home, env, f"file://{bare}", name="acme", trust=False, confirm=_no)
+    assert code == 1
+    assert "acme" not in (load_known_marketplaces(home, env).get("marketplaces") or {})
+
+
+@requires_git
+@pytest.mark.asyncio
+async def test_add_trust_flag_skips_prompt(tmp_path: Path) -> None:
+    bare = _make_bare(tmp_path, "acme", _marketplace_files())
+    env, home, reg = _env(tmp_path), _home(tmp_path), SkillRegistry()
+    code = await marketplace_add(reg, home, env, f"file://{bare}", name="acme", trust=True, confirm=None)
+    assert code == 0
+
+
+@requires_git
+@pytest.mark.asyncio
+async def test_add_name_conflict_errors(tmp_path: Path) -> None:
+    bare = _make_bare(tmp_path, "acme", _marketplace_files())
+    env, home, reg = _env(tmp_path), _home(tmp_path), SkillRegistry()
+    assert await marketplace_add(reg, home, env, f"file://{bare}", name="acme", trust=True) == 0
+    # 同名再 add → 冲突退出码 1
+    assert await marketplace_add(reg, home, env, f"file://{bare}", name="acme", trust=True) == 1
+
+
+@requires_git
+@pytest.mark.asyncio
+async def test_add_already_trusted_skips_prompt(tmp_path: Path) -> None:
+    """首个 add 以 --trust 落 trustedMarketplaces；同 url 再 add（另名）无 confirm 也直通。"""
+    bare = _make_bare(tmp_path, "acme", _marketplace_files())
+    env, home, reg = _env(tmp_path), _home(tmp_path), SkillRegistry()
+    assert await marketplace_add(reg, home, env, f"file://{bare}", name="acme", trust=True) == 0
+    # 同 url、不同 name、confirm=None、trust=False → 因 url 已 trusted 而直通
+    assert await marketplace_add(reg, home, env, f"file://{bare}", name="acme-two", trust=False, confirm=None) == 0
+
+
+# ── list / info / set / remove ───────────────────────────────────────────────
+@requires_git
+@pytest.mark.asyncio
+async def test_list_and_set_auto_update(tmp_path: Path) -> None:
+    bare = _make_bare(tmp_path, "acme", _marketplace_files())
+    env, home, reg = _env(tmp_path), _home(tmp_path), SkillRegistry()
+    await marketplace_add(reg, home, env, f"file://{bare}", name="acme", trust=True)
+    assert marketplace_list(home, env) == 0
+    assert marketplace_set(home, env, "acme", "auto-update", "true") == 0
+    assert (load_known_marketplaces(home, env).get("marketplaces") or {})["acme"].get("autoUpdate") is True
+    # 未知 key → 1
+    assert marketplace_set(home, env, "acme", "bogus", "x") == 1
+
+
+@requires_git
+@pytest.mark.asyncio
+async def test_info_and_remove(tmp_path: Path) -> None:
+    bare = _make_bare(tmp_path, "acme", _marketplace_files())
+    env, home, reg = _env(tmp_path), _home(tmp_path), SkillRegistry()
+    await marketplace_add(reg, home, env, f"file://{bare}", name="acme", trust=True)
+    assert marketplace_info(home, env, "acme") == 0
+    assert marketplace_info(home, env, "nope") == 1
+    # remove（无 installed plugin → 仅 prune clone）
+    assert await marketplace_remove(reg, home, env, "acme", confirm=_yes) == 0
+    assert "acme" not in (load_known_marketplaces(home, env).get("marketplaces") or {})
+
+
+@requires_git
+@pytest.mark.asyncio
+async def test_json_output_shape(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    bare = _make_bare(tmp_path, "acme", _marketplace_files())
+    env, home, reg = _env(tmp_path), _home(tmp_path), SkillRegistry()
+    await marketplace_add(reg, home, env, f"file://{bare}", name="acme", trust=True, json_output=True)
+    capsys.readouterr()  # 清空 add 的输出
+    marketplace_list(home, env, json_output=True)
+    out = capsys.readouterr().out
+    data = json.loads(out)
+    assert isinstance(data, list) and data[0]["name"] == "acme" and data[0]["trusted"] is True

--- a/tests/unit_tests/computer/cli/test_marketplace.py
+++ b/tests/unit_tests/computer/cli/test_marketplace.py
@@ -28,10 +28,13 @@ from pathlib import Path
 import pytest
 
 from a2c_smcp.computer.cli.commands.marketplace import (
+    _load_trusted,
+    _record_trust,
     default_marketplace_name,
     marketplace_add,
     marketplace_info,
     marketplace_list,
+    marketplace_refresh,
     marketplace_remove,
     marketplace_set,
     normalize_marketplace_url,
@@ -177,13 +180,15 @@ async def test_add_name_conflict_errors(tmp_path: Path) -> None:
 
 @requires_git
 @pytest.mark.asyncio
-async def test_add_already_trusted_skips_prompt(tmp_path: Path) -> None:
-    """首个 add 以 --trust 落 trustedMarketplaces；同 url 再 add（另名）无 confirm 也直通。"""
+async def test_add_name_already_trusted_skips_prompt(tmp_path: Path) -> None:
+    """name 已在 trustedMarketplaces（如经 settings/policy 预信任）→ add 该 name 无 confirm 也直通（按 name 判定）。"""
     bare = _make_bare(tmp_path, "acme", _marketplace_files())
     env, home, reg = _env(tmp_path), _home(tmp_path), SkillRegistry()
-    assert await marketplace_add(reg, home, env, f"file://{bare}", name="acme", trust=True) == 0
-    # 同 url、不同 name、confirm=None、trust=False → 因 url 已 trusted 而直通
-    assert await marketplace_add(reg, home, env, f"file://{bare}", name="acme-two", trust=False, confirm=None) == 0
+    _record_trust("acme", env)  # 预信任 name=acme（非 URL）
+    # name=acme 未在 known_marketplaces，但已 trusted → confirm=None、trust=False 直通
+    assert await marketplace_add(reg, home, env, f"file://{bare}", name="acme", trust=False, confirm=None) == 0
+    # 信任键空间是 name：另一个未信任的 name 仍需 confirm（缺则退出码 1）
+    assert await marketplace_add(reg, home, env, f"file://{bare}", name="other", trust=False, confirm=None) == 1
 
 
 # ── list / info / set / remove ───────────────────────────────────────────────
@@ -224,3 +229,69 @@ async def test_json_output_shape(tmp_path: Path, capsys: pytest.CaptureFixture[s
     out = capsys.readouterr().out
     data = json.loads(out)
     assert isinstance(data, list) and data[0]["name"] == "acme" and data[0]["trusted"] is True
+
+
+# ── #6 trust 撤销 / revoke trust on remove ────────────────────────────────────
+@requires_git
+@pytest.mark.asyncio
+async def test_remove_revokes_trust(tmp_path: Path) -> None:
+    bare = _make_bare(tmp_path, "acme", _marketplace_files())
+    env, home, reg = _env(tmp_path), _home(tmp_path), SkillRegistry()
+    await marketplace_add(reg, home, env, f"file://{bare}", name="acme", trust=True)
+    assert "acme" in _load_trusted(env)
+    await marketplace_remove(reg, home, env, "acme", confirm=_yes)
+    assert "acme" not in _load_trusted(env)  # remove 撤销信任，避免只增不减
+
+
+# ── #2 no_clone 仅注册意图 / no_clone registers intent only ───────────────────
+@pytest.mark.asyncio
+async def test_no_clone_registers_intent(tmp_path: Path) -> None:
+    """no_clone=True → 记 known_marketplaces（installLocation 空）但不 clone/stage skill。无需 git。"""
+    env, home, reg = _env(tmp_path), _home(tmp_path), SkillRegistry()
+    code = await marketplace_add(reg, home, env, "https://github.com/team/acme.git", name="acme", trust=True, no_clone=True)
+    assert code == 0
+    mps = load_known_marketplaces(home, env).get("marketplaces") or {}
+    assert "acme" in mps and mps["acme"].get("installLocation") == ""
+    assert reg.active_refs() == []  # 未 clone → 无 skill 注册
+
+
+# ── #2 refresh 三态 / refresh updated|unchanged|missing ───────────────────────
+def _commit_push_skill(work: Path, skill: str) -> None:
+    """向 work 工作仓加一个 skill 并 push 到 origin(bare)（供 refresh 拉取，造 updated 态）。"""
+    _write(work, {f"plugins/audit/skills/{skill}/SKILL.md": _skill_md(skill)})
+    _git(work, "add", "-A")
+    _git(work, "commit", "-q", "-m", f"add {skill}")
+    _git(work, "push", "-q", "origin", "main")
+
+
+@requires_git
+@pytest.mark.asyncio
+async def test_refresh_states(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    # work + bare（work origin=bare，便于 push 造 updated 态）
+    work = tmp_path / "acme-work"
+    work.mkdir(parents=True, exist_ok=True)
+    _git(work, "init", "-q", "-b", "main")
+    _write(work, _marketplace_files())
+    _git(work, "add", "-A")
+    _git(work, "commit", "-q", "-m", "init")
+    bare = tmp_path / "acme.git"
+    _git(tmp_path, "clone", "-q", "--bare", str(work), str(bare))
+    _git(work, "remote", "add", "origin", str(bare))
+
+    env, home, reg = _env(tmp_path), _home(tmp_path), SkillRegistry()
+    await marketplace_add(reg, home, env, f"file://{bare}", name="acme", trust=True)
+    capsys.readouterr()  # 清空 add 的成功行，避免污染后续 json 读取
+
+    # unchanged：add 后立即 refresh，sha 未变
+    await marketplace_refresh(reg, home, env, "all", json_output=True)
+    assert json.loads(capsys.readouterr().out)[0]["status"] == "unchanged"
+
+    # updated：push 新 skill 后 refresh 拉取
+    _commit_push_skill(work, "newskill")
+    await marketplace_refresh(reg, home, env, "all", json_output=True)
+    assert json.loads(capsys.readouterr().out)[0]["status"] == "updated"
+    assert "audit:newskill" in {str(r.get("name")) for r in reg.active_refs()}
+
+    # missing：未知 name
+    await marketplace_refresh(reg, home, env, "ghost", json_output=True)
+    assert json.loads(capsys.readouterr().out)[0]["status"] == "missing"

--- a/tests/unit_tests/computer/cli/test_skill.py
+++ b/tests/unit_tests/computer/cli/test_skill.py
@@ -1,0 +1,83 @@
+# -*- coding: utf-8 -*-
+# filename: test_skill.py
+# @Time    : 2026/05/27
+# @Author  : JQQ
+# @Email   : jqq1716@gmail.com
+# @Software: PyCharm
+"""
+``skill`` 命令 handler 单元测试（v0.2.1 #68）/ Skill command handler unit tests。
+
+设计依据 / Design: python-sdk docs/design-0.2.1-cli-marketplace-ux.md §4.4。
+
+测试意图 / Test intentions（预置 SkillRegistry 注册三源 + 一个孤儿，不触网）:
+- list 跨源扁平：name / source / enabled / orphan；``--source mp|mcp|user`` 过滤；
+- info：命中（含孤儿）/ 未命中；``--json`` 形态。
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from a2c_smcp.computer.cli.commands.skill import skill_info, skill_list
+from a2c_smcp.computer.skills.registry import SkillRegistry
+
+
+def _ref(name: str, source: str, root: Path) -> dict:
+    return {"name": name, "source": source, "path": str(root), "description": f"{name} desc"}
+
+
+def _registry(tmp_path: Path) -> SkillRegistry:
+    reg = SkillRegistry()
+    assert reg.register(_ref("my-skill", "user", tmp_path / "u"))  # user 1 段
+    assert reg.register(_ref("audit:lint", "marketplace:acme", tmp_path / "m"))  # marketplace 2 段
+    assert reg.register(_ref("mcp:blender:render", "mcp:blender", tmp_path / "x"))  # mcp 3 段
+    assert reg.register(_ref("audit:gone", "marketplace:acme", tmp_path / "g"))
+    reg.mark_orphan("audit:gone")  # 孤儿（从 active 排除，但 skill list 仍展示并标记）
+    return reg
+
+
+def test_list_all_sources(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    reg = _registry(tmp_path)
+    assert skill_list(reg, json_output=True) == 0
+    data = json.loads(capsys.readouterr().out)
+    by_name = {r["name"]: r for r in data}
+    assert set(by_name) == {"my-skill", "audit:lint", "mcp:blender:render", "audit:gone"}
+    assert by_name["audit:gone"]["orphan"] is True and by_name["audit:gone"]["enabled"] is False
+    assert by_name["my-skill"]["orphan"] is False
+
+
+def test_list_source_filter(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    reg = _registry(tmp_path)
+    skill_list(reg, source="mp", json_output=True)
+    mp = json.loads(capsys.readouterr().out)
+    assert {r["name"] for r in mp} == {"audit:lint", "audit:gone"}
+
+    skill_list(reg, source="mcp", json_output=True)
+    mcp = json.loads(capsys.readouterr().out)
+    assert {r["name"] for r in mcp} == {"mcp:blender:render"}
+
+    skill_list(reg, source="user", json_output=True)
+    user = json.loads(capsys.readouterr().out)
+    assert {r["name"] for r in user} == {"my-skill"}
+
+
+def test_list_unknown_source(tmp_path: Path) -> None:
+    assert skill_list(_registry(tmp_path), source="bogus") == 1
+
+
+def test_info_found_and_orphan(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    reg = _registry(tmp_path)
+    assert skill_info(reg, "audit:lint", json_output=True) == 0
+    found = json.loads(capsys.readouterr().out)
+    assert found["source"] == "marketplace:acme" and found["enabled"] is True
+    # 孤儿也可 info（all_refs 含孤儿）
+    assert skill_info(reg, "audit:gone", json_output=True) == 0
+    orphan = json.loads(capsys.readouterr().out)
+    assert orphan["orphan"] is True
+
+
+def test_info_not_found(tmp_path: Path) -> None:
+    assert skill_info(_registry(tmp_path), "no-such-skill") == 1


### PR DESCRIPTION
## 摘要

为 #68（S15，WBS 项 E 的 **marketplace + skill** 子集）补齐 `a2c-computer` 的 CLI 表面层。既有后端（`skills/staging`、`settings/reconciler`、`settings/store`、`settings/installer`、`skills/registry`、`settings/mcp_config`）已就绪，本 PR 只做**纯 Computer 侧 CLI 表面**，包裹既有逻辑，**无 A2C 协议变更**（`smcp.py`/`agent`/`server` 不动；naming 0.2.2 已先行落地）。

Closes #68（合 `develop-v0.2.1` 非默认分支，需手动关闭）。依赖 #61(staging)/#62(reconciler)/#66(computer 接入 PR #74) 均已合入。

## 改动

**新增 `cli/commands/`（REPL 与 Typer 共用 handler）**
- `marketplace.py`：`add`（首次 `y/N` trust + `--trust`；非交互缺 flag → 退出码 1；trust 落 user `trustedMarketplaces`）/ `list` / `info` / `remove`（级联卸 plugin + `prune`，`--keep-plugins`）/ `refresh` / `set auto-update=<bool>`
- `skill.py`：`list`（跨源扁平 + `--source mp\|mcp\|user`）/ `info`（只读两动词，含孤儿）
- `__init__.py`：`build_mcp_callbacks(comp)` 共享接缝（#69 plugin 命令复用）

**新增 UI 基建**
- `completer.py`：`A2CCompleter` 多 namespace 可扩展骨架（marketplace/skill 全实现 + 动态名补全；plugin/settings 子命令骨架先行）
- `progress.py`：clone spinner + 刷新汇总表
- `banner.py`：zero-state 引导框（§10.1）
- `help.py`：分组 namespace help（§10.2，单一事实源，迁入原硬编码 help 表）

**改动现有**
- `computer.py`：`skill_home` property + `mark_skills_dirty()`
- `skills/registry.py`：`all_refs()`（含孤儿，供 `skill list` 的 orphan 标志）
- `cli/interactive_impl.py`：`marketplace`/`skill` 派发 + help 委托 + 启动 banner + completer 注入（现有 server/inputs/socket/notify 派发**原地不动**，backward-compat）
- `cli/main.py`：`marketplace_app`/`skill_app` Typer 子命令（非交互不 boot Computer、不连 socket）

## 测试

- **单元**：marketplace（trust 门 / 冲突 / list-info-set-remove / --json）、skill（三源 + 孤儿 + --source）、completer（各上下文）、banner、help
- **集成**：Typer `CliRunner` 全栈（add --trust → list → info → remove；缺 --trust 退出码 1；skill list 跨进程重建 registry）+ REPL `FakePromptSession` trust 流程
- **E2E**（pexpect）：`marketplace add` → trust `[y/N]` → `y` → clone → `marketplace list` 见 `acme`
- 既有 e2e `test_help_shows_table` 同步更新为分组 help 断言（help 输出由 §10.2 刻意改为 namespace 折叠视图）
- `uv run poe lint` 净（ruff + mypy 93 files 0 issue）；非 e2e 全套 **1494 passed**

## 边界 / 下游 handoff → #69
- plugin/settings **命令** + 全局 flag（`--json`/`--settings`/`--add-dir`/`--approve-all-mcp`）+ MCP 批准框 + completer 的 plugin/settings **动态名**补全
- 完整 REPL dispatcher 抽取（现有命令保持原地）；git clone **byte-级 %** 进度需 staging 暴露 stderr hook
- 非交互 `skill list --source mcp` 的 live MCP 列举需运行中服务器（REPL 才全）

🤖 Generated with [Claude Code](https://claude.com/claude-code)