### PR TITLE
feat(computer): v0.2.1 S12 inputs/env/secret（VS Code 对标）解析链 + keyring + envFile (#65)

### DIFF
--- a/a2c_smcp/computer/computer.py
+++ b/a2c_smcp/computer/computer.py
@@ -648,8 +648,12 @@ class Computer(BaseComputer[PromptSession]):
         if not env_file or not isinstance(env_file, str):
             return rendered
         params = rendered.get("server_parameters")
-        if not isinstance(params, dict) or "env" not in params and "command" not in params:
-            # 非 stdio（sse/http 无 env/command）→ 不适用 / not applicable to sse/http
+        if not isinstance(params, dict) or ("env" not in params and "command" not in params):
+            # 非 stdio（sse/http 无 env/command）→ envFile 不适用，记 WARN（已填但被忽略）+ 原样返回。
+            # non-stdio (sse/http) → envFile not applicable; WARN that it is ignored, then passthrough.
+            name = rendered.get("name", "unknown")
+            srv_type = rendered.get("type", "unknown")
+            logger.warning(f"envFile 在非 stdio（{srv_type}）server 上不适用，已忽略: {name} / envFile ignored on non-stdio server")
             return rendered
         file_env = load_env_file(Path(env_file))
         if not file_env:

--- a/a2c_smcp/computer/computer.py
+++ b/a2c_smcp/computer/computer.py
@@ -27,6 +27,7 @@ All classes and methods use Google style docstrings (bilingual: Chinese and Engl
 
 import asyncio
 import json
+import os
 import weakref
 from collections import deque
 from collections.abc import Callable, Sequence
@@ -58,7 +59,7 @@ from a2c_smcp.computer.blob import (
     default_thresholds,
 )
 from a2c_smcp.computer.desktop.organize import organize_desktop
-from a2c_smcp.computer.inputs.render import ConfigRender
+from a2c_smcp.computer.inputs.render import ConfigRender, load_env_file
 from a2c_smcp.computer.inputs.resolver import InputNotFoundError, InputResolver
 from a2c_smcp.computer.mcp_clients.manager import MCPServerManager
 from a2c_smcp.computer.mcp_clients.model import MCPServerConfig, MCPServerInput
@@ -308,26 +309,14 @@ class Computer(BaseComputer[PromptSession]):
             auto_reconnect=self._auto_reconnect,
             message_handler=self._on_manager_change,
         )
-        # 中文: 对每个 Server 配置执行：model_dump -> 按需渲染(遇到占位符才解析 input) -> 重新校验生成不可变对象
-        # English: For each server config: model_dump -> on-demand render (resolve inputs only when referenced) ->
-        #          model_validate to rebuild immutable object
+        # 中文: 对每个 Server 配置执行：渲染(占位符解析链 + 预定义变量) + envFile 合并 + 校验生成不可变对象。
+        #       统一复用 _arender_and_validate_server（DRY，#65）；失败时按稳妥策略保留原配置继续。
+        # English: Render (resolution chain + predefined vars) + envFile merge + validate, reusing
+        #          _arender_and_validate_server (DRY). On failure, keep the original config and continue.
         validated_servers: list[MCPServerConfig] = []
-
-        async def _resolve_input_by_id(input_id: str) -> Any:
-            try:
-                return await self._input_resolver.aresolve_by_id(input_id, session=session)
-            except InputNotFoundError:
-                # 未找到输入项，按要求保留原始输出并打印警告
-                logger.warning(f"未定义的输入占位符: {input_id} / Undefined input placeholder: {input_id}")
-                raise
-
-        # 注意: 假设 self._mcp_servers 为 Iterable[MCPServerConfig]
         for server_cfg in self._mcp_servers:
             try:
-                raw = server_cfg.model_dump(mode="json")
-                rendered = await self._config_render.arender(raw, _resolve_input_by_id)
-                validated = type(server_cfg).model_validate(rendered)
-                validated_servers.append(validated)
+                validated_servers.append(await self._arender_and_validate_server(server_cfg, session=session))
             except Exception as e:
                 logger.error(f"配置渲染或校验失败: {getattr(server_cfg, 'name', 'unknown')} - {e}", exc_info=True)
                 # 按稳妥策略: 保留原配置继续
@@ -632,6 +621,45 @@ class Computer(BaseComputer[PromptSession]):
         if self._skill_watcher is not None:
             self._skill_watcher.mark_internal_write(path)
 
+    def _render_variables(self) -> dict[str, str]:
+        """
+        预定义渲染变量（对标 VS Code，§9.1）/ Predefined render variables (VS Code parity)。
+
+        ``workspaceFolder`` 取首个已登记 workdir（绑定当前任务的单根代表），无则 ``os.getcwd()``；
+        ``userHome``=用户主目录；``pathSeparator``=``os.sep``。``${env:VAR}`` 不在此（由 render 直接读
+        进程环境）。``workspaceFolder`` takes the first registered workdir, else cwd.
+        """
+        workspace = str(self._registered_workdirs[0]) if self._registered_workdirs else os.getcwd()
+        return {
+            "workspaceFolder": workspace,
+            "userHome": os.path.expanduser("~"),
+            "pathSeparator": os.sep,
+        }
+
+    def _apply_env_file(self, rendered: dict[str, Any]) -> dict[str, Any]:
+        """
+        合并 ``envFile`` 的 ``KEY=VALUE`` 进 stdio server 的 ``env``（显式 env 胜，§9.1）/ Merge envFile into env。
+
+        仅对 stdio（``server_parameters.env`` 存在）生效；sse/http 无 env 字段，原样返回。envFile **路径**
+        已在 :meth:`ConfigRender.arender` 渲染（``${workspaceFolder}`` 等已展开）。**显式 ``env`` 同名项覆盖
+        envFile**（显式胜）。本方法不改 ``envFile`` 字段本身（spawn 仅消费 ``server_parameters.env``）。
+        """
+        env_file = rendered.get("envFile") or rendered.get("env_file")
+        if not env_file or not isinstance(env_file, str):
+            return rendered
+        params = rendered.get("server_parameters")
+        if not isinstance(params, dict) or "env" not in params and "command" not in params:
+            # 非 stdio（sse/http 无 env/command）→ 不适用 / not applicable to sse/http
+            return rendered
+        file_env = load_env_file(Path(env_file))
+        if not file_env:
+            return rendered
+        explicit_env = params.get("env") or {}
+        # 显式 env 同名项胜：先铺 envFile，再覆盖以显式值 / explicit env wins over envFile
+        params["env"] = {**file_env, **explicit_env}
+        rendered["server_parameters"] = params
+        return rendered
+
     async def _arender_and_validate_server(
         self,
         server: MCPServerConfig | dict[str, Any],
@@ -680,15 +708,18 @@ class Computer(BaseComputer[PromptSession]):
                 # 透传异常到上层，由上层决定是否回退或继续
                 raise
 
+        variables = self._render_variables()
         try:
             if isinstance(server, dict):
                 raw = server
-                rendered = await self._config_render.arender(raw, _resolve_input_by_id)
+                rendered = await self._config_render.arender(raw, _resolve_input_by_id, variables=variables)
+                rendered = self._apply_env_file(rendered)
                 # 使用 TypeAdapter 将 union 类型解析为具体模型
                 validated: MCPServerConfig = TypeAdapter(MCPServerConfig).validate_python(rendered)
             else:
                 raw = server.model_dump(mode="json")
-                rendered = await self._config_render.arender(raw, _resolve_input_by_id)
+                rendered = await self._config_render.arender(raw, _resolve_input_by_id, variables=variables)
+                rendered = self._apply_env_file(rendered)
                 validated = type(server).model_validate(rendered)
             return validated
         except Exception as e:

--- a/a2c_smcp/computer/inputs/plugin_pool.py
+++ b/a2c_smcp/computer/inputs/plugin_pool.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+# filename: plugin_pool.py
+# @Time    : 2026/05/27
+# @Author  : JQQ
+# @Email   : jqq1716@gmail.com
+# @Software: PyCharm
+"""
+plugin ``mcp-servers/inputs.json`` 入池消歧 / Plugin inputs pool disambiguation（v0.2.1 #65，§9.3 D2）。
+
+plugin 的 inputs 是 plugin-scoped（协议 v1 不跨 plugin 共享）；合进 Computer 全局 inputs 池时，为避免
+两个 plugin 同 ``id`` 撞（如都用 ``api_token``），**池内存前缀 id** ``<plugin>@<marketplace>/<id>``
+（决策 #65 方案 a：自动前缀消歧，对用户透明、零打断）。plugin 内 ``${input:<id>}`` 引用用**裸 id**，由
+:class:`resolver.InputResolver` 在该 plugin 上下文里回退到带前缀池条目（见 resolver ``plugin``/``marketplace``
+关键字）。user/CLI 直接定义的 inputs（非 plugin 来源）无前缀，裸 id 入池（沿用现状）。
+
+本模块只负责**读取 + 校验 + 前缀改写**；实时挂载（enumerate installed plugins → 填池 → spawn）属 #69。
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from pydantic import TypeAdapter, ValidationError
+
+from a2c_smcp.computer.mcp_clients.model import MCPServerInput
+from a2c_smcp.utils.logger import get_logger
+
+logger = get_logger("computer")
+
+_MCP_INPUT_ADAPTER: TypeAdapter[MCPServerInput] = TypeAdapter(MCPServerInput)
+
+
+def prefix_input_id(plugin: str, marketplace: str, input_id: str) -> str:
+    """
+    构造带前缀的池内 id ``<plugin>@<marketplace>/<id>`` / Build the prefixed pool id。
+
+    与 ``installer`` 的 plugin_id ``<plugin>@<marketplace>`` 命名空间一致（§9.3 D2）。
+    """
+    return f"{plugin}@{marketplace}/{input_id}"
+
+
+def _read_input_defs(inputs_json: Path) -> list[Any]:
+    """读 inputs.json → 原始 input 定义列表；兼容 ``{"inputs": [...]}`` 与裸 ``[...]``；畸形 → ``[]``。"""
+    try:
+        raw = inputs_json.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return []
+    except OSError as e:  # pragma: no cover - 读权限/IO 异常
+        logger.warning(f"读取 plugin inputs.json 失败 / Failed to read plugin inputs.json: {inputs_json}: {e}")
+        return []
+    try:
+        data = json.loads(raw)
+    except (json.JSONDecodeError, ValueError):
+        logger.warning(f"plugin inputs.json JSON 畸形，跳过 / Malformed plugin inputs.json, skip: {inputs_json}")
+        return []
+    if isinstance(data, Mapping):
+        defs = data.get("inputs", [])
+    else:
+        defs = data
+    return list(defs) if isinstance(defs, list) else []
+
+
+def load_plugin_inputs(inputs_json: Path, plugin: str, marketplace: str) -> list[MCPServerInput]:
+    """
+    读取并前缀化 plugin 的 inputs 定义 / Load and prefix a plugin's input definitions。
+
+    逐项校验为 :class:`MCPServerInput`（复用 ``mcp_config`` 的 field-tolerant 范式：畸形条目记 WARN 跳过、
+    **不抛**），再把 ``id`` 改写为 :func:`prefix_input_id`（frozen 模型经 ``model_copy(update=)`` 重建）。
+    文件缺失 / 畸形 → ``[]``。
+    """
+    result: list[MCPServerInput] = []
+    for idef in _read_input_defs(inputs_json):
+        try:
+            inp = _MCP_INPUT_ADAPTER.validate_python(idef)
+        except ValidationError as exc:
+            raw_id = idef.get("id") if isinstance(idef, Mapping) else "<unknown>"
+            logger.warning(f"plugin input 定义畸形，跳过 / Invalid plugin input def, skip [{raw_id}]: {exc}")
+            continue
+        prefixed = prefix_input_id(plugin, marketplace, inp.id)
+        result.append(inp.model_copy(update={"id": prefixed}))
+    return result

--- a/a2c_smcp/computer/inputs/render.py
+++ b/a2c_smcp/computer/inputs/render.py
@@ -2,28 +2,76 @@
 文件名: render.py
 作者: JQQ
 创建日期: 2025/9/18
-最后修改日期: 2025/9/18
+最后修改日期: 2026/5/27
 版权: 2023 JQQ. All rights reserved.
 依赖: re, typing
 描述:
-  中文: 针对 MCP 配置的按需渲染器，识别占位符 ${input:<id>} 并通过回调异步解析，支持递归容器结构与深度限制。
-  English: On-demand renderer for MCP configs. Detects placeholders ${input:<id>} and resolves them via async callback,
-           supports container recursion with depth limiting.
+  中文: MCP 配置按需渲染器。识别占位符并替换，支持递归容器与深度限制。
+        v0.2.1 #65（§9.1，对标 VS Code）：除 ``${input:<id>}``（经回调走解析链）外，新增
+        ``${env:<VAR>}``（进程环境变量，缺失→空串 + WARN）与预定义变量 ``${workspaceFolder}`` /
+        ``${userHome}`` / ``${pathSeparator}``。未知占位符保持原样（向后兼容）。
+  English: On-demand renderer for MCP configs. v0.2.1 adds ``${env:VAR}`` (process env, missing → empty
+           + WARN) and predefined ``${workspaceFolder}`` / ``${userHome}`` / ``${pathSeparator}`` on top
+           of ``${input:id}``. Unknown placeholders are left untouched (backward compatible).
 """
 
 from __future__ import annotations
 
+import os
 import re
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Mapping
+from pathlib import Path
 from typing import Any
 
 from a2c_smcp.utils.logger import get_logger
 
 logger = get_logger("computer")
 
-# 中文: 匹配占位符 ${input:xxx} 的正则
-# English: Regex to match placeholder ${input:xxx}
-PLACEHOLDER_PATTERN = re.compile(r"\$\{input:([^}]+)}")
+
+def load_env_file(path: Path) -> dict[str, str]:
+    """
+    加载 VS Code 风格 ``envFile`` 的 ``KEY=VALUE`` 行（§9.1）/ Load a VS Code-style ``envFile``。
+
+    解析规则：跳过空行与 ``#`` 注释；容忍前缀 ``export ``；去除值两端成对引号；无 ``=`` 的行跳过 + WARN。
+    文件缺失 / 读失败 → ``{}`` + WARN（容错，不抛）。变量展开**不**在此发生——envFile 值按字面取，
+    占位符（如 ``${workspaceFolder}``）由调用方在渲染整份配置时（含 envFile **路径**）先行替换。
+    """
+    try:
+        text = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        logger.warning(f"envFile 不存在，跳过: {path} / envFile not found, skip")
+        return {}
+    except OSError as e:  # pragma: no cover - 读权限/IO 异常
+        logger.warning(f"envFile 读取失败，跳过: {path}: {e} / failed to read envFile, skip")
+        return {}
+
+    result: dict[str, str] = {}
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("export "):
+            line = line[len("export ") :].strip()
+        if "=" not in line:
+            logger.warning(f"envFile 行无 '='，跳过: {raw_line!r} / envFile line without '=', skip")
+            continue
+        key, _, value = line.partition("=")
+        key = key.strip()
+        value = value.strip()
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
+            value = value[1:-1]
+        if key:
+            result[key] = value
+    return result
+
+
+# 中文: 匹配任意 ${...} 占位符；token 由 _aresolve_token 按前缀分派（input:/env:/预定义）
+# English: Match any ${...} placeholder; the inner token is dispatched by prefix in _aresolve_token.
+PLACEHOLDER_PATTERN = re.compile(r"\$\{([^}]+)}")
+
+_PREDEFINED_VARS = ("workspaceFolder", "userHome", "pathSeparator")
+
+ResolveInput = Callable[[str], Awaitable[Any]]
 
 
 class ConfigRender:
@@ -35,64 +83,104 @@ class ConfigRender:
     def __init__(self, *, max_depth: int = 10) -> None:
         self._max_depth = max_depth
 
-    async def arender(self, data: Any, resolve_input: Callable[[str], Awaitable[Any]], _depth: int = 0) -> Any:
+    async def arender(
+        self,
+        data: Any,
+        resolve_input: ResolveInput,
+        *,
+        variables: Mapping[str, str] | None = None,
+        env: Mapping[str, str] | None = None,
+        _depth: int = 0,
+    ) -> Any:
         """
         中文: 递归渲染任意结构的数据，字符串中按需替换占位符。
         English: Recursively render arbitrary structured data, replacing placeholders in strings on demand.
+
+        :param variables: 预定义变量映射（workspaceFolder/userHome/pathSeparator）/ predefined variables.
+        :param env: ``${env:VAR}`` 取值来源（默认 ``os.environ``，可注入便于测试）/ source for ``${env:VAR}``.
         """
         if _depth > self._max_depth:
             logger.error("渲染深度超过限制，停止递归 / Rendering depth exceeded, stop recursion")
             return data
 
         if isinstance(data, dict):
-            return {k: await self.arender(v, resolve_input, _depth + 1) for k, v in data.items()}
+            return {k: await self.arender(v, resolve_input, variables=variables, env=env, _depth=_depth + 1) for k, v in data.items()}
         if isinstance(data, list):
-            return [await self.arender(x, resolve_input, _depth + 1) for x in data]
+            return [await self.arender(x, resolve_input, variables=variables, env=env, _depth=_depth + 1) for x in data]
         if isinstance(data, str):
-            return await ConfigRender.arender_str(data, resolve_input)
+            return await ConfigRender.arender_str(data, resolve_input, variables=variables, env=env)
         return data
 
     @staticmethod
-    async def arender_str(s: str, resolve_input: Callable[[str], Awaitable[Any]]) -> Any:
+    async def _aresolve_token(
+        token: str,
+        resolve_input: ResolveInput,
+        variables: Mapping[str, str] | None,
+        env: Mapping[str, str] | None,
+    ) -> tuple[bool, Any]:
         """
-        中文: 对字符串中的所有占位符进行按需替换；若替换为非字符串值，返回替换后的非字符串值（用于纯占位符情况）。
-        English: Replace placeholders lazily; if the entire string is a single placeholder and resolves to a non-string,
-        return that value.
+        解析单个占位符 token / Resolve a single placeholder token。
+
+        返回 ``(matched, value)``：``matched=False`` 表示未知占位符，调用方应**保持原样**不替换。
+        Returns ``(matched, value)``; ``matched=False`` means unknown placeholder → caller leaves it as-is.
+        """
+        if token.startswith("input:"):
+            input_id = token[len("input:") :]
+            try:
+                return True, await resolve_input(input_id)
+            except KeyError:
+                logger.warning(f"未找到输入项: {input_id} / Input id not found: {input_id}")
+                return False, None
+            except Exception as e:  # pragma: no cover
+                logger.error(f"解析输入失败: {input_id}, 错误: {e}", exc_info=True)
+                return False, None
+        if token.startswith("env:"):
+            var = token[len("env:") :]
+            source: Mapping[str, str] = os.environ if env is None else env
+            val = source.get(var)
+            if val is None:
+                logger.warning(f"环境变量未定义，替换为空串: {var} / Env var undefined, substitute empty: {var}")
+                return True, ""  # VS Code parity：缺失 env → 空串
+            return True, val
+        if token in _PREDEFINED_VARS:
+            val = (variables or {}).get(token)
+            if val is None:
+                logger.warning(f"预定义变量未提供，替换为空串: {token} / Predefined var missing, substitute empty: {token}")
+                return True, ""
+            return True, val
+        return False, None  # 未知占位符 → 保持原样 / unknown → leave as-is
+
+    @staticmethod
+    async def arender_str(
+        s: str,
+        resolve_input: ResolveInput,
+        *,
+        variables: Mapping[str, str] | None = None,
+        env: Mapping[str, str] | None = None,
+    ) -> Any:
+        """
+        中文: 对字符串中的所有占位符按需替换；若整串恰为单一占位符且解析为非字符串值，返回该非字符串值。
+        English: Replace placeholders lazily; if the whole string is a single placeholder resolving to a
+        non-string (e.g. ``${input:x}`` → dict), return that value.
         """
         matches = list(PLACEHOLDER_PATTERN.finditer(s))
         if not matches:
             return s
 
-        # 如果字符串仅包含单一占位符且没有其他字符，允许返回非字符串类型
+        # 整串恰为单一占位符 → 允许返回非字符串类型（例如 ${input:x} 解析为 dict/list）
         if len(matches) == 1 and matches[0].span() == (0, len(s)):
-            input_id = matches[0].group(1)
-            try:
-                return await resolve_input(input_id)
-            except KeyError:
-                logger.warning(f"未找到输入项: {input_id} / Input id not found: {input_id}")
-                return s
-            except Exception as e:  # pragma: no cover
-                logger.error(f"解析输入失败: {input_id}, 错误: {e}", exc_info=True)
-                return s
+            matched, value = await ConfigRender._aresolve_token(matches[0].group(1), resolve_input, variables, env)
+            return value if matched else s
 
-        # 否则逐个替换为其字符串表现形式
+        # 否则逐个替换为其字符串表现形式（未知占位符保持原样）
         result = s
         offset = 0
         for m in matches:
             start, end = m.span()
-            input_id = m.group(1)
-            try:
-                value = await resolve_input(input_id)
-            except KeyError:
-                logger.warning(f"未找到输入项: {input_id} / Input id not found: {input_id}")
+            matched, value = await ConfigRender._aresolve_token(m.group(1), resolve_input, variables, env)
+            if not matched:
                 continue
-            except Exception as e:  # pragma: no cover
-                logger.error(f"解析输入失败: {input_id}, 错误: {e}", exc_info=True)
-                continue
-
-            # 将非字符串值转换为字符串嵌入
             repl = str(value)
-            # 由于我们在原始字符串上替换，位置需要考虑之前替换带来的偏移
             result = result[: start + offset] + repl + result[end + offset :]
             offset += len(repl) - (end - start)
         return result

--- a/a2c_smcp/computer/inputs/resolver.py
+++ b/a2c_smcp/computer/inputs/resolver.py
@@ -137,9 +137,11 @@ class InputResolver(BaseInputResolver[PromptSession]):
                 self._cache[resolved_id] = stored
                 return stored
 
-        # 解析链步骤 5：交互 prompt——password 在 headless（无 env+无 keyring+无 TTY）下硬错误，绝不落明文
+        # 解析链步骤 5：交互 prompt——password 在 headless（无 env + 无 TTY）下硬错误，绝不落明文。
+        # keyring 已在步骤 3 穷尽并 miss，无 TTY 时无论 keyring 是否可用都拿不到密钥 → 统一硬错误
+        # （而非落到 prompt 在 headless 抛不透明 OSError / 静默返回 ""）。
         has_tty = self._has_tty(sess)
-        if is_password and not has_tty and not self._secret_store.available:
+        if is_password and not has_tty:
             raise SecretResolutionError(
                 f"secret '{resolved_id}' 无法解析；请设置环境变量 {env_var_name(resolved_id)} 或在 TTY 重试 / "
                 f"cannot resolve secret; set {env_var_name(resolved_id)} or retry in a TTY",

--- a/a2c_smcp/computer/inputs/resolver.py
+++ b/a2c_smcp/computer/inputs/resolver.py
@@ -2,23 +2,35 @@
 文件名: resolver.py
 作者: JQQ
 创建日期: 2025/9/18
-最后修改日期: 2025/9/18
+最后修改日期: 2026/5/27
 版权: 2023 JQQ. All rights reserved.
 依赖: prompt_toolkit, rich
 描述:
   中文: inputs 解析器定义与实现。按需根据 id 解析三类输入：promptString、pickString、command。
-  English: Input resolvers. Lazily resolve three kinds of inputs by id: promptString, pickString, command.
+        v0.2.1 #65（§9.3，对标 VS Code SecretStorage）：在交互 prompt 前前插解析链
+        env(`A2C_INPUT_<ID>`) → keyring（仅 password）→ 明文 value store（仅非密钥），并在**交互 prompt
+        得值后**按类持久化（password→keyring、非密钥→明文 state；env 命中/command/headless 不落盘）。
+        密钥在 headless（无 env+无 keyring+无 TTY）下**硬错误**，绝不落明文。
+  English: Input resolvers. v0.2.1 #65 prepends an env→keyring→plaintext resolution chain and persists
+           interactively-prompted values by type (secrets to OS keyring, non-secrets to plaintext state);
+           headless secrets hard-error rather than ever writing plaintext.
 """
 
 from __future__ import annotations
 
-from collections.abc import Iterable
+import os
+import re
+import sys
+from collections.abc import Iterable, Mapping
 from typing import Any
 
 from prompt_toolkit import PromptSession
 
 from a2c_smcp.computer.inputs.base import BaseInputResolver
 from a2c_smcp.computer.inputs.cli_io import ainput_pick, ainput_prompt, arun_command
+from a2c_smcp.computer.inputs.plugin_pool import prefix_input_id
+from a2c_smcp.computer.inputs.secret_store import SecretStore
+from a2c_smcp.computer.inputs.value_store import ValueStore
 from a2c_smcp.computer.mcp_clients.model import (
     MCPServerCommandInput,
     MCPServerInput,
@@ -34,29 +46,104 @@ class InputNotFoundError(KeyError):
     pass
 
 
+class SecretResolutionError(RuntimeError):
+    """
+    中文: ``password:true`` input 在 headless（无 ``A2C_INPUT_<ID>`` env、无 keyring、无 TTY）下无法解析。
+    English: A ``password:true`` input cannot be resolved headless (no env, no keyring, no TTY).
+
+    设计要求**硬错误**而非降级落明文（§9.3，杜绝把密钥明文落盘的反模式）。
+    """
+
+
+def env_var_name(input_id: str) -> str:
+    """
+    把 input id 映射为环境变量名 ``A2C_INPUT_<ID_UPPER>``（非字母数字 → ``_``）/ Map id to env var name。
+
+    含前缀 plugin id（``<plugin>@<mp>/<id>``）一并归一，如 ``frontend@team/figma_token`` →
+    ``A2C_INPUT_FRONTEND_TEAM_FIGMA_TOKEN``。
+    """
+    return "A2C_INPUT_" + re.sub(r"[^A-Z0-9]", "_", input_id.upper())
+
+
 class InputResolver(BaseInputResolver[PromptSession]):
     """
-    中文: 输入解析器，支持基于 id 的惰性解析与结果缓存。
-    English: Input resolver with lazy per-id resolution and result cache.
+    中文: 输入解析器，支持基于 id 的惰性解析、解析链取值与按类持久化。
+    English: Input resolver with lazy per-id resolution, a resolution chain, and per-type persistence.
     """
 
-    def __init__(self, inputs: Iterable[MCPServerInput], session: PromptSession | None = None) -> None:
+    def __init__(
+        self,
+        inputs: Iterable[MCPServerInput],
+        session: PromptSession | None = None,
+        *,
+        env: Mapping[str, str] | None = None,
+        value_store: ValueStore | None = None,
+        secret_store: SecretStore | None = None,
+    ) -> None:
         """
-        中文: CLI 特化的输入解析器，支持可选的 PromptSession 注入。
-        English: CLI-specialized input resolver with optional PromptSession injection.
+        中文: CLI 特化的输入解析器，支持可选的 PromptSession 注入 + 解析链存储注入（便于测试）。
+        English: CLI-specialized resolver with optional PromptSession + resolution-chain store injection (testable).
         """
         super().__init__(inputs, session=session)
+        self._env: Mapping[str, str] = os.environ if env is None else env
+        self._value_store: ValueStore = value_store if value_store is not None else ValueStore(env=self._env)
+        self._secret_store: SecretStore = secret_store if secret_store is not None else SecretStore()
 
-    async def aresolve_by_id(self, input_id: str, *, session: PromptSession | None = None) -> Any:
-        if input_id in self._cache:
-            return self._cache[input_id]
+    async def aresolve_by_id(
+        self,
+        input_id: str,
+        *,
+        session: PromptSession | None = None,
+        plugin: str | None = None,
+        marketplace: str | None = None,
+    ) -> Any:
+        # 1. 定位定义：裸 id 未命中且给了 plugin 上下文 → 回退查带前缀池条目（§9.3 D2）
+        #    Locate the definition; with plugin context, bare id falls back to the prefixed pool entry.
         cfg = self._inputs.get(input_id)
-        if not cfg:
+        resolved_id = input_id
+        if cfg is None and plugin and marketplace:
+            prefixed = prefix_input_id(plugin, marketplace, input_id)
+            prefixed_cfg = self._inputs.get(prefixed)
+            if prefixed_cfg is not None:
+                cfg, resolved_id = prefixed_cfg, prefixed
+        if cfg is None:
             raise InputNotFoundError(input_id)
 
-        # 优先使用调用时传入的 session，其次使用初始化指定的 self.session
-        # Prefer provided session; fallback to self.session
+        # 2. 进程内 cache（按解析后的池 id 缓存，避免不同 plugin 的同裸 id 串味）
+        if resolved_id in self._cache:
+            return self._cache[resolved_id]
+
         sess = session or self.session
+        is_password = isinstance(cfg, MCPServerPromptStringInput) and bool(cfg.password)
+        is_plain_persistable = isinstance(cfg, (MCPServerPromptStringInput, MCPServerPickStringInput)) and not is_password
+
+        # 解析链步骤 2：环境变量 A2C_INPUT_<ID>（编排层注入，命中不落盘）
+        env_val = self._env.get(env_var_name(resolved_id))
+        if env_val is not None:
+            self._cache[resolved_id] = env_val
+            return env_val
+
+        # 解析链步骤 3：OS keyring（仅 password:true）
+        if is_password:
+            secret = self._secret_store.get(resolved_id)
+            if secret is not None:
+                self._cache[resolved_id] = secret
+                return secret
+
+        # 解析链步骤 4：明文 value store（仅非密钥 promptString/pickString）
+        if is_plain_persistable:
+            stored = self._value_store.get(resolved_id)
+            if stored is not None:
+                self._cache[resolved_id] = stored
+                return stored
+
+        # 解析链步骤 5：交互 prompt——password 在 headless（无 env+无 keyring+无 TTY）下硬错误，绝不落明文
+        has_tty = self._has_tty(sess)
+        if is_password and not has_tty and not self._secret_store.available:
+            raise SecretResolutionError(
+                f"secret '{resolved_id}' 无法解析；请设置环境变量 {env_var_name(resolved_id)} 或在 TTY 重试 / "
+                f"cannot resolve secret; set {env_var_name(resolved_id)} or retry in a TTY",
+            )
 
         if isinstance(cfg, MCPServerPromptStringInput):
             value = await self._aresolve_prompt(cfg, session=sess)
@@ -68,8 +155,27 @@ class InputResolver(BaseInputResolver[PromptSession]):
             logger.warning(f"未知输入类型: {type(cfg)} / Unknown input type")
             value = None
 
-        self._cache[input_id] = value
+        # 解析后持久化（仅**交互 prompt 得值**时落盘，§9.3「prompt 得」；headless/默认回退不持久化）：
+        #   password → keyring（keyring 不可用 → 仅会话缓存、绝不落明文）；非密钥 → 明文 value store。
+        if has_tty and value is not None:
+            if is_password:
+                if not self._secret_store.set(resolved_id, str(value)):
+                    logger.debug(f"keyring 不可用，密钥 {resolved_id} 仅会话缓存、不落明文 / keyring unavailable, secret cached only")
+            elif is_plain_persistable:
+                self._value_store.set(resolved_id, value)
+
+        self._cache[resolved_id] = value
         return value
+
+    @staticmethod
+    def _has_tty(session: PromptSession | None) -> bool:
+        """是否处于可交互环境（注入了 session，或 stdin 是 TTY）/ Whether interactive (session injected or stdin is a TTY)。"""
+        if session is not None:
+            return True
+        try:
+            return sys.stdin.isatty()
+        except Exception:  # pragma: no cover - 防御性：stdin 被替换为非标准对象
+            return False
 
     async def _aresolve_prompt(self, cfg: MCPServerPromptStringInput, *, session: PromptSession | None = None) -> str:
         msg = cfg.description or f"请输入 {cfg.id} / Please input {cfg.id}"

--- a/a2c_smcp/computer/inputs/secret_store.py
+++ b/a2c_smcp/computer/inputs/secret_store.py
@@ -1,0 +1,122 @@
+# -*- coding: utf-8 -*-
+# filename: secret_store.py
+# @Time    : 2026/05/27
+# @Author  : JQQ
+# @Email   : jqq1716@gmail.com
+# @Software: PyCharm
+"""
+密钥（``password:true`` input）的 OS keyring 封装 / OS keyring wrapper for secret inputs（v0.2.1 #65，§9.3）。
+
+对标 VS Code SecretStorage：``keyring`` 库自动选 macOS Keychain / Windows Credential Manager /
+Linux Secret Service（libsecret）。``keyring`` 是**可选依赖**（``pip install a2c-smcp[keyring]``）——
+故在此**惰性 import**：缺失不破坏模块导入，仅令 :func:`keyring_available` 返回 ``False``，由
+:mod:`resolver` 走 headless 降级（env）或硬错误（**绝不写明文**，§9.3）。
+
+键空间：service=``a2c-computer``、key=**全局 ``<id>``**（与模型「Input id 全局唯一」一致）。
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from a2c_smcp.utils.logger import get_logger
+
+logger = get_logger("computer")
+
+SERVICE_NAME = "a2c-computer"
+
+# 可用性探测结果缓存（None=未探测）/ Cached availability probe (None = not probed yet).
+_available: bool | None = None
+
+
+def _load_keyring() -> Any | None:
+    """惰性 import keyring；缺失返回 ``None`` / Lazily import keyring; ``None`` if not installed。"""
+    try:
+        # 惰性 import 是本模块设计核心（可选依赖缺失不破坏导入）/ lazy import is intentional (optional dep)
+        import keyring  # noqa: PLC0415
+
+        return keyring
+    except ImportError:
+        return None
+
+
+def keyring_available(*, force_recheck: bool = False) -> bool:
+    """
+    探测 OS keyring 是否可用 / Probe whether an OS keyring backend is usable。
+
+    判定：``keyring`` 已安装 **且** 当前 backend 非 ``fail``/``null``（容器/CI/无 Secret Service 环境下
+    ``keyring`` 会回退到 ``fail.Keyring``，此时不可用）。结果缓存（``force_recheck`` 可重探，便于测试）。
+    """
+    global _available
+    if _available is not None and not force_recheck:
+        return _available
+
+    kr = _load_keyring()
+    if kr is None:
+        _available = False
+        return False
+    try:
+        backend = kr.get_keyring()
+        # fail.Keyring / chainer 为空 → 不可用。以模块路径判定，避免硬依赖具体类。
+        mod = type(backend).__module__
+        _available = "fail" not in mod and backend is not None
+    except Exception as e:  # pragma: no cover - 后端探测异常按不可用处理
+        logger.debug(f"keyring 后端探测异常，按不可用处理 / keyring backend probe failed, treat unavailable: {e}")
+        _available = False
+    return _available
+
+
+class SecretStore:
+    """
+    中文: ``password:true`` input 值的 OS keyring 存取；keyring 不可用时为安全降级（get→None / set→False）。
+    English: OS keyring store for ``password:true`` input values; degrades safely when keyring unavailable.
+    """
+
+    def __init__(self, *, service: str = SERVICE_NAME) -> None:
+        self._service = service
+
+    @property
+    def available(self) -> bool:
+        return keyring_available()
+
+    def get(self, input_id: str) -> str | None:
+        """从 keyring 取密钥；不可用或未存返回 ``None`` / Get secret; ``None`` if unavailable or absent。"""
+        if not keyring_available():
+            return None
+        kr = _load_keyring()
+        if kr is None:  # pragma: no cover - available 已保证 kr 非空
+            return None
+        try:
+            secret: str | None = kr.get_password(self._service, input_id)
+            return secret
+        except Exception as e:  # pragma: no cover - keyring 运行期异常
+            logger.warning(f"keyring 读取失败 / keyring get failed for {input_id}: {e}")
+            return None
+
+    def set(self, input_id: str, value: str) -> bool:
+        """写密钥进 keyring，返回是否成功；不可用 → ``False``（**绝不**降级落明文）/ Store secret; ``False`` if unavailable。"""
+        if not keyring_available():
+            return False
+        kr = _load_keyring()
+        if kr is None:  # pragma: no cover
+            return False
+        try:
+            kr.set_password(self._service, input_id, value)
+            return True
+        except Exception as e:  # pragma: no cover - keyring 运行期异常
+            logger.warning(f"keyring 写入失败 / keyring set failed for {input_id}: {e}")
+            return False
+
+    def delete(self, input_id: str) -> bool:
+        """从 keyring 删除密钥，返回是否删除发生 / Delete secret; returns whether deletion happened。"""
+        if not keyring_available():
+            return False
+        kr = _load_keyring()
+        if kr is None:  # pragma: no cover
+            return False
+        try:
+            kr.delete_password(self._service, input_id)
+            return True
+        except Exception as e:  # keyring 在未存时抛 PasswordDeleteError，按未删除处理
+            logger.debug(f"keyring 删除未发生 / keyring delete no-op for {input_id}: {e}")
+            return False

--- a/a2c_smcp/computer/inputs/value_store.py
+++ b/a2c_smcp/computer/inputs/value_store.py
@@ -1,0 +1,113 @@
+# -*- coding: utf-8 -*-
+# filename: value_store.py
+# @Time    : 2026/05/27
+# @Author  : JQQ
+# @Email   : jqq1716@gmail.com
+# @Software: PyCharm
+"""
+非密钥 input 值的明文持久化 / Plaintext persistence for non-secret input values（v0.2.1 #65，§9.3）。
+
+对标 VS Code：promptString/pickString 这类**非密钥**输入首次解析后落明文 state，跨重启复用、不再
+prompt。密钥（``password:true``）**绝不**进此文件——走 :mod:`secret_store` 的 OS keyring（§9.3 安全
+不变量）。文件位于 ``$XDG_STATE_HOME/a2c/input-values.json``（XDG-first，回退 ``~/.local/state/a2c``），
+``0600`` 权限、原子写、gitignored。
+
+键空间：**全局** ``<id>``（与模型「Input id 全局唯一、跨类型不重复」一致；无 workspace 维度）。
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from a2c_smcp.utils.atomic_io import atomic_write_text
+from a2c_smcp.utils.logger import get_logger
+from a2c_smcp.utils.path import resolve_xdg_first
+
+logger = get_logger("computer")
+
+XDG_STATE_HOME_ENV = "XDG_STATE_HOME"
+_A2C_STATE_SUBDIR = "a2c"
+VALUE_STORE_FILENAME = "input-values.json"
+
+
+def resolve_value_store_path(env: Mapping[str, str] | None = None) -> Path:
+    """
+    解析明文 value store 路径 / Resolve the plaintext value-store path。
+
+    优先 ``$XDG_STATE_HOME/a2c/input-values.json``（XDG_STATE_HOME 须为绝对路径，否则按 XDG 规范忽略），
+    回退 ``~/.local/state/a2c/input-values.json``。复用 :func:`resolve_xdg_first`（与 ``settings/scope.py``
+    的 user config dir 同范式，区别仅在 env 变量与子目录）。
+    """
+    environ: Mapping[str, str] = os.environ if env is None else env
+    base = resolve_xdg_first(
+        environ,
+        XDG_STATE_HOME_ENV,
+        _A2C_STATE_SUBDIR,
+        fallback=Path.home() / ".local" / "state" / _A2C_STATE_SUBDIR,
+    )
+    return base / VALUE_STORE_FILENAME
+
+
+class ValueStore:
+    """
+    中文: 非密钥 input 值的明文存储（``{id: value}`` 扁平 map），原子写 + ``0600``。
+    English: Plaintext store for non-secret input values (flat ``{id: value}`` map), atomic + ``0600``.
+    """
+
+    def __init__(self, env: Mapping[str, str] | None = None) -> None:
+        self._path = resolve_value_store_path(env)
+
+    @property
+    def path(self) -> Path:
+        return self._path
+
+    def load(self) -> dict[str, Any]:
+        """
+        读取全量 map；文件不存在或畸形 JSON → ``{}``（field-tolerant，不抛）。
+        Load the whole map; missing file or malformed JSON → ``{}`` (tolerant, never raises).
+        """
+        try:
+            raw = self._path.read_text(encoding="utf-8")
+        except FileNotFoundError:
+            return {}
+        except OSError as e:  # pragma: no cover - 防御性：读权限/IO 异常
+            logger.warning(f"读取 value store 失败，按空处理 / Failed to read value store, treat as empty: {e}")
+            return {}
+        try:
+            data = json.loads(raw)
+        except (json.JSONDecodeError, ValueError):
+            logger.warning(f"value store JSON 畸形，按空处理 / Malformed value store JSON, treat as empty: {self._path}")
+            return {}
+        return data if isinstance(data, dict) else {}
+
+    def get(self, input_id: str) -> Any | None:
+        """按 id 取值；不存在返回 ``None`` / Get value by id; ``None`` if absent。"""
+        return self.load().get(input_id)
+
+    def set(self, input_id: str, value: Any) -> None:
+        """写入/覆盖 id 的值（原子写 + ``0600``）/ Set value for id (atomic + ``0600``)。"""
+        data = self.load()
+        data[input_id] = value
+        self._atomic_write(data)
+
+    def delete(self, input_id: str) -> bool:
+        """删除 id 的值，返回是否删除发生 / Delete value for id; returns whether deletion happened。"""
+        data = self.load()
+        if input_id not in data:
+            return False
+        data.pop(input_id, None)
+        self._atomic_write(data)
+        return True
+
+    def _atomic_write(self, data: Mapping[str, Any]) -> None:
+        # 原子写（复用共享原语）后立即 chmod 0600——value store 虽仅存非密钥，仍按最小可见性硬化。
+        # Atomic write (shared primitive) then chmod 0600 — defense-in-depth even for non-secret values.
+        atomic_write_text(self._path, json.dumps(data, ensure_ascii=False, indent=2) + "\n")
+        try:
+            os.chmod(self._path, 0o600)
+        except OSError as e:  # pragma: no cover - 例如 Windows / 特殊文件系统不支持 chmod
+            logger.debug(f"chmod 0600 失败（非致命）/ chmod 0600 failed (non-fatal): {e}")

--- a/a2c_smcp/computer/mcp_clients/model.py
+++ b/a2c_smcp/computer/mcp_clients/model.py
@@ -62,9 +62,19 @@ class BaseMCPServerConfig(BaseModel):
         title="VRL脚本",
         description="用于对工具返回值进行动态转换和格式化的VRL脚本。配置后会在初始化时进行语法检查。",
     )
+    # VS Code 对标的 envFile（v0.2.1 #65，§9.1）：spawn 时从 .env 加载 KEY=VALUE 进 stdio server 的 env，
+    # 显式 env 同名项覆盖 envFile（显式胜）。SDK 加性字段（设计 §1092「待协议追认」），仅 Computer 本地
+    # spawn 消费、不在 client:get_config 展开变量；非 stdio（sse/http 无 env）忽略此字段。
+    # VS Code-parity envFile: at spawn, load KEY=VALUE from .env into a stdio server's env (explicit env wins).
+    env_file: str | None = Field(default=None, alias="envFile", title="环境变量文件", description="VS Code 风格 envFile，spawn 时加载")
 
-    model_config: ClassVar[ConfigDict] = ConfigDict(extra="forbid", arbitrary_types_allowed=False, frozen=True)
-    """配置字段在初始化完成后不允许修改"""
+    model_config: ClassVar[ConfigDict] = ConfigDict(
+        extra="forbid",
+        arbitrary_types_allowed=False,
+        frozen=True,
+        populate_by_name=True,
+    )
+    """配置字段在初始化完成后不允许修改；``populate_by_name`` 令 ``envFile``(alias) 与 ``env_file``(名) 均可填充"""
 
     @field_validator("vrl")
     @classmethod

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,11 @@ cli = [
     "rich >=14.1.0,<15.0.0",
     "prompt-toolkit >=3.0.52,<4.0.0",
 ]
+# v0.2.1 #65：OS keyring（password:true input 的 SecretStorage 后端，对标 VS Code）。可选——
+# 缺失/不可用时 inputs 解析链降级到 env（A2C_INPUT_<ID>），核心功能不依赖它（§9.3 / 决策 #27）。
+keyring = [
+    "keyring >=25,<26",
+]
 
 [build-system]
 requires = ["hatchling"]
@@ -100,6 +105,8 @@ module = [
     "msgpack.*",
     "yaml",
     "yaml.*",
+    "keyring",
+    "keyring.*",
 ]
 ignore_missing_imports = true
 

--- a/tests/unit_tests/computer/inputs/test_envfile.py
+++ b/tests/unit_tests/computer/inputs/test_envfile.py
@@ -15,12 +15,28 @@ envFile 加载 + 合并单元测试（v0.2.1 #65，§9.1）/ envFile load + merg
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 
 import pytest
 
 from a2c_smcp.computer.computer import Computer
 from a2c_smcp.computer.inputs.render import load_env_file
+
+
+@pytest.fixture
+def attach_logger_to_caplog(caplog):
+    """让项目 logger "a2c_smcp" 的日志被 caplog 捕获（其禁用了 propagate）/ Capture project logger into caplog。"""
+    logger = logging.getLogger("a2c_smcp")
+    prev_level, prev_prop = logger.level, logger.propagate
+    logger.setLevel(logging.DEBUG)
+    logger.addHandler(caplog.handler)
+    try:
+        yield
+    finally:
+        logger.removeHandler(caplog.handler)
+        logger.setLevel(prev_level)
+        logger.propagate = prev_prop
 
 
 def test_load_env_file_parsing(tmp_path: Path) -> None:
@@ -67,10 +83,13 @@ def test_apply_env_file_no_envfile_passthrough(tmp_path: Path) -> None:
     assert comp._apply_env_file(rendered) == rendered
 
 
-def test_apply_env_file_non_stdio_passthrough(tmp_path: Path) -> None:
+def test_apply_env_file_non_stdio_passthrough_and_warns(tmp_path: Path, caplog, attach_logger_to_caplog) -> None:
+    caplog.set_level("WARNING", logger="a2c_smcp")
     comp = _comp(tmp_path)
     rendered = {"name": "s", "type": "sse", "server_parameters": {"url": "http://x"}, "envFile": str(tmp_path / ".env")}
+    # sse/http 填 envFile → 行为仍 passthrough（原样返回）+ 记一条 WARN（#65 fix-review #4）
     assert comp._apply_env_file(rendered) == rendered
+    assert any("非 stdio" in rec.message for rec in caplog.records)
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/computer/inputs/test_envfile.py
+++ b/tests/unit_tests/computer/inputs/test_envfile.py
@@ -1,0 +1,88 @@
+# -*- coding: utf-8 -*-
+# filename: test_envfile.py
+# @Time    : 2026/05/27
+# @Author  : JQQ
+# @Email   : jqq1716@gmail.com
+# @Software: PyCharm
+"""
+envFile 加载 + 合并单元测试（v0.2.1 #65，§9.1）/ envFile load + merge unit tests。
+
+测试意图 / Test intentions:
+- ``load_env_file``：KEY=VALUE / 注释 / 引号 / export / 缺文件→{} / 无 '=' 行跳过；
+- ``Computer._apply_env_file``：stdio 合并、显式 env 胜、非 stdio（sse）原样、无 envFile 原样；
+- 端到端：envFile 路径含 ``${workspaceFolder}`` 经渲染后再加载（_arender_and_validate_server）。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from a2c_smcp.computer.computer import Computer
+from a2c_smcp.computer.inputs.render import load_env_file
+
+
+def test_load_env_file_parsing(tmp_path: Path) -> None:
+    f = tmp_path / ".env"
+    f.write_text(
+        "# comment\n\nA=1\nexport B=two\nQUOTED=\"q v\"\nSINGLE='s'\nNOEQ line\n",
+        encoding="utf-8",
+    )
+    assert load_env_file(f) == {"A": "1", "B": "two", "QUOTED": "q v", "SINGLE": "s"}
+
+
+def test_load_env_file_missing(tmp_path: Path) -> None:
+    assert load_env_file(tmp_path / "nope.env") == {}
+
+
+def _comp(tmp_path: Path) -> Computer:
+    return Computer(
+        name="t",
+        inputs=set(),
+        mcp_servers=set(),
+        auto_connect=False,
+        auto_reconnect=False,
+        registered_workdirs=[tmp_path],
+    )
+
+
+def test_apply_env_file_explicit_wins(tmp_path: Path) -> None:
+    (tmp_path / ".env").write_text("A=fromfile\nB=fromfile\n", encoding="utf-8")
+    comp = _comp(tmp_path)
+    rendered = {
+        "name": "s",
+        "type": "stdio",
+        "server_parameters": {"command": "node", "env": {"A": "explicit"}},
+        "envFile": str(tmp_path / ".env"),
+    }
+    out = comp._apply_env_file(rendered)
+    # 显式 env 同名项胜；envFile 补充缺失项 / explicit wins, envFile fills the rest
+    assert out["server_parameters"]["env"] == {"A": "explicit", "B": "fromfile"}
+
+
+def test_apply_env_file_no_envfile_passthrough(tmp_path: Path) -> None:
+    comp = _comp(tmp_path)
+    rendered = {"name": "s", "type": "stdio", "server_parameters": {"command": "node", "env": {"A": "1"}}}
+    assert comp._apply_env_file(rendered) == rendered
+
+
+def test_apply_env_file_non_stdio_passthrough(tmp_path: Path) -> None:
+    comp = _comp(tmp_path)
+    rendered = {"name": "s", "type": "sse", "server_parameters": {"url": "http://x"}, "envFile": str(tmp_path / ".env")}
+    assert comp._apply_env_file(rendered) == rendered
+
+
+@pytest.mark.asyncio
+async def test_render_then_envfile_with_workspacefolder(tmp_path: Path) -> None:
+    (tmp_path / ".env").write_text("FROM_FILE=yes\n", encoding="utf-8")
+    comp = _comp(tmp_path)  # registered_workdirs=[tmp_path] → ${workspaceFolder}=tmp_path
+    raw = {
+        "name": "s",
+        "type": "stdio",
+        "server_parameters": {"command": "node", "env": {"EXPLICIT": "v"}},
+        "envFile": "${workspaceFolder}/.env",
+    }
+    validated = await comp._arender_and_validate_server(raw)
+    assert validated.server_parameters.env == {"EXPLICIT": "v", "FROM_FILE": "yes"}
+    assert validated.env_file == str(tmp_path / ".env")  # 字段保留、路径已渲染

--- a/tests/unit_tests/computer/inputs/test_plugin_inputs_prefix.py
+++ b/tests/unit_tests/computer/inputs/test_plugin_inputs_prefix.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+# filename: test_plugin_inputs_prefix.py
+# @Time    : 2026/05/27
+# @Author  : JQQ
+# @Email   : jqq1716@gmail.com
+# @Software: PyCharm
+"""
+plugin inputs 入池消歧单元测试（v0.2.1 #65，§9.3 D2）/ Plugin inputs prefix-disambiguation unit tests。
+
+测试意图 / Test intentions:
+- ``prefix_input_id`` 形态 ``<plugin>@<marketplace>/<id>``；
+- ``load_plugin_inputs`` 把 inputs.json 逐项校验为 MCPServerInput 并前缀化 id；兼容 ``{"inputs":[...]}`` 与裸 ``[...]``；
+- 畸形条目跳过（不抛）；文件缺失 → ``[]``；两 plugin 同裸 id 前缀后不撞。
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from a2c_smcp.computer.inputs.plugin_pool import load_plugin_inputs, prefix_input_id
+
+
+def test_prefix_input_id() -> None:
+    assert prefix_input_id("frontend", "my-team", "figma_token") == "frontend@my-team/figma_token"
+
+
+def _write(p: Path, obj: object) -> Path:
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(json.dumps(obj), encoding="utf-8")
+    return p
+
+
+def test_load_wraps_and_prefixes(tmp_path: Path) -> None:
+    f = _write(
+        tmp_path / "inputs.json",
+        {"inputs": [{"id": "api_token", "type": "promptString", "description": "token", "password": True}]},
+    )
+    out = load_plugin_inputs(f, "frontend", "my-team")
+    assert len(out) == 1
+    assert out[0].id == "frontend@my-team/api_token"
+    assert out[0].password is True  # 其余字段保留 / other fields preserved
+
+
+def test_load_bare_list(tmp_path: Path) -> None:
+    f = _write(tmp_path / "inputs.json", [{"id": "x", "type": "promptString", "description": "d"}])
+    out = load_plugin_inputs(f, "p", "mp")
+    assert [i.id for i in out] == ["p@mp/x"]
+
+
+def test_load_skips_malformed_entries(tmp_path: Path) -> None:
+    f = _write(
+        tmp_path / "inputs.json",
+        {"inputs": [{"id": "ok", "type": "promptString", "description": "d"}, {"bogus": True}]},
+    )
+    out = load_plugin_inputs(f, "p", "mp")
+    assert [i.id for i in out] == ["p@mp/ok"]  # 畸形条目被跳过 / malformed entry skipped
+
+
+def test_load_missing_file_returns_empty(tmp_path: Path) -> None:
+    assert load_plugin_inputs(tmp_path / "nope.json", "p", "mp") == []
+
+
+def test_load_malformed_json_returns_empty(tmp_path: Path) -> None:
+    f = tmp_path / "inputs.json"
+    f.write_text("{ broken", encoding="utf-8")
+    assert load_plugin_inputs(f, "p", "mp") == []
+
+
+def test_two_plugins_same_id_no_collision(tmp_path: Path) -> None:
+    a = load_plugin_inputs(_write(tmp_path / "a.json", [{"id": "token", "type": "promptString", "description": "d"}]), "a", "mp")
+    b = load_plugin_inputs(_write(tmp_path / "b.json", [{"id": "token", "type": "promptString", "description": "d"}]), "b", "mp")
+    assert a[0].id == "a@mp/token"
+    assert b[0].id == "b@mp/token"
+    assert a[0].id != b[0].id

--- a/tests/unit_tests/computer/inputs/test_render_vars.py
+++ b/tests/unit_tests/computer/inputs/test_render_vars.py
@@ -1,0 +1,111 @@
+# -*- coding: utf-8 -*-
+# filename: test_render_vars.py
+# @Time    : 2026/05/27
+# @Author  : JQQ
+# @Email   : jqq1716@gmail.com
+# @Software: PyCharm
+"""
+render 变量替换单元测试（v0.2.1 #65，§9.1）/ Render variable-substitution unit tests。
+
+测试意图 / Test intentions:
+- ``${env:VAR}`` 命中 / 缺失（空串 + WARN）；预定义 ``${workspaceFolder}``/``${userHome}``/``${pathSeparator}``；
+- ``${input:}`` 仍走回调；混合串拼接；未知占位符保持原样；递归 dict/list。
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from a2c_smcp.computer.inputs.render import ConfigRender
+
+
+@pytest.fixture(autouse=True)
+def attach_project_logger_to_caplog(caplog):
+    logger = logging.getLogger("a2c_smcp")
+    prev_level, prev_prop = logger.level, logger.propagate
+    logger.setLevel(logging.DEBUG)
+    logger.addHandler(caplog.handler)
+    try:
+        yield
+    finally:
+        logger.removeHandler(caplog.handler)
+        logger.setLevel(prev_level)
+        logger.propagate = prev_prop
+
+
+async def _noop_resolve(_id: str):  # pragma: no cover - 仅当含 ${input:} 时调用
+    return f"<{_id}>"
+
+
+@pytest.mark.asyncio
+async def test_env_hit() -> None:
+    out = await ConfigRender.arender_str("L=${env:LOG_LEVEL}", _noop_resolve, env={"LOG_LEVEL": "debug"})
+    assert out == "L=debug"
+
+
+@pytest.mark.asyncio
+async def test_env_missing_empty_and_warn(caplog) -> None:
+    caplog.set_level("WARNING", logger="a2c_smcp")
+    out = await ConfigRender.arender_str("L=${env:NOPE}", _noop_resolve, env={})
+    assert out == "L="
+    assert any("环境变量未定义" in rec.message for rec in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_predefined_vars() -> None:
+    vars_ = {"workspaceFolder": "/work", "userHome": "/home/u", "pathSeparator": ":"}
+    out = await ConfigRender.arender_str("${workspaceFolder}/x:${userHome}${pathSeparator}", _noop_resolve, variables=vars_)
+    assert out == "/work/x:/home/u:"
+
+
+@pytest.mark.asyncio
+async def test_predefined_missing_empty_and_warn(caplog) -> None:
+    caplog.set_level("WARNING", logger="a2c_smcp")
+    out = await ConfigRender.arender_str("${workspaceFolder}", _noop_resolve, variables={})
+    assert out == ""
+    assert any("预定义变量未提供" in rec.message for rec in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_input_still_resolves() -> None:
+    async def resolver(_id: str):
+        return "RESOLVED"
+
+    out = await ConfigRender.arender_str("v=${input:figma}", resolver)
+    assert out == "v=RESOLVED"
+
+
+@pytest.mark.asyncio
+async def test_mixed_input_env_predefined() -> None:
+    async def resolver(_id: str):
+        return "TOK"
+
+    out = await ConfigRender.arender_str(
+        "${input:t}@${env:HOST}:${workspaceFolder}",
+        resolver,
+        variables={"workspaceFolder": "/w"},
+        env={"HOST": "localhost"},
+    )
+    assert out == "TOK@localhost:/w"
+
+
+@pytest.mark.asyncio
+async def test_unknown_placeholder_left_as_is() -> None:
+    out = await ConfigRender.arender_str("keep ${unknownVar} here", _noop_resolve)
+    assert out == "keep ${unknownVar} here"
+
+
+@pytest.mark.asyncio
+async def test_recursive_dict_and_list() -> None:
+    cr = ConfigRender()
+    data = {"env": {"LOG": "${env:LV}", "WS": "${workspaceFolder}"}, "args": ["${env:LV}"]}
+    out = await cr.arender(data, _noop_resolve, variables={"workspaceFolder": "/w"}, env={"LV": "info"})
+    assert out == {"env": {"LOG": "info", "WS": "/w"}, "args": ["info"]}
+
+
+@pytest.mark.asyncio
+async def test_single_env_placeholder_returns_string() -> None:
+    out = await ConfigRender.arender_str("${env:X}", _noop_resolve, env={"X": "val"})
+    assert out == "val"

--- a/tests/unit_tests/computer/inputs/test_resolver.py
+++ b/tests/unit_tests/computer/inputs/test_resolver.py
@@ -36,7 +36,8 @@ class _StubSecretStore:
 @pytest.mark.asyncio
 async def test_resolver_prompt_path(monkeypatch):
     inputs = [MCPServerPromptStringInput(id="p1", description="desc", default="d", password=True, type="promptString")]
-    # 注入可用 secret_store：password 在无 TTY 下若 keyring 不可用会硬错误，这里令其可用以走 prompt 路径
+    # 注入可用 secret_store 以承接 prompt 后的 keyring 持久化；password 在无 TTY 下一律硬错误（#65 fix-review #1），
+    # 故模拟交互（_has_tty→True，保持 session=None）走 prompt 路径
     r = InputResolver(inputs, secret_store=_StubSecretStore(available=True))
 
     async def fake_prompt(message: str, *, password: bool = False, default: str | None = None, session: PromptSession | None = None) -> str:
@@ -49,6 +50,7 @@ async def test_resolver_prompt_path(monkeypatch):
     import a2c_smcp.computer.inputs.resolver as resolver_mod
 
     monkeypatch.setattr(resolver_mod, "ainput_prompt", fake_prompt)
+    monkeypatch.setattr(resolver_mod.InputResolver, "_has_tty", staticmethod(lambda session: True))
 
     v = await r.aresolve_by_id("p1")
     assert v == "typed"

--- a/tests/unit_tests/computer/inputs/test_resolver.py
+++ b/tests/unit_tests/computer/inputs/test_resolver.py
@@ -16,10 +16,28 @@ from a2c_smcp.computer.mcp_clients.model import (
 )
 
 
+class _StubSecretStore:
+    """可用的内存 secret store stub（避免 headless password 硬错误，#65）/ Available in-memory secret store stub。"""
+
+    def __init__(self, *, available: bool = True) -> None:
+        self.available = available
+        self._store: dict[str, str] = {}
+
+    def get(self, input_id: str) -> str | None:
+        return self._store.get(input_id)
+
+    def set(self, input_id: str, value: str) -> bool:
+        if not self.available:
+            return False
+        self._store[input_id] = value
+        return True
+
+
 @pytest.mark.asyncio
 async def test_resolver_prompt_path(monkeypatch):
     inputs = [MCPServerPromptStringInput(id="p1", description="desc", default="d", password=True, type="promptString")]
-    r = InputResolver(inputs)
+    # 注入可用 secret_store：password 在无 TTY 下若 keyring 不可用会硬错误，这里令其可用以走 prompt 路径
+    r = InputResolver(inputs, secret_store=_StubSecretStore(available=True))
 
     async def fake_prompt(message: str, *, password: bool = False, default: str | None = None, session: PromptSession | None = None) -> str:
         assert "desc" in message

--- a/tests/unit_tests/computer/inputs/test_resolver_chain.py
+++ b/tests/unit_tests/computer/inputs/test_resolver_chain.py
@@ -1,0 +1,168 @@
+# -*- coding: utf-8 -*-
+# filename: test_resolver_chain.py
+# @Time    : 2026/05/27
+# @Author  : JQQ
+# @Email   : jqq1716@gmail.com
+# @Software: PyCharm
+"""
+解析链单元测试（v0.2.1 #65，§9.3）/ Resolution-chain unit tests。
+
+链序：cache → env(`A2C_INPUT_<ID>`) → keyring(password) → 明文 value store(非密钥) → prompt → default。
+持久化：仅**交互 prompt 得值**（有 TTY/session）按类落盘；env 命中/headless/command 不落盘。
+密钥 headless（无 env+无 keyring+无 TTY）→ ``SecretResolutionError``，绝不落明文。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import a2c_smcp.computer.inputs.resolver as resolver_mod
+from a2c_smcp.computer.inputs.plugin_pool import prefix_input_id
+from a2c_smcp.computer.inputs.resolver import InputResolver, SecretResolutionError, env_var_name
+from a2c_smcp.computer.inputs.value_store import ValueStore
+from a2c_smcp.computer.mcp_clients.model import (
+    MCPServerCommandInput,
+    MCPServerPickStringInput,
+    MCPServerPromptStringInput,
+)
+
+_SESSION: Any = object()  # 非 None → _has_tty 视为可交互 / non-None → treated as interactive (TTY)
+
+
+class _Secret:
+    def __init__(self, *, available: bool = True, seed: dict[str, str] | None = None) -> None:
+        self.available = available
+        self._store: dict[str, str] = dict(seed or {})
+
+    def get(self, k: str) -> str | None:
+        return self._store.get(k) if self.available else None
+
+    def set(self, k: str, v: str) -> bool:
+        if not self.available:
+            return False
+        self._store[k] = v
+        return True
+
+
+def _vstore(tmp_path: Path) -> ValueStore:
+    return ValueStore({"XDG_STATE_HOME": str(tmp_path)})
+
+
+def test_env_var_name_normalization() -> None:
+    assert env_var_name("figma_token") == "A2C_INPUT_FIGMA_TOKEN"
+    assert env_var_name("frontend@my-team/api.key") == "A2C_INPUT_FRONTEND_MY_TEAM_API_KEY"
+
+
+@pytest.mark.asyncio
+async def test_env_hit_not_persisted(tmp_path: Path) -> None:
+    inputs = [MCPServerPromptStringInput(id="tok", description="d")]
+    vs = _vstore(tmp_path)
+    r = InputResolver(inputs, env={"A2C_INPUT_TOK": "from-env"}, value_store=vs, secret_store=_Secret())
+    assert await r.aresolve_by_id("tok", session=_SESSION) == "from-env"
+    # env 命中不落盘（编排层拥有）/ env hit is never persisted
+    assert vs.get("tok") is None
+
+
+@pytest.mark.asyncio
+async def test_keyring_hit_for_password(tmp_path: Path) -> None:
+    inputs = [MCPServerPromptStringInput(id="sec", description="d", password=True)]
+    sec = _Secret(seed={"sec": "from-keyring"})
+    r = InputResolver(inputs, env={}, value_store=_vstore(tmp_path), secret_store=sec)
+    assert await r.aresolve_by_id("sec", session=_SESSION) == "from-keyring"
+
+
+@pytest.mark.asyncio
+async def test_value_store_hit_for_non_password(tmp_path: Path) -> None:
+    inputs = [MCPServerPromptStringInput(id="name", description="d")]
+    vs = _vstore(tmp_path)
+    vs.set("name", "stored-val")
+    r = InputResolver(inputs, env={}, value_store=vs, secret_store=_Secret())
+    assert await r.aresolve_by_id("name", session=_SESSION) == "stored-val"
+
+
+@pytest.mark.asyncio
+async def test_prompt_persists_password_to_keyring(tmp_path: Path, monkeypatch) -> None:
+    inputs = [MCPServerPromptStringInput(id="sec", description="d", password=True)]
+    sec = _Secret(available=True)
+    vs = _vstore(tmp_path)
+
+    async def fake_prompt(*_a, **_k):
+        return "typed-secret"
+
+    monkeypatch.setattr(resolver_mod, "ainput_prompt", fake_prompt)
+    r = InputResolver(inputs, env={}, value_store=vs, secret_store=sec)
+    assert await r.aresolve_by_id("sec", session=_SESSION) == "typed-secret"
+    # 密钥进 keyring，绝不进明文 value store / secret → keyring, never plaintext
+    assert sec.get("sec") == "typed-secret"
+    assert vs.get("sec") is None
+
+
+@pytest.mark.asyncio
+async def test_prompt_persists_non_password_to_value_store(tmp_path: Path, monkeypatch) -> None:
+    inputs = [MCPServerPickStringInput(id="region", description="d", options=["us", "eu"], default="us")]
+    vs = _vstore(tmp_path)
+
+    async def fake_pick(*_a, **_k):
+        return "eu"
+
+    monkeypatch.setattr(resolver_mod, "ainput_pick", fake_pick)
+    r = InputResolver(inputs, env={}, value_store=vs, secret_store=_Secret())
+    assert await r.aresolve_by_id("region", session=_SESSION) == "eu"
+    assert vs.get("region") == "eu"
+
+
+@pytest.mark.asyncio
+async def test_headless_password_hard_errors_without_persist(tmp_path: Path) -> None:
+    inputs = [MCPServerPromptStringInput(id="sec", description="d", password=True)]
+    vs = _vstore(tmp_path)
+    # session=None + 无 env + keyring 不可用 → headless 硬错误（密钥不落明文）
+    r = InputResolver(inputs, env={}, value_store=vs, secret_store=_Secret(available=False))
+    with pytest.raises(SecretResolutionError):
+        await r.aresolve_by_id("sec", session=None)
+    assert vs.get("sec") is None  # 绝不落明文 / never written to plaintext
+
+
+@pytest.mark.asyncio
+async def test_command_not_persisted(tmp_path: Path, monkeypatch) -> None:
+    inputs = [MCPServerCommandInput(id="cmd", description="d", command="echo hi")]
+    vs = _vstore(tmp_path)
+
+    async def fake_run(*_a, **_k):
+        return "hi"
+
+    monkeypatch.setattr(resolver_mod, "arun_command", fake_run)
+    r = InputResolver(inputs, env={}, value_store=vs, secret_store=_Secret())
+    assert await r.aresolve_by_id("cmd", session=_SESSION) == "hi"
+    assert vs.get("cmd") is None  # command 真相是命令，不持久化值
+
+
+@pytest.mark.asyncio
+async def test_plugin_prefix_fallback(tmp_path: Path) -> None:
+    """裸 id 在 plugin 上下文回退到带前缀池条目（D2）/ bare id resolves to prefixed pool entry in plugin context。"""
+    pid = prefix_input_id("frontend", "my-team", "api_token")
+    inputs = [MCPServerPromptStringInput(id=pid, description="d")]
+    vs = _vstore(tmp_path)
+    # env 用前缀归一名命中 → 验证 resolved_id 用的是带前缀 id
+    r = InputResolver(inputs, env={env_var_name(pid): "v"}, value_store=vs, secret_store=_Secret())
+    assert await r.aresolve_by_id("api_token", plugin="frontend", marketplace="my-team", session=_SESSION) == "v"
+
+
+@pytest.mark.asyncio
+async def test_two_plugins_same_bare_id_no_collision(tmp_path: Path) -> None:
+    a = prefix_input_id("plugin-a", "mp", "token")
+    b = prefix_input_id("plugin-b", "mp", "token")
+    inputs = [
+        MCPServerPromptStringInput(id=a, description="d"),
+        MCPServerPromptStringInput(id=b, description="d"),
+    ]
+    r = InputResolver(
+        inputs,
+        env={env_var_name(a): "A", env_var_name(b): "B"},
+        value_store=_vstore(tmp_path),
+        secret_store=_Secret(),
+    )
+    assert await r.aresolve_by_id("token", plugin="plugin-a", marketplace="mp", session=_SESSION) == "A"
+    assert await r.aresolve_by_id("token", plugin="plugin-b", marketplace="mp", session=_SESSION) == "B"

--- a/tests/unit_tests/computer/inputs/test_resolver_chain.py
+++ b/tests/unit_tests/computer/inputs/test_resolver_chain.py
@@ -126,6 +126,18 @@ async def test_headless_password_hard_errors_without_persist(tmp_path: Path) -> 
 
 
 @pytest.mark.asyncio
+async def test_headless_password_hard_errors_when_keyring_available_but_unseeded(tmp_path: Path) -> None:
+    """keyring 可用但该密钥未播种 + 无 TTY → 仍硬错误（#65 fix-review #1，中间态）/ available-but-unseeded headless hard-errors。"""
+    inputs = [MCPServerPromptStringInput(id="sec", description="d", password=True)]
+    vs = _vstore(tmp_path)
+    # available=True 但 seed 为空（步骤 3 keyring miss）+ session=None + 无 env → 应硬错误，不走 prompt
+    r = InputResolver(inputs, env={}, value_store=vs, secret_store=_Secret(available=True))
+    with pytest.raises(SecretResolutionError):
+        await r.aresolve_by_id("sec", session=None)
+    assert vs.get("sec") is None  # 绝不落明文 / never written to plaintext
+
+
+@pytest.mark.asyncio
 async def test_command_not_persisted(tmp_path: Path, monkeypatch) -> None:
     inputs = [MCPServerCommandInput(id="cmd", description="d", command="echo hi")]
     vs = _vstore(tmp_path)

--- a/tests/unit_tests/computer/inputs/test_secret_store.py
+++ b/tests/unit_tests/computer/inputs/test_secret_store.py
@@ -1,0 +1,97 @@
+# -*- coding: utf-8 -*-
+# filename: test_secret_store.py
+# @Time    : 2026/05/27
+# @Author  : JQQ
+# @Email   : jqq1716@gmail.com
+# @Software: PyCharm
+"""
+``SecretStore`` 单元测试（v0.2.1 #65）/ Secret store unit tests（§9.3）。
+
+不硬依赖真实 keyring（可选依赖）：用 fake backend monkeypatch ``_load_keyring`` / ``keyring_available``。
+
+测试意图 / Test intentions:
+- keyring 可用：get/set/delete 往返；
+- keyring 不可用（缺失或 fail backend）：get→None、set→False、delete→False（安全降级，绝不落明文）；
+- 可用性探测：fail.* backend 判定不可用。
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import a2c_smcp.computer.inputs.secret_store as ss
+from a2c_smcp.computer.inputs.secret_store import SecretStore, keyring_available
+
+
+class _FakeKeyring:
+    """内存 fake keyring 后端模块 / In-memory fake keyring backend module。"""
+
+    def __init__(self, backend_module: str = "keyring.backends.fake") -> None:
+        self._store: dict[tuple[str, str], str] = {}
+        self._backend_module = backend_module
+
+    def get_keyring(self):  # type: ignore[no-untyped-def]
+        backend = type("Backend", (), {})
+        backend.__module__ = self._backend_module
+        return backend()
+
+    def get_password(self, service: str, key: str) -> str | None:
+        return self._store.get((service, key))
+
+    def set_password(self, service: str, key: str, value: str) -> None:
+        self._store[(service, key)] = value
+
+    def delete_password(self, service: str, key: str) -> None:
+        if (service, key) not in self._store:
+            raise RuntimeError("PasswordDeleteError")
+        del self._store[(service, key)]
+
+
+@pytest.fixture(autouse=True)
+def _reset_probe_cache():
+    ss._available = None
+    yield
+    ss._available = None
+
+
+def test_available_with_real_backend(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(ss, "_load_keyring", lambda: _FakeKeyring("keyring.backends.macOS"))
+    assert keyring_available(force_recheck=True) is True
+
+
+def test_unavailable_when_keyring_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(ss, "_load_keyring", lambda: None)
+    assert keyring_available(force_recheck=True) is False
+    store = SecretStore()
+    assert store.get("x") is None
+    assert store.set("x", "secret") is False
+    assert store.delete("x") is False
+
+
+def test_unavailable_when_fail_backend(monkeypatch: pytest.MonkeyPatch) -> None:
+    # fail.Keyring → 不可用（容器/CI/无 Secret Service）
+    monkeypatch.setattr(ss, "_load_keyring", lambda: _FakeKeyring("keyring.backends.fail"))
+    assert keyring_available(force_recheck=True) is False
+
+
+def test_get_set_delete_roundtrip(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = _FakeKeyring("keyring.backends.SecretService")
+    monkeypatch.setattr(ss, "_load_keyring", lambda: fake)
+    store = SecretStore()
+    assert store.get("token") is None
+    assert store.set("token", "s3cr3t") is True
+    assert store.get("token") == "s3cr3t"
+    # 落进 fake 的是 (service, key) / stored under (service, key)
+    assert fake._store[("a2c-computer", "token")] == "s3cr3t"
+    assert store.delete("token") is True
+    assert store.get("token") is None
+    assert store.delete("token") is False  # 已删 → no-op
+
+
+def test_probe_cache(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(ss, "_load_keyring", lambda: _FakeKeyring("keyring.backends.macOS"))
+    assert keyring_available(force_recheck=True) is True
+    # 缓存命中：即便切到缺失也仍返回缓存值（除非 force_recheck）
+    monkeypatch.setattr(ss, "_load_keyring", lambda: None)
+    assert keyring_available() is True
+    assert keyring_available(force_recheck=True) is False

--- a/tests/unit_tests/computer/inputs/test_value_store.py
+++ b/tests/unit_tests/computer/inputs/test_value_store.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+# filename: test_value_store.py
+# @Time    : 2026/05/27
+# @Author  : JQQ
+# @Email   : jqq1716@gmail.com
+# @Software: PyCharm
+"""
+``ValueStore`` 单元测试（v0.2.1 #65）/ Non-secret value store unit tests（§9.3）。
+
+测试意图 / Test intentions:
+- 路径解析：``XDG_STATE_HOME`` 绝对 → XDG-first；未设/相对 → ``~/.local/state/a2c`` 回退；
+- get/set/delete/load 往返；畸形 JSON / 非 dict 顶层 → ``{}``；落盘 ``0600``。
+"""
+
+from __future__ import annotations
+
+import stat
+import sys
+from pathlib import Path
+
+import pytest
+
+from a2c_smcp.computer.inputs.value_store import VALUE_STORE_FILENAME, ValueStore, resolve_value_store_path
+
+
+def test_path_xdg_first(tmp_path: Path) -> None:
+    p = resolve_value_store_path({"XDG_STATE_HOME": str(tmp_path)})
+    assert p == (tmp_path / "a2c" / VALUE_STORE_FILENAME).resolve()
+
+
+def test_path_fallback_when_unset_or_relative(tmp_path: Path) -> None:
+    fallback = (Path.home() / ".local" / "state" / "a2c" / VALUE_STORE_FILENAME).expanduser().resolve()
+    assert resolve_value_store_path({}) == fallback
+    # 相对值按 XDG 规范视为未设置 → 回退 / relative value treated as unset per XDG spec
+    assert resolve_value_store_path({"XDG_STATE_HOME": "relative/dir"}) == fallback
+
+
+def test_set_get_delete_roundtrip(tmp_path: Path) -> None:
+    store = ValueStore({"XDG_STATE_HOME": str(tmp_path)})
+    assert store.get("k") is None
+    store.set("k", "v")
+    assert store.get("k") == "v"
+    store.set("k2", "v2")
+    assert store.load() == {"k": "v", "k2": "v2"}
+    assert store.delete("k") is True
+    assert store.get("k") is None
+    assert store.delete("missing") is False
+
+
+def test_malformed_json_treated_as_empty(tmp_path: Path) -> None:
+    store = ValueStore({"XDG_STATE_HOME": str(tmp_path)})
+    store.path.parent.mkdir(parents=True, exist_ok=True)
+    store.path.write_text("{ not json", encoding="utf-8")
+    assert store.load() == {}
+    # 非 dict 顶层（如 list）也按空处理 / non-dict top-level → empty
+    store.path.write_text("[1, 2, 3]", encoding="utf-8")
+    assert store.load() == {}
+
+
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="POSIX 权限位 / POSIX mode bits")
+def test_written_file_is_0600(tmp_path: Path) -> None:
+    store = ValueStore({"XDG_STATE_HOME": str(tmp_path)})
+    store.set("k", "v")
+    mode = stat.S_IMODE(store.path.stat().st_mode)
+    assert mode == 0o600

--- a/tests/unit_tests/computer/mcp_clients/test_model.py
+++ b/tests/unit_tests/computer/mcp_clients/test_model.py
@@ -131,6 +131,23 @@ def test_server_config_inheritance():
     assert isinstance(http_config.server_parameters, StreamableHttpParameters)
 
 
+def test_env_file_camelcase_alias_and_default():
+    """v0.2.1 #65：envFile（camelCase alias）与 env_file（字段名）均可填充；默认 None。"""
+    # 默认 None / default None
+    base = StdioServerConfig(name="s", server_parameters=StdioServerParameters(command="node"))
+    assert base.env_file is None
+
+    # camelCase alias（mcp.json 风格）/ camelCase alias as in mcp.json
+    by_alias = StdioServerConfig.model_validate(
+        {"name": "s", "type": "stdio", "server_parameters": {"command": "node"}, "envFile": "${workspaceFolder}/.env"},
+    )
+    assert by_alias.env_file == "${workspaceFolder}/.env"
+
+    # populate_by_name：字段名也可 / field name also accepted
+    by_name = StdioServerConfig(name="s", server_parameters=StdioServerParameters(command="node"), env_file="/x/.env")
+    assert by_name.env_file == "/x/.env"
+
+
 def test_mcp_config_union():
     """测试MCPServerConfig类型别名接受所有子类型"""
     servers: list[MCPServerConfig] = [

--- a/uv.lock
+++ b/uv.lock
@@ -24,6 +24,9 @@ cli = [
     { name = "rich" },
     { name = "typer" },
 ]
+keyring = [
+    { name = "keyring" },
+]
 
 [package.dev-dependencies]
 build = [
@@ -51,6 +54,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.12.15,<4.0.0" },
+    { name = "keyring", marker = "extra == 'keyring'", specifier = ">=25,<26" },
     { name = "mcp", specifier = "==1.15.0" },
     { name = "msgpack", specifier = ">=1.1.0,<2.0.0" },
     { name = "prompt-toolkit", marker = "extra == 'cli'", specifier = ">=3.0.52,<4.0.0" },
@@ -63,7 +67,7 @@ requires-dist = [
     { name = "vrl-python", specifier = ">=0.1.0,<0.2.0" },
     { name = "watchdog", specifier = ">=6.0.0,<7.0.0" },
 ]
-provides-extras = ["cli"]
+provides-extras = ["cli", "keyring"]
 
 [package.metadata.requires-dev]
 build = [{ name = "bump-my-version", specifier = ">=1.2.4" }]
@@ -252,6 +256,15 @@ wheels = [
 ]
 
 [[package]]
+name = "backports-tarfile"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/86/72/cd9b395f25e290e633655a100af28cb253e4393396264a98bd5f5951d50f/backports_tarfile-1.2.0.tar.gz", hash = "sha256:d75e02c268746e1b8144c278978b6e98e85de6ad16f8e4b0844a154557eca991", size = 86406, upload-time = "2024-05-28T17:01:54.731Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/fa/123043af240e49752f1c4bd24da5053b6bd00cad78c2be53c0d1e8b975bc/backports.tarfile-1.2.0-py3-none-any.whl", hash = "sha256:77e284d754527b01fb1e6fa8a1afe577858ebe4e9dad8919e34c862cb399bc34", size = 30181, upload-time = "2024-05-28T17:01:53.112Z" },
+]
+
+[[package]]
 name = "bidict"
 version = "0.23.1"
 source = { registry = "https://pypi.org/simple" }
@@ -296,6 +309,51 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/8c/58f469717fa48465e4a50c014a0400602d3c437d7c0c468e17ada824da3a/certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316", size = 160538, upload-time = "2025-11-12T02:54:51.517Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/70/7d/9bc192684cea499815ff478dfcdc13835ddf401365057044fb721ec6bddb/certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b", size = 159438, upload-time = "2025-11-12T02:54:49.735Z" },
+]
+
+[[package]]
+name = "cffi"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b1/b7/1200d354378ef52ec227395d95c2576330fd22a869f7a70e88e1447eb234/cffi-2.0.0-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:baf5215e0ab74c16e2dd324e8ec067ef59e41125d3eade2b863d294fd5035c92", size = 209613, upload-time = "2025-09-08T23:22:29.475Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/56/6033f5e86e8cc9bb629f0077ba71679508bdf54a9a5e112a3c0b91870332/cffi-2.0.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:730cacb21e1bdff3ce90babf007d0a0917cc3e6492f336c2f0134101e0944f93", size = 216476, upload-time = "2025-09-08T23:22:31.063Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/7f/55fecd70f7ece178db2f26128ec41430d8720f2d12ca97bf8f0a628207d5/cffi-2.0.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:6824f87845e3396029f3820c206e459ccc91760e8fa24422f8b0c3d1731cbec5", size = 203374, upload-time = "2025-09-08T23:22:32.507Z" },
+    { url = "https://files.pythonhosted.org/packages/84/ef/a7b77c8bdc0f77adc3b46888f1ad54be8f3b7821697a7b89126e829e676a/cffi-2.0.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:9de40a7b0323d889cf8d23d1ef214f565ab154443c42737dfe52ff82cf857664", size = 202597, upload-time = "2025-09-08T23:22:34.132Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/91/500d892b2bf36529a75b77958edfcd5ad8e2ce4064ce2ecfeab2125d72d1/cffi-2.0.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8941aaadaf67246224cee8c3803777eed332a19d909b47e29c9842ef1e79ac26", size = 215574, upload-time = "2025-09-08T23:22:35.443Z" },
+    { url = "https://files.pythonhosted.org/packages/44/64/58f6255b62b101093d5df22dcb752596066c7e89dd725e0afaed242a61be/cffi-2.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:a05d0c237b3349096d3981b727493e22147f934b20f6f125a3eba8f994bec4a9", size = 218971, upload-time = "2025-09-08T23:22:36.805Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/49/fa72cebe2fd8a55fbe14956f9970fe8eb1ac59e5df042f603ef7c8ba0adc/cffi-2.0.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:94698a9c5f91f9d138526b48fe26a199609544591f859c870d477351dc7b2414", size = 211972, upload-time = "2025-09-08T23:22:38.436Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/28/dd0967a76aab36731b6ebfe64dec4e981aff7e0608f60c2d46b46982607d/cffi-2.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:5fed36fccc0612a53f1d4d9a816b50a36702c28a2aa880cb8a122b3466638743", size = 217078, upload-time = "2025-09-08T23:22:39.776Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/df/a4f0fbd47331ceeba3d37c2e51e9dfc9722498becbeec2bd8bc856c9538a/cffi-2.0.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:21d1152871b019407d8ac3985f6775c079416c282e431a4da6afe7aefd2bccbe", size = 212529, upload-time = "2025-09-08T23:22:47.349Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/72/12b5f8d3865bf0f87cf1404d8c374e7487dcf097a1c91c436e72e6badd83/cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b21e08af67b8a103c71a250401c78d5e0893beff75e28c53c98f4de42f774062", size = 220097, upload-time = "2025-09-08T23:22:48.677Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/95/7a135d52a50dfa7c882ab0ac17e8dc11cec9d55d2c18dda414c051c5e69e/cffi-2.0.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:1e3a615586f05fc4065a8b22b8152f0c1b00cdbc60596d187c2a74f9e3036e4e", size = 207983, upload-time = "2025-09-08T23:22:50.06Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/c8/15cb9ada8895957ea171c62dc78ff3e99159ee7adb13c0123c001a2546c1/cffi-2.0.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:81afed14892743bbe14dacb9e36d9e0e504cd204e0b165062c488942b9718037", size = 206519, upload-time = "2025-09-08T23:22:51.364Z" },
+    { url = "https://files.pythonhosted.org/packages/78/2d/7fa73dfa841b5ac06c7b8855cfc18622132e365f5b81d02230333ff26e9e/cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba", size = 219572, upload-time = "2025-09-08T23:22:52.902Z" },
+    { url = "https://files.pythonhosted.org/packages/07/e0/267e57e387b4ca276b90f0434ff88b2c2241ad72b16d31836adddfd6031b/cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3925dd22fa2b7699ed2617149842d2e6adde22b262fcbfada50e3d195e4b3a94", size = 222963, upload-time = "2025-09-08T23:22:54.518Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/75/1f2747525e06f53efbd878f4d03bac5b859cbc11c633d0fb81432d98a795/cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2c8f814d84194c9ea681642fd164267891702542f028a15fc97d4674b6206187", size = 221361, upload-time = "2025-09-08T23:22:55.867Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/1e/d22cc63332bd59b06481ceaac49d6c507598642e2230f201649058a7e704/cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b", size = 212446, upload-time = "2025-09-08T23:23:03.472Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b", size = 220101, upload-time = "2025-09-08T23:23:04.792Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7f/e6647792fc5850d634695bc0e6ab4111ae88e89981d35ac269956605feba/cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2", size = 207948, upload-time = "2025-09-08T23:23:06.127Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1e/a5a1bd6f1fb30f22573f76533de12a00bf274abcdc55c8edab639078abb6/cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3", size = 206422, upload-time = "2025-09-08T23:23:07.753Z" },
+    { url = "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26", size = 219499, upload-time = "2025-09-08T23:23:09.648Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e1/a969e687fcf9ea58e6e2a928ad5e2dd88cc12f6f0ab477e9971f2309b57c/cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c", size = 222928, upload-time = "2025-09-08T23:23:10.928Z" },
+    { url = "https://files.pythonhosted.org/packages/36/54/0362578dd2c9e557a28ac77698ed67323ed5b9775ca9d3fe73fe191bb5d8/cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b", size = 221302, upload-time = "2025-09-08T23:23:12.42Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b", size = 220049, upload-time = "2025-09-08T23:23:20.853Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/89/76799151d9c2d2d1ead63c2429da9ea9d7aac304603de0c6e8764e6e8e70/cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c", size = 207793, upload-time = "2025-09-08T23:23:22.08Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/dd/3465b14bb9e24ee24cb88c9e3730f6de63111fffe513492bf8c808a3547e/cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef", size = 206300, upload-time = "2025-09-08T23:23:23.314Z" },
+    { url = "https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775", size = 219244, upload-time = "2025-09-08T23:23:24.541Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0f/1f177e3683aead2bb00f7679a16451d302c436b5cbf2505f0ea8146ef59e/cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205", size = 222828, upload-time = "2025-09-08T23:23:26.143Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/0f/cafacebd4b040e3119dcb32fed8bdef8dfe94da653155f9d0b9dc660166e/cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1", size = 220926, upload-time = "2025-09-08T23:23:27.873Z" },
+    { url = "https://files.pythonhosted.org/packages/be/b4/c56878d0d1755cf9caa54ba71e5d049479c52f9e4afc230f06822162ab2f/cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c", size = 221593, upload-time = "2025-09-08T23:23:31.91Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/0d/eb704606dfe8033e7128df5e90fee946bbcb64a04fcdaa97321309004000/cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8", size = 209354, upload-time = "2025-09-08T23:23:33.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/19/3c435d727b368ca475fb8742ab97c9cb13a0de600ce86f62eab7fa3eea60/cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc", size = 208480, upload-time = "2025-09-08T23:23:34.495Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/44/681604464ed9541673e486521497406fadcc15b5217c3e326b061696899a/cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592", size = 221584, upload-time = "2025-09-08T23:23:36.096Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8e/342a504ff018a2825d395d44d63a767dd8ebc927ebda557fecdaca3ac33a/cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512", size = 224443, upload-time = "2025-09-08T23:23:37.328Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/5e/b666bacbbc60fbf415ba9988324a132c9a7a0448a9a8f125074671c0f2c3/cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4", size = 223437, upload-time = "2025-09-08T23:23:38.945Z" },
 ]
 
 [[package]]
@@ -485,6 +543,54 @@ toml = [
 ]
 
 [[package]]
+name = "cryptography"
+version = "48.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9f/a9/db8f313fdcd85d767d4973515e1db101f9c71f95fced83233de224673757/cryptography-48.0.0.tar.gz", hash = "sha256:5c3932f4436d1cccb036cb0eaef46e6e2db91035166f1ad6505c3c9d5a635920", size = 832984, upload-time = "2026-05-04T22:59:38.133Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/6e/e90527eef33f309beb811cf7c982c3aeffcce8e3edb178baa4ca3ae4a6fa/cryptography-48.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f5333311663ea94f75dd408665686aaf426563556bb5283554a3539177e03b8c", size = 4690433, upload-time = "2026-05-04T22:57:40.373Z" },
+    { url = "https://files.pythonhosted.org/packages/90/04/673510ed51ddff56575f306cf1617d80411ee76831ccd3097599140efdfe/cryptography-48.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7995ef305d7165c3f11ae07f2517e5a4f1d5c18da1376a0a9ed496336b69e5f3", size = 4710620, upload-time = "2026-05-04T22:57:42.935Z" },
+    { url = "https://files.pythonhosted.org/packages/14/d5/e9c4ef932c8d800490c34d8bd589d64a31d5890e27ec9e9ad532be893294/cryptography-48.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:40ba1f85eaa6959837b1d51c9767e230e14612eea4ef110ee8854ada22da1bf5", size = 4696283, upload-time = "2026-05-04T22:57:45.294Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/29/174b9dfb60b12d59ecfc6cfa04bc88c21b42a54f01b8aae09bb6e51e4c7f/cryptography-48.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:369a6348999f94bbd53435c894377b20ab95f25a9065c283570e70150d8abc3c", size = 5296573, upload-time = "2026-05-04T22:57:47.933Z" },
+    { url = "https://files.pythonhosted.org/packages/95/38/0d29a6fd7d0d1373f0c0c88a04ba20e359b257753ac497564cd660fc1d55/cryptography-48.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:a0e692c683f4df67815a2d258b324e66f4738bd7a96a218c826dce4f4bd05d8f", size = 4743677, upload-time = "2026-05-04T22:57:50.067Z" },
+    { url = "https://files.pythonhosted.org/packages/30/be/eef653013d5c63b6a490529e0316f9ac14a37602965d4903efed1399f32b/cryptography-48.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:18349bbc56f4743c8b12dc32e2bccb2cf83ee8b69a3bba74ef8ae857e26b3d25", size = 4330808, upload-time = "2026-05-04T22:57:52.301Z" },
+    { url = "https://files.pythonhosted.org/packages/84/9e/500463e87abb7a0a0f9f256ec21123ecde0a7b5541a15e840ea54551fd81/cryptography-48.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:7e8eac43dfca5c4cccc6dad9a80504436fca53bb9bc3100a2386d730fbe6b602", size = 4695941, upload-time = "2026-05-04T22:57:54.603Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/dc/7303087450c2ec9e7fbb750e17c2abfbc658f23cbd0e54009509b7cc4091/cryptography-48.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9ccdac7d40688ecb5a3b4a604b8a88c8002e3442d6c60aead1db2a89a041560c", size = 5252579, upload-time = "2026-05-04T22:57:57.207Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/c0/7101d3b7215edcdc90c45da544961fd8ed2d6448f77577460fa75a8443f7/cryptography-48.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:bd72e68b06bb1e96913f97dd4901119bc17f39d4586a5adf2d3e47bc2b9d58b5", size = 4743326, upload-time = "2026-05-04T22:57:59.535Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/d8/5b833bad13016f562ab9d063d68199a4bd121d18458e439515601d3357ec/cryptography-48.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:59baa2cb386c4f0b9905bd6eb4c2a79a69a128408fd31d32ca4d7102d4156321", size = 4826672, upload-time = "2026-05-04T22:58:01.996Z" },
+    { url = "https://files.pythonhosted.org/packages/98/e1/7074eb8bf3c135558c73fc2bcf0f5633f912e6fb87e868a55c454080ef09/cryptography-48.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9249e3cd978541d665967ac2cb2787fd6a62bddf1e75b3e347a594d7dacf4f74", size = 4972574, upload-time = "2026-05-04T22:58:03.968Z" },
+    { url = "https://files.pythonhosted.org/packages/89/6e/18e07a618bb5442ba10cf4df16e99c071365528aa570dfcb8c02e25a303b/cryptography-48.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8c7378637d7d88016fa6791c159f698b3d3eed28ebf844ac36b9dc04a14dae18", size = 4684776, upload-time = "2026-05-04T22:58:13.712Z" },
+    { url = "https://files.pythonhosted.org/packages/be/6a/4ea3b4c6c6759794d5ee2103c304a5076dc4b19ae1f9fe47dba439e159e9/cryptography-48.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cc90c0b39b2e3c65ef52c804b72e3c58f8a04ab2a1871272798e5f9572c17d20", size = 4698121, upload-time = "2026-05-04T22:58:16.448Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/59/6ff6ad6cae03bb887da2a5860b2c9805f8dac969ef01ce563336c49bd1d1/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:76341972e1eff8b4bea859f09c0d3e64b96ce931b084f9b9b7db8ef364c30eff", size = 4690042, upload-time = "2026-05-04T22:58:18.544Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/b4/fc334ed8cfd705aca282fe4d8f5ae64a8e0f74932e9feecb344610cf6e4d/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:55b7718303bf06a5753dcdccf2f3945cf18ad7bffde41b61226e4db31ab89a9c", size = 5282526, upload-time = "2026-05-04T22:58:20.75Z" },
+    { url = "https://files.pythonhosted.org/packages/11/08/9f8c5386cc4cd90d8255c7cdd0f5baf459a08502a09de30dc51f553d38dc/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:a64697c641c7b1b2178e573cbc31c7c6684cd56883a478d75143dbb7118036db", size = 4733116, upload-time = "2026-05-04T22:58:23.627Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/77/99307d7574045699f8805aa500fa0fb83422d115b5400a064ddd306d7750/cryptography-48.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:561215ea3879cb1cbbf272867e2efda62476f240fb58c64de6b393ae19246741", size = 4316030, upload-time = "2026-05-04T22:58:25.581Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/36/a608b98337af3cb2aff4818e406649d30572b7031918b04c87d979495348/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:ad64688338ed4bc1a6618076ba75fd7194a5f1797ac60b47afe926285adb3166", size = 4689640, upload-time = "2026-05-04T22:58:27.747Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/a6/825010a291b4438aecc1f568bc428189fc1175515223632477c07dc0a6df/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:906cbf0670286c6e0044156bc7d4af9cbb0ef6db9f73e52c3ec56ba6bdde5336", size = 5237657, upload-time = "2026-05-04T22:58:29.848Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/09/4e76a09b4caa29aad535ddc806f5d4c5d01885bd978bd984fbc6ca032cae/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:ea8990436d914540a40ab24b6a77c0969695ed52f4a4874c5137ccf7045a7057", size = 4732362, upload-time = "2026-05-04T22:58:32.009Z" },
+    { url = "https://files.pythonhosted.org/packages/18/78/444fa04a77d0cb95f417dda20d450e13c56ba8e5220fc892a1658f44f882/cryptography-48.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c18684a7f0cc9a3cb60328f496b8e3372def7c5d2df39ac267878b05565aaaae", size = 4819580, upload-time = "2026-05-04T22:58:34.254Z" },
+    { url = "https://files.pythonhosted.org/packages/38/85/ea67067c70a1fd4be2c63d35eeed82658023021affccc7b17705f8527dd2/cryptography-48.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9be5aafa5736574f8f15f262adc81b2a9869e2cfe9014d52a44633905b40d52c", size = 4963283, upload-time = "2026-05-04T22:58:36.376Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ac/f5b5995b87770c693e2596559ffafe195b4033a57f14a82268a2842953f3/cryptography-48.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:614d0949f4790582d2cc25553abd09dd723025f0c0e7c67376a1d77196743d6e", size = 4683266, upload-time = "2026-05-04T22:58:46.064Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/c6/8b14f67e18338fbc4adb76f66c001f5c3610b3e2d1837f268f47a347dbbb/cryptography-48.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7ce4bfae76319a532a2dc68f82cc32f5676ee792a983187dac07183690e5c66f", size = 4696228, upload-time = "2026-05-04T22:58:48.22Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/73/f808fbae9514bd91b47875b003f13e284c8c6bdfd904b7944e803937eec1/cryptography-48.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:2eb992bbd4661238c5a397594c83f5b4dc2bc5b848c365c8f991b6780efcc5c7", size = 4689097, upload-time = "2026-05-04T22:58:50.9Z" },
+    { url = "https://files.pythonhosted.org/packages/93/01/d86632d7d28db8ae83221995752eeb6639ffb374c2d22955648cf8d52797/cryptography-48.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:22a5cb272895dce158b2cacdfdc3debd299019659f42947dbdac6f32d68fe832", size = 5283582, upload-time = "2026-05-04T22:58:53.017Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e1/50edc7a50334807cc4791fc4a0ce7468b4a1416d9138eab358bfc9a3d70b/cryptography-48.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2b4d59804e8408e2fea7d1fbaf218e5ec984325221db76e6a241a9abd6cdd95c", size = 4730479, upload-time = "2026-05-04T22:58:55.611Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/af/99a582b1b1641ff5911ac559beb45097cf79efd4ead4657f578ef1af2d47/cryptography-48.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:984a20b0f62a26f48a3396c72e4bc34c66e356d356bf370053066b3b6d54634a", size = 4326481, upload-time = "2026-05-04T22:58:57.607Z" },
+    { url = "https://files.pythonhosted.org/packages/90/ee/89aa26a06ef0a7d7611788ffd571a7c50e368cc6a4d5eef8b4884e866edb/cryptography-48.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:5a5ed8fde7a1d09376ca0b40e68cd59c69fe23b1f9768bd5824f54681626032a", size = 4688713, upload-time = "2026-05-04T22:59:00.077Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ba/bcb1b0bb7a33d4c7c0c4d4c7874b4a62ae4f56113a5f4baefa362dfb1f0f/cryptography-48.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:8cd666227ef7af430aa5914a9910e0ddd703e75f039cef0825cd0da71b6b711a", size = 5238165, upload-time = "2026-05-04T22:59:02.317Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/70/ca4003b1ce5ca3dc3186ada51908c8a9b9ff7d5cab83cc0d43ee14ec144f/cryptography-48.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:9071196d81abc88b3516ac8cdfad32e2b66dd4a5393a8e68a961e9161ddc6239", size = 4729947, upload-time = "2026-05-04T22:59:05.255Z" },
+    { url = "https://files.pythonhosted.org/packages/44/a0/4ec7cf774207905aef1a8d11c3750d5a1db805eb380ee4e16df317870128/cryptography-48.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1e2d54c8be6152856a36f0882ab231e70f8ec7f14e93cf87db8a2ed056bf160c", size = 4822059, upload-time = "2026-05-04T22:59:07.802Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/75/a2e55f99c16fcac7b5d6c1eb19ad8e00799854d6be5ca845f9259eae1681/cryptography-48.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a5da777e32ffed6f85a7b2b3f7c5cbc88c146bfcd0a1d7baf5fcc6c52ee35dd4", size = 4960575, upload-time = "2026-05-04T22:59:09.851Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/17/3861e17c56fa0fd37491a14a8673fdb77c57fc5693cafe745ea8b06dba75/cryptography-48.0.0-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:fdfef35d751d510fcef5252703621574364fec16418c4a1e5e1055248401054b", size = 4637126, upload-time = "2026-05-04T22:59:20.197Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/0a/7e226dbff530f21480727eb764973a7bff2b912f8e15cd4f129e71b56d1d/cryptography-48.0.0-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:0890f502ddf7d9c6426129c3f49f5c0a39278ed7cd6322c8755ffca6ee675a13", size = 4667270, upload-time = "2026-05-04T22:59:22.647Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/f2/5a72274ca9f1b2a8b44a662ee0bf1b435909deb473d6f97bcd035bcdbc71/cryptography-48.0.0-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:ecde28a596bead48b0cfd2a1b4416c3d43074c2d785e3a398d7ec1fc4d0f7fbb", size = 4636797, upload-time = "2026-05-04T22:59:24.912Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/e1/48cedb2fe63626e91ded1edad159e2a4fb8b6906c4425eb7749673077ce7/cryptography-48.0.0-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:4defde8685ae324a9eb9d818717e93b4638ef67070ac9bc15b8ca85f63048355", size = 4666800, upload-time = "2026-05-04T22:59:27.474Z" },
+]
+
+[[package]]
 name = "executing"
 version = "2.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -666,6 +772,18 @@ wheels = [
 ]
 
 [[package]]
+name = "importlib-metadata"
+version = "9.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "zipp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/3d/2d244233ac4f76e38533cfcb2991c9eb4c7bf688ae0a036d30725b8faafe/importlib_metadata-9.0.0-py3-none-any.whl", hash = "sha256:2d21d1cc5a017bd0559e36150c21c830ab1dc304dedd1b7ea85d20f45ef3edd7", size = 27789, upload-time = "2026-03-20T06:42:55.665Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -687,6 +805,51 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b9/93/3caece250cdf267fcb39e6a82ada0e7e8e8fb37207331309dbf6865d7497/inline_snapshot-0.27.2.tar.gz", hash = "sha256:5ecc7ccfdcbf8d9273d3fa9fb55b829720680ef51bb1db12795fd1b0f4a3783c", size = 347133, upload-time = "2025-08-11T07:49:55.134Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8f/7f/9e41fd793827af8cbe812fff625d62b3b47603d62145b718307ef4e381eb/inline_snapshot-0.27.2-py3-none-any.whl", hash = "sha256:7c11f78ad560669bccd38d6d3aa3ef33d6a8618d53bd959019dca3a452272b7e", size = 68004, upload-time = "2025-08-11T07:49:53.904Z" },
+]
+
+[[package]]
+name = "jaraco-classes"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/c0/ed4a27bc5571b99e3cff68f8a9fa5b56ff7df1c2251cc715a652ddd26402/jaraco.classes-3.4.0.tar.gz", hash = "sha256:47a024b51d0239c0dd8c8540c6c7f484be3b8fcf0b2d85c13825780d3b3f3acd", size = 11780, upload-time = "2024-03-31T07:27:36.643Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/66/b15ce62552d84bbfcec9a4873ab79d993a1dd4edb922cbfccae192bd5b5f/jaraco.classes-3.4.0-py3-none-any.whl", hash = "sha256:f662826b6bed8cace05e7ff873ce0f9283b5c924470fe664fff1c2f00f581790", size = 6777, upload-time = "2024-03-31T07:27:34.792Z" },
+]
+
+[[package]]
+name = "jaraco-context"
+version = "6.1.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "backports-tarfile", marker = "python_full_version < '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/af/50/4763cd07e722bb6285316d390a164bc7e479db9d90daa769f22578f698b4/jaraco_context-6.1.2.tar.gz", hash = "sha256:f1a6c9d391e661cc5b8d39861ff077a7dc24dc23833ccee564b234b81c82dfe3", size = 16801, upload-time = "2026-03-20T22:13:33.922Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/58/bc8954bda5fcda97bd7c19be11b85f91973d67a706ed4a3aec33e7de22db/jaraco_context-6.1.2-py3-none-any.whl", hash = "sha256:bf8150b79a2d5d91ae48629d8b427a8f7ba0e1097dd6202a9059f29a36379535", size = 7871, upload-time = "2026-03-20T22:13:32.808Z" },
+]
+
+[[package]]
+name = "jaraco-functools"
+version = "4.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/36/cf/ea4ef2920830dea3f5ab2ea4da6fb67724e6dca80ee2553788c3607243d0/jaraco_functools-4.5.0.tar.gz", hash = "sha256:3bb5665ea4a020cf78a7040e89154c77edadb3ca74f366479669c5999aa70b03", size = 20272, upload-time = "2026-05-15T21:34:10.025Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/9a/982e48afcffcd727a9144506720ffd4224b6b7e355c98641866f38b7c043/jaraco_functools-4.5.0-py3-none-any.whl", hash = "sha256:79ce39246eddbde4b3a03b77ea5f0f7878dc669b166a66cf3fa8e266aa3fa2f4", size = 10594, upload-time = "2026-05-15T21:34:08.595Z" },
+]
+
+[[package]]
+name = "jeepney"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/6f/357efd7602486741aa73ffc0617fb310a29b588ed0fd69c2399acbb85b0c/jeepney-0.9.0.tar.gz", hash = "sha256:cf0e9e845622b81e4a28df94c40345400256ec608d0e55bb8a3feaa9163f5732", size = 106758, upload-time = "2025-02-27T18:51:01.684Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/a3/e137168c9c44d18eff0376253da9f1e9234d0239e0ee230d2fee6cea8e55/jeepney-0.9.0-py3-none-any.whl", hash = "sha256:97e5714520c16fc0a45695e5365a2e11b81ea79bba796e26f9f1d178cb182683", size = 49010, upload-time = "2025-02-27T18:51:00.104Z" },
 ]
 
 [[package]]
