### PR TITLE
feat(uat): 添加 UAT Skill — tmux 终端自动化验收测试框架

### DIFF
--- a/.claude/skills/UAT/SKILL.md
+++ b/.claude/skills/UAT/SKILL.md
@@ -1,0 +1,253 @@
+---
+name: uat
+description: 执行 A2C-SMCP Python SDK 的用户验收测试（UAT）。通过 tmux MCP 工具在真实终端环境中验证 CLI 命令和端到端协议流程。
+---
+
+# UAT - User Acceptance Testing Skill
+
+## Description
+
+用户验收测试（UAT）技能。通过 tmux 终端自动化工具，以真实用户视角对 A2C-SMCP SDK 的 CLI
+命令和协议流程进行端到端验收测试。
+
+## Instructions
+
+### 角色定位
+
+你是一名 QA 测试工程师，负责对 A2C-SMCP Python SDK 执行用户验收测试。你将使用 tmux MCP
+工具在真实终端环境中模拟用户操作，验证 CLI 命令和协议交互是否符合预期。
+
+### 前置条件检查
+
+执行任何测试前，**必须**确认以下条件：
+
+1. **项目已安装**：`uv sync --all-groups` 已执行，`a2c-computer` 命令可用
+2. **tmux MCP 可用**：能调用 `mcp__tmux__*` 系列工具（创建 session、执行命令、捕获输出）
+3. **测试 marketplace 仓库可访问**：有可用的 Git URL 用于 marketplace 测试
+
+如果任一条件未满足，**停止测试**并提示用户先完成准备工作。
+
+### 执行协议
+
+1. **加载场景**：根据用户指定的场景，读取对应的 `resources/scenarios/<scenario>.md`
+2. **准备环境**：按场景要求创建 tmux session、启动必要进程
+3. **逐用例执行**：
+   - 通过 tmux `execute-command` 发送 CLI 命令
+   - 通过 tmux `capture-pane` 获取输出
+   - 对比预期结果，标记 PASS / FAIL
+4. **收集日志**：捕获所有 tmux pane 的完整输出
+5. **输出报告**：汇总所有用例的执行结果
+
+### tmux 环境管理
+
+#### Session 命名规范
+
+```
+a2c-uat              # 主 session
+a2c-uat-server       # Server 进程（需要完整链路时）
+a2c-uat-computer     # Computer 进程（需要完整链路时）
+a2c-uat-agent        # Agent 进程（需要完整链路时）
+a2c-uat-cli          # 独立 CLI 命令（不需要完整链路时）
+```
+
+#### 日志捕获策略
+
+**所有测试必须保证三端日志可收集**。具体策略：
+
+1. **tmux pane 捕获**：每个测试步骤后，使用 `capture-pane` 获取对应 pane 的完整输出
+2. **文件日志兜底**：Server/Computer/Agent 的输出同时重定向到 `/tmp/a2c-uat-logs/` 目录
+3. **失败时全量收集**：任一用例 FAIL 时，立即捕获所有 tmux pane 的最近 200 行输出
+
+日志文件路径约定：
+
+```
+/tmp/a2c-uat-logs/
+├── server.log        # Server 进程输出
+├── computer.log      # Computer CLI 输出
+└── agent.log         # Agent 客户端输出
+```
+
+启动进程时使用 `tee` 双写：
+
+```bash
+uv run python server_script.py 2>&1 | tee /tmp/a2c-uat-logs/server.log
+```
+
+#### 进程生命周期
+
+```
+1. 创建 tmux session + windows
+2. 启动进程（重定向到日志文件）
+3. 等待进程就绪（轮询 capture-pane 检查输出）
+4. 执行测试用例
+5. 测试完成后 kill session（自动清理所有进程）
+```
+
+### CLI-only 场景 vs 完整链路场景
+
+#### CLI-only 场景（如 marketplace-ops）
+
+只需要一个 tmux window，直接执行 `a2c-computer` 子命令：
+
+```
+tmux session: a2c-uat
+└── window: cli  →  a2c-computer marketplace add <url> --trust
+```
+
+启动方式：
+
+1. 创建 tmux session `a2c-uat`
+2. 在默认 window 中执行命令
+3. `capture-pane` 获取输出验证
+
+#### 完整链路场景（如 full-protocol）
+
+需要三个 tmux window，分别运行 Server / Computer / Agent：
+
+```
+tmux session: a2c-uat
+├── window: server     →  Server 进程（端口动态分配，写入 /tmp/a2c-uat-port）
+├── window: computer   →  a2c-computer run --url http://127.0.0.1:<PORT>
+└── window: agent      →  Agent 客户端 Python 脚本
+```
+
+启动流程（严格按顺序）：
+
+1. 创建 tmux session `a2c-uat`
+2. 创建 3 个 window（server / computer / agent）
+3. **先启动 Server**：在 server window 执行启动脚本，等待端口就绪
+4. **再启动 Computer**：读取端口后执行 `a2c-computer run --url ...`，等待连接成功
+5. **最后启动 Agent**：执行 Agent 客户端脚本
+
+详见 `resources/test-env-setup.md`。
+
+### 测试原则
+
+- **真实进程视角**：测试启动真实的 Python 进程，不使用 mock
+- **可观测性**：每个关键步骤捕获 tmux pane 输出；失败时全量收集所有 pane 日志
+- **幂等性**：测试不应产生残留状态（marketplace remove 清理、tmp 目录隔离）
+- **独立性**：每个场景可独立执行
+- **容错性**：单个用例失败不阻塞后续用例执行
+
+### 二次复验机制
+
+对所有 **FAIL** 结果执行二次复验：
+
+1. **重试执行**：等待 2-3 秒后重新执行相同命令
+2. **pane 输出复查**：增加 `capture-pane` 的行数，检查是否有延迟输出
+3. **综合判定**：两次结果一致则采信，不一致标记为 **Flaky**
+
+### 报告格式
+
+```
+## UAT 报告 - [场景名称]
+日期：YYYY-MM-DD
+分支：[当前分支]
+环境：tmux session a2c-uat
+
+### 测试结果摘要
+- 总用例数：N
+- 通过：N ✅
+- 失败：N ❌
+- 跳过：N ⏭️
+
+### 用例详情
+| # | 用例 | 优先级 | 结果 | 复验 | 备注 |
+|---|------|--------|------|------|------|
+| 1 | ...  | P0     | ✅   | -    |      |
+
+### 失败用例详情
+#### [用例名称]
+- **步骤**：...
+- **预期**：...
+- **实际**：...
+- **tmux 输出**：
+  ```
+  [粘贴 capture-pane 内容]
+  ```
+- **日志线索**：[从 /tmp/a2c-uat-logs/ 中提取的关键错误信息]
+
+### 进程日志摘要
+#### Server
+```
+[最近 N 行关键输出]
+```
+#### Computer
+```
+[最近 N 行关键输出]
+```
+#### Agent
+```
+[最近 N 行关键输出]
+```
+```
+
+## User-invocable
+
+- name: uat
+- description: 执行 A2C-SMCP SDK 用户验收测试（UAT）。指定场景名执行单场景；不指定场景则进入全量测试模式。
+
+## Arguments
+
+- scenario: （可选）测试场景名称（如 marketplace-ops, full-protocol）。不填则全量执行。
+
+## Prompt
+
+请执行 UAT 测试。
+
+首先确认前置条件：
+
+1. `a2c-computer` 命令是否可用？
+2. tmux MCP 工具是否可用？
+3. 测试 marketplace 仓库是否可访问？
+
+---
+
+**判断执行模式：**
+
+### 单场景模式（`$scenario` 已指定）
+
+加载场景 `$scenario` 的测试用例并开始执行。
+
+---
+
+### 全量测试模式（未指定 `$scenario`）
+
+扫描 `resources/scenarios/` 目录，获取所有可用场景列表。
+
+#### 执行顺序
+
+1. **CLI-only 场景优先**（无需多进程）：marketplace-ops → plugin-management → settings-scope
+2. **完整链路场景随后**（需多进程）：full-protocol → strict-mode → blob-transfer → skill-discovery
+
+#### 全量测试执行协议
+
+对每个场景，严格按以下步骤执行：
+
+**步骤 1：环境准备**
+
+按场景类型（CLI-only / 完整链路）创建 tmux session 和必要的进程。
+
+**步骤 2：执行场景**
+
+执行该场景的所有测试用例，完整流程：加载场景 → 逐用例执行（发送命令、捕获输出、对比预期、标记 PASS/FAIL）→ 输出该场景 UAT 报告
+
+**步骤 3：环境清理**
+
+每个场景完成后：
+1. 捕获所有 tmux pane 输出作为日志
+2. Kill tmux session 清理进程
+3. 清理 `/tmp/a2c-uat-*` 临时文件
+
+**步骤 4：上下文管理**
+
+执行 `/compact [场景名] UAT 完成。通过 X/Y 用例。[若有失败：失败用例：xxx]` 压缩上下文。
+
+**步骤 5：结果判断**
+
+- **全部通过（✅）**：继续下一个场景
+- **存在失败（❌）**：压缩上下文后，**立即中止全量测试**，输出已完成场景的进度汇总
+
+#### 全量测试完成后
+
+输出总汇总报告。

