### PR TITLE
fix(server+smcp): v0.2.1 A2CSkillRef 必选字段 + 旧路由收编 _relay_client_call + 飞行断连守卫 (#50, #46)

### DIFF
--- a/a2c_smcp/server/namespace.py
+++ b/a2c_smcp/server/namespace.py
@@ -391,80 +391,42 @@ class SMCPNamespace(BaseNamespace):
             ),
         )
 
-    async def on_client_get_tools(self, sid: str, data: GetToolsReq) -> GetToolsRet:
+    async def on_client_get_tools(self, sid: str, data: GetToolsReq) -> GetToolsRet | ErrorPayload:
         """
-        获取指定Computer的工具列表
-        Get tool list of specified Computer
+        获取指定 Computer 的工具列表 / Get tool list of specified Computer（``client:get_tools``）.
+
+        经 :meth:`_relay_client_call` 统一 isolation + flat ErrorPayload 透传（v0.2.2：所有 ``client:*``
+        ack 统一 flat ErrorPayload，旧路由非豁免）。
+        Routed via ``_relay_client_call`` (unified isolation + flat ErrorPayload pass-through; v0.2.2
+        makes flat ErrorPayload uniform across all ``client:*`` acks — old routes are not exempt).
 
         Args:
-            sid (str): 发起者的ID，一般是Agent / Initiator ID, usually Agent
-            data (GetToolsReq): 其中包含computer字段，指向Computer的Name / Contains computer field pointing to Computer's Name
+            sid (str): 发起者 SID，一般是 Agent / Initiator SID, usually Agent.
+            data (GetToolsReq): 含 ``computer`` 字段，指向 Computer 的 Name / contains ``computer``.
 
         Returns:
-            GetToolsRet: Computer的工具列表 / Computer's tool list
+            GetToolsRet | ErrorPayload: 工具列表，或 Computer 回传的 flat ErrorPayload。
         """