@@ -714,6 +877,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
+]
+
+[[package]]
+name = "keyring"
+version = "25.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "importlib-metadata", marker = "python_full_version < '3.12'" },
+    { name = "jaraco-classes" },
+    { name = "jaraco-context" },
+    { name = "jaraco-functools" },
+    { name = "jeepney", marker = "sys_platform == 'linux'" },
+    { name = "pywin32-ctypes", marker = "sys_platform == 'win32'" },
+    { name = "secretstorage", marker = "sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/4b/674af6ef2f97d56f0ab5153bf0bfa28ccb6c3ed4d1babf4305449668807b/keyring-25.7.0.tar.gz", hash = "sha256:fe01bd85eb3f8fb3dd0405defdeac9a5b4f6f0439edbb3149577f244a2e8245b", size = 63516, upload-time = "2025-11-16T16:26:09.482Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/db/e655086b7f3a705df045bf0933bdd9c2f79bb3c97bfef1384598bb79a217/keyring-25.7.0-py3-none-any.whl", hash = "sha256:be4a0b195f149690c166e850609a477c532ddbfbaed96a404d4e43f8d5e2689f", size = 39160, upload-time = "2025-11-16T16:26:08.402Z" },
 ]
 
 [[package]]
@@ -831,6 +1012,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "more-itertools"
+version = "11.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/de/1d/f4da6f02cdffe04d6362210b807146a26044c88d839208aec273bb0d9184/more_itertools-11.1.0.tar.gz", hash = "sha256:48e8f4d9e7e5878571ecf6f2b4e57634f93cd474cc8cfbd2376f2d11b396e30d", size = 145772, upload-time = "2026-05-22T14:14:29.909Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/3d/1087453384dbde46a8c7f9356eead2c58be8a7bf156bca40243377c85715/more_itertools-11.1.0-py3-none-any.whl", hash = "sha256:4b65538ae22f6fed0ce4874efd317463a7489796a0939fa66824dd542125a192", size = 72226, upload-time = "2026-05-22T14:14:28.824Z" },
 ]
 
 [[package]]