--- a/.claude/skills/UAT/resources/scenarios/full-protocol.md
+++ b/.claude/skills/UAT/resources/scenarios/full-protocol.md
@@ -1,0 +1,119 @@
+# 场景：full-protocol
+
+## 测试目标
+
+验证 Agent ↔ Server ↔ Computer 完整协议流程：连接、office 加入、tool_call 路由、
+SKILL 通知广播、版本握手、断连守卫。
+
+## 类型
+
+完整链路（需要 Server + Computer + Agent 三进程）
+
+## 前置条件
+
+1. `uv sync --all-groups` 已执行
+2. `a2c-computer` 命令可用
+3. tmux MCP 工具可用
+
+## 环境准备
+
+按 `resources/test-env-setup.md` 中"完整链路场景环境"的步骤，启动三个进程：
+
+1. 创建 tmux session `a2c-uat`
+2. 启动 Server（动态端口 → `/tmp/a2c-uat-port`）
+3. 启动 Computer（连接 Server）
+4. 启动 Agent（连接 Server）
+
+所有进程输出通过 `tee` 双写到 `/tmp/a2c-uat-logs/`。
+
+## 测试用例
+
+### F-01: Computer 连接并加入 office
+
+- **优先级**: P0
+- **步骤**:
+  1. 启动 Computer，连接 Server
+  2. Computer CLI 中执行 `join_office test-office-001`
+  3. 捕获 Computer pane 输出
+  4. 捕获 Server pane 输出
+- **预期结果**:
+  - Computer 输出包含连接成功提示
+  - `join_office` 返回成功
+
+### F-02: Agent 连接并发起 tool_call
+
+- **优先级**: P0
+- **前置**: F-01 成功，Computer 已加入 office 且有 MCP server
+- **步骤**:
+  1. Agent 连接 Server
+  2. Agent 通过 Socket.IO 发起 `client:call_tool` 事件
+  3. 等待 Computer 执行并返回结果
+  4. 捕获 Agent / Computer / Server 三端 pane 输出
+- **预期结果**:
+  - Agent 收到正确的 tool_call 返回结果
+  - Computer 日志显示 MCP server 执行了工具
+  - Server 日志显示消息路由
+
+### F-03: SKILL 通知广播（notify:update_skills）
+
+- **优先级**: P0
+- **前置**: F-01 成功，Agent 已连接
+- **步骤**:
+  1. Computer 更新 skills（通过 CLI 命令或 MCP server 上报）
+  2. 观察 Agent 是否收到 `notify:update_skills` 通知
+  3. 捕获三端 pane 输出
+- **预期结果**:
+  - Agent 收到 skills 更新通知
+  - Server 日志显示广播事件
+
+### F-04: 版本握手成功
+
+- **优先级**: P0
+- **步骤**:
+  1. Agent 携带正确 `a2c_version` query 参数连接 Server
+  2. 捕获 Server pane 输出
+- **预期结果**:
+  - 连接成功（非 4008 拒绝）
+  - Server 日志显示版本匹配
+
+### F-05: 版本不兼容拒绝（Socket.IO 4008）
+
+- **优先级**: P0
+- **步骤**:
+  1. Agent 携带不兼容版本（如 `a2c_version=99.0.0`）尝试连接
+  2. 捕获 Agent 和 Server pane 输出
+- **预期结果**:
+  - 连接被拒
+  - Agent 收到 4008 错误码
+  - Server 日志显示版本不兼容
+
+### F-06: Computer 断连后重连
+
+- **优先级**: P1
+- **前置**: F-01 成功
+- **步骤**:
+  1. Computer 正常连接
+  2. 模拟断连（kill Computer tmux window 后重新启动）
+  3. 观察 Server 和 Agent 日志
+  4. Computer 重新启动并连接
+  5. 观察恢复行为
+- **预期结果**:
+  - 断连后 Server 日志显示 disconnect
+  - 重连后 Computer 恢复正常
+  - 飞行中的请求不静默丢失（返回断连错误）
+
+## 清理
+
+1. Kill tmux session `a2c-uat`
+2. 清理 `/tmp/a2c-uat-port`、`/tmp/a2c-uat-logs/`、`/tmp/a2c-uat-skill-home/`
+
+## 日志收集
+
+完整链路场景必须收集三端日志：
+
+1. **Server pane**: `/tmp/a2c-uat-logs/server.log` + tmux capture-pane
+2. **Computer pane**: `/tmp/a2c-uat-logs/computer.log` + tmux capture-pane
+3. **Agent pane**: `/tmp/a2c-uat-logs/agent.log` + tmux capture-pane
+
+每个用例执行后，对三个 pane 都执行 `capture-pane lines: 50`。
+失败时增加到 `lines: 200` 并读取文件日志。