-        computer_name = data["computer"]
-
-        # 通过name获取computer的sid
-        # Get computer's sid by name
-        computer_sid = await self.get_sid_by_name(computer_name)
-        if not computer_sid:
-            raise ValueError(f"Computer with name '{computer_name}' not found")
-
-        session = await self.get_session(computer_sid)
-        if session["role"] != "computer":
-            raise SMCPNamespaceError("目前仅支持Computer获取工具列表")
-
-        # 验证Agent是否有权限获取该Computer的工具列表
-        # Verify if Agent has permission to get this Computer's tool list
-        agent_session = await self.get_session(sid)
-        computer_office_id = session.get("office_id")
-        agent_office_id = agent_session.get("office_id")
-
-        if computer_office_id != agent_office_id:
-            raise SMCPNamespaceError("目前仅支持Agent获取自己房间内Computer的工具列表")
-
-        client_response = await self.call(
-            GET_TOOLS_EVENT,
-            data,
-            to=computer_sid,
-            namespace=SMCP_NAMESPACE,
+        return cast(
+            "GetToolsRet | ErrorPayload",
+            await self._relay_client_call(sid, data, GET_TOOLS_EVENT, TypeAdapter(GetToolsRet)),
         )
 
-        return TypeAdapter(GetToolsRet).validate_python(client_response)
-
-    async def on_client_get_desktop(self, sid: str, data: GetDeskTopReq) -> GetDeskTopRet:
+    async def on_client_get_desktop(self, sid: str, data: GetDeskTopReq) -> GetDeskTopRet | ErrorPayload:
         """
-        获取指定Computer的桌面信息（窗口组织后的视图）。
-        Get desktop view from specified Computer.
+        获取指定 Computer 的桌面视图（窗口组织后）/ Get desktop view from specified Computer（``client:get_desktop``）.
 
-        要求：Agent 与 Computer 需在同一 office。
+        要求 Agent 与 Computer 同一 office；经 :meth:`_relay_client_call` 统一 isolation + flat
+        ErrorPayload 透传。
+        Requires same office; routed via ``_relay_client_call`` (unified isolation + flat ErrorPayload).
+
+        Returns:
+            GetDeskTopRet | ErrorPayload: 桌面视图，或 Computer 回传的 flat ErrorPayload。
         """
-        computer_name = data["computer"]
-
-        # 通过name获取computer的sid
-        # Get computer's sid by name
-        computer_sid = await self.get_sid_by_name(computer_name)
-        if not computer_sid:
-            raise ValueError(f"Computer with name '{computer_name}' not found")
-
-        session = await self.get_session(computer_sid)
-        if session["role"] != "computer":
-            raise SMCPNamespaceError("目前仅支持获取Computer桌面")
-
-        agent_session = await self.get_session(sid)
-        computer_office_id = session.get("office_id")
-        agent_office_id = agent_session.get("office_id")
-        if computer_office_id != agent_office_id:
-            raise SMCPNamespaceError("目前仅支持Agent获取自己房间内Computer的桌面")
-
-        client_response = await self.call(
-            GET_DESKTOP_EVENT,
-            data,
-            to=computer_sid,
-            namespace=SMCP_NAMESPACE,
+        return cast(
+            "GetDeskTopRet | ErrorPayload",
+            await self._relay_client_call(sid, data, GET_DESKTOP_EVENT, TypeAdapter(GetDeskTopRet)),
         )
-        return TypeAdapter(GetDeskTopRet).validate_python(client_response)
 
     async def _relay_client_call(
         self,
@@ -507,6 +469,12 @@ class SMCPNamespace(BaseNamespace):
             raise SMCPNamespaceError(f"目前仅支持 Computer 响应 {event} / target SID is not a Computer")
 
         agent_session = await self.get_session(sid)
+        if agent_session is None:
+            # 发起者（Agent）飞行中断连：会话已不存在。显式 raise 替代 None.get 的 AttributeError
+            # （对齐 #31 隔离不变量显式 raise）；协议许可 Server MAY 静默不 ack、不新增错误码（v0.2.2）。
+            # Originator (Agent) disconnected in-flight: session gone. Explicit raise instead of an
+            # AttributeError on None.get (aligns with #31). Protocol allows Server MAY silently not-ack.
+            raise SMCPNamespaceError(f"发起者会话不存在（可能已断连）：{event} / originator session gone")
         if session.get("office_id") != agent_session.get("office_id"):
             raise SMCPNamespaceError(
                 f"跨房间访问被拒绝：{event} 仅限同一 office / cross-office {event} access denied",
@@ -638,6 +606,10 @@ class SMCPNamespace(BaseNamespace):
 
         # 验证发起者权限：确保Agent在请求的房间内 / Verify initiator permission: ensure Agent is in the requested room
         agent_session = await self.get_session(sid)
+        if agent_session is None:
+            # 发起者飞行中断连防御（同 _relay_client_call）：显式 raise 替代 None.get 的 AttributeError。
+            # In-flight disconnect guard (same as _relay_client_call): explicit raise over AttributeError.
+            raise SMCPNamespaceError("发起者会话不存在（可能已断连）：server:list_room / originator session gone")
         agent_office_id = agent_session.get("office_id")
 
         if agent_office_id != office_id:

--- a/a2c_smcp/server/sync_namespace.py
+++ b/a2c_smcp/server/sync_namespace.py
@@ -294,71 +294,28 @@ class SyncSMCPNamespace(SyncBaseNamespace):
             ),
         )
 
-    def on_client_get_tools(self, sid: str, data: GetToolsReq) -> GetToolsRet:
+    def on_client_get_tools(self, sid: str, data: GetToolsReq) -> GetToolsRet | ErrorPayload:
         """
-        同步：获取指定Computer的工具列表（使用 Socket.IO 的 call 等待客户端返回）
-        Sync: get tool list of specified Computer using Socket.IO call
+        同步：获取指定 Computer 的工具列表（``client:get_tools``）/ Sync: get tool list of specified Computer.
+
+        经 :meth:`_relay_client_call` 统一 isolation + flat ErrorPayload 透传（v0.2.2：所有 ``client:*``
+        ack 统一 flat ErrorPayload，旧路由非豁免）。
         """
-        computer_name = data["computer"]
-
-        # 通过name获取computer的sid
-        # Get computer's sid by name
-        computer_sid = self.get_sid_by_name(computer_name)
-        if not computer_sid:
-            raise ValueError(f"Computer with name '{computer_name}' not found")
-
-        session = self.get_session(computer_sid)
-        if session["role"] != "computer":
-            raise SMCPNamespaceError("目前仅支持Computer获取工具列表")
-
-        agent_session = self.get_session(sid)
-        computer_office_id = session.get("office_id")
-        agent_office_id = agent_session.get("office_id")
-        if computer_office_id != agent_office_id:
-            raise SMCPNamespaceError("目前仅支持Agent获取自己房间内Computer的工具列表")
-
-        client_response = self.call(
-            GET_TOOLS_EVENT,
-            data,
-            to=computer_sid,
-            namespace=SMCP_NAMESPACE,
+        return cast(
+            "GetToolsRet | ErrorPayload",
+            self._relay_client_call(sid, data, GET_TOOLS_EVENT, TypeAdapter(GetToolsRet)),
         )
 
-        return TypeAdapter(GetToolsRet).validate_python(client_response)
-
-    def on_client_get_desktop(self, sid: str, data: GetDeskTopReq) -> GetDeskTopRet:
+    def on_client_get_desktop(self, sid: str, data: GetDeskTopReq) -> GetDeskTopRet | ErrorPayload:
         """
-        同步：获取指定Computer的桌面信息（窗口组织后的视图）
-        Sync: get desktop view from specified Computer
+        同步：获取指定 Computer 的桌面视图（``client:get_desktop``）/ Sync: get desktop view from Computer.
 
-        要求：Agent 与 Computer 需在同一 office / Requirement: Agent and Computer must be in the same office
+        要求 Agent 与 Computer 同一 office；经 :meth:`_relay_client_call` 统一 isolation + flat ErrorPayload 透传。
         """
-        computer_name = data["computer"]
-
-        # 通过name获取computer的sid
-        # Get computer's sid by name
-        computer_sid = self.get_sid_by_name(computer_name)
-        if not computer_sid:
-            raise ValueError(f"Computer with name '{computer_name}' not found")
-
-        session = self.get_session(computer_sid)
-        if session["role"] != "computer":
-            raise SMCPNamespaceError("目前仅支持Computer获取桌面")
-
-        agent_session = self.get_session(sid)
-        computer_office_id = session.get("office_id")
-        agent_office_id = agent_session.get("office_id")
-        if computer_office_id != agent_office_id:
-            raise SMCPNamespaceError("目前仅支持Agent获取自己房间内Computer的桌面")
-
-        client_response = self.call(
-            GET_DESKTOP_EVENT,
-            data,
-            to=computer_sid,
-            namespace=SMCP_NAMESPACE,
+        return cast(
+            "GetDeskTopRet | ErrorPayload",
+            self._relay_client_call(sid, data, GET_DESKTOP_EVENT, TypeAdapter(GetDeskTopRet)),
         )
-
-        return TypeAdapter(GetDeskTopRet).validate_python(client_response)
 
     def _relay_client_call(
         self,
@@ -384,6 +341,10 @@ class SyncSMCPNamespace(SyncBaseNamespace):
             raise SMCPNamespaceError(f"目前仅支持 Computer 响应 {event} / target SID is not a Computer")
 
         agent_session = self.get_session(sid)
+        if agent_session is None:
+            # 发起者（Agent）飞行中断连：会话已不存在。显式 raise 替代 None.get 的 AttributeError
+            # （对齐 #31）；协议许可 Server MAY 静默不 ack、不新增错误码（v0.2.2）。
+            raise SMCPNamespaceError(f"发起者会话不存在（可能已断连）：{event} / originator session gone")
         if session.get("office_id") != agent_session.get("office_id"):
             raise SMCPNamespaceError(
                 f"跨房间访问被拒绝：{event} 仅限同一 office / cross-office {event} access denied",
@@ -492,6 +453,9 @@ class SyncSMCPNamespace(SyncBaseNamespace):
 
         # 验证发起者权限：确保Agent在请求的房间内 / Verify initiator permission: ensure Agent is in the requested room
         agent_session = self.get_session(sid)
+        if agent_session is None:
+            # 发起者飞行中断连防御（同 _relay_client_call）：显式 raise 替代 None.get 的 AttributeError。
+            raise SMCPNamespaceError("发起者会话不存在（可能已断连）：server:list_room / originator session gone")
         agent_office_id = agent_session.get("office_id")
 
         if agent_office_id != office_id:

--- a/a2c_smcp/smcp.py
+++ b/a2c_smcp/smcp.py
@@ -530,14 +530,20 @@ class ErrorPayload(TypedDict, total=False):
 # =====================================================================
 
 
-class A2CSkillRef(TypedDict, total=False):
+class A2CSkillRef(TypedDict):
     """
     SKILL 引用对象，``client:get_skills`` 返回列表元素。
     Skill reference object — element of ``client:get_skills`` return list.
 
-    协议依据 / Protocol: data-structures.md §A2CSkillRef；skill.md §1 命名 / §6 数据结构。
+    协议依据 / Protocol: data-structures.md §A2CSkillRef（v0.2.2 正式定稿必选集）；skill.md §1 命名 / §6 数据结构。
 
     关键约束 / Key invariants:
+      - **必选 4 字段**：``name`` / ``source`` / ``path`` / ``description``（``total=True`` 默认，PEP 655：
+        裸字段=必选、``NotRequired[]``=可选）。``description`` 跨三源恒存在（SKILL.md frontmatter 强制
+        name+description，marketplace §3.1）。Producer(Computer) **MUST** 发齐 4 必选；Consumer(Agent)
+        **MUST NOT** 假定任一可选字段存在。
+        Required 4: name/source/path/description (total=True + ``NotRequired[]`` optionals). Producer MUST
+        send all 4; Consumer MUST NOT assume any optional field is present.
       - ``name`` 是协议主键（合成全局唯一名，自 0.2.1 起为**裸名**：user 1 段 ``<skill>`` /
         marketplace 2 段 ``<plugin>:<skill>`` / mcp 3 段 ``mcp:<server>:<skill>``），Agent **MUST**
         当作不透明可比较字符串（**勿**解析结构，判来源用 ``source``）
@@ -553,20 +559,20 @@ class A2CSkillRef(TypedDict, total=False):
         carried by ``source`` and (MCP only) ``uri``.
     """
 
-    # 主键 / Primary key
+    # 主键 / Primary key（必选 / required）
     name: str  # 合成全局唯一裸名；如 user `my-helper` / marketplace `acme-audit:audit` / mcp `mcp:tfrobot-tools:code-review`
-    # 来源元数据 / Provenance（完整溯源；**不**进 name）
+    # 来源元数据 / Provenance（完整溯源；**不**进 name）（必选 / required）
     source: str  # 如 mcp:tfrobot-tools / marketplace:acme-skills / user
-    uri: str  # 仅 MCP 来源：skill://host/skill-name；Agent 非权威（skill.md §2）
-    # 物化输出 / Materialization output
+    uri: NotRequired[str]  # 仅 MCP 来源：skill://host/skill-name；Agent 非权威（skill.md §2）
+    # 物化输出 / Materialization output（必选 / required）
     path: str  # 必选：Computer 本地绝对目录路径，面向 Agent SDK（脚本执行/文件访问），LLM 永不可见
     # SKILL.md frontmatter 派生 / Derived from SKILL.md frontmatter
-    description: str  # marketplace SKILL v1 §3.1
-    license: str
-    compatibility: str
-    allowed_tools: list[str]  # frontmatter "allowed-tools" 规范化为 list
-    version: str
-    skill_metadata: dict[str, Any]  # frontmatter.metadata 透传；A2C 不解释 / passthrough, A2C does not interpret
+    description: str  # 必选 / required：marketplace SKILL v1 §3.1（跨三源强制）
+    license: NotRequired[str]
+    compatibility: NotRequired[str]
+    allowed_tools: NotRequired[list[str]]  # frontmatter "allowed-tools" 规范化为 list
+    version: NotRequired[str]
+    skill_metadata: NotRequired[dict[str, Any]]  # frontmatter.metadata 透传；A2C 不解释 / passthrough, A2C does not interpret
 
 
 class GetSkillsReq(AgentCallData, total=True):

--- a/tests/integration_tests/computer/cli/test_main.py
+++ b/tests/integration_tests/computer/cli/test_main.py
@@ -123,7 +123,9 @@ class _DummyInteractive:
     last_comp: Any | None = None
 
     @classmethod
-    async def coro(cls, comp: Any, init_client: Any | None = None) -> None:  # noqa: ARG003
+    async def coro(cls, comp: Any, init_client: Any | None = None, **kwargs: Any) -> None:  # noqa: ARG003
+        # **kwargs 吸收 CLI 演进新增的关键字参数（如 #69 的 approve_all_mcp）；本替身仅捕获调用，不断言其值。
+        # **kwargs absorbs CLI-evolving keyword args (e.g. #69's approve_all_mcp); this double only captures the call.
         cls.called = True
         cls.last_comp = comp
 
@@ -140,6 +142,7 @@ class _FakeComputer:
         auto_reconnect: bool = True,
         confirm_callback: Callable[[str, str, str, dict], bool] | None = None,
         input_resolver: Any | None = None,
+        registered_workdirs: Any | None = None,  # #69/S16：CLI --add-dir → registered_workdirs，替身需接受
     ) -> None:
         self.init_args = {
             "name": name,
@@ -149,6 +152,7 @@ class _FakeComputer:
             "auto_reconnect": auto_reconnect,
             "confirm_callback": confirm_callback,
             "input_resolver": input_resolver,
+            "registered_workdirs": registered_workdirs,
         }
 
     async def __aenter__(self) -> _FakeComputer:

--- a/tests/integration_tests/computer/test_computer.py
+++ b/tests/integration_tests/computer/test_computer.py
@@ -71,7 +71,10 @@ class _DictResolver:
     def __init__(self, mapping: dict[str, object]):
         self._m = mapping
 
-    async def aresolve_by_id(self, input_id: str, *, session: PromptSession | None = None):  # noqa: D401
+    async def aresolve_by_id(self, input_id: str, *, session: PromptSession | None = None, **kwargs: object):  # noqa: D401
+        # **kwargs 吸收 #69 Group A 新增的 plugin/marketplace 上下文（本替身按裸 id 映射，忽略上下文）。
+        # 缺它 → TypeError → 渲染失败被「保留原配置」策略吞掉 → 未渲染的 ${input:cmd} 当命令起 stdio → mcp 客户端无超时死等。
+        # **kwargs absorbs #69's plugin/marketplace context; without it a swallowed TypeError left ${input:} unrendered → hang.
         return self._m[input_id]
 
     def clear_cache(self, key: str | None = None):  # noqa: D401

--- a/tests/integration_tests/server/test_namespace_async.py
+++ b/tests/integration_tests/server/test_namespace_async.py
@@ -548,7 +548,8 @@ async def test_get_tools_cross_office_rejected(socketio_server, basic_server_por
     agent_sid = await _connect_join(agent, basic_server_port, "agent", "office-neg-A", "robot-neg-1")
     await _connect_join(computer, basic_server_port, "computer", "office-neg-B", "comp-neg-1")
 
-    with pytest.raises(SMCPNamespaceError, match="自己房间内Computer的工具列表"):
+    # v0.2.2 #46 起，client:get_tools 收编进 _relay_client_call，跨房间错误文案统一为通用 "跨房间" 模板。
+    with pytest.raises(SMCPNamespaceError, match="跨房间"):
         await socketio_server.on_client_get_tools(
             agent_sid,
             {"computer": "comp-neg-1", "agent": "robot-neg-1", "req_id": "neg-r1"},

--- a/tests/unit_tests/agent/test_v021_consume.py
+++ b/tests/unit_tests/agent/test_v021_consume.py
@@ -83,7 +83,7 @@ class TestAsyncGetSkills:
     async def test_returns_typed_ret(self, async_client: AsyncSMCPAgentClient) -> None:
         with patch.object(async_client, "call", new=AsyncMock()) as mock_call:
             mock_call.return_value = {
-                "skills": [{"name": "user:x:y", "source": "user", "path": "/s/x/y"}],
+                "skills": [{"name": "user:x:y", "source": "user", "path": "/s/x/y", "description": "demo skill"}],
                 "req_id": "should-be-overridden",
             }
             # 用 monkeypatch + 真实 req_id 比对：覆写 mock 返回 req_id 与生成的一致
@@ -95,7 +95,7 @@ class TestAsyncGetSkills:
 
             mock_call.side_effect = capture
             ret = await async_client.get_skills("comp-1")
-            assert ret["skills"] == [{"name": "user:x:y", "source": "user", "path": "/s/x/y"}]
+            assert ret["skills"] == [{"name": "user:x:y", "source": "user", "path": "/s/x/y", "description": "demo skill"}]
             _ = real_call
 
     @pytest.mark.asyncio
@@ -243,7 +243,7 @@ class TestSkillsUpdatedAutoRefresh:
     @pytest.mark.asyncio
     async def test_async_dispatches_on_skills_received(self, async_client: AsyncSMCPAgentClient) -> None:
         """成功重拉后回调 on_skills_received，参数透传 / Hook fires with passthrough args (v0.2.1+)."""
-        skills = [{"name": "user:x:y", "source": "user", "path": "/s/x/y"}]
+        skills = [{"name": "user:x:y", "source": "user", "path": "/s/x/y", "description": "demo skill"}]
         hook = AsyncMock()
         async_client.event_handler = hook  # type: ignore[assignment]
         with patch.object(async_client, "get_skills", new=AsyncMock(return_value={"skills": skills, "req_id": "r"})):
@@ -436,7 +436,7 @@ class TestSyncMirror:
     def test_sync_dispatches_on_skills_received(self, sync_client: SMCPAgentClient) -> None:
         """sync 镜像：成功重拉后回调 on_skills_received（v0.2.1+）.
         Sync mirror: hook fires with passthrough args (v0.2.1+)."""
-        skills = [{"name": "user:x:y", "source": "user", "path": "/s/x/y"}]
+        skills = [{"name": "user:x:y", "source": "user", "path": "/s/x/y", "description": "demo skill"}]
         hook = MagicMock()
         sync_client.event_handler = hook  # type: ignore[assignment]
         with patch.object(sync_client, "get_skills", new=MagicMock(return_value={"skills": skills, "req_id": "r"})):

--- a/tests/unit_tests/server/test_smcp_namespace.py
+++ b/tests/unit_tests/server/test_smcp_namespace.py
@@ -23,6 +23,7 @@ from a2c_smcp.smcp import (
     GET_DESKTOP_EVENT,
     GET_SKILL_EVENT,
     GET_SKILLS_EVENT,
+    GET_TOOLS_EVENT,
     SMCP_NAMESPACE,
     UPDATE_DESKTOP_EVENT,
     UPDATE_DESKTOP_NOTIFICATION,
@@ -604,7 +605,10 @@ class TestV021ClientRoutesAndUpdateSkills:
     @pytest.mark.asyncio
     async def test_on_client_get_skills_relays_and_returns_typed_ret(self, routed_ns):
         ns, agent_sid, comp_name, comp_sid = routed_ns
-        ns.call.return_value = {"skills": [{"name": "user:x:y", "source": "user", "path": "/s/x/y"}], "req_id": "r1"}
+        ns.call.return_value = {
+            "skills": [{"name": "user:x:y", "source": "user", "path": "/s/x/y", "description": "demo skill"}],
+            "req_id": "r1",
+        }
         ret = await ns.on_client_get_skills(agent_sid, {"agent": "agent-1", "req_id": "r1", "computer": comp_name})
         # call 携带正确事件名 + Computer 目标 SID / call must dispatch to right event + sid
         ns.call.assert_awaited_once()
@@ -614,7 +618,7 @@ class TestV021ClientRoutesAndUpdateSkills:
         assert kwargs["namespace"] == SMCP_NAMESPACE
         # 语义级断言：内容完整透传（拒绝 "TypeAdapter 把字段吃掉" 或 "被测函数 return data" 的退化）.
         # Semantic-level assertion: contents passed through (catches TypeAdapter swallowing fields).
-        assert ret["skills"] == [{"name": "user:x:y", "source": "user", "path": "/s/x/y"}]
+        assert ret["skills"] == [{"name": "user:x:y", "source": "user", "path": "/s/x/y", "description": "demo skill"}]
         assert ret["req_id"] == "r1"
 
     @pytest.mark.asyncio
@@ -783,3 +787,53 @@ class TestV021ClientRoutesAndUpdateSkills:
         with pytest.raises(SMCPNamespaceError, match="Computer"):
             await smcp_namespace.on_server_update_skills("a-sid", {"computer": "c1"})
         smcp_namespace.emit.assert_not_awaited()
+
+    # ── v0.2.2 #46：旧路由收编 _relay_client_call + 飞行断连防御 ───────────
+
+    @pytest.mark.asyncio
+    async def test_get_tools_relays_via_unified_helper(self, routed_ns):
+        """``client:get_tools`` 收编后经 ``_relay_client_call`` 转发到正确事件 + Computer SID.
+        get_tools now routes via the unified helper (right event + target sid)."""
+        ns, agent_sid, comp_name, comp_sid = routed_ns
+        ns.call.return_value = {"tools": [], "req_id": "r1"}
+        ret = await ns.on_client_get_tools(agent_sid, {"computer": comp_name})
+        ns.call.assert_awaited_once()
+        assert ns.call.call_args[0][0] == GET_TOOLS_EVENT
+        assert ns.call.call_args.kwargs["to"] == comp_sid
+        assert ret["tools"] == []
+
+    @pytest.mark.asyncio
+    async def test_get_tools_flat_error_passthrough(self, routed_ns):
+        """v0.2.2 旧路由非豁免：Computer 对 ``client:get_tools`` 返回 flat ErrorPayload → 原样透传，不强转 GetToolsRet.
+        Old route is not exempt: flat ErrorPayload from Computer is relayed verbatim (no coercion)."""
+        ns, agent_sid, comp_name, _comp_sid = routed_ns
+        err = {"code": int(ErrorCode.MCP_SERVER_NOT_FOUND), "message": "computer mcp not ready"}
+        ns.call.return_value = err
+        ret = await ns.on_client_get_tools(agent_sid, {"computer": comp_name})
+        assert ret["code"] == int(ErrorCode.MCP_SERVER_NOT_FOUND)
+
+    @pytest.mark.asyncio
+    async def test_get_desktop_flat_error_passthrough(self, routed_ns):
+        """``client:get_desktop`` 同样透传 flat ErrorPayload（收编 _relay_client_call 后）.
+        get_desktop likewise passes flat ErrorPayload through after migration."""
+        ns, agent_sid, comp_name, _comp_sid = routed_ns
+        err = {"code": int(ErrorCode.MCP_SERVER_NOT_FOUND), "message": "no desktop"}
+        ns.call.return_value = err
+        ret = await ns.on_client_get_desktop(agent_sid, {"computer": comp_name})
+        assert ret["code"] == int(ErrorCode.MCP_SERVER_NOT_FOUND)
+
+    @pytest.mark.asyncio
+    async def test_relay_agent_session_none_raises_namespace_error(self, smcp_namespace, mock_server):
+        """发起者（Agent）飞行中断连：``get_session(sid)`` → None → **显式 raise SMCPNamespaceError**（替代 AttributeError，#46/#31）.
+        Originator disconnected in-flight → explicit SMCPNamespaceError instead of AttributeError on None.get."""
+        smcp_namespace.server = mock_server
+        comp_sid = "c-sid"
+        comp_name = "c1"
+        smcp_namespace._name_to_sid_map = {comp_name: comp_sid}
+        sess_comp = {"role": "computer", "office_id": "room1", "name": comp_name}
+        # Computer 会话存在；发起者（Agent）会话已断连 → None / Computer ok, originator gone
+        smcp_namespace.get_session = AsyncMock(side_effect=lambda sid: sess_comp if sid == comp_sid else None)
+        smcp_namespace.call = AsyncMock()
+        with pytest.raises(SMCPNamespaceError, match="session gone"):
+            await smcp_namespace.on_client_get_tools("gone-agent-sid", {"computer": comp_name})
+        smcp_namespace.call.assert_not_awaited()  # 断连防御先于转发 / guard precedes relay

--- a/tests/unit_tests/server/test_smcp_namespace_sync.py
+++ b/tests/unit_tests/server/test_smcp_namespace_sync.py
@@ -22,6 +22,7 @@ from a2c_smcp.smcp import (
     GET_BLOB_EVENT,
     GET_SKILL_EVENT,
     GET_SKILLS_EVENT,
+    GET_TOOLS_EVENT,
     SMCP_NAMESPACE,
     UPDATE_SKILLS_NOTIFICATION,
     EnterOfficeReq,
@@ -167,7 +168,10 @@ class TestV021ClientRoutesAndUpdateSkillsSync:
 
     def test_on_client_get_skills_relays(self, routed_ns):
         ns, agent_sid, comp_name, comp_sid = routed_ns
-        ns.call.return_value = {"skills": [{"name": "user:x:y", "source": "user", "path": "/s/x/y"}], "req_id": "r1"}
+        ns.call.return_value = {
+            "skills": [{"name": "user:x:y", "source": "user", "path": "/s/x/y", "description": "demo skill"}],
+            "req_id": "r1",
+        }
         ret = ns.on_client_get_skills(agent_sid, {"agent": "agent-1", "req_id": "r1", "computer": comp_name})
         ns.call.assert_called_once()
         args, kwargs = ns.call.call_args
@@ -175,7 +179,7 @@ class TestV021ClientRoutesAndUpdateSkillsSync:
         assert kwargs["to"] == comp_sid
         assert kwargs["namespace"] == SMCP_NAMESPACE
         # 语义级断言：内容完整透传 / Semantic-level assertion: contents passed through
-        assert ret["skills"] == [{"name": "user:x:y", "source": "user", "path": "/s/x/y"}]
+        assert ret["skills"] == [{"name": "user:x:y", "source": "user", "path": "/s/x/y", "description": "demo skill"}]
         assert ret["req_id"] == "r1"
 
     def test_on_client_get_skill_relays(self, routed_ns):
@@ -309,3 +313,44 @@ class TestV021ClientRoutesAndUpdateSkillsSync:
         with pytest.raises(SMCPNamespaceError, match="Computer"):
             smcp_namespace.on_server_update_skills("a-sid", {"computer": "c1"})
         smcp_namespace.emit.assert_not_called()
+
+    # ── v0.2.2 #46（sync 镜像）：旧路由收编 _relay_client_call + 飞行断连防御 ──
+
+    def test_get_tools_relays_via_unified_helper(self, routed_ns):
+        """sync：``client:get_tools`` 收编后经 ``_relay_client_call`` 转发到正确事件 + Computer SID."""
+        ns, agent_sid, comp_name, comp_sid = routed_ns
+        ns.call.return_value = {"tools": [], "req_id": "r1"}
+        ret = ns.on_client_get_tools(agent_sid, {"computer": comp_name})
+        ns.call.assert_called_once()
+        assert ns.call.call_args[0][0] == GET_TOOLS_EVENT
+        assert ns.call.call_args.kwargs["to"] == comp_sid
+        assert ret["tools"] == []
+
+    def test_get_tools_flat_error_passthrough(self, routed_ns):
+        """sync：v0.2.2 旧路由非豁免——``client:get_tools`` 的 flat ErrorPayload 原样透传，不强转 GetToolsRet."""
+        ns, agent_sid, comp_name, _comp_sid = routed_ns
+        err = {"code": int(ErrorCode.MCP_SERVER_NOT_FOUND), "message": "computer mcp not ready"}
+        ns.call.return_value = err
+        ret = ns.on_client_get_tools(agent_sid, {"computer": comp_name})
+        assert ret["code"] == int(ErrorCode.MCP_SERVER_NOT_FOUND)
+
+    def test_get_desktop_flat_error_passthrough(self, routed_ns):
+        """sync：``client:get_desktop`` 同样透传 flat ErrorPayload."""
+        ns, agent_sid, comp_name, _comp_sid = routed_ns
+        err = {"code": int(ErrorCode.MCP_SERVER_NOT_FOUND), "message": "no desktop"}
+        ns.call.return_value = err
+        ret = ns.on_client_get_desktop(agent_sid, {"computer": comp_name})
+        assert ret["code"] == int(ErrorCode.MCP_SERVER_NOT_FOUND)
+
+    def test_relay_agent_session_none_raises_namespace_error(self, smcp_namespace, mock_server):
+        """sync：发起者飞行中断连 ``get_session(sid)`` → None → **显式 raise SMCPNamespaceError**（替代 AttributeError，#46/#31）."""
+        smcp_namespace.server = mock_server
+        comp_sid = "c-sid"
+        comp_name = "c1"
+        smcp_namespace._name_to_sid_map = {comp_name: comp_sid}
+        sess_comp = {"role": "computer", "office_id": "room1", "name": comp_name}
+        smcp_namespace.get_session = MagicMock(side_effect=lambda sid: sess_comp if sid == comp_sid else None)
+        smcp_namespace.call = MagicMock()
+        with pytest.raises(SMCPNamespaceError, match="session gone"):
+            smcp_namespace.on_client_get_tools("gone-agent-sid", {"computer": comp_name})
+        smcp_namespace.call.assert_not_called()

--- a/tests/unit_tests/test_smcp.py
+++ b/tests/unit_tests/test_smcp.py
@@ -147,17 +147,25 @@ class TestTypedDictsV021:
     """v0.2.1 TypedDict 镜像层可构造性烟雾测试（字段对齐 data-structures.md）。
     Smoke tests confirming v0.2.1 TypedDict mirror layer is constructable per data-structures.md."""
 
-    def test_a2c_skill_ref_minimal_required_fields(self) -> None:
-        """name / source / path 是协议主键 + 必选物化输出；total=False 允许仅设这三个。
-        name / source / path are required core fields; total=False permits a minimal ref."""
+    def test_a2c_skill_ref_required_field_set(self) -> None:
+        """v0.2.2：A2CSkillRef **4 必选** = name/source/path/description（去 total=False → total=True + NotRequired[]）。
+        ``__required_keys__`` 正式编码必选集（PEP 655），类型检查器可在编译期发现漏填（#50）。
+        v0.2.2: 4 required fields encoded in ``__required_keys__`` so the type checker catches omissions."""
+        assert A2CSkillRef.__required_keys__ == frozenset({"name", "source", "path", "description"})
+        assert A2CSkillRef.__optional_keys__ == frozenset(
+            {"uri", "license", "compatibility", "allowed_tools", "version", "skill_metadata"},
+        )
+        # 含全部 4 必选的最小 ref 合法 / minimal ref carrying all 4 required is valid
         ref: A2CSkillRef = {
             "name": "mcp:tfrobot-tools:code-review",
             "source": "mcp:tfrobot-tools",
             "path": "/tmp/skills/mcp/tfrobot-tools/code-review",
+            "description": "Code review skill",
         }
         assert ref["name"] == "mcp:tfrobot-tools:code-review"
         assert ref["source"].startswith("mcp:")
         assert ref["path"].startswith("/")
+        assert ref["description"] == "Code review skill"
 
     def test_a2c_skill_ref_full_with_frontmatter_fields(self) -> None:
         """完整 ref 含 SKILL.md frontmatter 派生字段 / Full ref includes frontmatter-derived fields."""
@@ -182,9 +190,10 @@ class TestTypedDictsV021:
             "name": "mcp:tfrobot-tools:code-review",
             "source": "mcp:tfrobot-tools",
             "path": "/tmp/skills/mcp/tfrobot-tools/code-review",
+            "description": "Code review skill",  # 必选 / required (v0.2.2)
             "uri": "skill://tfrobot-tools/code-review",
         }
-        assert ref["uri"].startswith("skill://")
+        assert ref.get("uri", "").startswith("skill://")
 
     def test_get_skills_req_required_fields(self) -> None:
         """GetSkillsReq total=True：agent / req_id / computer 都是必选。


### PR DESCRIPTION
## 概述

协议跟进 **a2c-smcp-protocol v0.2.2**（加性/澄清级，`PROTOCOL_VERSION` 仍 0.2.0，tag→`cfdf0cd`）。一并修复两个「协议先行已完成、待代码跟进」项。

Closes #50
Closes #46

## #50 — A2CSkillRef 必选字段（`a2c_smcp/smcp.py`）

- 去 `total=False` → **4 必选**：`name`/`source`/`path`/**`description`**；其余 6 个标 `NotRequired[]`（PEP 655）。
- 协议把 `description` 也定为必选（SKILL.md frontmatter 跨三源强制 name+description，marketplace §3.1）；Producer(Computer) MUST 发齐 4 必选，Consumer(Agent) MUST NOT 假定任一可选字段存在。
- `_relay_client_call` 处 `TypeAdapter(GetSkillsRet)` 运行时强制 `description`；producer 侧（staging）本就恒填，无需改。

## #46 — 旧路由收编 + 飞行断连防御（`server/namespace.py` + `sync_namespace.py` 双镜像）

- `on_client_get_tools` / `on_client_get_desktop` 收编进 `_relay_client_call`：统一 flat ErrorPayload 透传（v0.2.2 旧路由非豁免），返回签名扩为 `... | ErrorPayload`；8 处内联收敛到 1 个 helper。
- `_relay_client_call` + `on_server_list_room`：发起者飞行断连（`get_session(sid)→None`）时**显式 raise `SMCPNamespaceError`** 替代 `AttributeError`（对齐 #31；协议许可 Server MAY 静默不 ack、不新增错误码）。
- 跨房间 `get_tools` 错误文案统一为通用「跨房间」模板，更新断言。

## Drive-by（test-only，修 develop-v0.2.1 基线上 #69/#87 遗留的测试替身漂移，与 #50/#46 无关）

CLI/resolver 签名在 #69/S16 演进后，以下测试替身未跟更新（基线即红/挂死）：
- `test_main.py`：`_FakeComputer` 补 `registered_workdirs`；`_DummyInteractive.coro` 加 `**kwargs`（吸收 `approve_all_mcp`）。
- `test_computer.py`：`_DictResolver.aresolve_by_id` 加 `**kwargs`（吸收 `plugin`/`marketplace`）——修因 TypeError 被吞→`${input:}` 未渲染→stdio 客户端无超时死等的**挂死**。

> 注：CLI 集成测试（`test_interactive_*`/`test_marketplace` 等）可能仍有同类 #87 替身漂移，属 #87 独立清理范围，不在本 PR。

## 验证

- `uv run --no-sync poe lint` 净（ruff + mypy 98 文件）
- unit **1328 passed / 4 xfailed**
- #46 server 集成（namespace/isolation/get_resources/blob/tool_call）**51 passed**
- `test_main.py` 4 passed；`test_computer.py` 16 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)