@@ -1245,6 +1435,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
 name = "pydantic"
 version = "2.12.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1510,6 +1709,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pywin32-ctypes"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/9f/01a1a99704853cb63f253eea009390c88e7131c67e66a0a02099a8c917cb/pywin32-ctypes-0.2.3.tar.gz", hash = "sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755", size = 29471, upload-time = "2024-08-14T10:15:34.626Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl", hash = "sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8", size = 30756, upload-time = "2024-08-14T10:15:33.187Z" },
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1764,6 +1972,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/fa/05b6428a008e60f79546c943e54068316f32ec8ab5c4f73e4563934fbdc7/ruff-0.12.12-py3-none-win32.whl", hash = "sha256:173be2bfc142af07a01e3a759aba6f7791aa47acf3604f610b1c36db888df7b1", size = 12052870, upload-time = "2025-09-04T16:50:09.121Z" },
     { url = "https://files.pythonhosted.org/packages/85/60/d1e335417804df452589271818749d061b22772b87efda88354cf35cdb7a/ruff-0.12.12-py3-none-win_amd64.whl", hash = "sha256:e99620bf01884e5f38611934c09dd194eb665b0109104acae3ba6102b600fd0d", size = 13178016, upload-time = "2025-09-04T16:50:12.559Z" },
     { url = "https://files.pythonhosted.org/packages/28/7e/61c42657f6e4614a4258f1c3b0c5b93adc4d1f8575f5229d1906b483099b/ruff-0.12.12-py3-none-win_arm64.whl", hash = "sha256:2a8199cab4ce4d72d158319b63370abf60991495fb733db96cd923a34c52d093", size = 12256762, upload-time = "2025-09-04T16:50:15.737Z" },