--- a/.claude/skills/UAT/resources/scenarios/marketplace-ops.md
+++ b/.claude/skills/UAT/resources/scenarios/marketplace-ops.md
@@ -1,0 +1,181 @@
+# 场景：marketplace-ops
+
+## 测试目标
+
+验证 `a2c-computer marketplace` 子命令的完整生命周期：添加、列出、查看详情、刷新、删除。
+
+## 类型
+
+CLI-only（不需要 Server/Computer/Agent 多进程）
+
+## 前置条件
+
+1. `uv sync --all-groups` 已执行
+2. `a2c-computer` 命令可用
+3. 测试 marketplace Git 仓库已准备（见下方「测试仓库搭建」）
+
+## 测试仓库搭建
+
+测试使用本地裸仓库（`file://` 零网络），结构如下：
+
+```
+work/
+├── .tfrobot-plugin/
+│   └── marketplace.json     # 必须有，且 plugins[].source 必填
+└── plugins/
+    └── hello/
+        └── skills/
+            └── greet/
+                └── SKILL.md
+```
+
+`marketplace.json` 最小格式（**source 字段必填**，否则 plugin staging 跳过）：
+
+```json
+{
+  "version": "1.0.0",
+  "plugins": [
+    {
+      "name": "hello",
+      "source": "./plugins/hello"
+    }
+  ]
+}
+```
+
+搭建脚本（在 tmux 中通过 Bash 执行）：
+
+```bash
+WORK_DIR=$(mktemp -d) && WORK="$WORK_DIR/work" && mkdir -p "$WORK" && cd "$WORK"
+git init -q -b main && git config user.name "test" && git config user.email "test@test.com"
+mkdir -p .tfrobot-plugin
+cat > .tfrobot-plugin/marketplace.json << 'EOF'
+{"version":"1.0.0","plugins":[{"name":"hello","source":"./plugins/hello"}]}
+EOF
+mkdir -p plugins/hello/skills/greet
+cat > plugins/hello/skills/greet/SKILL.md << 'EOF'
+---
+name: greet
+description: A test greeting skill
+---
+# Greet
+Hello test skill.
+EOF
+git add -A . && git commit -q -m "init"
+BARE="$WORK_DIR/test-mp.git" && git clone -q --bare . "$BARE"
+echo "BARE_URL=file://$BARE"
+```
+
+## 环境变量
+
+```bash
+A2C_SKILL_HOME=/tmp/a2c-uat-skill-home-$$   # 使用 PID 隔离，避免 zsh rm -rf * 确认
+mkdir -p $A2C_SKILL_HOME
+```
+
+> 使用独立 SKILL_HOME 避免污染用户真实配置。用 PID 后缀避免 zsh glob 确认弹窗。
+> 测试完成后整体 `rm -rf /tmp/a2c-uat-skill-home-*` 清理。
+
+## 测试用例
+
+### M-01: marketplace add --trust（添加 marketplace）
+
+- **优先级**: P0
+- **步骤**:
+  1. 清理环境：`rm -rf /tmp/a2c-uat-skill-home/*`
+  2. 执行：`A2C_SKILL_HOME=/tmp/a2c-uat-skill-home uv run a2c-computer marketplace add <GIT_URL> --trust --json`
+  3. 捕获输出
+- **预期结果**:
+  - 退出码 0
+  - 输出包含成功添加信息（JSON 模式下返回 marketplace 名称和状态）
+  - `/tmp/a2c-uat-skill-home/marketplace/` 下出现对应目录
+
+### M-02: marketplace list（列出 marketplace）
+
+- **优先级**: P0
+- **前置**: M-01 成功
+- **步骤**:
+  1. 执行：`A2C_SKILL_HOME=/tmp/a2c-uat-skill-home uv run a2c-computer marketplace list --json`
+  2. 捕获输出
+- **预期结果**:
+  - 退出码 0
+  - JSON 输出包含刚添加的 marketplace
+  - 显示 trusted/cloned 状态
+
+### M-03: marketplace info（查看详情）
+
+- **优先级**: P0
+- **前置**: M-01 成功
+- **步骤**:
+  1. 从 M-01 输出获取 marketplace 名称
+  2. 执行：`A2C_SKILL_HOME=/tmp/a2c-uat-skill-home uv run a2c-computer marketplace info <NAME> --json`
+  3. 捕获输出
+- **预期结果**:
+  - 退出码 0
+  - 显示 marketplace 详情（skills 列表、strict 模式、auto-update 状态等）
+
+### M-04: marketplace refresh（刷新 marketplace）
+
+- **优先级**: P0
+- **前置**: M-01 成功
+- **步骤**:
+  1. 执行：`A2C_SKILL_HOME=/tmp/a2c-uat-skill-home uv run a2c-computer marketplace refresh <NAME> --json`
+  2. 捕获输出
+- **预期结果**:
+  - 退出码 0
+  - 显示刷新成功信息（git pull 或 re-clone 完成）
+
+### M-05: marketplace set auto-update（设置自动更新）
+
+- **优先级**: P1
+- **前置**: M-01 成功
+- **步骤**:
+  1. 执行：`A2C_SKILL_HOME=/tmp/a2c-uat-skill-home uv run a2c-computer marketplace set <NAME> auto-update=true --json`
+  2. 捕获输出
+- **预期结果**:
+  - 退出码 0
+  - 设置持久化（再次 `info` 可见 auto-update=true）
+
+### M-06: marketplace add（不带 --trust 应失败）
+
+- **优先级**: P1
+- **步骤**:
+  1. 执行：`A2C_SKILL_HOME=/tmp/a2c-uat-skill-home uv run a2c-computer marketplace add <GIT_URL> --json`
+  2. 捕获输出
+- **预期结果**:
+  - 退出码 1（非交互模式下必须 --trust）
+  - 输出包含 trust 确认相关错误信息
+
+### M-07: marketplace remove（删除 marketplace）
+
+- **优先级**: P0
+- **前置**: M-01 成功
+- **步骤**:
+  1. 执行：`A2C_SKILL_HOME=/tmp/a2c-uat-skill-home uv run a2c-computer marketplace remove <NAME> --json`
+  2. 捕获输出
+  3. 验证：再次 `marketplace list` 确认已移除
+- **预期结果**:
+  - 退出码 0
+  - marketplace 从列表消失
+  - clone 目录被清理
+
+### M-08: marketplace add 重复添加
+
+- **优先级**: P1
+- **前置**: M-01 成功
+- **步骤**:
+  1. 再次执行：`A2C_SKILL_HOME=/tmp/a2c-uat-skill-home uv run a2c-computer marketplace add <GIT_URL> --trust --json`
+  2. 捕获输出
+- **预期结果**:
+  - 退出码 1（已存在）
+  - 输出包含已存在提示
+
+## 清理
+
+```bash
+rm -rf /tmp/a2c-uat-skill-home
+```
+
+## 日志收集
+
+CLI-only 场景下日志即 tmux pane 输出。每个用例执行后必须 `capture-pane` 保存完整输出。

