### PR TITLE
feat(computer): v0.2.1 S8.1 marketplace strict 模式 + entry.skills override (#80)

### DIFF
--- a/a2c_smcp/computer/settings/installer.py
+++ b/a2c_smcp/computer/settings/installer.py
@@ -63,6 +63,8 @@ from a2c_smcp.computer.settings.store import (
 )
 from a2c_smcp.computer.skills.home import SOURCE_MARKETPLACE, marketplace_skill_dir
 from a2c_smcp.computer.skills.manifest import (
+    PluginManifestError,
+    check_strict_conflict,
     find_plugin_entry,
     load_bundled_servers,
     plugin_root_base,
@@ -316,6 +318,12 @@ async def install_plugin(
         timeout=timeout,
         env=env,
     )
+    # strict mode 冲突检测（§4.4，#80）：strict=false + plugin.json 声明组件 → 拒绝加载（**硬错误**）。
+    # 早检——在挂载 server / 注册 skill 前拦截，不依赖 staging 降级，保证原子失败（未挂 server、未注册 skill）。
+    try:
+        check_strict_conflict(entry, read_plugin_metadata(plugin_root))
+    except PluginManifestError as e:
+        raise PluginInstallError(str(e)) from e
     servers = load_bundled_servers(plugin_root)
 
     # 5：★冲突闸门（零变更）。owned = 自有同名白名单（其上次记录的 bundledMcpServers）。

--- a/a2c_smcp/computer/settings/installer.py
+++ b/a2c_smcp/computer/settings/installer.py
@@ -318,10 +318,12 @@ async def install_plugin(
         timeout=timeout,
         env=env,
     )
+    # plugin.json 读一次复用（冲突检测 + version 解析共用，与 staging._stage_one_plugin 姿态对齐，避免重复读盘）。
+    plugin_manifest = read_plugin_metadata(plugin_root)
     # strict mode 冲突检测（§4.4，#80）：strict=false + plugin.json 声明组件 → 拒绝加载（**硬错误**）。
     # 早检——在挂载 server / 注册 skill 前拦截，不依赖 staging 降级，保证原子失败（未挂 server、未注册 skill）。
     try:
-        check_strict_conflict(entry, read_plugin_metadata(plugin_root))
+        check_strict_conflict(entry, plugin_manifest)
     except PluginManifestError as e:
         raise PluginInstallError(str(e)) from e
     servers = load_bundled_servers(plugin_root)
@@ -375,7 +377,7 @@ async def install_plugin(
 
     # 8：★最后写账本（仅全成功）
     bundled_names = [cfg.name for cfg in servers]
-    resolved_version = version if version else resolve_plugin_version(entry, read_plugin_metadata(plugin_root), version_fallback)
+    resolved_version = version if version else resolve_plugin_version(entry, plugin_manifest, version_fallback)
     now = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
     record: InstalledPluginRecord = {"scope": scope, "installPath": str(plugin_root)}
     if project_path:

--- a/a2c_smcp/computer/skills/manifest.py
+++ b/a2c_smcp/computer/skills/manifest.py
@@ -170,7 +170,8 @@ def check_strict_conflict(entry: Mapping[str, Any], plugin_manifest: Mapping[str
 
 
 def _as_str_path_list(value: Any) -> list[str]:
-    """归一 ``string | array<string>`` → list[str]（非 str 项静默丢，语境化交调用方记日志）/ Normalize string|array<string>。"""
+    """归一 ``string | array<string>`` → list[str]（非 str 项**静默跳过**，与 :func:`iter_plugin_entries` 对畸形
+    manifest 子项的 silent-skip 姿态一致）/ Normalize string|array<string>; non-str items silently skipped。"""
     if isinstance(value, str):
         return [value]
     if isinstance(value, Sequence) and not isinstance(value, str | bytes):

--- a/a2c_smcp/computer/skills/manifest.py
+++ b/a2c_smcp/computer/skills/manifest.py
@@ -24,7 +24,11 @@ skills.staging (which now imports this module, so a back-edge would be a real cy
 **显式延后 / Deferred**：
 - **bundled MCP server inputs.json 入池消歧**（§9.3 D2 前缀）归 #65——本模块**枚举 server 时排除**
   ``inputs.json``，不解析 inputs 池。
-- **strict mode 组件路径覆写 / 冲突检测**（§3.4/§3.5）归 #80——本模块按约定路径解析，不做 strict 校验。
+
+**strict mode 组件路径覆写 / 冲突检测**（§4.3/§4.4，loading-behavior §1/§4/§6；#80）由本模块的纯函数
+:func:`entry_is_strict` / :func:`check_strict_conflict` / :func:`resolve_skill_override_dirs` 承载，供 staging
+（marketplace 注册）与 installer（plugin install 硬失败）共同消费。本 SDK 仅消费 ``skills`` + ``mcp-servers``，
+冲突检测仍按规范判**全六组件字段**（:data:`COMPONENT_FIELDS`），但覆写**路径扫描仅 ``skills``**。
 """
 
 from __future__ import annotations
@@ -39,6 +43,7 @@ from pydantic import TypeAdapter, ValidationError
 from a2c_smcp.computer.mcp_clients.model import MCPServerConfig
 from a2c_smcp.computer.skills.sources import DEFAULT_PLUGIN_ROOT
 from a2c_smcp.utils.logger import get_logger
+from a2c_smcp.utils.path import is_within
 
 logger = get_logger(__name__)
 
@@ -126,6 +131,87 @@ def resolve_plugin_version(entry: Mapping[str, Any], plugin_metadata: Mapping[st
         if isinstance(v, str) and v.strip():
             return v.strip()
     return fallback_sha
+
+
+# ── strict mode + 组件路径覆写（marketplace-v1 §4.3/§4.4 + loading-behavior.md §1/§4/§6；#80）─────
+# strict=false 下 plugin.json 不得再声明的组件字段全集（loading-behavior §6.2）。本 SDK 仅消费 skills +
+# mcp-servers，但冲突检测按规范判**全六字段**（前向兼容 CC 私有组件，防作者「以为生效实际被覆盖」）。
+COMPONENT_FIELDS: tuple[str, ...] = ("commands", "agents", "hooks", "skills", "mcpServers", "lspServers")
+
+
+def entry_is_strict(entry: Mapping[str, Any]) -> bool:
+    """marketplace 条目 ``strict`` 语义（§4.4，默认 ``True``）/ Whether the entry is in strict mode。
+
+    缺省 / 非 bool → ``True``（loading-behavior §4：strict=true 是更宽松、容错的默认模式）。
+    """
+    val = entry.get("strict")
+    return val if isinstance(val, bool) else True
+
+
+def manifest_declared_components(plugin_manifest: Mapping[str, Any]) -> list[str]:
+    """plugin.json 中**真值**组件字段名列表（空 / 缺 / falsy 不算声明）/ Truthy component fields declared in plugin.json。"""
+    return [f for f in COMPONENT_FIELDS if plugin_manifest.get(f)]
+
+
+def check_strict_conflict(entry: Mapping[str, Any], plugin_manifest: Mapping[str, Any]) -> None:
+    """strict=false 且 plugin.json 声明组件 → 抛 conflicting manifests（§4.4 / loading-behavior §6.2）。
+
+    strict=false 语义为「marketplace 条目是组件定义全集」；若 plugin 仓库 ``plugin.json`` 也声明组件，二者权威冲突
+    → **拒绝加载（硬错误）**，而非静默合并。strict=true（默认）恒不冲突（plugin.json 权威 + 条目追加合并）。
+    """
+    if entry_is_strict(entry):
+        return
+    declared = manifest_declared_components(plugin_manifest)
+    if declared:
+        raise PluginManifestError(
+            f"conflicting manifests: strict=false but plugin.json declares components {declared} "
+            "(marketplace-v1 §4.4: the marketplace entry is the authoritative component set)",
+        )
+
+
+def _as_str_path_list(value: Any) -> list[str]:
+    """归一 ``string | array<string>`` → list[str]（非 str 项静默丢，语境化交调用方记日志）/ Normalize string|array<string>。"""
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, Sequence) and not isinstance(value, str | bytes):
+        return [v for v in value if isinstance(v, str)]
+    return []
+
+
+def resolve_skill_override_dirs(
+    entry: Mapping[str, Any],
+    plugin_manifest: Mapping[str, Any],
+    plugin_root: Path,
+    *,
+    strict: bool,
+) -> list[Path]:
+    """解析 ``skills`` 组件路径覆写为**容器目录**列表（§4.3，追加进约定 ``skills/`` 之外）/ Resolve skills override container dirs。
+
+    源 = ``entry.skills``（恒取）+ ``plugin_manifest.skills``（仅 strict=true；strict=false 时 plugin 已无组件，
+    取空集亦无害——冲突在 :func:`check_strict_conflict` 已拦）。每项相对 ``plugin_root`` 解析后 ``is_within`` 防穿越
+    （越界记 ERROR 跳过，**不抛**），非目录记 WARNING 跳过；override 间按 resolve 后路径去重保序（与约定 ``skills/``
+    的去重交扫描方）。返回的是**容器**目录（其下 ``<name>/SKILL.md`` 为单个 SKILL，与约定 ``skills/`` 同构）。
+    """
+    raw: list[str] = _as_str_path_list(entry.get("skills"))
+    if strict:
+        raw.extend(_as_str_path_list(plugin_manifest.get("skills")))
+
+    plugin_root_resolved = plugin_root.resolve()
+    out: list[Path] = []
+    seen_paths: set[Path] = set()
+    for rel in raw:
+        cand = (plugin_root / rel).resolve()
+        if not is_within(cand, plugin_root_resolved):
+            logger.error("skills override path %r escapes plugin root %s, skipped", rel, plugin_root)
+            continue
+        if cand in seen_paths:
+            continue
+        if not cand.is_dir():
+            logger.warning("skills override path %r is not a directory at %s, skipped", rel, cand)
+            continue
+        seen_paths.add(cand)
+        out.append(cand)
+    return out
 
 
 # ── mcp-servers/<n>.json（plugin 携带 MCP server，文件式）/ bundled MCP server files ──────────

--- a/a2c_smcp/computer/skills/staging.py
+++ b/a2c_smcp/computer/skills/staging.py
@@ -93,9 +93,12 @@ from a2c_smcp.computer.skills.home import (
 )
 from a2c_smcp.computer.skills.manifest import (
     PluginManifestError,
+    check_strict_conflict,
+    entry_is_strict,
     read_marketplace_manifest,
     read_plugin_metadata,
     resolve_plugin_version,
+    resolve_skill_override_dirs,
 )
 from a2c_smcp.computer.skills.manifest import (
     plugin_root_base as resolve_plugin_root_base,
@@ -859,68 +862,84 @@ def _build_marketplace_ref(name: str, marketplace: str, frontmatter: dict[str, A
 def _scan_and_register_plugin_skills(
     marketplace: str,
     plugin_name: str,
-    plugin_root: Path,
+    skill_dirs: list[Path],
     version: str | None,
     registry: SkillRegistry,
     seen: set[str],
 ) -> list[str]:
     """
-    扫 ``<plugin 根>/skills/<skill>/SKILL.md`` 并注册 / Scan a plugin's ``skills/`` and register each SKILL。
+    扫给定**容器目录**下 ``<skill>/SKILL.md`` 并注册 / Scan SKILL container dirs and register each SKILL。
 
-    ``name = <plugin>:<skill>``（``<plugin>`` = entry.name、``<skill>`` = skill 目录 basename，frontmatter
-    仅作显示名、不改 ID，marketplace-v1 §2.1 防伪）。缺 frontmatter ``description`` / name 合成失败 / 本 run
-    重名 → 记 ERROR、跳过、不入册（失败降级，不抛）。仅扫 ``skills/`` 下**一级**（``iterdir``），不递归包内。
-
-    .. note::
-       仅扫**约定** ``skills/`` 目录；``entry.skills`` 组件路径覆写与 strict mode 冲突检测显式延后（见 #80）。
+    ``skill_dirs`` = 约定 ``<plugin 根>/skills`` + ``entry.skills`` / ``plugin.json.skills`` 覆写容器（§4.3，
+    strict=true 追加合并；见 :func:`~a2c_smcp.computer.skills.manifest.resolve_skill_override_dirs`）。容器按
+    resolve 后路径去重保序（约定径与覆写径同径只扫一次）。``name = <plugin>:<skill>``（``<plugin>`` = entry.name、
+    ``<skill>`` = skill 目录 basename，frontmatter 仅作显示名、不改 ID，marketplace-v1 §2.1 防伪）。缺 frontmatter
+    ``description`` / name 合成失败 / 本 run 重名（**跨容器**）→ 记 ERROR、跳过、不入册（失败降级，不抛）。每个容器
+    仅扫**一级**（``iterdir``），不递归包内。
     """
-    skills_dir = plugin_root / SKILLS_SUBDIR
-    if not skills_dir.is_dir():
+    # 容器去重（resolve 后路径），保序——约定 skills/ 与覆写路径可能同径，仅扫一次。
+    unique_dirs: list[Path] = []
+    seen_dirs: set[Path] = set()
+    for d in skill_dirs:
+        rp = d.resolve()
+        if rp in seen_dirs:
+            continue
+        seen_dirs.add(rp)
+        unique_dirs.append(d)
+
+    existing = [d for d in unique_dirs if d.is_dir()]
+    if not existing:
         logger.warning(
-            "marketplace %r plugin %r has no %s/ dir at %s; no SKILLs registered",
+            "marketplace %r plugin %r has no SKILL container dir (convention %s/ + overrides all absent); no SKILLs registered",
             marketplace,
             plugin_name,
             SKILLS_SUBDIR,
-            skills_dir,
         )
         return []
 
     registered: list[str] = []
-    for skill_dir in sorted(p for p in skills_dir.iterdir() if p.is_dir()):
-        skill_md = skill_dir / SKILL_MD
-        if not skill_md.is_file():
-            continue
-        try:
-            frontmatter = parse_skill_frontmatter(skill_md.read_text(encoding="utf-8"))
-        except OSError as e:
-            logger.error("marketplace %r plugin %r skill %r SKILL.md unreadable, skipped: %s", marketplace, plugin_name, skill_dir.name, e)
-            continue
-        if not frontmatter.get("description"):
-            logger.error(
-                "marketplace %r plugin %r skill %r missing frontmatter 'description', skipped",
-                marketplace,
-                plugin_name,
-                skill_dir.name,
-            )
-            continue
-        try:
-            name = synthesize_marketplace_name(plugin_name, skill_dir.name)
-        except SkillNameError as e:
-            logger.error(
-                "marketplace %r plugin %r skill name synthesis failed, skipped: %s (%s)",
-                marketplace,
-                plugin_name,
-                skill_dir.name,
-                e.reason,
-            )
-            continue
-        if name in seen:
-            logger.error("duplicate marketplace SKILL name within staging run, keeping first: %s (%s)", name, skill_dir)
-            continue
-        seen.add(name)
-        ref = _build_marketplace_ref(name, marketplace, frontmatter, version, skill_dir)
-        if registry.register_or_update(ref):
-            registered.append(name)
+    for skills_dir in existing:
+        for skill_dir in sorted(p for p in skills_dir.iterdir() if p.is_dir()):
+            skill_md = skill_dir / SKILL_MD
+            if not skill_md.is_file():
+                continue
+            try:
+                frontmatter = parse_skill_frontmatter(skill_md.read_text(encoding="utf-8"))
+            except OSError as e:
+                logger.error(
+                    "marketplace %r plugin %r skill %r SKILL.md unreadable, skipped: %s",
+                    marketplace,
+                    plugin_name,
+                    skill_dir.name,
+                    e,
+                )
+                continue
+            if not frontmatter.get("description"):
+                logger.error(
+                    "marketplace %r plugin %r skill %r missing frontmatter 'description', skipped",
+                    marketplace,
+                    plugin_name,
+                    skill_dir.name,
+                )
+                continue
+            try:
+                name = synthesize_marketplace_name(plugin_name, skill_dir.name)
+            except SkillNameError as e:
+                logger.error(
+                    "marketplace %r plugin %r skill name synthesis failed, skipped: %s (%s)",
+                    marketplace,
+                    plugin_name,
+                    skill_dir.name,
+                    e.reason,
+                )
+                continue
+            if name in seen:
+                logger.error("duplicate marketplace SKILL name within staging run, keeping first: %s (%s)", name, skill_dir)
+                continue
+            seen.add(name)
+            ref = _build_marketplace_ref(name, marketplace, frontmatter, version, skill_dir)
+            if registry.register_or_update(ref):
+                registered.append(name)
     return registered
 
 
@@ -1012,8 +1031,14 @@ async def _stage_one_plugin(
         env=env,
     )
     plugin_manifest = read_plugin_metadata(plugin_root)
+    # strict mode 冲突检测（§4.4）：strict=false + plugin.json 声明组件 → 抛 PluginManifestError，由外层
+    # per-plugin 循环捕获降级（该 plugin 不入册、不阻断其余，符 #61 失败降级铁律）。
+    check_strict_conflict(entry, plugin_manifest)
     version = resolve_plugin_version(entry, plugin_manifest, version_fallback)
-    return _scan_and_register_plugin_skills(marketplace, plugin_name, plugin_root, version, registry, seen)
+    # 扫描容器 = 约定 skills/ + entry.skills / plugin.json.skills 覆写（§4.3，strict=true 追加合并）。
+    override_dirs = resolve_skill_override_dirs(entry, plugin_manifest, plugin_root, strict=entry_is_strict(entry))
+    skill_dirs = [plugin_root / SKILLS_SUBDIR, *override_dirs]
+    return _scan_and_register_plugin_skills(marketplace, plugin_name, skill_dirs, version, registry, seen)
 
 
 def _record_known_marketplace(
@@ -1176,7 +1201,8 @@ async def stage_marketplace_skills(
                 env=env,
             )
             registered.extend(names)
-        except (SkillSourceError, SkillStagingError) as e:
+        except (SkillSourceError, SkillStagingError, PluginManifestError) as e:
+            # PluginManifestError 含 strict=false 冲突（§4.4）——预期降级，记 ERROR、该 plugin 不入册、不阻断其余。
             logger.error("marketplace %r plugin %r staging failed, skipped: %s", name, plugin_name, e)
         except Exception as e:  # 失败降级铁律：单 plugin 任意异常不阻断其余
             logger.error("marketplace %r plugin %r unexpected staging error, skipped: %s", name, plugin_name, e, exc_info=True)

--- a/tests/integration_tests/computer/settings/test_installer.py
+++ b/tests/integration_tests/computer/settings/test_installer.py
@@ -25,7 +25,13 @@ from pathlib import Path
 
 import pytest
 
-from a2c_smcp.computer.settings.installer import disable_plugin, enable_plugin, install_plugin, uninstall_plugin
+from a2c_smcp.computer.settings.installer import (
+    PluginInstallError,
+    disable_plugin,
+    enable_plugin,
+    install_plugin,
+    uninstall_plugin,
+)
 from a2c_smcp.computer.settings.store import load_installed_plugins
 from a2c_smcp.computer.skills.home import marketplace_skill_dir
 from a2c_smcp.computer.skills.registry import SkillRegistry
@@ -191,3 +197,45 @@ async def test_install_disable_enable_no_reclone(tmp_path: Path) -> None:
     assert captured == ["figma"]  # server 重挂
     settings = json.loads((home / "cfg" / "a2c" / "settings.json").read_text(encoding="utf-8"))
     assert settings["enabledPlugins"]["audit@acme-skills"] is True
+
+
+# ── strict mode 冲突 install 硬失败（§4.4；#80）────────────────────────────────
+def _strict_false_conflict_files() -> dict[str, str]:
+    """audit entry strict=false 但 plugin.json 声明组件（skills）→ conflicting manifests。"""
+    manifest = {
+        "name": "acme-skills",
+        "owner": {"name": "Acme"},
+        "metadata": {"pluginRoot": "./plugins"},
+        "plugins": [{"name": "audit", "source": "audit", "version": "1.2.0", "strict": False}],
+    }
+    server = {"name": "figma", "type": "stdio", "server_parameters": {"command": "echo"}}
+    return {
+        ".tfrobot-plugin/marketplace.json": json.dumps(manifest),
+        "plugins/audit/.tfrobot-plugin/plugin.json": json.dumps({"name": "audit", "skills": "x"}),
+        "plugins/audit/skills/lint/SKILL.md": _skill_md("lint"),
+        "plugins/audit/mcp-servers/figma.json": json.dumps(server),
+    }
+
+
+@requires_git
+async def test_install_strict_false_conflict_hard_fails_atomically(tmp_path: Path) -> None:
+    bare = _make_bare(tmp_path, "acme", _strict_false_conflict_files())
+    home = _home(tmp_path)
+    env = _env(home)
+    await _add_marketplace(home, bare, env)
+    reg = SkillRegistry()
+    captured: list[str] = []
+
+    async def _register(cfg) -> None:
+        captured.append(cfg.name)
+
+    # 早检拦截 → PluginInstallError（硬错误，conflicting manifests）
+    with pytest.raises(PluginInstallError, match="conflicting manifests"):
+        await install_plugin(
+            "audit@acme-skills", reg, home, env=env, existing_server_names=lambda: set(), register_server=_register,
+        )
+
+    # 原子失败：未挂 server、未注册 skill、未写 installed 记录
+    assert captured == []
+    assert reg.resolve("audit:lint") is None
+    assert "audit@acme-skills" not in load_installed_plugins(home=home)["plugins"]

--- a/tests/integration_tests/computer/skills/test_staging_marketplace.py
+++ b/tests/integration_tests/computer/skills/test_staging_marketplace.py
@@ -548,3 +548,79 @@ async def test_last_updated_preserved_on_reuse_refreshed_on_pull(tmp_path: Path)
     # refresh=True（实际 pull）→ lastUpdated 刷新
     await stage_marketplace_skills("acme-skills", _src(_url(bare)), reg, home, refresh=True, env=_env(home))
     assert load_known_marketplaces(home, _env(home))["marketplaces"]["acme-skills"]["lastUpdated"] != old
+
+
+# ── strict mode + entry.skills / plugin.json.skills override（§4.3/§4.4；#80）───────────────────
+@requires_git
+async def test_entry_skills_override_appended(tmp_path: Path) -> None:
+    # entry.skills 覆写路径 → 在约定 skills/ 之外**追加扫描**（strict 默认 true 合并语义）
+    manifest = {
+        "name": "acme-skills",
+        "owner": {"name": "Acme"},
+        "metadata": {"pluginRoot": "./plugins"},
+        "plugins": [{"name": "audit", "source": "audit", "version": "1.0.0", "skills": "extra-skills"}],
+    }
+    files = {
+        ".tfrobot-plugin/marketplace.json": json.dumps(manifest),
+        "plugins/audit/skills/conventional/SKILL.md": _skill_md("conventional"),
+        "plugins/audit/extra-skills/overridden/SKILL.md": _skill_md("overridden"),
+    }
+    _, bare = _make_bare(tmp_path, "acme", files)
+    home = _home(tmp_path)
+    reg = SkillRegistry()
+
+    names = await stage_marketplace_skills("acme-skills", _src(_url(bare)), reg, home, env=_env(home))
+    assert set(names) == {"audit:conventional", "audit:overridden"}  # 约定 + 覆写 追加合并
+    assert reg.resolve("audit:overridden") is not None
+
+
+@requires_git
+async def test_plugin_json_skills_override_appended(tmp_path: Path) -> None:
+    # plugin.json.skills 覆写路径（strict 默认 true）→ 追加扫描
+    manifest = {
+        "name": "acme-skills",
+        "owner": {"name": "Acme"},
+        "metadata": {"pluginRoot": "./plugins"},
+        "plugins": [{"name": "audit", "source": "audit"}],
+    }
+    files = {
+        ".tfrobot-plugin/marketplace.json": json.dumps(manifest),
+        "plugins/audit/.tfrobot-plugin/plugin.json": json.dumps({"name": "audit", "skills": "pj-skills", "version": "3.0.0"}),
+        "plugins/audit/skills/conventional/SKILL.md": _skill_md("conventional"),
+        "plugins/audit/pj-skills/from-plugin-json/SKILL.md": _skill_md("from-plugin-json"),
+    }
+    _, bare = _make_bare(tmp_path, "acme", files)
+    home = _home(tmp_path)
+    reg = SkillRegistry()
+
+    names = await stage_marketplace_skills("acme-skills", _src(_url(bare)), reg, home, env=_env(home))
+    assert set(names) == {"audit:conventional", "audit:from-plugin-json"}
+
+
+@requires_git
+async def test_strict_false_with_plugin_components_degrades_without_blocking_others(tmp_path: Path) -> None:
+    # strict=false + plugin.json 声明组件 → 该 plugin **不入册**（失败降级），同 marketplace 其余 plugin 不受影响
+    manifest = {
+        "name": "acme-skills",
+        "owner": {"name": "Acme"},
+        "metadata": {"pluginRoot": "./plugins"},
+        "plugins": [
+            {"name": "audit", "source": "audit", "strict": False},  # strict=false
+            {"name": "fmt", "source": "./plugins/fmt"},  # 正常 plugin，应仍注册
+        ],
+    }
+    files = {
+        ".tfrobot-plugin/marketplace.json": json.dumps(manifest),
+        # audit 的 plugin.json 声明组件 → 与 strict=false 冲突
+        "plugins/audit/.tfrobot-plugin/plugin.json": json.dumps({"name": "audit", "skills": "x"}),
+        "plugins/audit/skills/should-not-appear/SKILL.md": _skill_md("should-not-appear"),
+        "plugins/fmt/skills/format/SKILL.md": _skill_md("format"),
+    }
+    _, bare = _make_bare(tmp_path, "acme", files)
+    home = _home(tmp_path)
+    reg = SkillRegistry()
+
+    names = await stage_marketplace_skills("acme-skills", _src(_url(bare)), reg, home, env=_env(home))
+    assert names == ["fmt:format"]  # audit 降级不入册；fmt 不受阻断
+    assert reg.resolve("audit:should-not-appear") is None
+    assert reg.resolve("fmt:format") is not None

--- a/tests/unit_tests/computer/skills/test_manifest.py
+++ b/tests/unit_tests/computer/skills/test_manifest.py
@@ -254,6 +254,19 @@ def test_resolve_skill_override_dirs_plugin_json_only_when_strict(tmp_path: Path
     assert resolve_skill_override_dirs({}, {"skills": "pj-skills"}, tmp_path, strict=False) == []
 
 
+def test_resolve_skill_override_dirs_entry_always_taken_regardless_of_strict(tmp_path: Path) -> None:
+    # 契约锁定：entry.skills「恒取」（strict 无关）——strict=false 下 entry.skills 仍解析，仅 plugin.json.skills 被忽略
+    (tmp_path / "entry-skills").mkdir()
+    (tmp_path / "pj-skills").mkdir()
+    out = resolve_skill_override_dirs(
+        {"skills": "entry-skills"},
+        {"skills": "pj-skills"},
+        tmp_path,
+        strict=False,
+    )
+    assert out == [(tmp_path / "entry-skills").resolve()]  # entry 恒取；plugin.json 在 strict=false 下忽略
+
+
 def test_resolve_skill_override_dirs_traversal_and_non_dir_skipped(tmp_path: Path) -> None:
     (tmp_path / "ok").mkdir()
     (tmp_path / "afile").write_text("x", encoding="utf-8")

--- a/tests/unit_tests/computer/skills/test_manifest.py
+++ b/tests/unit_tests/computer/skills/test_manifest.py
@@ -26,15 +26,19 @@ import pytest
 from a2c_smcp.computer.mcp_clients.model import SseServerConfig, StdioServerConfig, StreamableHttpServerConfig
 from a2c_smcp.computer.skills.manifest import (
     PluginManifestError,
+    check_strict_conflict,
+    entry_is_strict,
     enumerate_bundled_server_files,
     find_plugin_entry,
     iter_plugin_entries,
     load_bundled_servers,
+    manifest_declared_components,
     parse_bundled_server,
     plugin_root_base,
     read_marketplace_manifest,
     read_plugin_metadata,
     resolve_plugin_version,
+    resolve_skill_override_dirs,
 )
 
 
@@ -194,3 +198,69 @@ def test_load_bundled_servers_any_malformed_raises(tmp_path: Path) -> None:
 
 def test_load_bundled_servers_empty(tmp_path: Path) -> None:
     assert load_bundled_servers(tmp_path) == []
+
+
+# ── strict mode + entry.skills override（§4.3/§4.4，loading-behavior §1/§4/§6；#80）─────────────
+def test_entry_is_strict_default_and_explicit() -> None:
+    assert entry_is_strict({}) is True  # 缺省 → True（默认更宽松、容错）
+    assert entry_is_strict({"strict": False}) is False
+    assert entry_is_strict({"strict": True}) is True
+    assert entry_is_strict({"strict": "false"}) is True  # 非 bool → 容错 True
+
+
+def test_manifest_declared_components() -> None:
+    # 六字段任一真值即声明；falsy（空 dict/list/None/缺）不算
+    assert manifest_declared_components({}) == []
+    assert manifest_declared_components({"skills": [], "commands": None, "version": "1.0"}) == []
+    assert manifest_declared_components({"skills": ["x"], "mcpServers": {"s": {}}, "version": "1.0"}) == ["skills", "mcpServers"]
+    assert manifest_declared_components({"hooks": "h", "agents": "a", "lspServers": {"l": {}}}) == ["agents", "hooks", "lspServers"]
+
+
+def test_check_strict_conflict_false_with_components_raises() -> None:
+    # strict=false + plugin.json 声明组件 → 拒绝加载（红→绿核心）
+    with pytest.raises(PluginManifestError, match="conflicting manifests"):
+        check_strict_conflict({"strict": False}, {"skills": ["mine"]})
+    with pytest.raises(PluginManifestError, match="conflicting manifests"):
+        check_strict_conflict({"strict": False}, {"commands": "cmds"})  # 即便本 SDK 不消费 commands 仍判冲突
+
+
+def test_check_strict_conflict_false_metadata_only_ok() -> None:
+    # strict=false + plugin.json 仅元数据（无组件）→ 不冲突
+    check_strict_conflict({"strict": False}, {"version": "1.0", "description": "d", "author": {"name": "x"}})
+    check_strict_conflict({"strict": False}, {})  # 缺 plugin.json → {} → 不冲突
+
+
+def test_check_strict_conflict_true_never_conflicts() -> None:
+    # strict=true（默认）恒不冲突：plugin.json 权威 + 条目追加合并
+    check_strict_conflict({}, {"skills": ["mine"], "commands": "c"})
+    check_strict_conflict({"strict": True}, {"mcpServers": {"s": {}}})
+
+
+def test_resolve_skill_override_dirs_entry_string_and_array(tmp_path: Path) -> None:
+    (tmp_path / "extra-skills").mkdir()
+    (tmp_path / "more").mkdir()
+    # entry.skills string
+    assert resolve_skill_override_dirs({"skills": "extra-skills"}, {}, tmp_path, strict=True) == [(tmp_path / "extra-skills").resolve()]
+    # entry.skills array（去重保序）
+    out = resolve_skill_override_dirs({"skills": ["extra-skills", "more", "extra-skills"]}, {}, tmp_path, strict=True)
+    assert out == [(tmp_path / "extra-skills").resolve(), (tmp_path / "more").resolve()]
+
+
+def test_resolve_skill_override_dirs_plugin_json_only_when_strict(tmp_path: Path) -> None:
+    (tmp_path / "pj-skills").mkdir()
+    # strict=true → 取 plugin.json.skills
+    assert resolve_skill_override_dirs({}, {"skills": "pj-skills"}, tmp_path, strict=True) == [(tmp_path / "pj-skills").resolve()]
+    # strict=false → 不取 plugin.json.skills（plugin 组件权威已交 entry；冲突另由 check_strict_conflict 拦）
+    assert resolve_skill_override_dirs({}, {"skills": "pj-skills"}, tmp_path, strict=False) == []
+
+
+def test_resolve_skill_override_dirs_traversal_and_non_dir_skipped(tmp_path: Path) -> None:
+    (tmp_path / "ok").mkdir()
+    (tmp_path / "afile").write_text("x", encoding="utf-8")
+    out = resolve_skill_override_dirs(
+        {"skills": ["../escape", "ok", "afile", "nonexistent"]},
+        {},
+        tmp_path,
+        strict=True,
+    )
+    assert out == [(tmp_path / "ok").resolve()]  # 越界 ../escape 跳过、非目录 afile 跳过、不存在跳过


### PR DESCRIPTION
## 概述

闭合 **#80**（S8.1 marketplace strict 模式 + entry.skills override，#61 评审显式延后项）——父 **#39** SKILL 子系统的最后一块延后项。

**纯 Computer 侧实现追赶**，对齐**已发布**的 `tfrobot-marketplace` protocol-v1 §4.3/§4.4 + `loading-behavior.md` §1/§4/§6。**无 A2C/marketplace 协议变更**（不动 `smcp.py`/`model.py`，`PROTOCOL_VERSION` 不变）。

## 规范行为（loading-behavior.md §1 矩阵 + §6.2）

| `strict` | `plugin.json` | 结果 |
|---|---|---|
| `true`(默认) | 存在/缺失 | 合并：约定 `skills/` + plugin.json.skills + entry.skills **追加扫描** |
| `false` | 声明六组件字段任一 | ❌ 硬错误 `conflicting manifests`，拒绝加载 |
| `false` | 仅元数据/缺失 | entry 为组件权威 |

## 改动

- **`skills/manifest.py`**（单一权威解析层，leaf）新增纯函数：`COMPONENT_FIELDS` + `entry_is_strict`（默认 True）+ `manifest_declared_components` + `check_strict_conflict`（strict=false 且 plugin.json 声明任一组件 → `PluginManifestError`）+ `resolve_skill_override_dirs`（`entry.skills` 恒取 + `plugin.json.skills` 仅 strict=true，`is_within` 沙箱防穿越、去重保序）。
- **`skills/staging.py`**：`_stage_one_plugin` 接入冲突检测（冲突 → per-plugin **失败降级**，不阻断其余，符 #61 铁律）+ override 解析；`_scan_and_register_plugin_skills` 改 `plugin_root` → `skill_dirs` 容器列表（约定 `skills/` + override，跨容器 `seen` 去重）。
- **`settings/installer.py`**：`install_plugin` 在挂载 server 前**早检** → 冲突译为 `PluginInstallError`（exit 1、**原子失败**：未挂 server / 未注册 skill），不依赖 staging 降级。

### 双分叉处置
- **staging**（marketplace 刷新）→ 失败降级（该 plugin 不入册、不阻断其余）。
- **install**（显式装单 plugin）→ 硬失败（`PluginInstallError`、原子）。

### 设计取舍
冲突检测识别**全六组件字段**（对齐 §6.2，前向兼容 CC 私有组件，防「以为生效实际被覆盖」）；override **路径扫描仅 `skills`**（本 SDK 仅消费 skills + mcp-servers）。

## 测试（红→绿，acceptance #1/#2）

- unit `test_manifest.py` +10（四纯函数，含 strict=false+组件→raise 核心）
- integration `test_staging_marketplace.py` +3（override 追加注册 + strict=false 冲突降级不阻断其余）
- integration `test_installer.py` +1（install 冲突→`PluginInstallError` 硬失败、原子）

## 验证

- `uv run poe lint`：ruff All checks passed + mypy **98 files no issues**
- 回归 **260 passed**（skills unit+integration + settings integration）+ CLI marketplace **4 passed** + manifest unit **28 passed**

## Acceptance

- [x] entry.skills / plugin.json.skills 覆写路径追加扫描（strict=true 合并语义）
- [x] strict=false + plugin.json 同时声明组件 → 拒绝加载（硬错误）+ 单测红→绿
- [x] `uv run poe lint` 净

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)