+]
+
+[[package]]
+name = "secretstorage"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "jeepney" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/46/f5af3402b579fd5e11573ce652019a67074317e18c1935cc0b4ba9b35552/secretstorage-3.5.0-py3-none-any.whl", hash = "sha256:0ce65888c0725fcb2c5bc0fdb8e5438eece02c523557ea40ce0703c266248137", size = 15554, upload-time = "2025-11-23T19:02:51.545Z" },
 ]
 
 [[package]]
@@ -2180,4 +2401,13 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f9/86/0f0dccb6e59a9e7f122c5afd43568b1d31b8ab7dda5f1b01fb5c7025c9a9/yarl-1.22.0-cp314-cp314t-win_amd64.whl", hash = "sha256:9fb17ea16e972c63d25d4a97f016d235c78dd2344820eb35bc034bc32012ee27", size = 96292, upload-time = "2025-10-06T14:12:15.398Z" },
     { url = "https://files.pythonhosted.org/packages/48/b7/503c98092fb3b344a179579f55814b613c1fbb1c23b3ec14a7b008a66a6e/yarl-1.22.0-cp314-cp314t-win_arm64.whl", hash = "sha256:9f6d73c1436b934e3f01df1e1b21ff765cd1d28c77dfb9ace207f746d4610ee1", size = 85171, upload-time = "2025-10-06T14:12:16.935Z" },
     { url = "https://files.pythonhosted.org/packages/73/ae/b48f95715333080afb75a4504487cbe142cae1268afc482d06692d605ae6/yarl-1.22.0-py3-none-any.whl", hash = "sha256:1380560bdba02b6b6c90de54133c81c9f2a453dee9912fe58c1dcced1edb7cff", size = 46814, upload-time = "2025-10-06T14:12:53.872Z" },
