### PR TITLE
feat(computer): v0.2.1 S16 CLI plugin + settings 命令 + 全局 flag + 启动期 MCP 批准框 (#69)

### DIFF
--- a/a2c_smcp/computer/cli/commands/__init__.py
+++ b/a2c_smcp/computer/cli/commands/__init__.py
@@ -23,8 +23,10 @@ so they unit-test in isolation. Only the cross-command seam lives here: :func:`b
 
 from __future__ import annotations
 
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:  # 仅类型，避免运行时循环导入 / type-only to dodge runtime import cycle
     from a2c_smcp.computer.computer import Computer
@@ -63,3 +65,41 @@ def build_mcp_callbacks(comp: Computer) -> McpCallbacks:
         await comp.aremove_server(name)
 
     return McpCallbacks(existing_server_names=_existing, register_server=_register, remove_server=_remove)
+
+
+# ── 跨命令解析 / 视图接缝（marketplace / skill / plugin / settings 共用）/ shared parse & view seams ──
+def flag_value(args: list[str], flag: str) -> str | None:
+    """取 ``--flag value`` 形态的值（**不支持** ``--flag=value``，REPL 简化）/ Extract a ``--flag value`` pair。
+
+    四个命令模块（marketplace / skill / plugin / settings）的 REPL dispatcher 共用，避免 4 处分叉。
+    """
+    if flag in args:
+        idx = args.index(flag)
+        if idx + 1 < len(args) and not args[idx + 1].startswith("--"):
+            return args[idx + 1]
+    return None
+
+
+def resolved_settings(
+    registered_workdirs: Sequence[Path],
+    active_workdir: Path | None,
+    env: Mapping[str, str] | None,
+    *,
+    flag_path: Path | None = None,
+) -> dict[str, Any]:
+    """六层合并 settings（含 policy first-source-wins）/ Six-layer merged settings incl. policy。
+
+    plugin（``enabledPlugins`` / gc 声明视图）与 settings（merged show / get）共用。policy 层承载企业
+    allowed/deniedMcpServers（POLICY_ONLY 字段，批准门控须读到），故统一注入。函数内 lazy import 沿用本仓
+    dodge-cycle 范式（settings.scope / settings.policy 不反向依赖 cli，无环，仅避免 ``import cli.commands`` 拉重）。
+    """
+    from a2c_smcp.computer.settings.policy import resolve_policy_settings
+    from a2c_smcp.computer.settings.scope import resolve_settings
+
+    return resolve_settings(
+        registered_workdirs=registered_workdirs,
+        active_workdir=active_workdir,
+        env=env,
+        flag_settings_path=flag_path,
+        policy_settings=resolve_policy_settings(env=env),
+    ).settings

--- a/a2c_smcp/computer/cli/commands/marketplace.py
+++ b/a2c_smcp/computer/cli/commands/marketplace.py
@@ -27,7 +27,7 @@ from typing import Any
 
 from rich.table import Table
 
-from a2c_smcp.computer.cli.commands import McpCallbacks
+from a2c_smcp.computer.cli.commands import McpCallbacks, flag_value
 from a2c_smcp.computer.cli.progress import clone_spinner, refresh_summary_table
 from a2c_smcp.computer.cli.utils import console
 from a2c_smcp.computer.settings.installer import uninstall_plugin
@@ -384,7 +384,7 @@ async def repl_dispatch(comp: Any, parts: list[str], *, session: Any) -> None:
         if not pos:
             console.print("[yellow]usage: marketplace add <git-url> [--name N] [--trust] [--auto-update] [--no-clone][/yellow]")
             return
-        name = _flag_value(args, "--name")
+        name = flag_value(args, "--name")
         code = await marketplace_add(
             registry, home, env, pos[0],
             name=name, trust="--trust" in args, auto_update="--auto-update" in args,
@@ -426,12 +426,3 @@ async def repl_dispatch(comp: Any, parts: list[str], *, session: Any) -> None:
         marketplace_set(home, env, pos[0], key, value, json_output=json_output)
     else:
         console.print(f"[yellow]unknown marketplace subcommand: {sub}[/yellow]")
-
-
-def _flag_value(args: list[str], flag: str) -> str | None:
-    """取 ``--flag value`` 形态的值（不支持 ``--flag=value``，REPL 简化）/ Extract a ``--flag value`` pair。"""
-    if flag in args:
-        idx = args.index(flag)
-        if idx + 1 < len(args) and not args[idx + 1].startswith("--"):
-            return args[idx + 1]
-    return None

--- a/a2c_smcp/computer/cli/commands/plugin.py
+++ b/a2c_smcp/computer/cli/commands/plugin.py
@@ -1,0 +1,586 @@
+# -*- coding: utf-8 -*-
+# filename: plugin.py
+# @Time    : 2026/05/27
+# @Author  : JQQ
+# @Email   : jqq1716@gmail.com
+# @Software: PyCharm
+"""
+``plugin`` 命令 handler（install / uninstall / enable / disable / list / info / gc）+ 启动期 MCP 批准框。
+Plugin command handlers + boot-time MCP approval box。
+
+设计依据 / Design: python-sdk docs/design-0.2.1-cli-marketplace-ux.md §4.3 / §9.2 / §10.6 / §12（S16，#69）。
+
+与 marketplace.py 同范式：handler 取**显式资源**（``registry`` / ``home`` / ``env``）+ flags，返回退出码
+（0 成功 / 1 用户错 / 2 网络错），包裹 :mod:`...settings.installer` 四动词 + :mod:`...settings.reconciler`
+gc。MCP 注入回调（``existing_server_names`` / ``register_server`` / ``remove_server`` / ``inject_inputs``）由
+REPL dispatcher 从活跃 ``Computer`` 装配后注入；Typer 非交互无 live Computer → 传 ``None``（ledger-only，
+MCP 挂载延到下次 REPL boot 经批准框落地）。
+
+**plugin 实时挂载 D2 上下文渲染（#69 Group A，§9.3 D2）**：plugin 的 ``mcp-servers/inputs.json`` 入池时 id
+前缀化为 ``<plugin>@<marketplace>/<id>``；挂载 bundled server 时，``_plugin_register_cb`` 携 plugin/marketplace
+上下文调 :meth:`Computer.aadd_or_aupdate_server`，使 server config 的裸 ``${input:id}`` 经 resolver D2 前缀回退
+解析。``_plugin_inject_inputs_cb`` 负责在 register 前把 inputs 注入 Computer 池。
+
+**MCP 批准框（#69 Group B，§9.2）**：:func:`run_mcp_approval` 在 REPL 启动期跑——解析 ``.tfrobot/mcp.json``
+定义层、套门控、对 ``PENDING`` server 弹 y/a/n（写 local scope）；非交互无 TTY → skip+WARN（``--approve-all-mcp``
+可全批、仅本次不落盘）。bundled / user-flag-policy origin 免批准（门控已判 ENABLED）。
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Awaitable, Callable, Mapping
+from pathlib import Path
+from typing import Any
+
+from rich.table import Table
+
+from a2c_smcp.computer.cli.commands import build_mcp_callbacks
+from a2c_smcp.computer.cli.progress import clone_spinner
+from a2c_smcp.computer.cli.utils import console
+from a2c_smcp.computer.inputs.plugin_pool import load_plugin_inputs
+from a2c_smcp.computer.settings.installer import (
+    ExistingServerNames,
+    InjectInputs,
+    MCPServerNameConflictError,
+    PluginInstallError,
+    RegisterServer,
+    RemoveServer,
+    disable_plugin,
+    enable_plugin,
+    install_plugin,
+    uninstall_plugin,
+)
+from a2c_smcp.computer.settings.mcp_config import (
+    McpApprovalStatus,
+    approve_all_project_mcp,
+    approve_mcp_server,
+    bundled_mcp_server_names,
+    deny_mcp_server,
+    gate_mcp_servers,
+    resolve_mcp_config,
+)
+from a2c_smcp.computer.settings.policy import resolve_policy_settings
+from a2c_smcp.computer.settings.reconciler import gc_plugins, list_orphan_plugins
+from a2c_smcp.computer.settings.scope import resolve_settings
+from a2c_smcp.computer.skills.manifest import MCP_INPUTS_FILENAME, MCP_SERVERS_SUBDIR
+from a2c_smcp.computer.skills.registry import SkillRegistry
+
+# 退出码语义（§4.6）/ Exit code semantics（与 marketplace.py 对齐）。
+EXIT_OK = 0
+EXIT_USER_ERROR = 1
+EXIT_NETWORK_ERROR = 2
+
+
+# ── 输出辅助 / output helpers ─────────────────────────────────────────────────
+def _err(msg: str, *, json_output: bool, code: int = EXIT_USER_ERROR, error_code: str | None = None, **extra: Any) -> int:
+    if json_output:
+        payload: dict[str, Any] = {"error": error_code or "error", "message": msg, **extra}
+        console.print_json(data=payload)
+    else:
+        console.print(f"[red]✗ {msg}[/red]")
+    return code
+
+
+def _ok(msg: str) -> int:
+    console.print(f"[green]✓ {msg}[/green]")
+    return EXIT_OK
+
+
+def _flag_value(args: list[str], flag: str) -> str | None:
+    """取 ``--flag value`` 形态的值（不支持 ``--flag=value``，REPL 简化）/ Extract a ``--flag value`` pair。"""
+    if flag in args:
+        idx = args.index(flag)
+        if idx + 1 < len(args) and not args[idx + 1].startswith("--"):
+            return args[idx + 1]
+    return None
+
+
+def _installed_records(home: Path, env: Mapping[str, str] | None, plugin_id: str) -> list[dict[str, Any]]:
+    """读 ``installed_plugins.json`` 中某 plugin 的全部 scope 记录（plain dict）/ All install records of a plugin。"""
+    from a2c_smcp.computer.settings.store import load_installed_plugins
+
+    return [dict(r) for r in load_installed_plugins(home=home, env=env).get("plugins", {}).get(plugin_id, [])]
+
+
+def _split_plugin_id(plugin_id: str) -> tuple[str, str] | None:
+    """``<plugin>@<marketplace>`` → ``(plugin, marketplace)``；格式非法 → ``None``。"""
+    plugin, _, marketplace = plugin_id.partition("@")
+    if not plugin or not marketplace:
+        return None
+    return plugin, marketplace
+
+
+def _resolved_settings(
+    registered_workdirs: tuple[Path, ...],
+    active_workdir: Path | None,
+    env: Mapping[str, str] | None,
+    *,
+    flag_path: Path | None = None,
+) -> Mapping[str, Any]:
+    """六层合并 settings（含 policy first-source-wins）/ Six-layer merged settings incl. policy。
+
+    policy 层承载企业 allowed/deniedMcpServers（POLICY_ONLY 字段）；批准门控须读到，故统一注入。
+    """
+    return resolve_settings(
+        registered_workdirs=registered_workdirs,
+        active_workdir=active_workdir,
+        env=env,
+        flag_settings_path=flag_path,
+        policy_settings=resolve_policy_settings(env=env),
+    ).settings
+
+
+# ── plugin 实时挂载 D2 上下文渲染回调（#69 Group A）/ plugin-mount D2 context callbacks ──
+def _plugin_register_cb(comp: Any, plugin: str, marketplace: str) -> RegisterServer:
+    """携 plugin/marketplace 上下文的 register 回调：bundled server 的裸 ``${input:id}`` 经此解析到带前缀池条目。"""
+
+    async def _register(cfg: Any) -> None:
+        await comp.aadd_or_aupdate_server(cfg, plugin=plugin, marketplace=marketplace)
+
+    return _register
+
+
+def _plugin_inject_inputs_cb(comp: Any, plugin: str, marketplace: str) -> InjectInputs:
+    """注入 plugin-scoped inputs 入池：从 ``<plugin_root>/mcp-servers/inputs.json`` 读、前缀化、逐条 add_or_update_input。"""
+
+    async def _inject(plugin_root: Path) -> None:
+        inputs_json = plugin_root / MCP_SERVERS_SUBDIR / MCP_INPUTS_FILENAME
+        for inp in load_plugin_inputs(inputs_json, plugin, marketplace):
+            comp.add_or_update_input(inp)
+
+    return _inject
+
+
+# ── handlers ──────────────────────────────────────────────────────────────────
+async def plugin_install(
+    registry: SkillRegistry,
+    home: Path,
+    env: Mapping[str, str] | None,
+    plugin_id: str,
+    *,
+    scope: str = "user",
+    project_path: str | None = None,
+    version: str | None = None,
+    existing_server_names: ExistingServerNames | None = None,
+    register_server: RegisterServer | None = None,
+    inject_inputs: InjectInputs | None = None,
+    json_output: bool = False,
+) -> int:
+    """安装单个 plugin（外来 MCP 同名硬抛、原子失败，§10.6）/ Install a plugin (foreign name conflict hard-throws)。"""
+    if _split_plugin_id(plugin_id) is None:
+        return _err(f"invalid plugin id {plugin_id!r} (expected '<plugin>@<marketplace>')", json_output=json_output)
+    try:
+        with clone_spinner(f"Installing {plugin_id}...", enabled=not json_output):
+            record = await install_plugin(
+                plugin_id, registry, home,
+                scope=scope, project_path=project_path, version=version, env=env,
+                existing_server_names=existing_server_names, register_server=register_server, inject_inputs=inject_inputs,
+            )
+    except MCPServerNameConflictError as e:
+        # §10.6 硬抛、退出码 1 + JSON error（无 rename/force 逃生口）。
+        return _err(str(e), json_output=json_output, error_code="mcp_server_name_conflict")
+    except PluginInstallError as e:
+        return _err(str(e), json_output=json_output)
+
+    servers = record.get("bundledMcpServers") or []
+    if json_output:
+        console.print_json(data={"installed": plugin_id, "scope": record.get("scope"), "bundledMcpServers": servers})
+        return EXIT_OK
+    detail = f" ({len(servers)} MCP server(s) mounted)" if servers else ""
+    return _ok(f"installed {plugin_id!r}{detail}")
+
+
+async def plugin_uninstall(
+    registry: SkillRegistry,
+    home: Path,
+    env: Mapping[str, str] | None,
+    plugin_id: str,
+    *,
+    keep_servers: bool = False,
+    remove_server: RemoveServer | None = None,
+    json_output: bool = False,
+) -> int:
+    """卸载单个 plugin（删 installPath 树 + 注销 skills + 级联停摘 bundled server + 删账本）/ Uninstall a plugin。"""
+    ok = await uninstall_plugin(plugin_id, registry, home, env=env, keep_servers=keep_servers, remove_server=remove_server)
+    if not ok:
+        return _err(f"plugin {plugin_id!r} not installed (no-op)", json_output=json_output)
+    if json_output:
+        console.print_json(data={"uninstalled": plugin_id, "keptServers": keep_servers})
+        return EXIT_OK
+    return _ok(f"uninstalled {plugin_id!r}" + (" (servers kept)" if keep_servers else ""))
+
+
+async def plugin_enable(
+    registry: SkillRegistry,
+    home: Path,
+    env: Mapping[str, str] | None,
+    plugin_id: str,
+    *,
+    existing_server_names: ExistingServerNames | None = None,
+    register_server: RegisterServer | None = None,
+    inject_inputs: InjectInputs | None = None,
+    json_output: bool = False,
+) -> int:
+    """启用单个 plugin（廉价复原：重挂 server + 复活 skills）/ Enable a plugin (cheap restore)。
+
+    **scope 契约**（installer §4.3）：从 ledger 逐 scope 读安装 scope 传入，绝不默认 ``user``，否则写错层、与 live
+    态背离。多 scope 记录 → 逐 scope enable。挂载前先经 ``inject_inputs`` 把 plugin-scoped inputs 注入池（#69 Group A）。
+    """
+    records = _installed_records(home, env, plugin_id)
+    if not records:
+        return _err(f"plugin {plugin_id!r} not installed (install it first)", json_output=json_output)
+    try:
+        for rec in records:
+            install_path = rec.get("installPath")
+            if inject_inputs is not None and isinstance(install_path, str) and install_path:
+                await inject_inputs(Path(install_path))
+            await enable_plugin(
+                plugin_id, registry, home,
+                scope=str(rec.get("scope", "user")), project_path=rec.get("projectPath"), env=env,
+                existing_server_names=existing_server_names, register_server=register_server,
+            )
+    except MCPServerNameConflictError as e:
+        return _err(str(e), json_output=json_output, error_code="mcp_server_name_conflict")
+    except PluginInstallError as e:
+        return _err(str(e), json_output=json_output)
+    if json_output:
+        console.print_json(data={"enabled": plugin_id, "scopes": [r.get("scope") for r in records]})
+        return EXIT_OK
+    return _ok(f"enabled {plugin_id!r}")
+
+
+async def plugin_disable(
+    registry: SkillRegistry,
+    home: Path,
+    env: Mapping[str, str] | None,
+    plugin_id: str,
+    *,
+    remove_server: RemoveServer | None = None,
+    json_output: bool = False,
+) -> int:
+    """禁用单个 plugin = 整 plugin 下线（停摘 bundled server + 隐藏 skills；物化层保留可一键复原）/ Disable a plugin。
+
+    **scope 契约**：同 :func:`plugin_enable`，从 ledger 逐 scope 读。
+    """
+    records = _installed_records(home, env, plugin_id)
+    if not records:
+        return _err(f"plugin {plugin_id!r} not installed (no-op)", json_output=json_output)
+    for rec in records:
+        await disable_plugin(
+            plugin_id, registry, home,
+            scope=str(rec.get("scope", "user")), project_path=rec.get("projectPath"), env=env, remove_server=remove_server,
+        )
+    if json_output:
+        console.print_json(data={"disabled": plugin_id, "scopes": [r.get("scope") for r in records]})
+        return EXIT_OK
+    return _ok(f"disabled {plugin_id!r} (whole plugin offline; enable to restore)")
+
+
+def _enabled_plugins_view(
+    home: Path, env: Mapping[str, str] | None, registered_workdirs: tuple[Path, ...], active_workdir: Path | None,
+) -> dict[str, Any]:
+    """六层合并视图的 ``enabledPlugins`` 映射（``id → bool``，缺省视为启用）/ Merged enabledPlugins map。"""
+    ep = _resolved_settings(registered_workdirs, active_workdir, env).get("enabledPlugins")
+    return dict(ep) if isinstance(ep, Mapping) else {}
+
+
+def plugin_list(
+    home: Path,
+    env: Mapping[str, str] | None,
+    *,
+    registered_workdirs: tuple[Path, ...] = (),
+    active_workdir: Path | None = None,
+    available: bool = False,
+    json_output: bool = False,
+) -> int:
+    """列出 installed plugin（默认 enabled；``--available`` 含 disabled）/ List installed plugins。"""
+    from a2c_smcp.computer.settings.store import load_installed_plugins
+
+    installed = load_installed_plugins(home=home, env=env).get("plugins", {})
+    enabled_map = _enabled_plugins_view(home, env, registered_workdirs, active_workdir)
+
+    rows: list[dict[str, Any]] = []
+    for pid, records in installed.items():
+        enabled = enabled_map.get(pid) is not False  # 缺省 / true = 启用；显式 false = 禁用
+        if not enabled and not available:
+            continue
+        scopes = sorted({str(r.get("scope")) for r in records})
+        bundled = sorted({s for r in records for s in (r.get("bundledMcpServers") or [])})
+        rows.append({"id": pid, "enabled": enabled, "scopes": scopes, "bundledMcpServers": bundled})
+    rows.sort(key=lambda r: str(r["id"]))
+
+    if json_output:
+        console.print_json(data=rows)
+        return EXIT_OK
+    if not rows:
+        console.print("[dim]No plugins installed. Install one: plugin install <plugin>@<marketplace>[/dim]")
+        return EXIT_OK
+    table = Table(title="Plugins", header_style="bold magenta")
+    for col in ("Plugin", "Enabled", "Scopes", "MCP servers"):
+        table.add_column(col)
+    for r in rows:
+        table.add_row(
+            str(r["id"]),
+            "✓" if r["enabled"] else "—",
+            ", ".join(r["scopes"]) or "—",
+            ", ".join(r["bundledMcpServers"]) or "—",
+        )
+    console.print(table)
+    return EXIT_OK
+
+
+def plugin_info(
+    home: Path,
+    env: Mapping[str, str] | None,
+    plugin_id: str,
+    *,
+    registered_workdirs: tuple[Path, ...] = (),
+    active_workdir: Path | None = None,
+    json_output: bool = False,
+) -> int:
+    """plugin 详情：scope / installPath / version / commitSha / enabled / bundledMcpServers / installedAt。"""
+    records = _installed_records(home, env, plugin_id)
+    if not records:
+        return _err(f"plugin {plugin_id!r} not installed", json_output=json_output)
+    enabled = _enabled_plugins_view(home, env, registered_workdirs, active_workdir).get(plugin_id) is not False
+    info: dict[str, Any] = {"id": plugin_id, "enabled": enabled, "records": records}
+    if json_output:
+        console.print_json(data=info)
+        return EXIT_OK
+    table = Table(title=f"Plugin · {plugin_id}", show_header=False)
+    table.add_column("Field", style="bold cyan")
+    table.add_column("Value")
+    table.add_row("enabled", "✓" if enabled else "—")
+    for idx, rec in enumerate(records):
+        prefix = f"[{rec.get('scope')}] " if len(records) > 1 else ""
+        for k in ("scope", "installPath", "version", "commitSha", "installedAt", "bundledMcpServers"):
+            if k in rec:
+                table.add_row(f"{prefix}{k}", str(rec[k]))
+        if idx < len(records) - 1:
+            table.add_row("", "")
+    console.print(table)
+    return EXIT_OK
+
+
+async def plugin_gc(
+    registry: SkillRegistry,
+    home: Path,
+    env: Mapping[str, str] | None,
+    *,
+    registered_workdirs: tuple[Path, ...] = (),
+    active_workdir: Path | None = None,
+    mcp_teardown: Callable[[list[str]], Awaitable[None]] | None = None,
+    confirm: Callable[[list[str]], Awaitable[bool]] | None = None,
+    json_output: bool = False,
+) -> int:
+    """清理孤儿 plugin（所有 scope 都不再声明 enabledPlugins[id]）/ GC orphan plugins。"""
+    declared = _resolved_settings(registered_workdirs, active_workdir, env)
+    orphans = list_orphan_plugins(home, declared, env=env)
+    if not orphans:
+        if json_output:
+            console.print_json(data={"removed": []})
+        else:
+            console.print("[dim]No orphan plugins.[/dim]")
+        return EXIT_OK
+    if confirm is not None and not await confirm(orphans):
+        return _err("aborted by user", json_output=json_output)
+    removed = await gc_plugins(orphans, registry, home, env=env, mcp_teardown=mcp_teardown)
+    if json_output:
+        console.print_json(data={"removed": removed})
+        return EXIT_OK
+    return _ok(f"gc removed {len(removed)} orphan plugin(s): {', '.join(removed) or '—'}")
+
+
+# ── MCP 批准框（启动期，§9.2，#69 Group B）/ MCP approval box (boot-time) ─────────
+def _mount_dict(srv: Any) -> dict[str, Any]:
+    """合并 resolved server 的 ``config``（含占位符）+ ``ext``（剥离的 envFile 等扩展字段）为挂载用 dict。
+
+    ★ 必须合回 ``ext``，否则 spawn 时 ``_apply_env_file`` 看不到 ``envFile`` → 静默丢失（#69 Group B 风险 2）。
+    """
+    return {**srv.config.model_dump(mode="json"), **dict(srv.ext)}
+
+
+async def run_mcp_approval(
+    comp: Any,
+    session: Any | None,
+    *,
+    approve_all: bool = False,
+    flag_config: Path | None = None,
+) -> None:
+    """启动期解析 ``.tfrobot/mcp.json`` 定义层 + 批准门控 + 挂载 ENABLED server（§9.2）/ Boot-time MCP approval + mount。
+
+    - bundled / user-flag-policy origin server → 门控判 ENABLED → 直挂（免批准框）；
+    - DISABLED（企业拒绝/不在白名单/显式 disabled）→ 跳过；
+    - PENDING（工作区共享未决）→ TTY 弹 y/a/n 写 local scope；非 TTY → skip+WARN，``approve_all`` 全批（仅本次不落盘）。
+
+    ``--approve-all-mcp`` 在**非交互**仅本次挂载、**不落盘**；TTY ``[a]`` 才写 enableAllProjectMcpServers（用户显式决定）。
+    """
+    aw = comp.active_workdir
+    env = os.environ
+    resolved = resolve_mcp_config(active_workdir=aw, env=env, flag_config_path=flag_config)
+
+    # 被 drop 的畸形 server/input 必须呈现（§5.6 / mcp_config 容错不静默，#69 Group B 风险 3）。
+    for e in resolved.errors:
+        console.print(f"[yellow]⚠ mcp.json: {e}[/yellow]")
+
+    if not resolved.servers:
+        return
+
+    settings = _resolved_settings(comp._registered_workdirs, aw, env, flag_path=flag_config)
+    bundled = bundled_mcp_server_names(comp.skill_home, env)
+    statuses = gate_mcp_servers(resolved, settings, bundled)
+
+    # mcp.json 定义的 input 入池（无前缀），供 server config 的裸 ${input:} 解析（#69 Group B 风险 3）。
+    for inp in resolved.inputs:
+        comp.add_or_update_input(inp)
+
+    approved_all_session = approve_all  # 非交互 --approve-all-mcp，或 TTY 选过一次 [a]
+
+    async def _mount(name: str) -> None:
+        try:
+            await comp.aadd_or_aupdate_server(_mount_dict(resolved.servers[name]), session=session)
+            console.print(f"[green]✓ mounted MCP server {name!r}[/green]")
+        except Exception as exc:  # 单个 server 挂载失败不阻断其余 / one failure must not block the rest
+            console.print(f"[red]✗ failed to mount MCP server {name!r}: {exc}[/red]")
+
+    for name, status in statuses.items():
+        if status == McpApprovalStatus.ENABLED:
+            await _mount(name)
+        elif status == McpApprovalStatus.DISABLED:
+            console.print(f"[dim]· MCP server {name!r} disabled (policy/denied), skipped[/dim]")
+        else:  # PENDING
+            if approved_all_session:
+                await _mount(name)
+                continue
+            if session is None:  # 非 TTY 且未 --approve-all-mcp → skip + WARN
+                console.print(
+                    f"[yellow]⚠ skipped pending MCP server {name!r} (no TTY); approve in REPL or pass --approve-all-mcp[/yellow]",
+                )
+                continue
+            srv = resolved.servers[name]
+            prompt = (
+                f"⚠ Unapproved workspace MCP server '{name}' (origin={srv.origin})\n"
+                "  [y]es this server · [a]ll project servers · [n]o (deny): "
+            )
+            ans = (await session.prompt_async(prompt)).strip().lower()
+            if ans in {"a", "all"}:
+                approve_all_project_mcp(active_workdir=aw)
+                approved_all_session = True
+                await _mount(name)
+            elif ans in {"y", "yes"}:
+                approve_mcp_server(name, active_workdir=aw)
+                await _mount(name)
+            else:
+                deny_mcp_server(name, active_workdir=aw)
+                console.print(f"[dim]· denied MCP server {name!r} (written to local scope)[/dim]")
+
+
+# ── REPL dispatcher（绑定 Computer 的活跃 registry / home / session）/ REPL adapter ──
+async def repl_dispatch(comp: Any, parts: list[str], *, session: Any) -> None:
+    """把 ``plugin ...`` REPL 行解析为 flags → 调 handler；变更后触发去抖 emit / Parse a REPL line and dispatch。"""
+    sub = parts[1].lower()
+    args = parts[2:]
+    registry = comp.skill_registry
+    home = comp.skill_home
+    env = os.environ
+    json_output = "--json" in args
+    pos = [a for a in args if not a.startswith("--")]
+    cbs = build_mcp_callbacks(comp)
+    aw = comp.active_workdir
+    # active workdir 作 project/local scope 的 project_path（plugin enable/disable 写 enabledPlugins 落 active 单根）。
+    project_path = str(aw) if aw is not None else None
+
+    if sub == "install":
+        if not pos:
+            console.print("[yellow]usage: plugin install <plugin>@<marketplace> [--version V] [--scope user|project|local][/yellow]")
+            return
+        plugin_id = pos[0]
+        split = _split_plugin_id(plugin_id)
+        if split is None:
+            console.print("[yellow]invalid plugin id (expected '<plugin>@<marketplace>')[/yellow]")
+            return
+        plugin, marketplace = split
+        scope = _flag_value(args, "--scope") or "user"
+        code = await plugin_install(
+            registry, home, env, plugin_id,
+            scope=scope, project_path=project_path if scope in ("project", "local") else None,
+            version=_flag_value(args, "--version"),
+            existing_server_names=cbs.existing_server_names,
+            register_server=_plugin_register_cb(comp, plugin, marketplace),
+            inject_inputs=_plugin_inject_inputs_cb(comp, plugin, marketplace),
+            json_output=json_output,
+        )
+        if code == EXIT_OK:
+            comp.mark_skills_dirty()
+    elif sub == "uninstall":
+        if not pos:
+            console.print("[yellow]usage: plugin uninstall <plugin>@<marketplace> [--keep-servers][/yellow]")
+            return
+        code = await plugin_uninstall(
+            registry, home, env, pos[0],
+            keep_servers="--keep-servers" in args, remove_server=cbs.remove_server, json_output=json_output,
+        )
+        if code == EXIT_OK:
+            comp.mark_skills_dirty()
+    elif sub == "enable":
+        if not pos:
+            console.print("[yellow]usage: plugin enable <plugin>@<marketplace>[/yellow]")
+            return
+        split = _split_plugin_id(pos[0])
+        if split is None:
+            console.print("[yellow]invalid plugin id (expected '<plugin>@<marketplace>')[/yellow]")
+            return
+        plugin, marketplace = split
+        code = await plugin_enable(
+            registry, home, env, pos[0],
+            existing_server_names=cbs.existing_server_names,
+            register_server=_plugin_register_cb(comp, plugin, marketplace),
+            inject_inputs=_plugin_inject_inputs_cb(comp, plugin, marketplace),
+            json_output=json_output,
+        )
+        if code == EXIT_OK:
+            comp.mark_skills_dirty()
+    elif sub == "disable":
+        if not pos:
+            console.print("[yellow]usage: plugin disable <plugin>@<marketplace>[/yellow]")
+            return
+        code = await plugin_disable(registry, home, env, pos[0], remove_server=cbs.remove_server, json_output=json_output)
+        if code == EXIT_OK:
+            comp.mark_skills_dirty()
+    elif sub == "list":
+        plugin_list(
+            home, env,
+            registered_workdirs=comp._registered_workdirs, active_workdir=aw,
+            available="--available" in args, json_output=json_output,
+        )
+    elif sub == "info":
+        if not pos:
+            console.print("[yellow]usage: plugin info <plugin>@<marketplace>[/yellow]")
+            return
+        plugin_info(home, env, pos[0], registered_workdirs=comp._registered_workdirs, active_workdir=aw, json_output=json_output)
+    elif sub == "gc":
+
+        async def _confirm(orphans: list[str]) -> bool:
+            ans = (await session.prompt_async(f"GC {len(orphans)} orphan plugin(s): {', '.join(orphans)}? [y/N]: ")).strip().lower()
+            return ans in {"y", "yes"}
+
+        code = await plugin_gc(
+            registry, home, env,
+            registered_workdirs=comp._registered_workdirs, active_workdir=aw,
+            mcp_teardown=_batch_teardown(cbs.remove_server), confirm=_confirm, json_output=json_output,
+        )
+        if code == EXIT_OK:
+            comp.mark_skills_dirty()
+    else:
+        console.print(f"[yellow]unknown plugin subcommand: {sub}[/yellow]")
+
+
+def _batch_teardown(remove_server: RemoveServer) -> Callable[[list[str]], Awaitable[None]]:
+    """把单个 ``remove_server`` 包成批量 teardown 回调（gc_plugins 的 ``mcp_teardown`` 入参为 name 列表）。"""
+
+    async def _teardown(names: list[str]) -> None:
+        for name in names:
+            await remove_server(name)
+
+    return _teardown

--- a/a2c_smcp/computer/cli/commands/plugin.py
+++ b/a2c_smcp/computer/cli/commands/plugin.py
@@ -35,7 +35,7 @@ from typing import Any
 
 from rich.table import Table
 
-from a2c_smcp.computer.cli.commands import build_mcp_callbacks
+from a2c_smcp.computer.cli.commands import build_mcp_callbacks, flag_value, resolved_settings
 from a2c_smcp.computer.cli.progress import clone_spinner
 from a2c_smcp.computer.cli.utils import console
 from a2c_smcp.computer.inputs.plugin_pool import load_plugin_inputs
@@ -60,9 +60,7 @@ from a2c_smcp.computer.settings.mcp_config import (
     gate_mcp_servers,
     resolve_mcp_config,
 )
-from a2c_smcp.computer.settings.policy import resolve_policy_settings
 from a2c_smcp.computer.settings.reconciler import gc_plugins, list_orphan_plugins
-from a2c_smcp.computer.settings.scope import resolve_settings
 from a2c_smcp.computer.skills.manifest import MCP_INPUTS_FILENAME, MCP_SERVERS_SUBDIR
 from a2c_smcp.computer.skills.registry import SkillRegistry
 
@@ -87,15 +85,6 @@ def _ok(msg: str) -> int:
     return EXIT_OK
 
 
-def _flag_value(args: list[str], flag: str) -> str | None:
-    """取 ``--flag value`` 形态的值（不支持 ``--flag=value``，REPL 简化）/ Extract a ``--flag value`` pair。"""
-    if flag in args:
-        idx = args.index(flag)
-        if idx + 1 < len(args) and not args[idx + 1].startswith("--"):
-            return args[idx + 1]
-    return None
-
-
 def _installed_records(home: Path, env: Mapping[str, str] | None, plugin_id: str) -> list[dict[str, Any]]:
     """读 ``installed_plugins.json`` 中某 plugin 的全部 scope 记录（plain dict）/ All install records of a plugin。"""
     from a2c_smcp.computer.settings.store import load_installed_plugins
@@ -109,26 +98,6 @@ def _split_plugin_id(plugin_id: str) -> tuple[str, str] | None:
     if not plugin or not marketplace:
         return None
     return plugin, marketplace
-
-
-def _resolved_settings(
-    registered_workdirs: tuple[Path, ...],
-    active_workdir: Path | None,
-    env: Mapping[str, str] | None,
-    *,
-    flag_path: Path | None = None,
-) -> Mapping[str, Any]:
-    """六层合并 settings（含 policy first-source-wins）/ Six-layer merged settings incl. policy。
-
-    policy 层承载企业 allowed/deniedMcpServers（POLICY_ONLY 字段）；批准门控须读到，故统一注入。
-    """
-    return resolve_settings(
-        registered_workdirs=registered_workdirs,
-        active_workdir=active_workdir,
-        env=env,
-        flag_settings_path=flag_path,
-        policy_settings=resolve_policy_settings(env=env),
-    ).settings
 
 
 # ── plugin 实时挂载 D2 上下文渲染回调（#69 Group A）/ plugin-mount D2 context callbacks ──
@@ -281,7 +250,7 @@ def _enabled_plugins_view(
     home: Path, env: Mapping[str, str] | None, registered_workdirs: tuple[Path, ...], active_workdir: Path | None,
 ) -> dict[str, Any]:
     """六层合并视图的 ``enabledPlugins`` 映射（``id → bool``，缺省视为启用）/ Merged enabledPlugins map。"""
-    ep = _resolved_settings(registered_workdirs, active_workdir, env).get("enabledPlugins")
+    ep = resolved_settings(registered_workdirs, active_workdir, env).get("enabledPlugins")
     return dict(ep) if isinstance(ep, Mapping) else {}
 
 
@@ -375,7 +344,7 @@ async def plugin_gc(
     json_output: bool = False,
 ) -> int:
     """清理孤儿 plugin（所有 scope 都不再声明 enabledPlugins[id]）/ GC orphan plugins。"""
-    declared = _resolved_settings(registered_workdirs, active_workdir, env)
+    declared = resolved_settings(registered_workdirs, active_workdir, env)
     orphans = list_orphan_plugins(home, declared, env=env)
     if not orphans:
         if json_output:
@@ -415,10 +384,16 @@ async def run_mcp_approval(
     - PENDING（工作区共享未决）→ TTY 弹 y/a/n 写 local scope；非 TTY → skip+WARN，``approve_all`` 全批（仅本次不落盘）。
 
     ``--approve-all-mcp`` 在**非交互**仅本次挂载、**不落盘**；TTY ``[a]`` 才写 enableAllProjectMcpServers（用户显式决定）。
+
+    **flag 层 schema 区分**（fix-review #1）：``flag_config`` 源自 ``--settings <file>``，是 **settings.json** flag 层
+    （喂 :func:`resolved_settings` 的 ``flag_path``——``{enabledPlugins/MCP 门控字段…}``）。它**不是 mcp.json**，故
+    **不**喂 ``resolve_mcp_config(flag_config_path=)``（后者期望 ``{servers,inputs}``、schema 不符）；flag-scope
+    **mcp.json 当前无 CLI 入口**（旧 ``--config`` 仅 ``_run_impl`` server 预加载、从不喂门控解析）。
     """
     aw = comp.active_workdir
     env = os.environ
-    resolved = resolve_mcp_config(active_workdir=aw, env=env, flag_config_path=flag_config)
+    # flag_config 是 settings.json（见 docstring）→ resolve_mcp_config 不收（避免 settings.json 当 mcp.json 误读）。
+    resolved = resolve_mcp_config(active_workdir=aw, env=env, flag_config_path=None)
 
     # 被 drop 的畸形 server/input 必须呈现（§5.6 / mcp_config 容错不静默，#69 Group B 风险 3）。
     for e in resolved.errors:
@@ -427,7 +402,7 @@ async def run_mcp_approval(
     if not resolved.servers:
         return
 
-    settings = _resolved_settings(comp._registered_workdirs, aw, env, flag_path=flag_config)
+    settings = resolved_settings(comp._registered_workdirs, aw, env, flag_path=flag_config)
     bundled = bundled_mcp_server_names(comp.skill_home, env)
     statuses = gate_mcp_servers(resolved, settings, bundled)
 
@@ -501,11 +476,11 @@ async def repl_dispatch(comp: Any, parts: list[str], *, session: Any) -> None:
             console.print("[yellow]invalid plugin id (expected '<plugin>@<marketplace>')[/yellow]")
             return
         plugin, marketplace = split
-        scope = _flag_value(args, "--scope") or "user"
+        scope = flag_value(args, "--scope") or "user"
         code = await plugin_install(
             registry, home, env, plugin_id,
             scope=scope, project_path=project_path if scope in ("project", "local") else None,
-            version=_flag_value(args, "--version"),
+            version=flag_value(args, "--version"),
             existing_server_names=cbs.existing_server_names,
             register_server=_plugin_register_cb(comp, plugin, marketplace),
             inject_inputs=_plugin_inject_inputs_cb(comp, plugin, marketplace),

--- a/a2c_smcp/computer/cli/commands/settings.py
+++ b/a2c_smcp/computer/cli/commands/settings.py
@@ -28,13 +28,13 @@ from collections.abc import Awaitable, Callable, Mapping
 from pathlib import Path
 from typing import Any
 
+from a2c_smcp.computer.cli.commands import flag_value, resolved_settings
 from a2c_smcp.computer.cli.utils import console
 from a2c_smcp.computer.settings.policy import resolve_policy_settings
 from a2c_smcp.computer.settings.schema import SettingsScope
 from a2c_smcp.computer.settings.scope import (
     apply_write,
     load_settings_file,
-    resolve_settings,
     user_settings_path,
     workdir_local_settings_path,
     workdir_project_settings_path,
@@ -57,14 +57,6 @@ def _err(msg: str, *, json_output: bool) -> int:
     return EXIT_USER_ERROR
 
 
-def _flag_value(args: list[str], flag: str) -> str | None:
-    if flag in args:
-        idx = args.index(flag)
-        if idx + 1 < len(args) and not args[idx + 1].startswith("--"):
-            return args[idx + 1]
-    return None
-
-
 def _writable_path(scope: str, active_workdir: Path | None, env: Mapping[str, str] | None) -> tuple[Path, SettingsScope]:
     """解析可写 scope 的 settings.json 路径 + enum；flag/policy/unknown → ``ValueError``。"""
     if scope == "user":
@@ -78,23 +70,6 @@ def _writable_path(scope: str, active_workdir: Path | None, env: Mapping[str, st
     raise ValueError(f"scope {scope!r} is read-only (writable: user|project|local)")
 
 
-def _merged(
-    home: Path,
-    env: Mapping[str, str] | None,
-    registered_workdirs: tuple[Path, ...],
-    active_workdir: Path | None,
-    flag_path: Path | None,
-) -> dict[str, Any]:
-    """六层合并 settings（含 policy first-source-wins）/ Six-layer merged settings incl. policy。"""
-    return resolve_settings(
-        registered_workdirs=registered_workdirs,
-        active_workdir=active_workdir,
-        env=env,
-        flag_settings_path=flag_path,
-        policy_settings=resolve_policy_settings(env=env),
-    ).settings
-
-
 def _read_scope(
     scope: str,
     home: Path,
@@ -106,7 +81,7 @@ def _read_scope(
 ) -> dict[str, Any] | None:
     """读单 scope（或 merged）settings dict；scope 非法或缺 active workdir → ``None``（调用方报错）。"""
     if scope == "merged":
-        return _merged(home, env, registered_workdirs, active_workdir, flag_path)
+        return resolved_settings(registered_workdirs, active_workdir, env, flag_path=flag_path)
     if scope == "user":
         return load_settings_file(user_settings_path(env), SettingsScope.USER)[0]
     if scope in ("project", "local"):
@@ -252,7 +227,7 @@ async def repl_dispatch(comp: Any, parts: list[str], *, session: Any) -> None:
     env = os.environ
     json_output = "--json" in args
     pos = [a for a in args if not a.startswith("--")]
-    scope = _flag_value(args, "--scope")
+    scope = flag_value(args, "--scope")
     registered = comp._registered_workdirs
     aw = comp.active_workdir
 
@@ -273,13 +248,18 @@ async def repl_dispatch(comp: Any, parts: list[str], *, session: Any) -> None:
         if len(pos) < 2:
             console.print("[yellow]usage: settings set <key> <value> [--scope user|project|local][/yellow]")
             return
-        # value = key 之后的整段（允许含空格的 JSON）/ value is everything after the key.
-        raw = " ".join(parts[2:])
-        value = raw.split(pos[0], 1)[1].strip() if pos[0] in raw else pos[1]
-        value = _strip_scope_flag(value)
-        code = settings_set(home, env, pos[0], value, scope=scope or "user", active_workdir=aw, json_output=json_output)
+        # value = key（parts[2]）之后、首个 --flag token 前的所有 token（重建含空格 JSON；停在**真 flag token**、
+        # 非子串——修 fix-review #3：旧 _strip_scope_flag 会误截含 "--scope" 子串的 value）。usage 契约：key 在 value 前。
+        key = pos[0]
+        value_tokens: list[str] = []
+        for tok in parts[3:]:
+            if tok.startswith("--"):
+                break
+            value_tokens.append(tok)
+        value = " ".join(value_tokens)
+        code = settings_set(home, env, key, value, scope=scope or "user", active_workdir=aw, json_output=json_output)
         _emit_keys = {"enabledPlugins", "enabledMcpjsonServers", "disabledMcpjsonServers", "enableAllProjectMcpServers"}
-        if code == EXIT_OK and pos[0] in _emit_keys:
+        if code == EXIT_OK and key in _emit_keys:
             comp.mark_skills_dirty()
     elif sub == "edit":
         code, post_save = settings_edit(home, env, scope=scope or "user", active_workdir=aw, reconcile_cb=None, json_output=json_output)
@@ -289,12 +269,3 @@ async def repl_dispatch(comp: Any, parts: list[str], *, session: Any) -> None:
                 await post_save()
     else:
         console.print(f"[yellow]unknown settings subcommand: {sub}[/yellow]")
-
-
-def _strip_scope_flag(value: str) -> str:
-    """从 set 的 value 段剥掉尾随的 ``--scope X`` / ``--json``（REPL 简化：flag 可在 value 后）。"""
-    for flag in ("--json",):
-        value = value.replace(flag, "")
-    if "--scope" in value:
-        value = value.split("--scope", 1)[0]
-    return value.strip()

--- a/a2c_smcp/computer/cli/commands/settings.py
+++ b/a2c_smcp/computer/cli/commands/settings.py
@@ -1,0 +1,300 @@
+# -*- coding: utf-8 -*-
+# filename: settings.py
+# @Time    : 2026/05/27
+# @Author  : JQQ
+# @Email   : jqq1716@gmail.com
+# @Software: PyCharm
+"""
+``settings`` 命令 handler（show / get / set / edit）/ Settings command handlers。
+
+设计依据 / Design: python-sdk docs/design-0.2.1-cli-marketplace-ux.md §4.5 / §5（S16，#69）。
+
+与 marketplace.py 同范式：handler 取**显式资源**（``home`` / ``env`` + scope/key/value）返回退出码。读经
+:func:`...scope.resolve_settings`（merged，含 policy first-source-wins）或单层 :func:`...scope.load_settings_file`；
+写经 :func:`...scope.apply_write`（**数组整体替换**、``undefined`` 删键，§5.4）+ store 原子写/锁。
+
+- **scope**：``user`` / ``project`` / ``local`` 可写；``flag`` / ``policy`` **只读**（set/edit 拒绝，退出码 1）；
+  ``merged``（默认 show）= 六层合并视图。project/local 需 active workdir。
+- settings.json **无 version 字段**（复刻 CC passthrough，§5）；写不注 version/保护头（``header=None``）。
+- ``edit`` 用 ``$EDITOR`` 打开该层文件，保存后经回调 reconcile（能力层对账 + 重跑 MCP 批准门控）。
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from collections.abc import Awaitable, Callable, Mapping
+from pathlib import Path
+from typing import Any
+
+from a2c_smcp.computer.cli.utils import console
+from a2c_smcp.computer.settings.policy import resolve_policy_settings
+from a2c_smcp.computer.settings.schema import SettingsScope
+from a2c_smcp.computer.settings.scope import (
+    apply_write,
+    load_settings_file,
+    resolve_settings,
+    user_settings_path,
+    workdir_local_settings_path,
+    workdir_project_settings_path,
+)
+from a2c_smcp.computer.settings.store import atomic_write_json, file_lock
+
+EXIT_OK = 0
+EXIT_USER_ERROR = 1
+
+# 可读 scope（show/get）/ readable scopes；可写 scope（set/edit）/ writable scopes。
+_READABLE = ("user", "project", "local", "flag", "policy", "merged")
+_WRITABLE = {"user", "project", "local"}
+
+
+def _err(msg: str, *, json_output: bool) -> int:
+    if json_output:
+        console.print_json(data={"error": msg})
+    else:
+        console.print(f"[red]✗ {msg}[/red]")
+    return EXIT_USER_ERROR
+
+
+def _flag_value(args: list[str], flag: str) -> str | None:
+    if flag in args:
+        idx = args.index(flag)
+        if idx + 1 < len(args) and not args[idx + 1].startswith("--"):
+            return args[idx + 1]
+    return None
+
+
+def _writable_path(scope: str, active_workdir: Path | None, env: Mapping[str, str] | None) -> tuple[Path, SettingsScope]:
+    """解析可写 scope 的 settings.json 路径 + enum；flag/policy/unknown → ``ValueError``。"""
+    if scope == "user":
+        return user_settings_path(env), SettingsScope.USER
+    if scope in ("project", "local"):
+        if active_workdir is None:
+            raise ValueError(f"scope {scope!r} requires an active workdir (use --add-dir at startup)")
+        if scope == "project":
+            return workdir_project_settings_path(active_workdir), SettingsScope.PROJECT
+        return workdir_local_settings_path(active_workdir), SettingsScope.LOCAL
+    raise ValueError(f"scope {scope!r} is read-only (writable: user|project|local)")
+
+
+def _merged(
+    home: Path,
+    env: Mapping[str, str] | None,
+    registered_workdirs: tuple[Path, ...],
+    active_workdir: Path | None,
+    flag_path: Path | None,
+) -> dict[str, Any]:
+    """六层合并 settings（含 policy first-source-wins）/ Six-layer merged settings incl. policy。"""
+    return resolve_settings(
+        registered_workdirs=registered_workdirs,
+        active_workdir=active_workdir,
+        env=env,
+        flag_settings_path=flag_path,
+        policy_settings=resolve_policy_settings(env=env),
+    ).settings
+
+
+def _read_scope(
+    scope: str,
+    home: Path,
+    env: Mapping[str, str] | None,
+    *,
+    registered_workdirs: tuple[Path, ...],
+    active_workdir: Path | None,
+    flag_path: Path | None,
+) -> dict[str, Any] | None:
+    """读单 scope（或 merged）settings dict；scope 非法或缺 active workdir → ``None``（调用方报错）。"""
+    if scope == "merged":
+        return _merged(home, env, registered_workdirs, active_workdir, flag_path)
+    if scope == "user":
+        return load_settings_file(user_settings_path(env), SettingsScope.USER)[0]
+    if scope in ("project", "local"):
+        if active_workdir is None:
+            return None
+        path = workdir_project_settings_path(active_workdir) if scope == "project" else workdir_local_settings_path(active_workdir)
+        enum = SettingsScope.PROJECT if scope == "project" else SettingsScope.LOCAL
+        return load_settings_file(path, enum)[0]
+    if scope == "flag":
+        if flag_path is None:
+            return {}
+        return load_settings_file(flag_path, SettingsScope.FLAG)[0]
+    if scope == "policy":
+        return resolve_policy_settings(env=env)
+    return None
+
+
+# ── handlers ──────────────────────────────────────────────────────────────────
+def settings_show(
+    home: Path,
+    env: Mapping[str, str] | None,
+    *,
+    scope: str = "merged",
+    registered_workdirs: tuple[Path, ...] = (),
+    active_workdir: Path | None = None,
+    flag_path: Path | None = None,
+    json_output: bool = False,
+) -> int:
+    """展示某 scope 的 settings（默认 merged 合并视图）/ Show settings of a scope (default merged)。"""
+    if scope not in _READABLE:
+        return _err(f"unknown scope {scope!r} (expected {'|'.join(_READABLE)})", json_output=json_output)
+    data = _read_scope(scope, home, env, registered_workdirs=registered_workdirs, active_workdir=active_workdir, flag_path=flag_path)
+    if data is None:
+        return _err(f"scope {scope!r} requires an active workdir (use --add-dir at startup)", json_output=json_output)
+    console.print_json(data=data)
+    return EXIT_OK
+
+
+def settings_get(
+    home: Path,
+    env: Mapping[str, str] | None,
+    key: str,
+    *,
+    scope: str = "merged",
+    registered_workdirs: tuple[Path, ...] = (),
+    active_workdir: Path | None = None,
+    flag_path: Path | None = None,
+    json_output: bool = False,
+) -> int:
+    """读取单字段（默认 merged 视图）/ Read a single field (default merged view)。"""
+    if scope not in _READABLE:
+        return _err(f"unknown scope {scope!r} (expected {'|'.join(_READABLE)})", json_output=json_output)
+    data = _read_scope(scope, home, env, registered_workdirs=registered_workdirs, active_workdir=active_workdir, flag_path=flag_path)
+    if data is None:
+        return _err(f"scope {scope!r} requires an active workdir (use --add-dir at startup)", json_output=json_output)
+    if key not in data:
+        return _err(f"key {key!r} not set in scope {scope!r}", json_output=json_output)
+    console.print_json(data={key: data[key]})
+    return EXIT_OK
+
+
+def settings_set(
+    home: Path,
+    env: Mapping[str, str] | None,
+    key: str,
+    value: str,
+    *,
+    scope: str = "user",
+    active_workdir: Path | None = None,
+    json_output: bool = False,
+) -> int:
+    """写单字段（user|project|local；flag/policy 只读）/ Write a single field (flag/policy read-only)。
+
+    值解析：JSON 优先（``true`` / ``["a","b"]`` / ``{...}``），失败回退字面字符串。写经 ``apply_write``——
+    对象递归深合并、**数组整体替换**、``null`` 删键（§5.4）。
+    """
+    if scope not in _WRITABLE:
+        return _err(f"scope {scope!r} is read-only (writable: {'|'.join(sorted(_WRITABLE))})", json_output=json_output)
+    try:
+        path, enum = _writable_path(scope, active_workdir, env)
+    except ValueError as e:
+        return _err(str(e), json_output=json_output)
+
+    try:
+        parsed: Any = json.loads(value)
+    except (json.JSONDecodeError, ValueError):
+        parsed = value  # 回退字面字符串 / fall back to a literal string
+
+    with file_lock(path):
+        existing, _errors = load_settings_file(path, enum)
+        updated = apply_write(existing, {key: parsed})
+        atomic_write_json(path, updated)
+
+    if json_output:
+        console.print_json(data={"scope": scope, "key": key, "value": parsed})
+        return EXIT_OK
+    console.print(f"[green]✓ set {key} in {scope} scope[/green]")
+    return EXIT_OK
+
+
+def settings_edit(
+    home: Path,
+    env: Mapping[str, str] | None,
+    *,
+    scope: str = "user",
+    active_workdir: Path | None = None,
+    editor: str | None = None,
+    reconcile_cb: Callable[[], Awaitable[None]] | None = None,
+    json_output: bool = False,
+) -> tuple[int, Callable[[], Awaitable[None]] | None]:
+    """用 ``$EDITOR`` 打开该层 settings.json，保存后交回 reconcile 回调（由 dispatcher await）/ Open in $EDITOR。
+
+    返回 ``(exit_code, post_save)``——``post_save`` 为 ``reconcile_cb``（仅编辑成功时非 None），由 async 调用方
+    await（本函数同步，子进程阻塞期 REPL 暂停）。flag/policy 只读 → 退出码 1。
+    """
+    if scope not in _WRITABLE:
+        return _err(f"scope {scope!r} is read-only (editable: {'|'.join(sorted(_WRITABLE))})", json_output=json_output), None
+    try:
+        path, _enum = _writable_path(scope, active_workdir, env)
+    except ValueError as e:
+        return _err(str(e), json_output=json_output), None
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if not path.exists():
+        path.write_text("{\n}\n", encoding="utf-8")  # 空骨架，便于编辑 / empty skeleton
+
+    edit_cmd = editor or (env or os.environ).get("EDITOR") or (env or os.environ).get("VISUAL") or "vi"
+    try:
+        subprocess.run([*edit_cmd.split(), str(path)], check=True)  # noqa: S603 — $EDITOR 子进程（CLI 运行时，非沙箱）
+    except (subprocess.CalledProcessError, FileNotFoundError) as e:
+        return _err(f"editor failed: {e}", json_output=json_output), None
+
+    console.print(f"[green]✓ edited {scope} settings ({path})[/green]")
+    return EXIT_OK, reconcile_cb
+
+
+# ── REPL dispatcher ────────────────────────────────────────────────────────────
+async def repl_dispatch(comp: Any, parts: list[str], *, session: Any) -> None:
+    """``settings show|get|set|edit ...`` REPL 行解析 → 调 handler / Parse a REPL settings line。"""
+    sub = parts[1].lower()
+    args = parts[2:]
+    home = comp.skill_home
+    env = os.environ
+    json_output = "--json" in args
+    pos = [a for a in args if not a.startswith("--")]
+    scope = _flag_value(args, "--scope")
+    registered = comp._registered_workdirs
+    aw = comp.active_workdir
+
+    if sub == "show":
+        settings_show(
+            home, env, scope=scope or "merged",
+            registered_workdirs=registered, active_workdir=aw, json_output=json_output,
+        )
+    elif sub == "get":
+        if not pos:
+            console.print("[yellow]usage: settings get <key> [--scope user|project|local|flag|policy|merged][/yellow]")
+            return
+        settings_get(
+            home, env, pos[0], scope=scope or "merged",
+            registered_workdirs=registered, active_workdir=aw, json_output=json_output,
+        )
+    elif sub == "set":
+        if len(pos) < 2:
+            console.print("[yellow]usage: settings set <key> <value> [--scope user|project|local][/yellow]")
+            return
+        # value = key 之后的整段（允许含空格的 JSON）/ value is everything after the key.
+        raw = " ".join(parts[2:])
+        value = raw.split(pos[0], 1)[1].strip() if pos[0] in raw else pos[1]
+        value = _strip_scope_flag(value)
+        code = settings_set(home, env, pos[0], value, scope=scope or "user", active_workdir=aw, json_output=json_output)
+        _emit_keys = {"enabledPlugins", "enabledMcpjsonServers", "disabledMcpjsonServers", "enableAllProjectMcpServers"}
+        if code == EXIT_OK and pos[0] in _emit_keys:
+            comp.mark_skills_dirty()
+    elif sub == "edit":
+        code, post_save = settings_edit(home, env, scope=scope or "user", active_workdir=aw, reconcile_cb=None, json_output=json_output)
+        if code == EXIT_OK:
+            comp.mark_skills_dirty()  # 编辑可能改 enabledPlugins/MCP 字段 → 触发去抖 emit
+            if post_save is not None:
+                await post_save()
+    else:
+        console.print(f"[yellow]unknown settings subcommand: {sub}[/yellow]")
+
+
+def _strip_scope_flag(value: str) -> str:
+    """从 set 的 value 段剥掉尾随的 ``--scope X`` / ``--json``（REPL 简化：flag 可在 value 后）。"""
+    for flag in ("--json",):
+        value = value.replace(flag, "")
+    if "--scope" in value:
+        value = value.split("--scope", 1)[0]
+    return value.strip()

--- a/a2c_smcp/computer/cli/commands/skill.py
+++ b/a2c_smcp/computer/cli/commands/skill.py
@@ -21,6 +21,7 @@ from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
+from a2c_smcp.computer.cli.commands import flag_value
 from a2c_smcp.computer.cli.utils import console
 from a2c_smcp.computer.skills.home import SOURCE_MARKETPLACE, SOURCE_MCP, SOURCE_USER
 from a2c_smcp.computer.skills.registry import SkillRegistry
@@ -127,7 +128,7 @@ def repl_dispatch(comp: Any, parts: list[str]) -> None:
     registry: SkillRegistry = comp.skill_registry
 
     if sub == "list":
-        skill_list(registry, source=_flag_value(args, "--source"), json_output=json_output)
+        skill_list(registry, source=flag_value(args, "--source"), json_output=json_output)
     elif sub == "info":
         if not pos:
             console.print("[yellow]usage: skill info <name>[/yellow]")
@@ -135,11 +136,3 @@ def repl_dispatch(comp: Any, parts: list[str]) -> None:
         skill_info(registry, pos[0], json_output=json_output)
     else:
         console.print(f"[yellow]unknown skill subcommand: {sub}[/yellow]")
-
-
-def _flag_value(args: list[str], flag: str) -> str | None:
-    if flag in args:
-        idx = args.index(flag)
-        if idx + 1 < len(args) and not args[idx + 1].startswith("--"):
-            return args[idx + 1]
-    return None

--- a/a2c_smcp/computer/cli/completer.py
+++ b/a2c_smcp/computer/cli/completer.py
@@ -31,6 +31,16 @@ logger = get_logger(__name__)
 # 触发动态名补全的 (namespace, subcommand) / commands whose positional arg is a dynamic name。
 _DYNAMIC_MARKETPLACE = {("marketplace", s) for s in ("info", "remove", "refresh", "set")}
 _DYNAMIC_SKILL = {("skill", "info")}
+# plugin 位置参数补 installed plugin id（取 installed_plugins.json）；install 补 available 暂不实现（返 []）。
+_DYNAMIC_PLUGIN = {("plugin", s) for s in ("uninstall", "enable", "disable", "info")}
+# settings get/set 的 key 补已知 settings.json 字段名（schema FIELD_* 集，静态）。
+_DYNAMIC_SETTINGS = {("settings", "get"), ("settings", "set")}
+# 已知 settings.json 顶层字段（与 schema.py FIELD_* 对齐；completer 静态名集，无需运行时反射）。
+_SETTINGS_KEYS = (
+    "extraKnownMarketplaces", "enabledPlugins", "strictKnownMarketplaces", "trustedMarketplaces",
+    "blockedMarketplaces", "enableAllProjectMcpServers", "enabledMcpjsonServers", "disabledMcpjsonServers",
+    "allowedMcpServers", "deniedMcpServers", "permissions",
+)
 
 
 class A2CCompleter(Completer):
@@ -72,10 +82,16 @@ class A2CCompleter(Completer):
                 return list((load_known_marketplaces(self._comp.skill_home, os.environ).get("marketplaces") or {}).keys())
             if (ns, sub) in _DYNAMIC_SKILL:
                 return [str(r.get("name")) for r in self._comp.get_skills() if r.get("name")]
+            if (ns, sub) in _DYNAMIC_PLUGIN:
+                from a2c_smcp.computer.settings.store import load_installed_plugins
+
+                return list((load_installed_plugins(self._comp.skill_home, os.environ).get("plugins") or {}).keys())
+            if (ns, sub) in _DYNAMIC_SETTINGS:
+                return list(_SETTINGS_KEYS)
         except Exception as e:  # 动态取名失败不应打断补全；记 DEBUG 便于排障（含编程错）/ never break completion
             logger.debug("completer: dynamic-name lookup for (%s %s) failed (%s)", ns, sub, e)
             return []
-        return []  # plugin / settings 动态名 → #69
+        return []
 
     @staticmethod
     def _match(candidates: Iterable[str], prefix: str) -> Iterator[Completion]:

--- a/a2c_smcp/computer/cli/help.py
+++ b/a2c_smcp/computer/cli/help.py
@@ -23,11 +23,11 @@ NAMESPACES: dict[str, str] = {
     "server": "MCP server lifecycle (add / rm / start / stop)",
     "inputs": "Input definitions and values",
     "marketplace": "SKILL marketplaces (git sources)",
-    "plugin": "Plugins — skill+mcp bundles (see #69)",
+    "plugin": "Plugins — skill+mcp bundles (install / enable / list ...)",
     "skill": "Skills cross-source query (list / info)",
     "socket": "Socket.IO connection control",
     "notify": "Send notifications to Agent",
-    "settings": "Edit settings.json files (see #69)",
+    "settings": "settings.json intent layer (show / get / set / edit)",
     "utility": "status / tools / mcp / desktop / render / tc / history",
 }
 
@@ -53,7 +53,12 @@ NAMESPACE_COMMANDS: dict[str, list[tuple[str, str]]] = {
         ("marketplace set <name> auto-update=<bool>", "设置 per-source auto-update / set flag"),
     ],
     "plugin": [
-        ("plugin install|uninstall|enable|disable|list|info", "（#69 落地）/ implemented in #69"),
+        ("plugin install <plugin>@<mp> [--version V] [--scope S]", "安装 plugin（外来 MCP 同名硬抛）/ install (name conflict aborts)"),
+        ("plugin uninstall <plugin>@<mp> [--keep-servers]", "卸载 plugin / uninstall"),
+        ("plugin enable|disable <plugin>@<mp>", "启用 / 禁用（整 plugin 上/下线）/ enable / disable (whole plugin)"),
+        ("plugin list [--available] [--json]", "列出 installed plugin / list plugins"),
+        ("plugin info <plugin>@<mp> [--json]", "plugin 详情 / plugin detail"),
+        ("plugin gc", "清理孤儿 plugin / gc orphan plugins"),
     ],
     "skill": [
         ("skill list [--source mp|mcp|user] [--json]", "跨源列出可见 SKILL / list skills"),
@@ -65,7 +70,12 @@ NAMESPACE_COMMANDS: dict[str, list[tuple[str, str]]] = {
         ("socket leave", "离开房间 / leave office"),
     ],
     "notify": [("notify update", "触发配置更新通知 / emit config updated notification")],
-    "settings": [("settings show|edit|get|set", "（#69 落地）/ implemented in #69")],
+    "settings": [
+        ("settings show [--scope user|project|local|flag|policy|merged]", "展示某 scope（默认 merged）/ show a scope (default merged)"),
+        ("settings get <key> [--scope ...]", "读取单字段 / read a field"),
+        ("settings set <key> <value> [--scope user|project|local]", "写单字段（flag/policy 只读）/ set a field (flag/policy read-only)"),
+        ("settings edit [--scope user|project|local]", "$EDITOR 编辑 + 保存后 reconcile / edit then reconcile"),
+    ],
     "utility": [
         ("status", "查看服务器状态 / show server status"),
         ("tools", "列出可用工具 / list tools"),
@@ -107,6 +117,17 @@ FLAGS: dict[tuple[str, str], list[str]] = {
     ("marketplace", "set"): ["--json"],
     ("skill", "list"): ["--source", "--json"],
     ("skill", "info"): ["--json"],
+    ("plugin", "install"): ["--version", "--scope", "--json"],
+    ("plugin", "uninstall"): ["--keep-servers", "--json"],
+    ("plugin", "enable"): ["--json"],
+    ("plugin", "disable"): ["--json"],
+    ("plugin", "list"): ["--available", "--json"],
+    ("plugin", "info"): ["--json"],
+    ("plugin", "gc"): ["--json"],
+    ("settings", "show"): ["--scope", "--json"],
+    ("settings", "get"): ["--scope", "--json"],
+    ("settings", "set"): ["--scope", "--json"],
+    ("settings", "edit"): ["--scope", "--json"],
 }
 
 

--- a/a2c_smcp/computer/cli/interactive_impl.py
+++ b/a2c_smcp/computer/cli/interactive_impl.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import json
 import os
+import sys
 from contextlib import AbstractContextManager
 from pathlib import Path
 from typing import Any, Protocol
@@ -24,6 +25,8 @@ from pydantic import TypeAdapter
 
 from a2c_smcp.computer.cli.banner import render_banner
 from a2c_smcp.computer.cli.commands import marketplace as mp_cmd
+from a2c_smcp.computer.cli.commands import plugin as plugin_cmd
+from a2c_smcp.computer.cli.commands import settings as settings_cmd
 from a2c_smcp.computer.cli.commands import skill as skill_cmd
 from a2c_smcp.computer.cli.help import render_help
 from a2c_smcp.computer.cli.utils import console, parse_kv_pairs, print_mcp_config, print_status, print_tools
@@ -54,12 +57,15 @@ async def interactive_loop(
     smcp_client_cls: type[Any],
     init_client: Any | None = None,
     completer: Completer | None = None,
+    approve_all_mcp: bool = False,
+    mcp_flag_config: Path | None = None,
 ) -> None:
     """
     中文: 交互循环的可注入实现；从 main.py 传入 PromptSession 工厂、patch_stdout 上下文与 SMCP 客户端类。
     English: DI-friendly interactive loop; main.py passes PromptSession factory, patch_stdout ctx and SMCP client class.
 
     completer: 可选 Tab 补全器（逐次传入 ``prompt_async``，trust y/N 等子提示不带补全）/ optional Tab completer.
+    approve_all_mcp / mcp_flag_config: 全局 flag ``--approve-all-mcp`` / ``--settings <file>``，透传给启动期 MCP 批准框（#69 Group B）。
     """
     session = session_factory()
     smcp_client = init_client
@@ -74,6 +80,14 @@ async def interactive_loop(
     # 后者会 ensure_skill_home() 强制解析并创建目录，而 banner 仅需"未启动=None→物化计数按 0"语义，不应在
     # 此处产生副作用（尤其未经 boot_up 的单测路径）。/ read raw _skill_home to avoid forcing resolution.
     render_banner(comp, comp._skill_home, os.environ)
+
+    # 启动期 MCP 批准框（§9.2，#69 Group B）：解析 .tfrobot/mcp.json 定义层 → 门控 → 挂载 ENABLED / 弹 PENDING。
+    # 非 TTY（管道/CI）→ 传 session=None 走 skip+WARN / --approve-all-mcp 分支（避免 prompt_async 在无终端下 EOF）。
+    try:
+        approval_session = session if sys.stdin.isatty() else None
+        await plugin_cmd.run_mcp_approval(comp, approval_session, approve_all=approve_all_mcp, flag_config=mcp_flag_config)
+    except Exception as e:  # pragma: no cover - 批准框失败不阻断进入 REPL
+        console.print(f"[yellow]⚠ MCP 批准门控初始化失败 / MCP approval init failed: {e}[/yellow]")
 
     while True:
         try:
@@ -497,6 +511,14 @@ async def interactive_loop(
             elif cmd == "skill" and len(parts) >= 2:
                 # v0.2.1 跨源 SKILL 只读查询（list / info，§4.4）；直读 Computer 活跃 registry。
                 skill_cmd.repl_dispatch(comp, parts)
+
+            elif cmd == "plugin" and len(parts) >= 2:
+                # v0.2.1 plugin 管理（install/uninstall/enable/disable/list/info/gc，§4.3，S16 #69）；变更后触发去抖 emit。
+                await plugin_cmd.repl_dispatch(comp, parts, session=session)
+
+            elif cmd == "settings" and len(parts) >= 2:
+                # v0.2.1 settings 意图层增删改查（show/get/set/edit，§4.5，S16 #69）。
+                await settings_cmd.repl_dispatch(comp, parts, session=session)
 
             else:
                 console.print("[yellow]未知命令 / Unknown command[/yellow]")

--- a/a2c_smcp/computer/cli/main.py
+++ b/a2c_smcp/computer/cli/main.py
@@ -25,6 +25,8 @@ from prompt_toolkit.patch_stdout import patch_stdout
 from pydantic import TypeAdapter
 
 from a2c_smcp.computer.cli.commands import marketplace as mp_cmd
+from a2c_smcp.computer.cli.commands import plugin as plugin_cmd
+from a2c_smcp.computer.cli.commands import settings as settings_cmd
 from a2c_smcp.computer.cli.commands import skill as skill_cmd
 from a2c_smcp.computer.cli.completer import A2CCompleter
 from a2c_smcp.computer.cli.interactive_impl import interactive_loop as _interactive_loop_impl
@@ -48,6 +50,12 @@ from a2c_smcp.smcp import MCPServerInput as SMCPServerInputDict
 app = typer.Typer(add_completion=False, help="A2C Computer CLI")
 # 使用全局 Console（引用模块属性，便于后续动态切换）
 console = console_util.console
+
+# ``--add-dir`` 是可重复 list 选项；提取为模块级 OptionInfo 单例规避 ruff B008（list 注解 + call-in-default），
+# 为 ruff 官方推荐做法。``_root`` 与 ``run`` 共用同一选项定义。/ module-level Option singleton to satisfy B008.
+_ADD_DIR_OPTION = typer.Option(
+    None, "--add-dir", help="注册工作目录（可重复；首个作 active-workdir）/ register a workdir (repeatable)",
+)
 
 
 # ------------------------------
@@ -98,6 +106,14 @@ def _root(
         "--no-color",
         help="关闭彩色输出（PyCharm控制台不渲染ANSI时可使用） / Disable ANSI colors",
     ),
+    json_output: bool = typer.Option(False, "--json", help="非交互默认 JSON 输出（子命令亦各带 --json）/ JSON output"),
+    settings_file: str | None = typer.Option(
+        None, "--settings", help="额外 settings.json（flag scope，最低优先级）/ extra settings.json (flag scope)",
+    ),
+    add_dir: list[str] | None = _ADD_DIR_OPTION,
+    approve_all_mcp: bool = typer.Option(
+        False, "--approve-all-mcp", help="启动期全批 pending MCP server（仅本次、不落盘）/ approve all pending MCP (this run)",
+    ),
 ) -> None:
     """
     根级入口：
@@ -124,10 +140,19 @@ def _root(
             computer_factory=computer_factory,
             config=None,
             inputs=None,
+            add_dir=add_dir,
+            approve_all_mcp=approve_all_mcp,
+            settings_file=settings_file,
         )
 
 
-async def _interactive_loop(comp: Computer, init_client: SMCPComputerClient | None = None) -> None:
+async def _interactive_loop(
+    comp: Computer,
+    init_client: SMCPComputerClient | None = None,
+    *,
+    approve_all_mcp: bool = False,
+    mcp_flag_config: Path | None = None,
+) -> None:
     """
     中文: 兼容外部引用的包装器，委托到 interactive_impl，并注入依赖。
     English: Backward-compatible wrapper that delegates to interactive_impl with dependencies injected.
@@ -139,6 +164,8 @@ async def _interactive_loop(comp: Computer, init_client: SMCPComputerClient | No
         smcp_client_cls=SMCPComputerClient,
         init_client=init_client,
         completer=A2CCompleter(comp),
+        approve_all_mcp=approve_all_mcp,
+        mcp_flag_config=mcp_flag_config,
     )
 
 
@@ -153,10 +180,17 @@ def _run_impl(
     computer_factory: str | None,
     config: str | None,
     inputs: str | None,
+    add_dir: list[str] | None = None,
+    approve_all_mcp: bool = False,
+    settings_file: str | None = None,
 ) -> None:
     """
     纯实现函数：不要在此处使用 Typer 的 Option 默认值，避免 OptionInfo 泄露到运行时。
     Both CLI (@app.command) 与回调 (@app.callback) 在需要时调用本函数。
+
+    add_dir / approve_all_mcp / settings_file 来自全局 flag ``--add-dir`` / ``--approve-all-mcp`` / ``--settings``
+    （#69 Group B/D）：``--add-dir`` 注册工作目录（→ ``registered_workdirs`` → ``active_workdir``，project/local
+    scope 与 ``${workspaceFolder}`` 的前置）；后两者透传启动期 MCP 批准框。
     """
 
     async def _amain() -> None:
@@ -175,12 +209,21 @@ def _run_impl(
             console.print("[red]计算机构造目标不可调用，将回退到默认 Computer[/red]")
             comp_factory_obj = Computer
 
+        # --add-dir → registered_workdirs（能力发现并集 + active_workdir=首个）。绝对化去重保序。
+        # 直接调用 run()（绕过 Typer）时 add_dir 可能泄漏 OptionInfo（非 list）→ isinstance 守卫为空（同 computer_factory 容错姿态）。
+        registered_workdirs: list[Path] = []
+        for d in add_dir if isinstance(add_dir, list) else []:
+            rp = Path(d).expanduser().resolve()
+            if rp not in registered_workdirs:
+                registered_workdirs.append(rp)
+
         comp = comp_factory_obj(
             name="friday_hands",
             inputs=set(),
             mcp_servers=set(),
             auto_connect=auto_connect,
             auto_reconnect=auto_reconnect,
+            registered_workdirs=tuple(registered_workdirs) or None,
         )
         async with comp:
             init_client: SMCPComputerClient | None = None
@@ -237,7 +280,13 @@ def _run_impl(
                 except Exception as e:  # pragma: no cover
                     console.print(f"[red]加载 Servers 失败 / Failed to load servers: {e}[/red]")
 
-            await _interactive_loop(comp, init_client=init_client)
+            # settings_file 直接调用 run() 时可能泄漏 OptionInfo → isinstance 守卫（同 add_dir / computer_factory 容错姿态）。
+            await _interactive_loop(
+                comp,
+                init_client=init_client,
+                approve_all_mcp=approve_all_mcp is True,
+                mcp_flag_config=Path(settings_file) if isinstance(settings_file, str) else None,
+            )
 
     asyncio.run(_amain())
 
@@ -275,6 +324,13 @@ def run(
         "-i",
         help="在启动时从文件加载 Inputs 定义（支持 @file 语法或直接文件路径） / Load Inputs from file at startup",
     ),
+    settings_file: str | None = typer.Option(
+        None, "--settings", help="额外 settings.json（flag scope，最低优先级）/ extra settings.json (flag scope)",
+    ),
+    add_dir: list[str] | None = _ADD_DIR_OPTION,
+    approve_all_mcp: bool = typer.Option(
+        False, "--approve-all-mcp", help="启动期全批 pending MCP server（仅本次、不落盘）/ approve all pending MCP (this run)",
+    ),
 ) -> None:
     """
     中文: 启动计算机并进入持续运行模式。后续将支持从配置文件加载 servers 与 inputs。
@@ -290,6 +346,9 @@ def run(
         computer_factory=computer_factory,
         config=config,
         inputs=inputs,
+        add_dir=add_dir,
+        approve_all_mcp=approve_all_mcp,
+        settings_file=settings_file,
     )
 
 
@@ -300,6 +359,10 @@ def run(
 # trust 缺 confirm（confirm=None）→ marketplace add 须显式 --trust，否则退出码 1（§4.6 / §11）。
 marketplace_app = typer.Typer(help="SKILL marketplaces (git sources)")
 skill_app = typer.Typer(help="Skills cross-source query (list / info)")
+# plugin / settings（S16 #69）：非交互无 live Computer → plugin install/enable 走 ledger-only（register=None），
+# MCP server 挂载延到下次 REPL boot 经批准框落地（§4.6）。settings 直读写物化意图层。
+plugin_app = typer.Typer(help="Plugins — skill+mcp bundles (install / enable / list ...)")
+settings_app = typer.Typer(help="settings.json intent layer (show / get / set / edit)")
 
 
 @marketplace_app.command("add")
@@ -389,8 +452,123 @@ def _skill_info(name: str = typer.Argument(...), json_output: bool = typer.Optio
     raise typer.Exit(skill_cmd.skill_info(reg, name, json_output=json_output))
 
 
+# ── plugin 子命令（非交互 ledger-only：无 MCP 回调，挂载延到下次 REPL boot）/ plugin subcommands ──
+@plugin_app.command("install")
+def _plugin_install(
+    plugin_id: str = typer.Argument(..., help="<plugin>@<marketplace>"),
+    scope: str = typer.Option("user", "--scope", help="user|project|local"),
+    version: str | None = typer.Option(None, "--version", help="锁版本（git tag/SHA）/ pin version"),
+    json_output: bool = typer.Option(False, "--json"),
+) -> None:
+    """安装 plugin（非交互 ledger-only；外来 MCP 同名硬抛退出码 1）/ Install a plugin (ledger-only)."""
+    code = asyncio.run(
+        plugin_cmd.plugin_install(
+            SkillRegistry(), ensure_skill_home(), os.environ, plugin_id, scope=scope, version=version, json_output=json_output,
+        ),
+    )
+    raise typer.Exit(code)
+
+
+@plugin_app.command("uninstall")
+def _plugin_uninstall(
+    plugin_id: str = typer.Argument(...),
+    keep_servers: bool = typer.Option(False, "--keep-servers"),
+    json_output: bool = typer.Option(False, "--json"),
+) -> None:
+    """卸载 plugin / Uninstall a plugin."""
+    code = asyncio.run(
+        plugin_cmd.plugin_uninstall(
+            SkillRegistry(), ensure_skill_home(), os.environ, plugin_id, keep_servers=keep_servers, json_output=json_output,
+        ),
+    )
+    raise typer.Exit(code)
+
+
+@plugin_app.command("enable")
+def _plugin_enable(plugin_id: str = typer.Argument(...), json_output: bool = typer.Option(False, "--json")) -> None:
+    """启用 plugin（非交互 ledger-only）/ Enable a plugin (ledger-only)."""
+    code = asyncio.run(
+        plugin_cmd.plugin_enable(SkillRegistry(), ensure_skill_home(), os.environ, plugin_id, json_output=json_output),
+    )
+    raise typer.Exit(code)
+
+
+@plugin_app.command("disable")
+def _plugin_disable(plugin_id: str = typer.Argument(...), json_output: bool = typer.Option(False, "--json")) -> None:
+    """禁用 plugin = 整 plugin 下线 / Disable a plugin (whole-plugin offline)."""
+    code = asyncio.run(
+        plugin_cmd.plugin_disable(SkillRegistry(), ensure_skill_home(), os.environ, plugin_id, json_output=json_output),
+    )
+    raise typer.Exit(code)
+
+
+@plugin_app.command("list")
+def _plugin_list(
+    available: bool = typer.Option(False, "--available", help="含 disabled / include disabled"),
+    json_output: bool = typer.Option(False, "--json"),
+) -> None:
+    """列出 installed plugin / List installed plugins."""
+    raise typer.Exit(plugin_cmd.plugin_list(ensure_skill_home(), os.environ, available=available, json_output=json_output))
+
+
+@plugin_app.command("info")
+def _plugin_info(plugin_id: str = typer.Argument(...), json_output: bool = typer.Option(False, "--json")) -> None:
+    """plugin 详情 / Plugin detail."""
+    raise typer.Exit(plugin_cmd.plugin_info(ensure_skill_home(), os.environ, plugin_id, json_output=json_output))
+
+
+@plugin_app.command("gc")
+def _plugin_gc(json_output: bool = typer.Option(False, "--json")) -> None:
+    """清理孤儿 plugin（非交互无 confirm → 直接清）/ GC orphan plugins (no confirm non-interactively)."""
+    code = asyncio.run(plugin_cmd.plugin_gc(SkillRegistry(), ensure_skill_home(), os.environ, confirm=None, json_output=json_output))
+    raise typer.Exit(code)
+
+
+# ── settings 子命令 / settings subcommands ────────────────────────────────────
+@settings_app.command("show")
+def _settings_show(
+    scope: str = typer.Option("merged", "--scope", help="user|project|local|flag|policy|merged"),
+    json_output: bool = typer.Option(True, "--json", help="JSON 输出（默认开）/ JSON output (default on)"),
+) -> None:
+    """展示某 scope 的 settings（默认 merged）/ Show settings (default merged)."""
+    raise typer.Exit(settings_cmd.settings_show(ensure_skill_home(), os.environ, scope=scope, json_output=json_output))
+
+
+@settings_app.command("get")
+def _settings_get(
+    key: str = typer.Argument(...),
+    scope: str = typer.Option("merged", "--scope"),
+    json_output: bool = typer.Option(True, "--json"),
+) -> None:
+    """读取单字段 / Read a single field."""
+    raise typer.Exit(settings_cmd.settings_get(ensure_skill_home(), os.environ, key, scope=scope, json_output=json_output))
+
+
+@settings_app.command("set")
+def _settings_set(
+    key: str = typer.Argument(...),
+    value: str = typer.Argument(..., help="JSON 优先，回退字面字符串 / JSON preferred, else literal"),
+    scope: str = typer.Option("user", "--scope", help="user|project|local（flag/policy 只读）"),
+    json_output: bool = typer.Option(False, "--json"),
+) -> None:
+    """写单字段（flag/policy 只读）/ Write a single field (flag/policy read-only)."""
+    raise typer.Exit(settings_cmd.settings_set(ensure_skill_home(), os.environ, key, value, scope=scope, json_output=json_output))
+
+
+@settings_app.command("edit")
+def _settings_edit(
+    scope: str = typer.Option("user", "--scope", help="user|project|local"),
+    json_output: bool = typer.Option(False, "--json"),
+) -> None:
+    """用 $EDITOR 打开该层 settings.json（非交互无 reconcile）/ Open settings.json in $EDITOR."""
+    code, _post = settings_cmd.settings_edit(ensure_skill_home(), os.environ, scope=scope, json_output=json_output)
+    raise typer.Exit(code)
+
+
 app.add_typer(marketplace_app, name="marketplace")
 app.add_typer(skill_app, name="skill")
+app.add_typer(plugin_app, name="plugin")
+app.add_typer(settings_app, name="settings")
 
 
 # 为 console_scripts 兼容提供入口

--- a/a2c_smcp/computer/computer.py
+++ b/a2c_smcp/computer/computer.py
@@ -625,11 +625,11 @@ class Computer(BaseComputer[PromptSession]):
         """
         预定义渲染变量（对标 VS Code，§9.1）/ Predefined render variables (VS Code parity)。
 
-        ``workspaceFolder`` 取首个已登记 workdir（绑定当前任务的单根代表），无则 ``os.getcwd()``；
+        ``workspaceFolder`` 取 active-workdir 单根（绑定当前任务，见 :attr:`active_workdir`），无则 ``os.getcwd()``；
         ``userHome``=用户主目录；``pathSeparator``=``os.sep``。``${env:VAR}`` 不在此（由 render 直接读
-        进程环境）。``workspaceFolder`` takes the first registered workdir, else cwd.
+        进程环境）。``workspaceFolder`` takes the active workdir (single bound root), else cwd.
         """
-        workspace = str(self._registered_workdirs[0]) if self._registered_workdirs else os.getcwd()
+        workspace = str(self.active_workdir) if self.active_workdir else os.getcwd()
         return {
             "workspaceFolder": workspace,
             "userHome": os.path.expanduser("~"),
@@ -669,6 +669,8 @@ class Computer(BaseComputer[PromptSession]):
         server: MCPServerConfig | dict[str, Any],
         *,
         session: PromptSession | None = None,
+        plugin: str | None = None,
+        marketplace: str | None = None,
     ) -> MCPServerConfig:
         """
         动态渲染并校验单个 MCP 服务器配置，支持原始字典或模型实例。
@@ -706,7 +708,10 @@ class Computer(BaseComputer[PromptSession]):
         # English: Resolve input value by input_id; raise InputNotFoundError if not defined
         async def _resolve_input_by_id(input_id: str) -> Any:
             try:
-                return await self._input_resolver.aresolve_by_id(input_id, session=session)
+                # plugin/marketplace 上下文（#69 Group A）：bundled server 的裸 ${input:id} 经此回退到
+                # 带前缀池条目 <plugin>@<marketplace>/<id>（§9.3 D2）。非 plugin 来源传 None=现状。
+                # plugin/marketplace context lets a bundled server's bare ${input:id} fall back to the prefixed pool entry.
+                return await self._input_resolver.aresolve_by_id(input_id, session=session, plugin=plugin, marketplace=marketplace)
             except InputNotFoundError:
                 logger.warning(f"未定义的输入占位符: {input_id} / Undefined input placeholder: {input_id}")
                 # 透传异常到上层，由上层决定是否回退或继续
@@ -731,7 +736,14 @@ class Computer(BaseComputer[PromptSession]):
             logger.error(f"动态渲染/校验MCP配置失败: {name} - {e}", exc_info=True)
             raise e
 
-    async def aadd_or_aupdate_server(self, server: MCPServerConfig | dict[str, Any], *, session: PromptSession | None = None) -> None:
+    async def aadd_or_aupdate_server(
+        self,
+        server: MCPServerConfig | dict[str, Any],
+        *,
+        session: PromptSession | None = None,
+        plugin: str | None = None,
+        marketplace: str | None = None,
+    ) -> None:
         """
         动态添加或更新某个MCP Server配置（支持 inputs 占位符解析）。
         Add or update a MCP Server config dynamically (supports inputs placeholder resolving).
@@ -739,6 +751,9 @@ class Computer(BaseComputer[PromptSession]):
         Args:
             session (PromptSession | None): Computer管理Session
             server (MCPServerConfig | dict[str, Any]): 待添加/更新的配置，可为模型或原始字典。
+            plugin / marketplace (str | None): plugin 实时挂载上下文（#69 Group A）；非 None 时 bundled server 的裸
+                ``${input:id}`` 解析到带前缀池条目 ``<plugin>@<marketplace>/<id>``（§9.3 D2）。普通来源传 None=现状。
+                Plugin mount context; when set, a bundled server's bare ``${input:id}`` resolves to the prefixed pool entry.
         """
         # 确保 manager 已初始化
         if self.mcp_manager is None:
@@ -748,7 +763,7 @@ class Computer(BaseComputer[PromptSession]):
                 message_handler=self._on_manager_change,
             )
 
-        validated = await self._arender_and_validate_server(server, session=session)
+        validated = await self._arender_and_validate_server(server, session=session, plugin=plugin, marketplace=marketplace)
         await self.mcp_manager.aadd_or_aupdate_server(validated)
 
     async def aremove_server(self, server_name: str, *, session: PromptSession | None = None) -> None:
@@ -1151,6 +1166,17 @@ class Computer(BaseComputer[PromptSession]):
         if self._skill_home is None:
             self._skill_home = self._resolve_skill_home()
         return self._skill_home
+
+    @property
+    def active_workdir(self) -> Path | None:
+        """绑定当前任务的 active-workdir 单根（取首个已登记 workdir，空闲=None）/ The single active workdir (None when idle)。
+
+        北极星（#53）两层模型：本属性是 **project/local scope 来源**（``.tfrobot/settings[.local].json`` /
+        ``mcp.json``）与渲染 ``${workspaceFolder}`` 的**单一事实源**；而 :attr:`_registered_workdirs` 作能力发现
+        并集（DropIn 扫描 / watcher）跨全部目录、不随 active 跳变。``resolve_mcp_config`` / ``resolve_settings``
+        的 ``active_workdir`` 与 MCP 批准框写 local 均经此（#69 Group B/C）。
+        """
+        return self._registered_workdirs[0] if self._registered_workdirs else None
 
     def mark_skills_dirty(self) -> None:
         """标记 SKILL 集合变更 → 去抖器在窗口内合并触发单次 ``emit_update_skills``（CLI marketplace 变更后调）。

--- a/a2c_smcp/computer/settings/installer.py
+++ b/a2c_smcp/computer/settings/installer.py
@@ -107,6 +107,9 @@ ExistingServerNames = Callable[[], set[str]]
 RegisterServer = Callable[[MCPServerConfig], Awaitable[None]]
 # 停止并移除一个 server（异步；CLI 包 ``Computer.aremove_server``）。
 RemoveServer = Callable[[str], Awaitable[None]]
+# 注入 plugin-scoped inputs 入池（异步；入参 plugin_root；CLI 包 ``load_plugin_inputs`` → ``Computer.add_or_update_input``）。
+# 在 register（→render bundled server 的 ${input:}）之前调，使裸 id 可经 D2 前缀回退解析（#69 Group A，§9.3 D2）。
+InjectInputs = Callable[[Path], Awaitable[None]]
 
 
 # ---------------------------------------------------------------------------
@@ -261,6 +264,7 @@ async def install_plugin(
     existing_server_names: ExistingServerNames | None = None,
     register_server: RegisterServer | None = None,
     remove_server: RemoveServer | None = None,
+    inject_inputs: InjectInputs | None = None,
 ) -> InstalledPluginRecord:
     """
     显式安装单个 plugin（**原子失败：冲突即抛、不留半装**）/ Install one plugin atomically。
@@ -282,6 +286,8 @@ async def install_plugin(
         锁版本由 entry source 的 ref 治理（version 仅作记录）。
     :param existing_server_names / register_server / remove_server: MCP 注入回调（``None`` = ledger-only）。
         **契约**：给了 ``register_server`` 就必须给 ``existing_server_names``（否则冲突闸门被静默旁路，违 §10.6）。
+    :param inject_inputs: 可选 plugin-scoped inputs 注入 hook（入参 ``plugin_root``）；在冲突闸门后、register 前调一次
+        （#69 Group A，§9.3 D2）。``None`` = 不注入。注入失败走补偿回滚上抛；注入的 inputs 不回滚（无害）。
     :return: 写入的 :class:`InstalledPluginRecord`。
     """
     plugin, marketplace = _split_plugin_id(plugin_id)
@@ -323,6 +329,11 @@ async def install_plugin(
     skills_before = set(_plugin_skill_names(registry, marketplace, plugin))
     registered: list[str] = []
     try:
+        # 注入 plugin-scoped inputs 入池（#69 Group A）：须在 register（→render bundled server 的 ``${input:}``）之前，
+        # 使裸 id 经 D2 前缀回退命中带前缀池条目。失败即走下方补偿回滚上抛；inputs 注入本身**不回滚**
+        # （悬空前缀 def 无害——仅在被引用时消费，而该 cfg 已回滚不挂载）。
+        if inject_inputs is not None:
+            await inject_inputs(plugin_root)
         if register_server is not None:
             for cfg in servers:
                 await register_server(cfg)

--- a/tests/e2e/computer/test_cli_plugin_settings_e2e.py
+++ b/tests/e2e/computer/test_cli_plugin_settings_e2e.py
@@ -1,0 +1,128 @@
+# -*- coding: utf-8 -*-
+# filename: test_cli_plugin_settings_e2e.py
+# @Time    : 2026/05/27
+# @Author  : JQQ
+# @Email   : jqq1716@gmail.com
+# @Software: PyCharm
+"""
+``plugin`` / ``settings`` 非交互 Typer 子命令 E2E（v0.2.1 #69）/ Plugin & settings non-interactive CLI E2E。
+
+设计依据 / Design: python-sdk docs/design-0.2.1-cli-marketplace-ux.md §4.3 / §4.5 / §4.6 验收（S16）。
+
+以 ``subprocess`` 跑真 ``a2c-computer`` 进程（确定性、无 TTY、无 MCP spawn；A2C_SKILL_HOME / XDG_* → tmp 隔离）:
+- marketplace add --trust → plugin install（**ledger-only**：非交互无 MCP 回调 → 不挂载 bundled server）→ list →
+  enable → info（§4.6 非交互姿态：MCP 挂载延到下次 REPL boot 经批准框落地）；
+- settings set/get/show 五级 scope；flag/policy **只读** → 退出码 1；plugin install 非法 id → 退出码 1。
+
+说明 / Note：plugin install **外来 MCP 同名硬抛**（§10.6）与 **MCP 批准框 y/a/n + 重启幂等**（§9.2）须 live
+Computer + MCP 注入回调（仅 REPL；非交互为 ledger-only、无冲突闸门），已由单测充分覆盖
+（``tests/unit_tests/computer/cli/test_plugin.py`` / ``test_mcp_approval.py``）；此处聚焦非交互真进程行为。
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+requires_git = pytest.mark.skipif(shutil.which("git") is None, reason="requires the git binary")
+
+_GIT_IDENTITY = ["-c", "user.email=test@example.com", "-c", "user.name=Test", "-c", "commit.gpgsign=false"]
+
+
+def _git(cwd: Path, *args: str) -> None:
+    subprocess.run(["git", *_GIT_IDENTITY, *args], cwd=str(cwd), check=True, capture_output=True, text=True)
+
+
+def _make_bare(tmp_path: Path) -> Path:
+    """裸仓：marketplace ``acme`` → plugin ``audit``（带 1 skill + bundled MCP server ``figma-mcp``）。"""
+    manifest = {
+        "name": "acme-skills",
+        "owner": {"name": "Acme"},
+        "metadata": {"pluginRoot": "./plugins"},
+        "plugins": [{"name": "audit", "source": "audit", "version": "1.0.0"}],
+    }
+    work = tmp_path / "acme-work"
+    (work / ".tfrobot-plugin").mkdir(parents=True, exist_ok=True)
+    (work / ".tfrobot-plugin" / "marketplace.json").write_text(json.dumps(manifest), encoding="utf-8")
+    skill = work / "plugins" / "audit" / "skills" / "audit-code" / "SKILL.md"
+    skill.parent.mkdir(parents=True, exist_ok=True)
+    skill.write_text("---\nname: audit-code\ndescription: a skill\nlicense: MIT\n---\n# audit-code\nbody\n", encoding="utf-8")
+    srv = work / "plugins" / "audit" / "mcp-servers" / "figma-mcp.json"
+    srv.parent.mkdir(parents=True, exist_ok=True)
+    srv.write_text(json.dumps({"name": "figma-mcp", "type": "stdio", "server_parameters": {"command": "cat"}}), encoding="utf-8")
+    _git(work, "init", "-q", "-b", "main")
+    _git(work, "add", "-A")
+    _git(work, "commit", "-q", "-m", "init")
+    bare = tmp_path / "acme.git"
+    _git(tmp_path, "clone", "-q", "--bare", str(work), str(bare))
+    return bare
+
+
+def _cli_env(tmp_path: Path) -> dict[str, str]:
+    return {
+        **os.environ,
+        "A2C_SKILL_HOME": str(tmp_path / "home"),
+        "XDG_CONFIG_HOME": str(tmp_path / "cfg"),
+        "XDG_STATE_HOME": str(tmp_path / "state"),
+        "XDG_DATA_HOME": str(tmp_path / "data"),
+    }
+
+
+def _run_cli(env: dict[str, str], *args: str) -> subprocess.CompletedProcess[str]:
+    """非交互调用 a2c-computer 子命令（console script 优先，回退 python -c main()）。"""
+    exe = shutil.which("a2c-computer")
+    cmd = [exe, *args] if exe else [sys.executable, "-c", "from a2c_smcp.computer.cli.main import main; main()", *args]
+    return subprocess.run(cmd, env=env, capture_output=True, text=True, timeout=120)
+
+
+@pytest.mark.e2e
+@requires_git
+def test_plugin_install_enable_list_noninteractive(tmp_path: Path) -> None:
+    env = _cli_env(tmp_path)
+    bare = _make_bare(tmp_path)
+
+    # marketplace add --trust → clone catalog
+    r = _run_cli(env, "marketplace", "add", f"file://{bare}", "--name", "acme", "--trust", "--json")
+    assert r.returncode == 0, r.stderr + r.stdout
+
+    # plugin install（非交互 ledger-only：无 MCP 回调 → 不挂载、记账本）
+    r = _run_cli(env, "plugin", "install", "audit@acme", "--json")
+    assert r.returncode == 0, r.stderr + r.stdout
+
+    # plugin list → 含 audit@acme
+    r = _run_cli(env, "plugin", "list", "--json")
+    assert r.returncode == 0 and "audit@acme" in r.stdout
+
+    # plugin enable / info
+    assert _run_cli(env, "plugin", "enable", "audit@acme", "--json").returncode == 0
+    r = _run_cli(env, "plugin", "info", "audit@acme", "--json")
+    assert r.returncode == 0 and "audit@acme" in r.stdout
+
+
+@pytest.mark.e2e
+def test_settings_set_get_show_and_readonly_noninteractive(tmp_path: Path) -> None:
+    env = _cli_env(tmp_path)
+
+    assert _run_cli(env, "settings", "set", "strictKnownMarketplaces", "true", "--json").returncode == 0
+    r = _run_cli(env, "settings", "get", "strictKnownMarketplaces", "--scope", "user", "--json")
+    assert r.returncode == 0 and "true" in r.stdout.lower()
+
+    # merged show 反映写入
+    r = _run_cli(env, "settings", "show", "--scope", "user", "--json")
+    assert r.returncode == 0 and "strictKnownMarketplaces" in r.stdout
+
+    # flag / policy 只读 → 退出码 1
+    assert _run_cli(env, "settings", "set", "deniedMcpServers", '["x"]', "--scope", "policy", "--json").returncode == 1
+    assert _run_cli(env, "settings", "set", "foo", "bar", "--scope", "flag", "--json").returncode == 1
+
+
+@pytest.mark.e2e
+def test_plugin_install_invalid_id_noninteractive(tmp_path: Path) -> None:
+    env = _cli_env(tmp_path)
+    assert _run_cli(env, "plugin", "install", "no-delimiter", "--json").returncode == 1

--- a/tests/unit_tests/computer/cli/test_completer.py
+++ b/tests/unit_tests/computer/cli/test_completer.py
@@ -22,7 +22,7 @@ from pathlib import Path
 from prompt_toolkit.document import Document
 
 from a2c_smcp.computer.cli.completer import A2CCompleter
-from a2c_smcp.computer.settings.store import save_known_marketplaces
+from a2c_smcp.computer.settings.store import save_installed_plugins, save_known_marketplaces
 
 
 class _FakeComp:
@@ -72,6 +72,24 @@ def test_dynamic_skill_name(tmp_path: Path) -> None:
     assert "audit:lint" in out and "mcp:blender:render" in out
 
 
-def test_plugin_subcommands_scaffold(tmp_path: Path) -> None:
-    # plugin namespace 子命令词作骨架先行补全（命令体由 #69 落地）
-    assert {"install", "enable", "disable"} <= set(_complete(_comp(tmp_path), "plugin "))
+def test_plugin_subcommands(tmp_path: Path) -> None:
+    assert {"install", "uninstall", "enable", "disable", "list", "info"} <= set(_complete(_comp(tmp_path), "plugin "))
+
+
+def test_settings_subcommands(tmp_path: Path) -> None:
+    assert {"show", "get", "set", "edit"} <= set(_complete(_comp(tmp_path), "settings "))
+
+
+def test_dynamic_plugin_name(tmp_path: Path) -> None:
+    # plugin enable/info 位置参数补 installed plugin id（取 installed_plugins.json，#69）
+    save_installed_plugins({"version": 1, "plugins": {"audit@acme": [{"scope": "user", "installPath": "/x"}]}}, home=tmp_path)
+    comp = A2CCompleter(_FakeComp(tmp_path))
+    assert "audit@acme" in _complete(comp, "plugin enable ")
+    assert "audit@acme" in _complete(comp, "plugin info ")
+
+
+def test_dynamic_settings_keys(tmp_path: Path) -> None:
+    # settings get/set 的 key 补已知 settings.json 字段（#69）
+    out = _complete(_comp(tmp_path), "settings set ")
+    assert {"enabledPlugins", "trustedMarketplaces", "enabledMcpjsonServers"} <= set(out)
+    assert "enabledPlugins" in _complete(_comp(tmp_path), "settings get enabled")

--- a/tests/unit_tests/computer/cli/test_help.py
+++ b/tests/unit_tests/computer/cli/test_help.py
@@ -31,3 +31,20 @@ def test_help_namespace_detail(capsys: pytest.CaptureFixture[str]) -> None:
 def test_help_unknown_namespace(capsys: pytest.CaptureFixture[str]) -> None:
     render_help("bogus")
     assert "unknown" in capsys.readouterr().out.lower()
+
+
+def test_help_plugin_detail_real_commands(capsys: pytest.CaptureFixture[str]) -> None:
+    render_help("plugin")
+    out = capsys.readouterr().out
+    # #69 落地：真命令行（非骨架占位），含 install/enable/gc
+    for verb in ("install", "enable", "gc"):
+        assert verb in out
+    assert "#69" not in out  # 骨架占位已替换
+
+
+def test_help_settings_detail_real_commands(capsys: pytest.CaptureFixture[str]) -> None:
+    render_help("settings")
+    out = capsys.readouterr().out
+    for verb in ("show", "get", "set", "edit"):
+        assert verb in out
+    assert "#69" not in out

--- a/tests/unit_tests/computer/cli/test_main.py
+++ b/tests/unit_tests/computer/cli/test_main.py
@@ -23,7 +23,7 @@ class DummyInteractive:
     last_init_client: Any | None = None
 
     @classmethod
-    async def coro(cls, comp: Any, init_client: Any | None = None) -> None:  # matches _interactive_loop signature
+    async def coro(cls, comp: Any, init_client: Any | None = None, **_: Any) -> None:  # matches _interactive_loop signature (+ #69 kwargs)
         cls.called = True
         cls.last_comp = comp
         cls.last_init_client = init_client
@@ -41,6 +41,7 @@ class FakeComputer:
         auto_reconnect: bool = True,
         confirm_callback: Callable[[str, str, str, dict], bool] | None = None,
         input_resolver: Any | None = None,
+        registered_workdirs: Any | None = None,
     ) -> None:
         self.init_args = {
             "inputs": inputs,
@@ -49,6 +50,7 @@ class FakeComputer:
             "auto_reconnect": auto_reconnect,
             "confirm_callback": confirm_callback,
             "input_resolver": input_resolver,
+            "registered_workdirs": registered_workdirs,
         }
 
     async def __aenter__(self) -> FakeComputer:

--- a/tests/unit_tests/computer/cli/test_mcp_approval.py
+++ b/tests/unit_tests/computer/cli/test_mcp_approval.py
@@ -30,8 +30,14 @@ from a2c_smcp.computer.settings.scope import user_settings_path, workdir_local_s
 
 @pytest.fixture(autouse=True)
 def _no_policy(monkeypatch: pytest.MonkeyPatch) -> None:
-    """policy 读取 OS 源不确定 → 测试中固定为空，保证确定性 / pin policy empty for determinism。"""
-    monkeypatch.setattr(plugin_cmd, "resolve_policy_settings", lambda **_: {})
+    """policy 读取 OS 源不确定 → 测试中固定为空，保证确定性 / pin policy empty for determinism。
+
+    fix-review #4 后 ``resolved_settings`` 移入 ``cli.commands.__init__``（函数内 lazy import policy），
+    故 monkeypatch 须打到来源模块 ``settings.policy``（lazy import 会取到打过的属性）。
+    """
+    import a2c_smcp.computer.settings.policy as policy_mod
+
+    monkeypatch.setattr(policy_mod, "resolve_policy_settings", lambda **_: {})
 
 
 def _env(tmp_path: Path) -> dict[str, str]:

--- a/tests/unit_tests/computer/cli/test_mcp_approval.py
+++ b/tests/unit_tests/computer/cli/test_mcp_approval.py
@@ -1,0 +1,198 @@
+# -*- coding: utf-8 -*-
+# filename: test_mcp_approval.py
+# @Time    : 2026/05/27
+# @Author  : JQQ
+# @Email   : jqq1716@gmail.com
+# @Software: PyCharm
+"""
+启动期 MCP 批准框单元测试（v0.2.1 #69 Group B，§9.2）/ Boot-time MCP approval-box unit tests。
+
+测试意图 / Test intentions（fake Computer 桩 + 内存 session；XDG 重定向隔离 user；policy monkeypatch 为空）:
+- PENDING + TTY ``[y]`` → 写 local ``enabledMcpjsonServers`` + 挂载；**重启幂等**（二次 gate → ENABLED、不再弹）；
+- PENDING + 非 TTY（session=None）→ skip+WARN、不挂、不写；``--approve-all-mcp`` → 挂载但**不落盘**；
+- ENABLED（user origin trusted）→ 直挂；DISABLED（local disabled）→ 跳过；
+- ``ext``（envFile）合回挂载 dict（否则 spawn 丢失）；``resolved.errors`` 呈现 WARN。
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import a2c_smcp.computer.cli.commands.plugin as plugin_cmd
+from a2c_smcp.computer.cli.commands.plugin import run_mcp_approval
+from a2c_smcp.computer.settings.scope import user_settings_path, workdir_local_settings_path
+
+
+@pytest.fixture(autouse=True)
+def _no_policy(monkeypatch: pytest.MonkeyPatch) -> None:
+    """policy 读取 OS 源不确定 → 测试中固定为空，保证确定性 / pin policy empty for determinism。"""
+    monkeypatch.setattr(plugin_cmd, "resolve_policy_settings", lambda **_: {})
+
+
+def _env(tmp_path: Path) -> dict[str, str]:
+    return {**os.environ, "XDG_CONFIG_HOME": str(tmp_path / "cfg")}
+
+
+def _write_json(path: Path, obj: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(obj), encoding="utf-8")
+
+
+def _project_mcp(wd: Path, servers: dict[str, Any]) -> None:
+    _write_json(wd / ".tfrobot" / "mcp.json", {"servers": servers, "inputs": []})
+
+
+def _user_mcp(env: dict[str, str], servers: dict[str, Any]) -> None:
+    _write_json(Path(env["XDG_CONFIG_HOME"]) / "a2c" / "mcp.json", {"servers": servers, "inputs": []})
+
+
+class _Session:
+    """内存 PromptSession 桩：按序返回预置答案 / in-memory prompt session returning canned answers。"""
+
+    def __init__(self, answers: list[str]) -> None:
+        self._answers = list(answers)
+        self.prompts: list[str] = []
+
+    async def prompt_async(self, prompt: str, **_: Any) -> str:
+        self.prompts.append(prompt)
+        return self._answers.pop(0)
+
+
+class _FakeComp:
+    def __init__(self, wd: Path | None, home: Path) -> None:
+        self.active_workdir = wd
+        self._registered_workdirs = (wd,) if wd is not None else ()
+        self.skill_home = home
+        self.injected: list[Any] = []
+        self.mounted: list[dict[str, Any]] = []
+
+    def add_or_update_input(self, inp: Any) -> None:
+        self.injected.append(inp)
+
+    async def aadd_or_aupdate_server(
+        self, cfg: dict[str, Any], *, session: Any = None, plugin: Any = None, marketplace: Any = None,
+    ) -> None:
+        self.mounted.append(cfg)
+
+
+def _mounted_names(comp: _FakeComp) -> set[str]:
+    return {str(m.get("name")) for m in comp.mounted}
+
+
+def _stdio() -> dict[str, Any]:
+    return {"type": "stdio", "server_parameters": {"command": "node"}}
+
+
+# ── PENDING + TTY [y] → 写 local + 挂载 + 重启幂等 ──────────────────────────────
+@pytest.mark.asyncio
+async def test_pending_approve_yes_writes_local_and_mounts_then_idempotent(tmp_path: Path) -> None:
+    wd, home, env = tmp_path / "proj", tmp_path / "home", _env(tmp_path)
+    wd.mkdir()
+    home.mkdir()
+    _project_mcp(wd, {"shared": _stdio()})  # project origin → 非 trusted → PENDING
+
+    comp = _FakeComp(wd, home)
+    sess = _Session(["y"])
+    # run_mcp_approval 读 os.environ 派生 XDG → 用 monkeypatch env 注入
+    import unittest.mock as _m
+
+    with _m.patch.dict(os.environ, env, clear=False):
+        await run_mcp_approval(comp, sess, approve_all=False, flag_config=None)
+    assert "shared" in _mounted_names(comp)  # [y] → 挂载
+    local = json.loads(workdir_local_settings_path(wd).read_text(encoding="utf-8"))
+    assert local["enabledMcpjsonServers"] == ["shared"]  # 写 local scope
+
+    # 重启幂等：二次启动 gate 读到 local enabled → ENABLED 直挂、不再弹（session 无答案也不报错）
+    comp2 = _FakeComp(wd, home)
+    sess2 = _Session([])
+    with _m.patch.dict(os.environ, env, clear=False):
+        await run_mcp_approval(comp2, sess2, approve_all=False, flag_config=None)
+    assert "shared" in _mounted_names(comp2)
+    assert sess2.prompts == []  # 不再弹批准框
+
+
+# ── PENDING + 非 TTY → skip+WARN（不挂不写）；--approve-all-mcp → 挂载不落盘 ──────
+@pytest.mark.asyncio
+async def test_pending_non_tty_skips_and_does_not_write(tmp_path: Path) -> None:
+    wd, home, env = tmp_path / "proj", tmp_path / "home", _env(tmp_path)
+    wd.mkdir()
+    home.mkdir()
+    _project_mcp(wd, {"shared": _stdio()})
+    comp = _FakeComp(wd, home)
+    import unittest.mock as _m
+
+    with _m.patch.dict(os.environ, env, clear=False):
+        await run_mcp_approval(comp, None, approve_all=False, flag_config=None)  # session=None = 非 TTY
+    assert _mounted_names(comp) == set()  # 未挂
+    assert not workdir_local_settings_path(wd).exists()  # 未写
+
+
+@pytest.mark.asyncio
+async def test_pending_non_tty_approve_all_mounts_without_persist(tmp_path: Path) -> None:
+    wd, home, env = tmp_path / "proj", tmp_path / "home", _env(tmp_path)
+    wd.mkdir()
+    home.mkdir()
+    _project_mcp(wd, {"shared": _stdio()})
+    comp = _FakeComp(wd, home)
+    import unittest.mock as _m
+
+    with _m.patch.dict(os.environ, env, clear=False):
+        await run_mcp_approval(comp, None, approve_all=True, flag_config=None)
+    assert "shared" in _mounted_names(comp)  # --approve-all-mcp → 挂载
+    assert not workdir_local_settings_path(wd).exists()  # 仅本次、不落盘
+
+
+# ── ENABLED（user origin trusted）直挂 ─────────────────────────────────────────
+@pytest.mark.asyncio
+async def test_user_origin_mounts_without_box(tmp_path: Path) -> None:
+    wd, home, env = tmp_path / "proj", tmp_path / "home", _env(tmp_path)
+    wd.mkdir()
+    home.mkdir()
+    _user_mcp(env, {"mine": _stdio()})  # user origin → trusted_origin → ENABLED、免批准
+    comp = _FakeComp(wd, home)
+    sess = _Session([])  # 不应被调用
+    import unittest.mock as _m
+
+    with _m.patch.dict(os.environ, env, clear=False):
+        await run_mcp_approval(comp, sess, approve_all=False, flag_config=None)
+    assert "mine" in _mounted_names(comp)
+    assert sess.prompts == []
+
+
+# ── ext（envFile）合回挂载 dict（#69 Group B 风险 2）─────────────────────────────
+@pytest.mark.asyncio
+async def test_envfile_ext_merged_into_mount_dict(tmp_path: Path) -> None:
+    wd, home, env = tmp_path / "proj", tmp_path / "home", _env(tmp_path)
+    wd.mkdir()
+    home.mkdir()
+    envfile = str(wd / ".env")
+    _user_mcp(env, {"mine": {**_stdio(), "envFile": envfile}})  # user origin → 直挂
+    comp = _FakeComp(wd, home)
+    import unittest.mock as _m
+
+    with _m.patch.dict(os.environ, env, clear=False):
+        await run_mcp_approval(comp, _Session([]), approve_all=False, flag_config=None)
+    mine = next(m for m in comp.mounted if m.get("name") == "mine")
+    assert mine.get("envFile") == envfile  # ext 合回，否则 spawn 丢 envFile
+
+
+# ── resolved.errors 呈现 WARN ──────────────────────────────────────────────────
+@pytest.mark.asyncio
+async def test_malformed_server_surfaces_warning(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    wd, home, env = tmp_path / "proj", tmp_path / "home", _env(tmp_path)
+    wd.mkdir()
+    home.mkdir()
+    # 畸形 server（缺 type）→ drop + error；valid 同存
+    _project_mcp(wd, {"bad": {"server_parameters": {}}, "good": _stdio()})
+    comp = _FakeComp(wd, home)
+    import unittest.mock as _m
+
+    with _m.patch.dict(os.environ, env, clear=False):
+        await run_mcp_approval(comp, None, approve_all=True, flag_config=None)
+    out = capsys.readouterr().out
+    assert "mcp.json" in out  # resolved.errors 呈现（被 drop 的 bad 不静默）

--- a/tests/unit_tests/computer/cli/test_plugin.py
+++ b/tests/unit_tests/computer/cli/test_plugin.py
@@ -1,0 +1,270 @@
+# -*- coding: utf-8 -*-
+# filename: test_plugin.py
+# @Time    : 2026/05/27
+# @Author  : JQQ
+# @Email   : jqq1716@gmail.com
+# @Software: PyCharm
+"""
+``plugin`` 命令 handler 单元测试（v0.2.1 #69）/ Plugin command handler unit tests。
+
+设计依据 / Design: python-sdk docs/design-0.2.1-cli-marketplace-ux.md §4.3 / §10.6（S16）。
+
+测试意图 / Test intentions（相对源 plugin → locate_plugin_root 无 git；monkeypatch stage；XDG 重定向隔离）:
+- install：happy（写账本 + 注册 bundled server）/ 外来同名硬抛退出码 1 + JSON error code / 非法 id 退出码 1；
+- enable/disable：**scope 从 ledger 读**（seed project scope → 写 project settings，不写 user）；
+- uninstall / list / info / gc 退出码与输出形态；
+- ``_plugin_inject_inputs_cb``：读 ``mcp-servers/inputs.json`` → 前缀化 → 注入 fake comp 池（#69 Group A）。
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from a2c_smcp.computer.cli.commands import plugin as plugin_cmd
+from a2c_smcp.computer.settings.scope import user_settings_path, workdir_project_settings_path
+from a2c_smcp.computer.settings.store import load_installed_plugins, save_installed_plugins, save_known_marketplaces
+from a2c_smcp.computer.skills.home import SOURCE_MARKETPLACE, marketplace_skill_dir
+from a2c_smcp.computer.skills.registry import SkillRegistry
+
+_SRC = {"type": "git", "url": "https://example.com/acme.git"}
+_STAGE = "a2c_smcp.computer.settings.installer.stage_marketplace_skills"
+
+
+# ── 辅助（镜像 test_installer.py）/ helpers mirroring test_installer.py ─────────
+def _home(tmp_path: Path) -> Path:
+    h = tmp_path / "skill-home"
+    h.mkdir()
+    return h
+
+
+def _env(tmp_path: Path) -> dict[str, str]:
+    return {**os.environ, "XDG_CONFIG_HOME": str(tmp_path / "cfg")}
+
+
+def _write_json(path: Path, obj: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(obj), encoding="utf-8")
+
+
+def _stdio(name: str, command: str = "node") -> dict:
+    return {"name": name, "type": "stdio", "server_parameters": {"command": command}}
+
+
+def _setup_catalog(home: Path, mp: str, plugin: str, *, servers: list[str], inputs: list[dict] | None = None) -> Path:
+    """造 catalog 树（相对源 plugin）+ marketplace.json + plugin mcp-servers/，seed known_marketplaces。"""
+    catalog = marketplace_skill_dir(home, mp)
+    manifest = {
+        "name": mp,
+        "owner": {"name": "X"},
+        "metadata": {"pluginRoot": "./plugins"},
+        "plugins": [{"name": plugin, "source": plugin, "version": "1.2.0"}],
+    }
+    _write_json(catalog / ".tfrobot-plugin" / "marketplace.json", manifest)
+    plugin_root = catalog / "plugins" / plugin
+    plugin_root.mkdir(parents=True, exist_ok=True)
+    for sname in servers:
+        _write_json(plugin_root / "mcp-servers" / f"{sname}.json", _stdio(sname))
+    if inputs is not None:
+        _write_json(plugin_root / "mcp-servers" / "inputs.json", {"inputs": inputs})
+    save_known_marketplaces(
+        {"version": 1, "marketplaces": {mp: {"source": _SRC, "installLocation": str(catalog.resolve()), "commitSha": "abc"}}},
+        home=home,
+    )
+    return plugin_root
+
+
+def _fake_stage(register_skill: bool = True):
+    async def _stage(name, source, registry, home, *, plugin_filter=None, auto_update=False, refresh=False, timeout=0.0, env=None):
+        if register_skill:
+            for plugin in plugin_filter or set():
+                registry.register_or_update(
+                    {
+                        "name": f"{plugin}:lint",
+                        "source": f"{SOURCE_MARKETPLACE}:{name}",
+                        "path": str(marketplace_skill_dir(home, name).resolve()),
+                    },
+                )
+        return [f"{p}:lint" for p in plugin_filter or set()]
+
+    return _stage
+
+
+class _FakeMCP:
+    """记录 MCP 注入回调调用 / records injected MCP callback invocations。"""
+
+    def __init__(self, existing: set[str] | None = None) -> None:
+        self.existing: set[str] = set(existing or ())
+        self.registered: list[Any] = []
+        self.removed: list[str] = []
+
+    def existing_names(self) -> set[str]:
+        return set(self.existing)
+
+    async def register(self, cfg: Any) -> None:
+        self.registered.append(cfg)
+
+    async def remove(self, name: str) -> None:
+        self.removed.append(name)
+
+
+# ── install ───────────────────────────────────────────────────────────────────
+@pytest.mark.asyncio
+async def test_install_happy_writes_ledger_and_registers_servers(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    home, env, reg = _home(tmp_path), _env(tmp_path), SkillRegistry()
+    _setup_catalog(home, "acme", "audit", servers=["figma-mcp"])
+    monkeypatch.setattr(_STAGE, _fake_stage())
+    mcp = _FakeMCP()
+
+    code = await plugin_cmd.plugin_install(
+        reg, home, env, "audit@acme",
+        existing_server_names=mcp.existing_names, register_server=mcp.register, json_output=True,
+    )
+    assert code == 0
+    assert "audit@acme" in load_installed_plugins(home=home, env=env)["plugins"]
+    assert [c.name for c in mcp.registered] == ["figma-mcp"]
+
+
+@pytest.mark.asyncio
+async def test_install_foreign_name_conflict_exit1_json_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str],
+) -> None:
+    home, env, reg = _home(tmp_path), _env(tmp_path), SkillRegistry()
+    _setup_catalog(home, "acme", "audit", servers=["figma-mcp"])
+    monkeypatch.setattr(_STAGE, _fake_stage())
+    # 外来同名（已存在且非自有）→ 硬抛、退出码 1、不写账本（§10.6）
+    mcp = _FakeMCP(existing={"figma-mcp"})
+
+    code = await plugin_cmd.plugin_install(
+        reg, home, env, "audit@acme",
+        existing_server_names=mcp.existing_names, register_server=mcp.register, json_output=True,
+    )
+    assert code == 1
+    assert json.loads(capsys.readouterr().out)["error"] == "mcp_server_name_conflict"
+    assert "audit@acme" not in load_installed_plugins(home=home, env=env)["plugins"]
+
+
+@pytest.mark.asyncio
+async def test_install_invalid_id_exit1(tmp_path: Path) -> None:
+    home, env, reg = _home(tmp_path), _env(tmp_path), SkillRegistry()
+    assert await plugin_cmd.plugin_install(reg, home, env, "nodelim", json_output=True) == 1
+
+
+# ── enable / disable：scope 从 ledger 读（不默认 user）/ scope read from ledger ──
+@pytest.mark.asyncio
+async def test_enable_reads_scope_from_ledger_writes_project_not_user(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    home, env, reg = _home(tmp_path), _env(tmp_path), SkillRegistry()
+    plugin_root = _setup_catalog(home, "acme", "audit", servers=["figma-mcp"])
+    monkeypatch.setattr(_STAGE, _fake_stage())
+    wd = tmp_path / "proj"
+    wd.mkdir()
+    # seed installed record at PROJECT scope（projectPath=wd）→ enable 必须写 project settings、不写 user
+    save_installed_plugins(
+        {"version": 1, "plugins": {"audit@acme": [{"scope": "project", "projectPath": str(wd), "installPath": str(plugin_root)}]}},
+        home=home,
+    )
+    mcp = _FakeMCP()
+    code = await plugin_cmd.plugin_enable(
+        reg, home, env, "audit@acme", existing_server_names=mcp.existing_names, register_server=mcp.register,
+    )
+    assert code == 0
+    # enabledPlugins[audit@acme]=true 写 project scope（active workdir），user scope 不动
+    proj = json.loads(workdir_project_settings_path(wd).read_text(encoding="utf-8"))
+    assert proj["enabledPlugins"]["audit@acme"] is True
+    user_ep = json.loads(user_settings_path(env).read_text()).get("enabledPlugins", {}) if user_settings_path(env).exists() else {}
+    assert "audit@acme" not in user_ep  # 未写 user scope
+
+
+@pytest.mark.asyncio
+async def test_enable_not_installed_exit1(tmp_path: Path) -> None:
+    home, env, reg = _home(tmp_path), _env(tmp_path), SkillRegistry()
+    assert await plugin_cmd.plugin_enable(reg, home, env, "ghost@acme") == 1
+
+
+@pytest.mark.asyncio
+async def test_disable_reads_scope_from_ledger(tmp_path: Path) -> None:
+    home, env, reg = _home(tmp_path), _env(tmp_path), SkillRegistry()
+    plugin_root = _setup_catalog(home, "acme", "audit", servers=["figma-mcp"])
+    save_installed_plugins(
+        {"version": 1, "plugins": {"audit@acme": [{"scope": "user", "installPath": str(plugin_root), "bundledMcpServers": ["figma-mcp"]}]}},
+        home=home,
+    )
+    mcp = _FakeMCP()
+    code = await plugin_cmd.plugin_disable(reg, home, env, "audit@acme", remove_server=mcp.remove)
+    assert code == 0
+    assert mcp.removed == ["figma-mcp"]  # 整 plugin 下线：摘 bundled server
+    user = json.loads(user_settings_path(env).read_text(encoding="utf-8"))
+    assert user["enabledPlugins"]["audit@acme"] is False
+
+
+# ── uninstall / list / info / gc ───────────────────────────────────────────────
+@pytest.mark.asyncio
+async def test_uninstall_not_installed_exit1(tmp_path: Path) -> None:
+    home, env, reg = _home(tmp_path), _env(tmp_path), SkillRegistry()
+    assert await plugin_cmd.plugin_uninstall(reg, home, env, "ghost@acme") == 1
+
+
+def test_list_and_info(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    home, env = _home(tmp_path), _env(tmp_path)
+    save_installed_plugins(
+        {"version": 1, "plugins": {"audit@acme": [{"scope": "user", "installPath": "/x", "bundledMcpServers": ["figma-mcp"]}]}},
+        home=home,
+    )
+    assert plugin_cmd.plugin_list(home, env, json_output=True) == 0
+    rows = json.loads(capsys.readouterr().out)
+    assert rows[0]["id"] == "audit@acme" and rows[0]["enabled"] is True
+    assert plugin_cmd.plugin_info(home, env, "audit@acme", json_output=True) == 0
+    assert plugin_cmd.plugin_info(home, env, "ghost@acme", json_output=True) == 1
+
+
+def test_list_hides_disabled_unless_available(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    home, env = _home(tmp_path), _env(tmp_path)
+    save_installed_plugins({"version": 1, "plugins": {"audit@acme": [{"scope": "user", "installPath": "/x"}]}}, home=home)
+    # 显式 disable
+    from a2c_smcp.computer.settings.scope import apply_write
+    from a2c_smcp.computer.settings.scope import user_settings_path as _usp
+    from a2c_smcp.computer.settings.store import atomic_write_json
+
+    atomic_write_json(_usp(env), apply_write({}, {"enabledPlugins": {"audit@acme": False}}))
+    plugin_cmd.plugin_list(home, env, json_output=True)
+    assert json.loads(capsys.readouterr().out) == []  # 默认隐藏 disabled
+    plugin_cmd.plugin_list(home, env, available=True, json_output=True)
+    assert json.loads(capsys.readouterr().out)[0]["enabled"] is False  # --available 含 disabled
+
+
+@pytest.mark.asyncio
+async def test_gc_no_orphans(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    home, env, reg = _home(tmp_path), _env(tmp_path), SkillRegistry()
+    # enabledPlugins 声明 audit@acme（在 user settings）→ 非孤儿；installed 仅 audit@acme → 无孤儿
+    from a2c_smcp.computer.settings.scope import apply_write
+    from a2c_smcp.computer.settings.scope import user_settings_path as _usp
+    from a2c_smcp.computer.settings.store import atomic_write_json
+
+    atomic_write_json(_usp(env), apply_write({}, {"enabledPlugins": {"audit@acme": True}}))
+    save_installed_plugins({"version": 1, "plugins": {"audit@acme": [{"scope": "user", "installPath": "/x"}]}}, home=home)
+    assert await plugin_cmd.plugin_gc(reg, home, env, json_output=True) == 0
+    assert json.loads(capsys.readouterr().out)["removed"] == []
+
+
+# ── _plugin_inject_inputs_cb：D2 入池消歧（#69 Group A）/ inject prefixed inputs ─
+@pytest.mark.asyncio
+async def test_inject_inputs_cb_prefixes_and_injects(tmp_path: Path) -> None:
+    home = _home(tmp_path)
+    plugin_root = _setup_catalog(
+        home, "acme", "audit", servers=["figma-mcp"],
+        inputs=[{"id": "figma_token", "type": "promptString", "description": "tok", "password": True}],
+    )
+    injected: list[Any] = []
+
+    class _Comp:
+        def add_or_update_input(self, inp: Any) -> None:
+            injected.append(inp)
+
+    cb = plugin_cmd._plugin_inject_inputs_cb(_Comp(), "audit", "acme")
+    await cb(plugin_root)
+    assert len(injected) == 1
+    assert injected[0].id == "audit@acme/figma_token"  # 前缀化（§9.3 D2）

--- a/tests/unit_tests/computer/cli/test_plugin.py
+++ b/tests/unit_tests/computer/cli/test_plugin.py
@@ -268,3 +268,55 @@ async def test_inject_inputs_cb_prefixes_and_injects(tmp_path: Path) -> None:
     await cb(plugin_root)
     assert len(injected) == 1
     assert injected[0].id == "audit@acme/figma_token"  # 前缀化（§9.3 D2）
+
+
+# ── repl_dispatch（REPL 解析胶水层；fix-review #2）/ REPL parse glue ────────────
+class _ReplComp:
+    """plugin repl_dispatch 所需最小 fake（build_mcp_callbacks + register/inject 闭包所需接口）。"""
+
+    def __init__(self, home: Path, registry: SkillRegistry) -> None:
+        self.skill_home = home
+        self.skill_registry = registry
+        self._registered_workdirs: tuple[Path, ...] = ()
+        self.active_workdir: Path | None = None
+        self.dirty = 0
+        self._servers: list[Any] = []
+        self.injected: list[Any] = []
+
+    @property
+    def mcp_servers(self) -> list[Any]:
+        return list(self._servers)
+
+    def mark_skills_dirty(self) -> None:
+        self.dirty += 1
+
+    def add_or_update_input(self, inp: Any) -> None:
+        self.injected.append(inp)
+
+    async def aadd_or_aupdate_server(self, cfg: Any, *, session: Any = None, plugin: Any = None, marketplace: Any = None) -> None:
+        self._servers.append(cfg)
+
+    async def aremove_server(self, name: str) -> None:
+        self._servers = [s for s in self._servers if getattr(s, "name", None) != name]
+
+
+@pytest.mark.asyncio
+async def test_repl_install_marks_dirty_and_fires_register(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "cfg"))
+    home, reg = _home(tmp_path), SkillRegistry()
+    _setup_catalog(home, "acme", "audit", servers=["figma-mcp"])
+    monkeypatch.setattr(_STAGE, _fake_stage())
+    comp = _ReplComp(home, reg)
+    await plugin_cmd.repl_dispatch(comp, ["plugin", "install", "audit@acme"], session=None)
+    assert comp.dirty == 1  # 成功 → 触发去抖 emit
+    assert "audit@acme" in load_installed_plugins(home=home)["plugins"]
+    assert any(getattr(s, "name", None) == "figma-mcp" for s in comp._servers)  # register cb fired（实时挂载）
+
+
+@pytest.mark.asyncio
+async def test_repl_list_and_unknown_subcommand_no_raise(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "cfg"))
+    comp = _ReplComp(_home(tmp_path), SkillRegistry())
+    await plugin_cmd.repl_dispatch(comp, ["plugin", "list"], session=None)  # 空 → 无错
+    await plugin_cmd.repl_dispatch(comp, ["plugin", "bogus"], session=None)  # 未知子命令 → no-op
+    assert comp.dirty == 0

--- a/tests/unit_tests/computer/cli/test_settings.py
+++ b/tests/unit_tests/computer/cli/test_settings.py
@@ -114,3 +114,57 @@ def test_edit_readonly_scopes_exit1(tmp_path: Path, scope: str) -> None:
     code, post_save = settings_cmd.settings_edit(home, env, scope=scope, editor="true", json_output=True)
     assert code == 1
     assert post_save is None
+
+
+# ── repl_dispatch（REPL 解析胶水层；fix-review #2/#3）/ REPL parse glue ─────────
+class _FakeComp:
+    """settings repl_dispatch 所需最小 fake（repl 用 os.environ 作 env，故 XDG 经 monkeypatch 隔离）。"""
+
+    def __init__(self, home: Path) -> None:
+        self.skill_home = home
+        self._registered_workdirs: tuple[Path, ...] = ()
+        self.active_workdir: Path | None = None
+        self.dirty = 0
+
+    def mark_skills_dirty(self) -> None:
+        self.dirty += 1
+
+
+@pytest.mark.asyncio
+async def test_repl_set_reconstructs_spaced_json_and_stops_at_flag(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "cfg"))
+    comp = _FakeComp(tmp_path / "home")
+    # value 含空格（["a", "b"] 被空格切成 2 token）+ 尾随 --scope → 重建含空格 JSON、停在真 flag token（Group C）
+    parts = ["settings", "set", "trustedMarketplaces", '["a",', '"b"]', "--scope", "user"]
+    await settings_cmd.repl_dispatch(comp, parts, session=None)
+    data = json.loads(user_settings_path(os.environ).read_text(encoding="utf-8"))
+    assert data["trustedMarketplaces"] == ["a", "b"]
+
+
+@pytest.mark.asyncio
+async def test_repl_set_value_with_doubledash_substring_not_truncated(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "cfg"))
+    comp = _FakeComp(tmp_path / "home")
+    # value 字面含 "--scope" 子串（非独立 flag token）→ 不应被截断（旧 _strip_scope_flag 的 bug，Group C 修复）
+    parts = ["settings", "set", "note", "a--scope-thing", "--scope", "user"]
+    await settings_cmd.repl_dispatch(comp, parts, session=None)
+    data = json.loads(user_settings_path(os.environ).read_text(encoding="utf-8"))
+    assert data["note"] == "a--scope-thing"  # 完整保留，不在 "--scope" 子串处截断
+
+
+@pytest.mark.asyncio
+async def test_repl_set_emit_key_marks_dirty(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "cfg"))
+    comp = _FakeComp(tmp_path / "home")
+    await settings_cmd.repl_dispatch(comp, ["settings", "set", "enabledMcpjsonServers", '["x"]', "--json"], session=None)
+    assert comp.dirty == 1  # 能力/MCP 字段写入 → 触发去抖 emit
+
+
+@pytest.mark.asyncio
+async def test_repl_get_and_unknown_subcommand_no_raise(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "cfg"))
+    comp = _FakeComp(tmp_path / "home")
+    # 缺失键 get（退出码 1，不抛）+ 未知子命令（no-op，不抛）
+    await settings_cmd.repl_dispatch(comp, ["settings", "get", "neverset"], session=None)
+    await settings_cmd.repl_dispatch(comp, ["settings", "bogus"], session=None)
+    assert comp.dirty == 0

--- a/tests/unit_tests/computer/cli/test_settings.py
+++ b/tests/unit_tests/computer/cli/test_settings.py
@@ -1,0 +1,116 @@
+# -*- coding: utf-8 -*-
+# filename: test_settings.py
+# @Time    : 2026/05/27
+# @Author  : JQQ
+# @Email   : jqq1716@gmail.com
+# @Software: PyCharm
+"""
+``settings`` 命令 handler 单元测试（v0.2.1 #69 Group D，§4.5/§5.4）/ Settings command handler unit tests。
+
+测试意图 / Test intentions（XDG_CONFIG_HOME 重定向隔离 user settings）:
+- set：JSON 优先解析 / 数组**整体替换**（非追加）/ flag·policy 只读退出码 1；
+- get：merged / 指定 scope 读单字段；缺失键退出码 1；
+- show：merged 默认 / 指定 scope；非法 scope 退出码 1；
+- edit：$EDITOR（桩）打开 → 返回 (0, reconcile_cb)；flag/policy 只读退出码 1。
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from a2c_smcp.computer.cli.commands import settings as settings_cmd
+from a2c_smcp.computer.settings.scope import user_settings_path
+
+
+def _home(tmp_path: Path) -> Path:
+    h = tmp_path / "home"
+    h.mkdir()
+    return h
+
+
+def _env(tmp_path: Path) -> dict[str, str]:
+    return {**os.environ, "XDG_CONFIG_HOME": str(tmp_path / "cfg")}
+
+
+# ── set ─────────────────────────────────────────────────────────────────────
+def test_set_json_scalar_and_get_roundtrip(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    home, env = _home(tmp_path), _env(tmp_path)
+    assert settings_cmd.settings_set(home, env, "strictKnownMarketplaces", "true", scope="user", json_output=True) == 0
+    capsys.readouterr()
+    assert settings_cmd.settings_get(home, env, "strictKnownMarketplaces", scope="user", json_output=True) == 0
+    assert json.loads(capsys.readouterr().out) == {"strictKnownMarketplaces": True}  # JSON true → bool
+
+
+def test_set_array_whole_replace(tmp_path: Path) -> None:
+    home, env = _home(tmp_path), _env(tmp_path)
+    settings_cmd.settings_set(home, env, "trustedMarketplaces", '["a","b"]', scope="user")
+    settings_cmd.settings_set(home, env, "trustedMarketplaces", '["c"]', scope="user")  # 整体替换、非追加
+    data = json.loads(user_settings_path(env).read_text(encoding="utf-8"))
+    assert data["trustedMarketplaces"] == ["c"]  # §5.4 数组整体替换
+
+
+def test_set_literal_string_fallback(tmp_path: Path) -> None:
+    home, env = _home(tmp_path), _env(tmp_path)
+    settings_cmd.settings_set(home, env, "customField", "not-json-value", scope="user")
+    data = json.loads(user_settings_path(env).read_text(encoding="utf-8"))
+    assert data["customField"] == "not-json-value"  # 非 JSON → 字面字符串
+
+
+@pytest.mark.parametrize("scope", ["flag", "policy"])
+def test_set_readonly_scopes_exit1(tmp_path: Path, scope: str) -> None:
+    home, env = _home(tmp_path), _env(tmp_path)
+    assert settings_cmd.settings_set(home, env, "deniedMcpServers", '["x"]', scope=scope, json_output=True) == 1
+
+
+def test_set_project_without_active_workdir_exit1(tmp_path: Path) -> None:
+    home, env = _home(tmp_path), _env(tmp_path)
+    assert settings_cmd.settings_set(home, env, "foo", "1", scope="project", active_workdir=None, json_output=True) == 1
+
+
+# ── get / show ──────────────────────────────────────────────────────────────
+def test_get_missing_key_exit1(tmp_path: Path) -> None:
+    home, env = _home(tmp_path), _env(tmp_path)
+    assert settings_cmd.settings_get(home, env, "neverset", scope="user", json_output=True) == 1
+
+
+def test_show_unknown_scope_exit1(tmp_path: Path) -> None:
+    home, env = _home(tmp_path), _env(tmp_path)
+    assert settings_cmd.settings_show(home, env, scope="bogus", json_output=True) == 1
+
+
+def test_show_merged_default(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    home, env = _home(tmp_path), _env(tmp_path)
+    settings_cmd.settings_set(home, env, "strictKnownMarketplaces", "true", scope="user")
+    capsys.readouterr()
+    assert settings_cmd.settings_show(home, env, scope="merged", json_output=True) == 0
+    assert json.loads(capsys.readouterr().out).get("strictKnownMarketplaces") is True
+
+
+# ── edit ──────────────────────────────────────────────────────────────────────
+@pytest.mark.asyncio
+async def test_edit_opens_editor_and_returns_reconcile_cb(tmp_path: Path) -> None:
+    home, env = _home(tmp_path), _env(tmp_path)
+    called = {"n": 0}
+
+    async def _reconcile() -> None:
+        called["n"] += 1
+
+    # editor="true" → 子进程退出 0、不改文件；返回 (0, reconcile_cb)
+    code, post_save = settings_cmd.settings_edit(home, env, scope="user", editor="true", reconcile_cb=_reconcile)
+    assert code == 0
+    assert post_save is _reconcile
+    assert user_settings_path(env).exists()  # 空骨架已建
+    await post_save()
+    assert called["n"] == 1
+
+
+@pytest.mark.parametrize("scope", ["flag", "policy"])
+def test_edit_readonly_scopes_exit1(tmp_path: Path, scope: str) -> None:
+    home, env = _home(tmp_path), _env(tmp_path)
+    code, post_save = settings_cmd.settings_edit(home, env, scope=scope, editor="true", json_output=True)
+    assert code == 1
+    assert post_save is None

--- a/tests/unit_tests/computer/test_computer.py
+++ b/tests/unit_tests/computer/test_computer.py
@@ -319,7 +319,10 @@ class DummyResolver(InputResolver):
     def clear_cache(self, key: str | None = None) -> None:  # pragma: no cover - only used in update_inputs case
         self.cleared = True
 
-    async def aresolve_by_id(self, input_id: str, *, session: PromptSession | None = None):
+    async def aresolve_by_id(
+        self, input_id: str, *, session: PromptSession | None = None, plugin: str | None = None, marketplace: str | None = None,
+    ):
+        # 接受 #69 Group A 的 plugin/marketplace 上下文 kwargs（默认 None；本 stub 仅按裸 id 查表）。
         return self.mapping[input_id]
 
 

--- a/tests/unit_tests/computer/test_computer_render_context.py
+++ b/tests/unit_tests/computer/test_computer_render_context.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+# filename: test_computer_render_context.py
+# @Time    : 2026/05/27
+# @Author  : JQQ
+# @Email   : jqq1716@gmail.com
+# @Software: PyCharm
+"""
+Computer 渲染上下文透传 + active_workdir 单元测试（v0.2.1 #69 Group A/C）/ render context + active_workdir。
+
+测试意图 / Test intentions:
+- ``active_workdir``：空 registered_workdirs → None；非空 → 首个（绑定任务单根）；
+- ``_render_variables``：``workspaceFolder`` 走 active_workdir，无则 cwd；
+- 渲染上下文（Group A）：bundled server 的裸 ``${input:id}`` 经 plugin/marketplace 上下文解析到带前缀池条目
+  （§9.3 D2）；env 命中（headless 安全，password 在 env 命中先于 TTY 守卫）；无上下文 → InputNotFoundError。
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from a2c_smcp.computer.computer import Computer
+from a2c_smcp.computer.mcp_clients.model import MCPServerPromptStringInput
+
+
+def test_active_workdir_property(tmp_path: Path) -> None:
+    assert Computer(name="t").active_workdir is None  # 空闲
+    comp = Computer(name="t", registered_workdirs=[tmp_path, tmp_path / "b"])
+    assert comp.active_workdir == tmp_path  # 取首个（绑定任务单根）
+
+
+def test_render_variables_uses_active_workdir(tmp_path: Path) -> None:
+    comp = Computer(name="t", registered_workdirs=[tmp_path])
+    assert comp._render_variables()["workspaceFolder"] == str(tmp_path)
+    assert Computer(name="t")._render_variables()["workspaceFolder"] == os.getcwd()  # 无 → cwd
+
+
+_CFG = {"name": "s", "type": "stdio", "server_parameters": {"command": "node", "args": ["${input:token}"]}}
+
+
+@pytest.mark.asyncio
+async def test_render_context_resolves_prefixed_input(monkeypatch: pytest.MonkeyPatch) -> None:
+    # 前缀化 id 入池 + bare ${input:token} 经 plugin/marketplace 上下文回退到 audit@acme/token（§9.3 D2）。
+    # env 命中（A2C_INPUT_AUDIT_ACME_TOKEN）→ headless 安全（password 在 env 命中先于无 TTY 守卫）。
+    monkeypatch.setenv("A2C_INPUT_AUDIT_ACME_TOKEN", "secret-val")
+    comp = Computer(name="t")
+    comp.add_or_update_input(MCPServerPromptStringInput(id="audit@acme/token", description="d", password=True, type="promptString"))
+
+    validated = await comp._arender_and_validate_server(dict(_CFG), plugin="audit", marketplace="acme")
+    assert "secret-val" in json.dumps(validated.model_dump(mode="json"))  # 渲染命中
+
+
+@pytest.mark.asyncio
+async def test_render_without_context_leaves_placeholder(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("A2C_INPUT_AUDIT_ACME_TOKEN", "secret-val")
+    comp = Computer(name="t")
+    comp.add_or_update_input(MCPServerPromptStringInput(id="audit@acme/token", description="d", password=True, type="promptString"))
+    # 无 plugin/marketplace 上下文 → 裸 token 不在池、无前缀回退 → render 容错保留占位符（不解析、不泄漏 env 值）
+    validated = await comp._arender_and_validate_server(dict(_CFG))
+    dumped = json.dumps(validated.model_dump(mode="json"))
+    assert "${input:token}" in dumped and "secret-val" not in dumped


### PR DESCRIPTION
## 概述

实现 #69（S16 CLI plugin + settings 命令 + 全局 flag）—— 父 tracking #53 的最后一个就绪可起项。**纯 Computer 侧 CLI 表面层，无 A2C 协议变更**（PROTOCOL_VERSION 不变，无新事件/数据结构/错误码，与 #68 同性质）。把 #63/#64/#62/#65 既有后端接成 CLI 命令 + REPL/Typer 双入口 + 启动期 MCP 批准框，并补 #65 遗留的两个下游 handoff（plugin 实时挂载 D2 上下文渲染 + 多根 workspaceFolder 复核）。

## 变更分组

### Group A — plugin 实时挂载 D2 上下文渲染（§9.3 handoff）
- `computer.py`：`aadd_or_aupdate_server` / `_arender_and_validate_server` 加 `plugin`/`marketplace` 透传到 `InputResolver.aresolve_by_id`（默认 `None`=现状）。bundled server 的裸 `${input:id}` 经 D2 前缀回退解析到 `<plugin>@<marketplace>/<id>` 池条目。
- `installer.py`：`install_plugin` 加可选 `inject_inputs` hook（`load_bundled_servers` 后、register 前调一次，入参 `plugin_root`），默认 `None`=no-op。`plugin.py` 经 `load_plugin_inputs` 注池。

### Group B — `.tfrobot/mcp.json` 启动接入 + MCP 批准框（§9.2，#64 消费方）
- `plugin.run_mcp_approval`：`resolve_mcp_config` → `gate_mcp_servers` → **ENABLED 直挂 / DISABLED 跳过 / PENDING** TTY `y·a·n` 写 **local scope**（重启幂等）/ 非 TTY **skip+WARN**（`--approve-all-mcp` 仅本次、不落盘）。注入 `resolved.inputs`、**合回 `ext`（envFile）**、呈现 `resolved.errors` WARN。`interactive_loop` 启动期调（非 TTY 传 `session=None`）。

### Group C — 多根 workspaceFolder 复核（#65 fix-review 🟡3）
- 新增 `Computer.active_workdir` 属性（`registered_workdirs[0]`，绑定任务单根）；`_render_variables` 的 `workspaceFolder` 走之，与批准流共用单一 active-workdir 事实源（行为与今日一致）。

### Group D — 命令/接线
- 新增 `cli/commands/plugin.py`：install/uninstall/enable/disable/list/info/gc + 批准框。**外来 MCP 同名硬抛退出码 1 + JSON error（§10.6，无逃生口）**；**enable/disable scope 从 ledger 读、不默认 user**（契约对齐）。
- 新增 `cli/commands/settings.py`：show/get/set/edit。merged 默认；写**数组整体替换**（§5.4）；**flag/policy 只读 → 退出码 1**；`edit` 用 `$EDITOR` + 保存后 reconcile。
- `interactive_impl.py` 加 plugin/settings dispatch + 启动期批准框；`main.py` 加 `plugin_app`/`settings_app` Typer sub-app + 全局 flag `--json`/`--settings`/`--add-dir`/`--approve-all-mcp`（`--add-dir` → `registered_workdirs`，B/C 前置）；`completer` plugin/settings 动态名；`help` 真命令行 + FLAGS。

## 验收（#69 标准）
- [x] plugin install 外来 MCP 同名硬抛（退出码 1 + JSON error）→ install→enable（单测 + e2e）
- [x] MCP 批准框 pending→`y` 写 local→**重启不再弹**（`test_mcp_approval` 重启幂等用例）
- [x] settings show/get/set 五级 scope；flag/policy 只读
- [x] Typer 子命令与 REPL 同名同义
- [x] `uv run poe lint` 净（ruff + mypy **98 source files**）

## 测试
- 单测：`test_plugin`（11）· `test_mcp_approval`（6，含重启幂等）· `test_settings`（12）· `test_computer_render_context`（4）+ `test_completer`/`test_help` 扩充；全量单测 **1314 passed, 4 xfailed**。
- e2e：`test_cli_plugin_settings_e2e`（3，非交互真进程：marketplace add→plugin install→enable→list + settings set/get/show + flag/policy 只读 + 非法 id）。

> §10.6 外来同名硬抛与 §9.2 批准框 y/a/n 须 live Computer + MCP 注入回调（仅 REPL；非交互为 ledger-only、无冲突闸门），由单测充分覆盖；e2e 聚焦确定性非交互真进程行为（REPL pexpect 需真 MCP server spawn，过脆故不纳入）。

## 范围外（另行）
- boot 期 marketplace `reconcile()`（fresh boot 物化 enabledPlugins skills）；envFile 进协议 `client:get_config` 追认（#65「待协议追认」）；strict/白名单 #80。

🤖 Generated with [Claude Code](https://claude.com/claude-code)