--- a/.claude/skills/UAT/resources/test-env-setup.md
+++ b/.claude/skills/UAT/resources/test-env-setup.md
@@ -1,0 +1,165 @@
+# 测试环境搭建指南
+
+## 前置准备
+
+```bash
+# 确保依赖已安装
+uv sync --all-groups
+
+# 创建日志目录
+mkdir -p /tmp/a2c-uat-logs
+
+# 确认 a2c-computer 可用
+uv run a2c-computer --help
+```
+
+## CLI-only 场景环境
+
+只需一个 tmux session，直接执行子命令：
+
+### tmux 操作序列
+
+1. **创建 session**
+
+```
+mcp__tmux__create-session  name: a2c-uat
+```
+
+2. **获取 pane ID**
+
+```
+mcp__tmux__list-windows  sessionId: <session-id>
+mcp__tmux__list-panes    windowId: <window-id>
+```
+
+3. **执行命令**
+
+```
+mcp__tmux__execute-command  paneId: <pane-id>  command: cd /Users/liulonggang/PycharmProjects/python-sdk && uv run a2c-computer marketplace list --json
+```
+
+4. **捕获输出**
+
+```
+mcp__tmux__capture-pane  paneId: <pane-id>  lines: 50
+```
+
+5. **清理**
+
+```
+mcp__tmux__kill-session  sessionId: <session-id>
+```
+
+## 完整链路场景环境
+
+需要三个 window，按顺序启动 Server → Computer → Agent。
+
+### 步骤 1：创建 session + 日志目录
+
+```
+mcp__tmux__create-session  name: a2c-uat
+```
+
+```bash
+mkdir -p /tmp/a2c-uat-logs
+```
+
+### 步骤 2：启动 Server
+
+在 server window 中执行：
+
+```bash
+cd /Users/liulonggang/PycharmProjects/python-sdk && uv run python -c "
+import socket, sys, time
+from tests.e2e.conftest import _run_server_process
+from multiprocessing import Event
+
+# 获取空闲端口
+s = socket.socket(); s.bind(('127.0.0.1', 0))
+port = s.getsockname()[1]; s.close()
+
+# 写入端口文件供其他进程读取
+with open('/tmp/a2c-uat-port', 'w') as f:
+    f.write(str(port))
+
+print(f'SERVER_PORT={port}', flush=True)
+e = Event()
+_run_server_process(port, e)
+e.wait()
+" 2>&1 | tee /tmp/a2c-uat-logs/server.log
+```
+
+等待 `capture-pane` 输出中出现 `SERVER_PORT=` 后，读取端口号。
+
+### 步骤 3：启动 Computer
+
+创建新 window，执行：
+
+```bash
+cd /Users/liulonggang/PycharmProjects/python-sdk && PORT=$(cat /tmp/a2c-uat-port) && uv run a2c-computer run --url http://127.0.0.1:$PORT --approve-all-mcp --no-color 2>&1 | tee /tmp/a2c-uat-logs/computer.log
+```
+
+等待 `capture-pane` 输出中出现连接成功提示。
+
+### 步骤 4：启动 Agent
+
+创建新 window，执行 Agent 测试脚本。Agent 使用同步客户端：
+
+```bash
+cd /Users/liulonggang/PycharmProjects/python-sdk && uv run python -c "
+import socketio
+from a2c_smcp.smcp import SMCP_NAMESPACE
+
+PORT = open('/tmp/a2c-uat-port').read().strip()
+url = f'http://127.0.0.1:{PORT}'
+print(f'Agent connecting to {url}', flush=True)
+
+client = socketio.Client()
+client.connect(url, socketio_path='/socket.io', namespaces=[SMCP_NAMESPACE], transports=['polling'], wait=True, wait_timeout=10)
+print('Agent connected', flush=True)
+# ... 测试交互 ...
+" 2>&1 | tee /tmp/a2c-uat-logs/agent.log
+```
+
+### 步骤 5：测试执行
+
+按场景用例，通过 `execute-command` 在对应 window 的 pane 中发送命令，通过
+`capture-pane` 获取输出。
+
+### 步骤 6：日志收集
+
+测试完成后或失败时，收集所有 pane 日志：
+
+```
+# 对每个 pane 执行
+mcp__tmux__capture-pane  paneId: <server-pane>   lines: 200
+mcp__tmux__capture-pane  paneId: <computer-pane>  lines: 200
+mcp__tmux__capture-pane  paneId: <agent-pane>     lines: 200
+```
+
+同时读取文件日志作为补充：
+
+```bash
+cat /tmp/a2c-uat-logs/server.log
+cat /tmp/a2c-uat-logs/computer.log
+cat /tmp/a2c-uat-logs/agent.log
+```
+
+### 步骤 7：清理
+
+```
+mcp__tmux__kill-session  sessionId: <session-id>
+```
+
+```bash
+rm -f /tmp/a2c-uat-port /tmp/a2c-uat-logs/*.log
+```
+
+## 关键注意事项
+
+1. **端口动态分配**：每次测试分配随机端口，通过 `/tmp/a2c-uat-port` 文件传递
+2. **进程启动顺序**：必须 Server 就绪后才能启动 Computer 和 Agent
+3. **日志双写**：所有进程输出通过 `tee` 同时写入文件和 tmux pane
+4. **等待策略**：使用 `capture-pane` 轮询检查关键字符串（如 `SERVER_PORT=`、`connected`），
+   每次间隔 1-2 秒，最多等待 15 秒
+5. **环境隔离**：SKILL_HOME 使用临时目录，避免污染用户真实配置