+]
+
+[[package]]
+name = "zipp"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/d8/eab98a517c14134c0b2eb4e2387bc5f457334293ec5d2dd3857ec2966802/zipp-4.1.0.tar.gz", hash = "sha256:4cb57381f544315db7688e976e922a2b18cdb513d21cc194eb42232ba2a3e602", size = 26214, upload-time = "2026-05-18T20:08:57.967Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/13/547360d81e6d88d58492968ffda9f9542854f11310ee556fef14260cc886/zipp-4.1.0-py3-none-any.whl", hash = "sha256:25ad4e16390cd314347dd8f1de67a2ac538ae658ed4ab9db16029c07c188e97f", size = 10238, upload-time = "2026-05-18T20:08:57.045Z" },
 ]


### PR DESCRIPTION
## 概述

#65（S12，父 #53）补齐 Computer 侧 MCP server 配置的「完整对标 VS Code SecretStorage」取值/渲染层（设计 §9.3 / 决策 #27）。**纯 Computer 侧、无 A2C 协议变更**：变量**只在 MCP server 本地 spawn 时**展开，**绝不**进 `client:get_config` / `client:get_skills` 发往 Agent 的 payload（密钥值不离开 Computer，`PROTOCOL_VERSION` 不变）。

依赖 #56（已合）已满足。

## 取值解析链（`resolver.py`，命中即止）

```
cache → env(A2C_INPUT_<ID>) → keyring(仅 password) → 明文 value store(仅非密钥) → prompt → default
```

- **持久化**（仅**交互 prompt 得值**时，§9.3「prompt 得」）：`password:true`→OS keyring；非密钥 promptString/pickString→明文 state；env 命中 / command / headless 回退**不落盘**。
- **headless 降级**：`password:true` + 无 env + 无 keyring + 无 TTY → `SecretResolutionError` 硬错误，**绝不落明文**（杜绝把密钥明文落盘的反模式）。
- **键空间**：全局 `<id>`（与「Input id 全局唯一、跨类型不重复」一致）。

## 改动

**新增 `inputs/`**
- `value_store.py` — 非密钥明文 state（`$XDG_STATE_HOME/a2c/input-values.json`，`0600` 原子写；复用 `resolve_xdg_first` + `atomic_write_text`）。
- `secret_store.py` — `keyring` **惰性 import**（可选依赖缺失不破坏导入）+ 可用性探测 + 安全降级（service=`a2c-computer`、key=`<id>`）。
- `plugin_pool.py` — plugin `inputs.json` 入池前缀消歧 `<plugin>@<marketplace>/<id>`（§9.3 D2 方案 a，自动透明）。