### PR DESCRIPTION
## Summary

- 新增 UAT Skill（`.claude/skills/UAT/`），参照 TFRobotFrontPortal UAT 模式，将 Playwright 替换为 tmux MCP 工具，适配 CLI/SDK 项目的终端交互测试
- 包含 **marketplace-ops** 场景（CLI-only，8 个用例全部验证通过）和 **full-protocol** 场景（完整链路，Server+Computer+Agent 三进程）
- 提供完整的测试环境搭建指南、日志收集策略、测试仓库搭建脚本

### 验证结果（marketplace-ops 8/8 PASS）

| 用例 | 结果 |
|------|------|
| marketplace add --trust | ✅ |
| marketplace list | ✅ |
| marketplace info | ✅ |
| marketplace refresh | ✅ |
| marketplace set auto-update | ✅ |
| marketplace add 不带 --trust（应失败）| ✅ |
| marketplace remove | ✅ |
| marketplace add 重复（应失败）| ✅ |

### 文件结构

```
.claude/skills/UAT/
├── SKILL.md                              # 主技能文件
└── resources/
    ├── test-env-setup.md                 # 环境搭建指南
    └── scenarios/
        ├── marketplace-ops.md            # 场景1: marketplace CRUD
        └── full-protocol.md              # 场景2: 完整协议流程
```

## Test plan

- [x] 场景 1 marketplace-ops：8 个用例全部通过
- [ ] 场景 2 full-protocol：待后续补充验证
- [ ] 通过 `/uat marketplace-ops` 调用验证 Skill 可被正确加载执行

🤖 Generated with [Claude Code](https://claude.com/claude-code)