**改动（加性、向后兼容）**
- `inputs/resolver.py` — 解析链 + 按类持久化 + plugin 上下文裸 id 前缀回退 + `env_var_name` + `SecretResolutionError`。
- `inputs/render.py` — `${env:VAR}`（缺失→空串 + WARN）+ 预定义 `${workspaceFolder}`/`${userHome}`/`${pathSeparator}` + `load_env_file`；未知占位符保持原样。
- `mcp_clients/model.py` — `BaseMCPServerConfig` 加 `env_file`（alias `envFile` + `populate_by_name`）；加性 SDK 字段（设计 §1092「待协议追认」），仅 stdio spawn 消费。
- `computer.py` — `_render_variables` + `_apply_env_file`（envFile 合并进 stdio env、**显式 env 同名项胜**）；`boot_up` 收敛复用 `_arender_and_validate_server`（DRY）。
- `pyproject.toml` — `keyring >=25,<26` 可选依赖（`a2c-smcp[keyring]`）+ mypy `ignore_missing_imports`。

## 验证

- `uv run --no-sync poe lint` — ✅ ruff All checks passed + mypy **96 files no issues**
- `pytest tests/unit_tests/computer/inputs` — ✅ **68 passed**（value / secret / resolver-chain / render-vars / plugin-prefix / envfile + 既有回归）
- `pytest tests/unit_tests/computer tests/integration_tests/computer` — ✅ **1058 passed, 2 skipped, 4 xfailed**

安全不变量已测：密钥 headless 硬错误且 value_store 无写入；`${input:}`/`${env:}` 在 get_config/get_skills 不展开（spawn-only 渲染）。

## 下游 handoff（→ #69）

- plugin server **实时挂载**用 D2 plugin 上下文渲染（enumerate installed plugins → 填池 → spawn）；本 PR 只交付消歧**机制 + helper + 单测**。
- `envFile` 进协议 `client:get_config` 待后续 add-feature 追认（本 PR 仅 SDK 内字段）。
- keyring key 的 workspace 隔离（v0.2.1 用全局 `<id>`）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)