### PR TITLE
feat(uat): 添加 UAT Skill — tmux 终端自动化验收测试框架

### DIFF
--- a/.claude/skills/UAT/SKILL.md
+++ b/.claude/skills/UAT/SKILL.md
@@ -1,0 +1,253 @@
+---
+name: uat
+description: 执行 A2C-SMCP Python SDK 的用户验收测试（UAT）。通过 tmux MCP 工具在真实终端环境中验证 CLI 命令和端到端协议流程。
+---
+
+# UAT - User Acceptance Testing Skill
+
+## Description
+
+用户验收测试（UAT）技能。通过 tmux 终端自动化工具，以真实用户视角对 A2C-SMCP SDK 的 CLI
+命令和协议流程进行端到端验收测试。
+
+## Instructions
+
+### 角色定位
+
+你是一名 QA 测试工程师，负责对 A2C-SMCP Python SDK 执行用户验收测试。你将使用 tmux MCP
+工具在真实终端环境中模拟用户操作，验证 CLI 命令和协议交互是否符合预期。
+
+### 前置条件检查
+
+执行任何测试前，**必须**确认以下条件：
+
+1. **项目已安装**：`uv sync --all-groups` 已执行，`a2c-computer` 命令可用
+2. **tmux MCP 可用**：能调用 `mcp__tmux__*` 系列工具（创建 session、执行命令、捕获输出）
+3. **测试 marketplace 仓库可访问**：有可用的 Git URL 用于 marketplace 测试
+
+如果任一条件未满足，**停止测试**并提示用户先完成准备工作。
+
+### 执行协议
+
+1. **加载场景**：根据用户指定的场景，读取对应的 `resources/scenarios/<scenario>.md`
+2. **准备环境**：按场景要求创建 tmux session、启动必要进程
+3. **逐用例执行**：
+   - 通过 tmux `execute-command` 发送 CLI 命令
+   - 通过 tmux `capture-pane` 获取输出
+   - 对比预期结果，标记 PASS / FAIL
+4. **收集日志**：捕获所有 tmux pane 的完整输出
+5. **输出报告**：汇总所有用例的执行结果
+
+### tmux 环境管理
+
+#### Session 命名规范
+
+```
+a2c-uat              # 主 session
+a2c-uat-server       # Server 进程（需要完整链路时）
+a2c-uat-computer     # Computer 进程（需要完整链路时）
+a2c-uat-agent        # Agent 进程（需要完整链路时）
+a2c-uat-cli          # 独立 CLI 命令（不需要完整链路时）
+```
+
+#### 日志捕获策略
+
+**所有测试必须保证三端日志可收集**。具体策略：
+
+1. **tmux pane 捕获**：每个测试步骤后，使用 `capture-pane` 获取对应 pane 的完整输出
+2. **文件日志兜底**：Server/Computer/Agent 的输出同时重定向到 `/tmp/a2c-uat-logs/` 目录
+3. **失败时全量收集**：任一用例 FAIL 时，立即捕获所有 tmux pane 的最近 200 行输出
+
+日志文件路径约定：
+
+```
+/tmp/a2c-uat-logs/
+├── server.log        # Server 进程输出
+├── computer.log      # Computer CLI 输出
+└── agent.log         # Agent 客户端输出
+```
+
+启动进程时使用 `tee` 双写：
+
+```bash
+uv run python server_script.py 2>&1 | tee /tmp/a2c-uat-logs/server.log
+```
+
+#### 进程生命周期
+
+```
+1. 创建 tmux session + windows
+2. 启动进程（重定向到日志文件）
+3. 等待进程就绪（轮询 capture-pane 检查输出）
+4. 执行测试用例
+5. 测试完成后 kill session（自动清理所有进程）
+```
+
+### CLI-only 场景 vs 完整链路场景
+
+#### CLI-only 场景（如 marketplace-ops）
+
+只需要一个 tmux window，直接执行 `a2c-computer` 子命令：
+
+```
+tmux session: a2c-uat
+└── window: cli  →  a2c-computer marketplace add <url> --trust
+```
+
+启动方式：
+
+1. 创建 tmux session `a2c-uat`
+2. 在默认 window 中执行命令
+3. `capture-pane` 获取输出验证
+
+#### 完整链路场景（如 full-protocol）
+
+需要三个 tmux window，分别运行 Server / Computer / Agent：
+
+```
+tmux session: a2c-uat
+├── window: server     →  Server 进程（端口动态分配，写入 /tmp/a2c-uat-port）
+├── window: computer   →  a2c-computer run --url http://127.0.0.1:<PORT>
+└── window: agent      →  Agent 客户端 Python 脚本
+```
+
+启动流程（严格按顺序）：
+
+1. 创建 tmux session `a2c-uat`
+2. 创建 3 个 window（server / computer / agent）
+3. **先启动 Server**：在 server window 执行启动脚本，等待端口就绪
+4. **再启动 Computer**：读取端口后执行 `a2c-computer run --url ...`，等待连接成功
+5. **最后启动 Agent**：执行 Agent 客户端脚本
+
+详见 `resources/test-env-setup.md`。
+
+### 测试原则
+
+- **真实进程视角**：测试启动真实的 Python 进程，不使用 mock
+- **可观测性**：每个关键步骤捕获 tmux pane 输出；失败时全量收集所有 pane 日志
+- **幂等性**：测试不应产生残留状态（marketplace remove 清理、tmp 目录隔离）
+- **独立性**：每个场景可独立执行
+- **容错性**：单个用例失败不阻塞后续用例执行
+
+### 二次复验机制
+
+对所有 **FAIL** 结果执行二次复验：
+
+1. **重试执行**：等待 2-3 秒后重新执行相同命令
+2. **pane 输出复查**：增加 `capture-pane` 的行数，检查是否有延迟输出
+3. **综合判定**：两次结果一致则采信，不一致标记为 **Flaky**
+
+### 报告格式
+
+```
+## UAT 报告 - [场景名称]
+日期：YYYY-MM-DD
+分支：[当前分支]
+环境：tmux session a2c-uat
+
+### 测试结果摘要
+- 总用例数：N
+- 通过：N ✅
+- 失败：N ❌
+- 跳过：N ⏭️
+
+### 用例详情
+| # | 用例 | 优先级 | 结果 | 复验 | 备注 |
+|---|------|--------|------|------|------|
+| 1 | ...  | P0     | ✅   | -    |      |
+
+### 失败用例详情
+#### [用例名称]
+- **步骤**：...
+- **预期**：...
+- **实际**：...
+- **tmux 输出**：
+  ```
+  [粘贴 capture-pane 内容]
+  ```
+- **日志线索**：[从 /tmp/a2c-uat-logs/ 中提取的关键错误信息]
+
+### 进程日志摘要
+#### Server
+```
+[最近 N 行关键输出]
+```
+#### Computer
+```
+[最近 N 行关键输出]
+```
+#### Agent
+```
+[最近 N 行关键输出]
+```
+```
+
+## User-invocable
+
+- name: uat
+- description: 执行 A2C-SMCP SDK 用户验收测试（UAT）。指定场景名执行单场景；不指定场景则进入全量测试模式。
+
+## Arguments
+
+- scenario: （可选）测试场景名称（如 marketplace-ops, full-protocol）。不填则全量执行。
+
+## Prompt
+
+请执行 UAT 测试。
+
+首先确认前置条件：
+
+1. `a2c-computer` 命令是否可用？
+2. tmux MCP 工具是否可用？
+3. 测试 marketplace 仓库是否可访问？
+
+---
+
+**判断执行模式：**
+
+### 单场景模式（`$scenario` 已指定）
+
+加载场景 `$scenario` 的测试用例并开始执行。
+
+---
+
+### 全量测试模式（未指定 `$scenario`）
+
+扫描 `resources/scenarios/` 目录，获取所有可用场景列表。
+
+#### 执行顺序
+
+1. **CLI-only 场景优先**（无需多进程）：marketplace-ops → plugin-management → settings-scope
+2. **完整链路场景随后**（需多进程）：full-protocol → strict-mode → blob-transfer → skill-discovery
+
+#### 全量测试执行协议
+
+对每个场景，严格按以下步骤执行：
+
+**步骤 1：环境准备**
+
+按场景类型（CLI-only / 完整链路）创建 tmux session 和必要的进程。
+
+**步骤 2：执行场景**
+
+执行该场景的所有测试用例，完整流程：加载场景 → 逐用例执行（发送命令、捕获输出、对比预期、标记 PASS/FAIL）→ 输出该场景 UAT 报告
+
+**步骤 3：环境清理**
+
+每个场景完成后：
+1. 捕获所有 tmux pane 输出作为日志
+2. Kill tmux session 清理进程
+3. 清理 `/tmp/a2c-uat-*` 临时文件
+
+**步骤 4：上下文管理**
+
+执行 `/compact [场景名] UAT 完成。通过 X/Y 用例。[若有失败：失败用例：xxx]` 压缩上下文。
+
+**步骤 5：结果判断**
+
+- **全部通过（✅）**：继续下一个场景
+- **存在失败（❌）**：压缩上下文后，**立即中止全量测试**，输出已完成场景的进度汇总
+
+#### 全量测试完成后
+
+输出总汇总报告。

--- a/.claude/skills/UAT/resources/scenarios/full-protocol.md
+++ b/.claude/skills/UAT/resources/scenarios/full-protocol.md
@@ -1,0 +1,119 @@
+# 场景：full-protocol
+
+## 测试目标
+
+验证 Agent ↔ Server ↔ Computer 完整协议流程：连接、office 加入、tool_call 路由、
+SKILL 通知广播、版本握手、断连守卫。
+
+## 类型
+
+完整链路（需要 Server + Computer + Agent 三进程）
+
+## 前置条件
+
+1. `uv sync --all-groups` 已执行
+2. `a2c-computer` 命令可用
+3. tmux MCP 工具可用
+
+## 环境准备
+
+按 `resources/test-env-setup.md` 中"完整链路场景环境"的步骤，启动三个进程：
+
+1. 创建 tmux session `a2c-uat`
+2. 启动 Server（动态端口 → `/tmp/a2c-uat-port`）
+3. 启动 Computer（连接 Server）
+4. 启动 Agent（连接 Server）
+
+所有进程输出通过 `tee` 双写到 `/tmp/a2c-uat-logs/`。
+
+## 测试用例
+
+### F-01: Computer 连接并加入 office
+
+- **优先级**: P0
+- **步骤**:
+  1. 启动 Computer，连接 Server
+  2. Computer CLI 中执行 `join_office test-office-001`
+  3. 捕获 Computer pane 输出
+  4. 捕获 Server pane 输出
+- **预期结果**:
+  - Computer 输出包含连接成功提示
+  - `join_office` 返回成功
+
+### F-02: Agent 连接并发起 tool_call
+
+- **优先级**: P0
+- **前置**: F-01 成功，Computer 已加入 office 且有 MCP server
+- **步骤**:
+  1. Agent 连接 Server
+  2. Agent 通过 Socket.IO 发起 `client:call_tool` 事件
+  3. 等待 Computer 执行并返回结果
+  4. 捕获 Agent / Computer / Server 三端 pane 输出
+- **预期结果**:
+  - Agent 收到正确的 tool_call 返回结果
+  - Computer 日志显示 MCP server 执行了工具
+  - Server 日志显示消息路由
+
+### F-03: SKILL 通知广播（notify:update_skills）
+
+- **优先级**: P0
+- **前置**: F-01 成功，Agent 已连接
+- **步骤**:
+  1. Computer 更新 skills（通过 CLI 命令或 MCP server 上报）
+  2. 观察 Agent 是否收到 `notify:update_skills` 通知
+  3. 捕获三端 pane 输出
+- **预期结果**:
+  - Agent 收到 skills 更新通知
+  - Server 日志显示广播事件
+
+### F-04: 版本握手成功
+
+- **优先级**: P0
+- **步骤**:
+  1. Agent 携带正确 `a2c_version` query 参数连接 Server
+  2. 捕获 Server pane 输出
+- **预期结果**:
+  - 连接成功（非 4008 拒绝）
+  - Server 日志显示版本匹配
+
+### F-05: 版本不兼容拒绝（Socket.IO 4008）
+
+- **优先级**: P0
+- **步骤**:
+  1. Agent 携带不兼容版本（如 `a2c_version=99.0.0`）尝试连接
+  2. 捕获 Agent 和 Server pane 输出
+- **预期结果**:
+  - 连接被拒
+  - Agent 收到 4008 错误码
+  - Server 日志显示版本不兼容
+
+### F-06: Computer 断连后重连
+
+- **优先级**: P1
+- **前置**: F-01 成功
+- **步骤**:
+  1. Computer 正常连接
+  2. 模拟断连（kill Computer tmux window 后重新启动）
+  3. 观察 Server 和 Agent 日志
+  4. Computer 重新启动并连接
+  5. 观察恢复行为
+- **预期结果**:
+  - 断连后 Server 日志显示 disconnect
+  - 重连后 Computer 恢复正常
+  - 飞行中的请求不静默丢失（返回断连错误）
+
+## 清理
+
+1. Kill tmux session `a2c-uat`
+2. 清理 `/tmp/a2c-uat-port`、`/tmp/a2c-uat-logs/`、`/tmp/a2c-uat-skill-home/`
+
+## 日志收集
+
+完整链路场景必须收集三端日志：
+
+1. **Server pane**: `/tmp/a2c-uat-logs/server.log` + tmux capture-pane
+2. **Computer pane**: `/tmp/a2c-uat-logs/computer.log` + tmux capture-pane
+3. **Agent pane**: `/tmp/a2c-uat-logs/agent.log` + tmux capture-pane
+
+每个用例执行后，对三个 pane 都执行 `capture-pane lines: 50`。
+失败时增加到 `lines: 200` 并读取文件日志。

--- a/.claude/skills/UAT/resources/scenarios/marketplace-ops.md
+++ b/.claude/skills/UAT/resources/scenarios/marketplace-ops.md
@@ -1,0 +1,181 @@
+# 场景：marketplace-ops
+
+## 测试目标
+
+验证 `a2c-computer marketplace` 子命令的完整生命周期：添加、列出、查看详情、刷新、删除。
+
+## 类型
+
+CLI-only（不需要 Server/Computer/Agent 多进程）
+
+## 前置条件
+
+1. `uv sync --all-groups` 已执行
+2. `a2c-computer` 命令可用
+3. 测试 marketplace Git 仓库已准备（见下方「测试仓库搭建」）
+
+## 测试仓库搭建
+
+测试使用本地裸仓库（`file://` 零网络），结构如下：
+
+```
+work/
+├── .tfrobot-plugin/
+│   └── marketplace.json     # 必须有，且 plugins[].source 必填
+└── plugins/
+    └── hello/
+        └── skills/
+            └── greet/
+                └── SKILL.md
+```
+
+`marketplace.json` 最小格式（**source 字段必填**，否则 plugin staging 跳过）：
+
+```json
+{
+  "version": "1.0.0",
+  "plugins": [
+    {
+      "name": "hello",
+      "source": "./plugins/hello"
+    }
+  ]
+}
+```
+
+搭建脚本（在 tmux 中通过 Bash 执行）：
+
+```bash
+WORK_DIR=$(mktemp -d) && WORK="$WORK_DIR/work" && mkdir -p "$WORK" && cd "$WORK"
+git init -q -b main && git config user.name "test" && git config user.email "test@test.com"
+mkdir -p .tfrobot-plugin
+cat > .tfrobot-plugin/marketplace.json << 'EOF'
+{"version":"1.0.0","plugins":[{"name":"hello","source":"./plugins/hello"}]}
+EOF
+mkdir -p plugins/hello/skills/greet
+cat > plugins/hello/skills/greet/SKILL.md << 'EOF'
+---
+name: greet
+description: A test greeting skill
+---
+# Greet
+Hello test skill.
+EOF
+git add -A . && git commit -q -m "init"
+BARE="$WORK_DIR/test-mp.git" && git clone -q --bare . "$BARE"
+echo "BARE_URL=file://$BARE"
+```
+
+## 环境变量
+
+```bash
+A2C_SKILL_HOME=/tmp/a2c-uat-skill-home-$$   # 使用 PID 隔离，避免 zsh rm -rf * 确认
+mkdir -p $A2C_SKILL_HOME
+```
+
+> 使用独立 SKILL_HOME 避免污染用户真实配置。用 PID 后缀避免 zsh glob 确认弹窗。
+> 测试完成后整体 `rm -rf /tmp/a2c-uat-skill-home-*` 清理。
+
+## 测试用例
+
+### M-01: marketplace add --trust（添加 marketplace）
+
+- **优先级**: P0
+- **步骤**:
+  1. 清理环境：`rm -rf /tmp/a2c-uat-skill-home/*`
+  2. 执行：`A2C_SKILL_HOME=/tmp/a2c-uat-skill-home uv run a2c-computer marketplace add <GIT_URL> --trust --json`
+  3. 捕获输出
+- **预期结果**:
+  - 退出码 0
+  - 输出包含成功添加信息（JSON 模式下返回 marketplace 名称和状态）
+  - `/tmp/a2c-uat-skill-home/marketplace/` 下出现对应目录
+
+### M-02: marketplace list（列出 marketplace）
+
+- **优先级**: P0
+- **前置**: M-01 成功
+- **步骤**:
+  1. 执行：`A2C_SKILL_HOME=/tmp/a2c-uat-skill-home uv run a2c-computer marketplace list --json`
+  2. 捕获输出
+- **预期结果**:
+  - 退出码 0
+  - JSON 输出包含刚添加的 marketplace
+  - 显示 trusted/cloned 状态
+
+### M-03: marketplace info（查看详情）
+
+- **优先级**: P0
+- **前置**: M-01 成功
+- **步骤**:
+  1. 从 M-01 输出获取 marketplace 名称
+  2. 执行：`A2C_SKILL_HOME=/tmp/a2c-uat-skill-home uv run a2c-computer marketplace info <NAME> --json`
+  3. 捕获输出
+- **预期结果**:
+  - 退出码 0
+  - 显示 marketplace 详情（skills 列表、strict 模式、auto-update 状态等）
+
+### M-04: marketplace refresh（刷新 marketplace）
+
+- **优先级**: P0
+- **前置**: M-01 成功
+- **步骤**:
+  1. 执行：`A2C_SKILL_HOME=/tmp/a2c-uat-skill-home uv run a2c-computer marketplace refresh <NAME> --json`
+  2. 捕获输出
+- **预期结果**:
+  - 退出码 0
+  - 显示刷新成功信息（git pull 或 re-clone 完成）
+
+### M-05: marketplace set auto-update（设置自动更新）
+
+- **优先级**: P1
+- **前置**: M-01 成功
+- **步骤**:
+  1. 执行：`A2C_SKILL_HOME=/tmp/a2c-uat-skill-home uv run a2c-computer marketplace set <NAME> auto-update=true --json`
+  2. 捕获输出
+- **预期结果**:
+  - 退出码 0
+  - 设置持久化（再次 `info` 可见 auto-update=true）
+
+### M-06: marketplace add（不带 --trust 应失败）
+
+- **优先级**: P1
+- **步骤**:
+  1. 执行：`A2C_SKILL_HOME=/tmp/a2c-uat-skill-home uv run a2c-computer marketplace add <GIT_URL> --json`
+  2. 捕获输出
+- **预期结果**:
+  - 退出码 1（非交互模式下必须 --trust）
+  - 输出包含 trust 确认相关错误信息
+
+### M-07: marketplace remove（删除 marketplace）
+
+- **优先级**: P0
+- **前置**: M-01 成功
+- **步骤**:
+  1. 执行：`A2C_SKILL_HOME=/tmp/a2c-uat-skill-home uv run a2c-computer marketplace remove <NAME> --json`
+  2. 捕获输出
+  3. 验证：再次 `marketplace list` 确认已移除
+- **预期结果**:
+  - 退出码 0
+  - marketplace 从列表消失
+  - clone 目录被清理
+
+### M-08: marketplace add 重复添加
+
+- **优先级**: P1
+- **前置**: M-01 成功
+- **步骤**:
+  1. 再次执行：`A2C_SKILL_HOME=/tmp/a2c-uat-skill-home uv run a2c-computer marketplace add <GIT_URL> --trust --json`
+  2. 捕获输出
+- **预期结果**:
+  - 退出码 1（已存在）
+  - 输出包含已存在提示
+
+## 清理
+
+```bash
+rm -rf /tmp/a2c-uat-skill-home
+```
+
+## 日志收集
+
+CLI-only 场景下日志即 tmux pane 输出。每个用例执行后必须 `capture-pane` 保存完整输出。

--- a/.claude/skills/UAT/resources/test-env-setup.md
+++ b/.claude/skills/UAT/resources/test-env-setup.md
@@ -1,0 +1,165 @@
+# 测试环境搭建指南
+
+## 前置准备
+
+```bash
+# 确保依赖已安装
+uv sync --all-groups
+
+# 创建日志目录
+mkdir -p /tmp/a2c-uat-logs
+
+# 确认 a2c-computer 可用
+uv run a2c-computer --help
+```
+
+## CLI-only 场景环境
+
+只需一个 tmux session，直接执行子命令：
+
+### tmux 操作序列
+
+1. **创建 session**
+
+```
+mcp__tmux__create-session  name: a2c-uat
+```
+
+2. **获取 pane ID**
+
+```
+mcp__tmux__list-windows  sessionId: <session-id>
+mcp__tmux__list-panes    windowId: <window-id>
+```
+
+3. **执行命令**
+
+```
+mcp__tmux__execute-command  paneId: <pane-id>  command: cd /Users/liulonggang/PycharmProjects/python-sdk && uv run a2c-computer marketplace list --json
+```
+
+4. **捕获输出**
+
+```
+mcp__tmux__capture-pane  paneId: <pane-id>  lines: 50
+```
+
+5. **清理**
+
+```
+mcp__tmux__kill-session  sessionId: <session-id>
+```
+
+## 完整链路场景环境
+
+需要三个 window，按顺序启动 Server → Computer → Agent。
+
+### 步骤 1：创建 session + 日志目录
+
+```
+mcp__tmux__create-session  name: a2c-uat
+```
+
+```bash
+mkdir -p /tmp/a2c-uat-logs
+```
+
+### 步骤 2：启动 Server
+
+在 server window 中执行：
+
+```bash
+cd /Users/liulonggang/PycharmProjects/python-sdk && uv run python -c "
+import socket, sys, time
+from tests.e2e.conftest import _run_server_process
+from multiprocessing import Event
+
+# 获取空闲端口
+s = socket.socket(); s.bind(('127.0.0.1', 0))
+port = s.getsockname()[1]; s.close()
+
+# 写入端口文件供其他进程读取
+with open('/tmp/a2c-uat-port', 'w') as f:
+    f.write(str(port))
+
+print(f'SERVER_PORT={port}', flush=True)
+e = Event()
+_run_server_process(port, e)
+e.wait()
+" 2>&1 | tee /tmp/a2c-uat-logs/server.log
+```
+
+等待 `capture-pane` 输出中出现 `SERVER_PORT=` 后，读取端口号。
+
+### 步骤 3：启动 Computer
+
+创建新 window，执行：
+
+```bash
+cd /Users/liulonggang/PycharmProjects/python-sdk && PORT=$(cat /tmp/a2c-uat-port) && uv run a2c-computer run --url http://127.0.0.1:$PORT --approve-all-mcp --no-color 2>&1 | tee /tmp/a2c-uat-logs/computer.log
+```
+
+等待 `capture-pane` 输出中出现连接成功提示。
+
+### 步骤 4：启动 Agent
+
+创建新 window，执行 Agent 测试脚本。Agent 使用同步客户端：
+
+```bash
+cd /Users/liulonggang/PycharmProjects/python-sdk && uv run python -c "
+import socketio
+from a2c_smcp.smcp import SMCP_NAMESPACE
+
+PORT = open('/tmp/a2c-uat-port').read().strip()
+url = f'http://127.0.0.1:{PORT}'
+print(f'Agent connecting to {url}', flush=True)
+
+client = socketio.Client()
+client.connect(url, socketio_path='/socket.io', namespaces=[SMCP_NAMESPACE], transports=['polling'], wait=True, wait_timeout=10)
+print('Agent connected', flush=True)
+# ... 测试交互 ...
+" 2>&1 | tee /tmp/a2c-uat-logs/agent.log
+```
+
+### 步骤 5：测试执行
+
+按场景用例，通过 `execute-command` 在对应 window 的 pane 中发送命令，通过
+`capture-pane` 获取输出。
+
+### 步骤 6：日志收集
+
+测试完成后或失败时，收集所有 pane 日志：
+
+```
+# 对每个 pane 执行
+mcp__tmux__capture-pane  paneId: <server-pane>   lines: 200
+mcp__tmux__capture-pane  paneId: <computer-pane>  lines: 200
+mcp__tmux__capture-pane  paneId: <agent-pane>     lines: 200
+```
+
+同时读取文件日志作为补充：
+
+```bash
+cat /tmp/a2c-uat-logs/server.log
+cat /tmp/a2c-uat-logs/computer.log
+cat /tmp/a2c-uat-logs/agent.log
+```
+
+### 步骤 7：清理
+
+```
+mcp__tmux__kill-session  sessionId: <session-id>
+```
+
+```bash
+rm -f /tmp/a2c-uat-port /tmp/a2c-uat-logs/*.log
+```
+
+## 关键注意事项
+
+1. **端口动态分配**：每次测试分配随机端口，通过 `/tmp/a2c-uat-port` 文件传递
+2. **进程启动顺序**：必须 Server 就绪后才能启动 Computer 和 Agent
+3. **日志双写**：所有进程输出通过 `tee` 同时写入文件和 tmux pane
+4. **等待策略**：使用 `capture-pane` 轮询检查关键字符串（如 `SERVER_PORT=`、`connected`），
+   每次间隔 1-2 秒，最多等待 15 秒
+5. **环境隔离**：SKILL_HOME 使用临时目录，避免污染用户真实配置

--- a/.claude/skills/uat-scenario/SKILL.md
+++ b/.claude/skills/uat-scenario/SKILL.md
@@ -1,0 +1,370 @@
+---
+name: uat-scenario
+description:
+  创建、更新或删除 UAT 场景文档，确保以 tmux 终端交互验证为核心，符合 A2C-SMCP
+  SDK 的 UAT 最佳实践。重型场景自动加载对应设计指南。无参数时自动扫描 Git
+  变更，分析受影响的场景并批量更新。
+argument-hint:
+  "[create|update|delete] <场景名称>  （留空则自动扫描 Git 变更）"
+---
+
+# UAT 场景管理 — Create / Update / Delete / Auto-Scan
+
+你是一名资深 QA 架构师，负责按标准流程管理 A2C-SMCP SDK 的 UAT 场景体系。你的工作
+不仅是编写场景文档，还包括分析测试环境依赖（测试仓库、MCP 配置）、生成环境需求报告、
+维护场景参考文档的完整性。
+
+## 使用方式
+
+```
+/uat-scenario                                      # 无参数：自动扫描 Git 变更，批量评估受影响场景
+/uat-scenario create strict-mode                   # 新建场景
+/uat-scenario update marketplace-ops 增加 refresh 失败用例  # 更新场景
+/uat-scenario delete deprecated-scenario           # 删除场景
+/uat-scenario existing:scenarios/marketplace-ops.md  # 改造已有场景
+```
+
+如果省略动作前缀，通过上下文推断：提到已有场景名 + 增/改/删描述 →
+update；`existing:` 前缀 → update（改造模式）；描述全新场景 → create。
+
+## 动作分流
+
+| 动作          | 触发条件                                                | 执行路径                        |
+| ------------- | ------------------------------------------------------- | ------------------------------- |
+| **auto-scan** | 参数为空                                                | → [自动扫描流程](#自动扫描流程) |
+| **create**    | 明确 `create` 或描述的是新场景                          | → [创建流程](#创建流程)         |
+| **update**    | 明确 `update`/`extend`/`existing:` 前缀，后跟已有场景名 | → [更新流程](#更新流程)         |
+| **delete**    | 明确 `delete`/`remove`                                  | → [删除流程](#删除流程)         |
+
+## Input
+
+$ARGUMENTS
+
+---
+
+## 自动扫描流程
+
+> 触发条件：`/uat-scenario` 不带任何参数。
+>
+> 目标：检查自 UAT 场景最后更新以来的所有 Git 变更，评估哪些场景需要新增或更新。
+
+### Step A-1: 确定 UAT 基准时间
+
+```bash
+git log --format="%ai %H %s" -- ".claude/skills/UAT/resources/scenarios/" | head -5
+```
+
+取第一行的日期时间作为 **基准时间 T**。
+
+### Step A-2: 收集 Git 变更
+
+```bash
+git log --oneline --after="<T>" -- a2c_smcp/ tests/
+```
+
+如果 commit 较多（>15 条），再用 `git diff --stat` 聚焦关键文件变动：
+
+- `a2c_smcp/computer/cli/` — CLI 命令变更
+- `a2c_smcp/computer/skills/` — SKILL 系统变更
+- `a2c_smcp/server/` — Server 协议变更
+- `a2c_smcp/agent/` — Agent 客户端变更
+- `a2c_smcp/smcp.py` — 协议定义变更
+- `tests/e2e/` — e2e 测试变更（可能暴露新的测试点）
+
+### Step A-3: 建立"变更 → 场景"映射
+
+读取 `.claude/skills/UAT/resources/scenarios/` 下所有场景文件，提取功能范围关键词。
+
+映射规则：
+
+| 变更特征                                             | 可能影响的场景                               |
+| ---------------------------------------------------- | -------------------------------------------- |
+| `cli/commands/marketplace`                           | `marketplace-ops.md`                         |
+| `skills/manifest.py`, `skills/staging.py`            | `strict-mode.md`, `skill-discovery.md`       |
+| `skills/resource.py`, `utils/blob.py`                | `blob-transfer.md`                           |
+| `server/`, `smcp.py` 中的 events                     | `full-protocol.md`                           |
+| `computer/cli/commands/plugin`                       | `plugin-management.md`                       |
+| `computer/cli/commands/settings`                     | `settings-scope.md`                          |
+| `computer/skills/watcher.py`                         | `skill-discovery.md`（watcher 相关用例）     |
+| `computer/skills/sandbox.py`                         | 新场景（sandbox-security.md）                |
+| `smcp.py` 中 ErrorCode 变更                          | `full-protocol.md`（错误码验证）             |
+| 全新的 CLI 子命令或协议事件，无对应场景文件          | → 候选新增场景                               |
+
+### Step A-4: 输出变更影响报告
+
+在执行修改前，先输出分析报告：
+
+```
+## UAT 场景更新扫描报告
+
+**基准时间**：<T>
+**新增 commits**：<N> 条
+
+### 受影响场景评估
+
+| 场景文件 | 影响程度 | 建议动作 | 关联变更摘要 |
+|---------|---------|---------|------------|
+| marketplace-ops.md | 高 | update | feat: marketplace set 新增 strict 选项 |
+| strict-mode.md（新） | — | create | feat: 全新的 strict 模式 |
+
+### 可忽略变更
+
+以下变更判断为不影响 UAT 场景（纯重构/类型标注/文档）：
+- <commit>: refactor: ...
+```
+
+### Step A-5: 逐场景执行更新/创建
+
+按影响程度从高到低，对每个需要变更的场景执行对应的 update 或 create 流程。
+
+### Step A-6: 汇总
+
+```
+✅ 本轮扫描完成：更新 X 个场景，新增 Y 个场景，无需变更 Z 个场景。
+```
+
+---
+
+## 创建流程
+
+### Step 1: 信息采集与范围确认
+
+向用户确认以下信息：
+
+1. **功能范围**：覆盖哪些 CLI 命令 / 协议事件 / 子系统？
+2. **场景类型**：CLI-only 还是完整链路？
+3. **核心用户流程**：主要操作路径是什么？
+4. **环境依赖**：是否需要测试仓库、MCP server 配置、特定 Server 版本？
+5. **配置差异**：是否有 strict/non-strict、inline/blob 等配置组合需要覆盖？
+
+### Step 2: 环境依赖分析
+
+> **为什么要做这一步？** 测试环境依赖是 UAT 的地基。如果场景需要的测试仓库或
+> MCP 配置不存在，测试无法执行。
+
+检查 `.claude/skills/UAT/resources/test-env-setup.md` 中已有的环境配置，
+逐项核对新场景所需的环境：
+
+- **测试仓库**：是否需要特定 manifest 结构的 marketplace Git 仓库？
+- **MCP Server**：是否需要特定的 MCP server 配置（stdio/http/sse）？
+- **Server 版本**：是否需要特定协议版本（版本握手测试）？
+- **SKILL_HOME**：是否需要干净的隔离环境？
+
+**判断结果**：
+
+- **无缺口** → 跳到 Step 4
+- **有缺口** → 进入 Step 3
+
+### Step 3: 生成环境需求报告
+
+将报告输出到 `.claude/skills/UAT/resources/env-requests/` 目录，文件名格式
+`env-request-<场景名>.md`：
+
+```markdown
+# 环境需求报告 — [场景名称]
+
+> 关联 UAT 场景：`scenarios/<name>.md`  请求日期：YYYY-MM-DD  状态：🟡 待准备 | 🟢 已就绪
+
+## 需求背景
+
+[一句话说明为什么需要这些环境配置]
+
+## 需求清单
+
+### 1. 测试 Marketplace 仓库
+
+| 字段 | 要求 | 说明 |
+| ---- | ---- | ---- |
+| manifest strict | true/false | 用于测试 strict 模式 |
+| plugin 数量 | ≥2 | 用于测试多 plugin 场景 |
+| skill 数量 | ≥3 | 用于测试 skill 发现 |
+
+**仓库结构**：[描述或给出目录树]
+
+### 2. MCP Server 配置
+
+[如有需要]
+
+## 对现有环境的影响
+
+- [ ] 不影响现有环境
+- [ ] 需要新建测试仓库
+- [ ] 需要修改 test-env-setup.md
+
+## 验证方式
+
+[环境准备完成后，如何验证配置正确]
+```
+
+**交接动作**：报告生成后告知用户，并暂停场景编写直到环境就绪。
+
+### Step 4: 选择场景类型 & 加载设计指南
+
+根据场景特征，判断类型并加载对应的设计指南：
+
+| 场景类型             | 特征                                                        | 设计指南                                 |
+| -------------------- | ----------------------------------------------------------- | ---------------------------------------- |
+| **CLI 命令类**       | 仅涉及 CLI 子命令（无需 Server/Computer/Agent）             | 无需加载，遵循通用原则                    |
+| **协议流程类**       | 涉及 Agent↔Server↔Computer 完整链路                         | `resources/guides/protocol-flow.md`      |
+| **Marketplace/Plugin 类** | 涉及 marketplace CRUD、strict 模式、plugin 生命周期   | `resources/guides/marketplace-plugin.md` |
+| **二进制/Blob 传输类** | 涉及 SKILL blob handle、二进制 tool_call、SHA256 校验     | `resources/guides/blob-transfer.md`      |
+
+### Step 5: 编写场景文档
+
+输出到 `.claude/skills/UAT/resources/scenarios/<name>.md`。
+
+#### 通用设计原则
+
+**1. UAT ≠ 单元测试**
+
+> UAT 的本质是站在用户视角验证产品功能，用户操作的是终端命令行，不是 Python API。
+
+- 每个用例必须包含 **tmux 终端操作步骤**
+- 断言必须基于 **终端可观测性**（命令输出、退出码、日志文本）
+- **Python API 仅作为辅助**：用于准备测试环境或触发无法通过 CLI 触发的状态
+
+严禁出现：
+
+- 用例步骤仅包含 Python 函数调用，没有 CLI 命令
+- 断言仅验证函数返回值
+- 将"函数返回 None"作为通过条件
+
+**2. 操作成本感知**
+
+- CLI-only 场景按命令依赖关系编排
+- 完整链路场景按"先建环境 → 再测功能 → 最后清理"编排
+- 寻找**状态复用机会**：一个用例的终态是下一个用例的前置条件
+
+**3. 环境隔离**
+
+使用 `A2C_SKILL_HOME=/tmp/a2c-uat-skill-home-$$` 隔离环境，避免污染真实配置。
+临时目录在清理步骤中删除。
+
+**4. 日志可收集**
+
+所有进程输出通过 `tee` 双写到 `/tmp/a2c-uat-logs/`，确保三端日志可追溯。
+
+#### 断言编写指南
+
+| 类型     | 好的断言                                  | 坏的断言                              |
+| -------- | ----------------------------------------- | ------------------------------------- |
+| 退出码   | 命令退出码为 0                            | 函数无异常抛出                        |
+| 输出内容 | JSON 输出包含 `"skills": 1`              | 内部变量值为 1                        |
+| 错误信息 | 输出包含 `"error": "name conflict"`      | 异常类型为 ValueError                 |
+| 状态变更 | 再次 list 已不包含该 marketplace          | 内部缓存已清除                        |
+| 进程行为 | Computer pane 显示 "connected"           | socketio.Client.connected 为 True    |
+| 文件状态 | clone 目录存在且包含 marketplace.json     | Path.exists() 返回 True              |
+
+#### 文档结构
+
+1. **测试目标** — 一句话，强调用户视角
+2. **类型** — CLI-only / 完整链路
+3. **前置条件** — 环境依赖、测试仓库、MCP 配置
+4. **环境变量** — A2C_SKILL_HOME 等隔离配置
+5. **测试用例** — 按优先级分组（P0/P1/P2），每个用例包含 tmux 命令 + 输出断言
+6. **清理** — 恢复环境的步骤
+7. **日志收集** — 指定哪些 pane 输出需要捕获
+
+#### 用例编号规则
+
+- 场景缩写 + 两位数字：如 `M-01`（Marketplace）、`F-01`（Full-protocol）
+- P0 从 01 开始，P1/P2 接续编号
+- 清理用例使用 99
+
+### Step 6: 更新 test-env-setup.md
+
+如果新场景需要特殊的环境配置（如新的测试仓库结构），更新
+`.claude/skills/UAT/resources/test-env-setup.md` 中对应章节。
+
+### Step 7: 验证清单
+
+- [ ] 每个用例都有 tmux 终端操作步骤（非 Python API 调用）
+- [ ] 所有断言基于终端可观测性（输出文本、退出码、文件状态）
+- [ ] 前置条件中的环境依赖在 test-env-setup.md 中有记录
+- [ ] 用例编号遵循 `缩写-NN` 规则，无重复
+- [ ] P0 用例覆盖核心用户流程
+- [ ] 异常场景包含具体的错误输出描述（错误信息、退出码）
+- [ ] 清理用例能恢复到初始状态（保证幂等性）
+- [ ] 环境使用 `A2C_SKILL_HOME` 隔离，不污染真实配置
+- [ ] 日志收集策略已标注（CLI-only 仅 pane 输出；完整链路需三端）
+- [ ] 如有新增环境需求，已生成环境需求报告
+
+---
+
+## 更新流程
+
+### Step 1: 定位目标场景
+
+读取 `.claude/skills/UAT/resources/scenarios/<name>.md`。
+
+### Step 2a: 理解变更意图（标准更新）
+
+| 变更类型       | 示例                                       | 影响范围                   |
+| -------------- | ------------------------------------------ | -------------------------- |
+| **新增用例**   | 「增加 marketplace refresh 失败用例」      | 新增用例，可能调整编排策略 |
+| **修改用例**   | 「M-04 的预期结果需要改」                  | 局部修改，保持编排不变     |
+| **调整编排**   | 「P1 和 P2 用例重新分组」                  | 重排结构，检查依赖         |
+| **补充验证点** | 「增加退出码验证」                         | 在已有用例中追加断言       |
+| **修正错误**   | 「这个命令路径写错了」                     | 直接修正                   |
+
+### Step 2b: 质量审计（改造模式）
+
+按质量审计清单检查：
+
+| 检查项                 | 问题特征                     | 改造方向                                     |
+| ---------------------- | ---------------------------- | -------------------------------------------- |
+| 缺少 tmux 命令步骤     | 用例仅描述"调用函数"        | 补充完整终端命令                             |
+| 断言不基于终端输出     | 断言为"返回 None"           | 改为"输出包含 xxx"、"退出码为 0"            |
+| 缺少环境隔离           | 未设置 A2C_SKILL_HOME       | 补充隔离变量                                 |
+| 缺少退出码验证         | 只验证输出不验证退出码      | 补充退出码断言                               |
+| 缺少错误输出描述       | 异常用例只说"应报错"        | 明确具体的错误信息文本                       |
+| 缺少清理步骤           | 测试后未清理临时文件/目录   | 补充清理命令                                 |
+
+### Step 3: 加载设计指南
+
+判断场景类型，加载对应指南，确保变更符合设计原则。
+
+### Step 4: 执行变更
+
+读取并编辑场景文件。变更完成后：
+
+1. 更新场景文档的测试目标和编排结构
+2. 如有新增环境需求，走 [创建流程 Step 3](#step-3-生成环境需求报告)
+
+### Step 5: 变更验证清单
+
+- [ ] 用例编号连续，无跳号或重复
+- [ ] 编排结构间的依赖仍然正确
+- [ ] 环境隔离配置正确
+- [ ] 新增的环境需求已生成报告（如有）
+
+---
+
+## 删除流程
+
+### Step 1: 确认删除目标
+
+读取目标场景文件，展示基本信息，请用户确认。
+
+### Step 2: 检查依赖
+
+检查是否有其他场景或文档引用了该场景。
+
+### Step 3: 执行删除
+
+1. 删除场景文件
+2. 如有对应的环境需求报告，提示用户是否一并清理
+3. 检查 test-env-setup.md 是否需要更新
+
+---
+
+## 设计指南索引
+
+| 指南                    | 适用场景                                     | 文件                                    |
+| ----------------------- | -------------------------------------------- | --------------------------------------- |
+| 协议流程类              | Server+Computer+Agent 完整链路               | `resources/guides/protocol-flow.md`     |
+| Marketplace/Plugin 类   | marketplace CRUD、strict 模式、plugin 生命周期 | `resources/guides/marketplace-plugin.md` |
+| 二进制/Blob 传输类      | blob handle、二进制 tool_call、SHA256 校验   | `resources/guides/blob-transfer.md`     |
+
+指南随实践积累持续扩展。当发现新的场景类型有独特的设计模式时，创建新的指南文件并
+在此注册。

--- a/.claude/skills/uat-scenario/resources/guides/blob-transfer.md
+++ b/.claude/skills/uat-scenario/resources/guides/blob-transfer.md
@@ -1,0 +1,92 @@
+# 场景设计指南：二进制 / Blob 传输类
+
+适用于涉及 SKILL blob handle、二进制 tool_call、SHA256 校验等二进制传输场景。
+
+## 核心特征
+
+- **阈值切换**：根据 inline_budget（默认 256B）自动切换 inline ↔ blob handle
+- **SHA256 一致性**：mint 端和 serve 端的 SHA256/total_size 必须一致
+- **渐进披露**：get_skills → get_skill → get_blob 三级渐进
+- **完整链路必须**：blob 传输需要 Agent 发起请求，经 Server 路由到 Computer 解析
+
+## 设计原则
+
+### 1. 阈值边界测试
+
+blob 传输的核心是 inline_budget 阈值。必须覆盖三个边界：
+
+| 资源大小 | 传输模式 | 测试要点 |
+| -------- | -------- | -------- |
+| < inline_budget（如 100B） | inline | 直接在响应中返回内容 |
+| = inline_budget（如 256B） | 边界 | 确认含等号的边界行为 |
+| > inline_budget（如 1KB） | blob handle | 返回 handle，需二次获取 |
+
+**测试方法**：准备三个不同大小的测试资源文件，分别请求并验证传输模式。
+
+### 2. SHA256 端到端验证
+
+blob 传输的完整性依赖 SHA256 校验。验证流程：
+
+1. **mint 端**：Computer 创建 blob handle 时计算 SHA256
+2. **serve 端**：Agent 通过 blob handle 获取内容后验证 SHA256
+
+用例中必须：
+- 在请求资源时记录返回的 SHA256 和 total_size
+- 获取 blob 内容后，对比 SHA256 是否一致
+- 验证 total_size 与实际内容长度一致
+
+### 3. 渐进披露的三级验证
+
+SKILL 资源获取遵循三级渐进模式：
+
+```
+Level 1: get_skills → 返回 skill 列表（含 metadata，不含资源内容）
+Level 2: get_skill  → 返回单个 skill 详情（含 inline 资源或 blob handle）
+Level 3: get_blob   → 通过 handle 获取完整 blob 内容
+```
+
+每个 level 是一个独立用例，验证：
+
+| Level | 验证要点 |
+| ----- | -------- |
+| 1 | skills 列表包含预期的 skill 名称和基本信息 |
+| 2 | inline 资源直接包含内容；大资源返回 blob handle |
+| 3 | blob handle 可解析为完整内容，SHA256 一致 |
+
+### 4. 二进制 tool_call 的 sideband
+
+tool_call 返回二进制数据（如图片）时走 sideband blob：
+
+1. Agent 发起 tool_call
+2. Computer 执行 MCP 工具，返回二进制结果
+3. SDK 自动将大二进制转为 blob handle
+4. Agent 通过 blob handle 获取完整二进制
+
+测试需要：
+- 准备一个返回二进制数据的 MCP server（如返回图片）
+- 发起 tool_call 并验证返回值中包含 blob handle
+- 通过 blob handle 获取并验证二进制完整性
+
+### 5. 完整链路环境
+
+blob 传输场景需要完整的 Agent ↔ Server ↔ Computer 链路，且 Computer 需要挂载
+一个能返回不同大小资源的 MCP server。
+
+环境拓扑：
+
+```
+tmux session: a2c-uat
+├── window: server     →  Server
+├── window: computer   →  a2c-computer run --url <URL> --config <blob-test-mcp.json>
+└── window: agent      →  Agent 测试脚本
+```
+
+`blob-test-mcp.json` 需要配置一个能返回多种大小资源的 MCP server。
+
+## 验证清单补充项
+
+- [ ] 阈值边界三个区间（小/等/大）均有覆盖
+- [ ] SHA256 端到端验证（mint vs serve 一致性）
+- [ ] 渐进披露三级均有对应用例
+- [ ] 二进制 tool_call sideband 有独立用例
+- [ ] 完整链路环境已搭建（含 blob-test MCP server）

--- a/.claude/skills/uat-scenario/resources/guides/marketplace-plugin.md
+++ b/.claude/skills/uat-scenario/resources/guides/marketplace-plugin.md
@@ -1,0 +1,102 @@
+# 场景设计指南：Marketplace / Plugin 类
+
+适用于涉及 marketplace 增删改查、plugin 生命周期管理、strict 模式验证的 UAT 场景。
+
+## 核心特征
+
+- **CLI-only 为主**：大部分操作无需 Server/Computer/Agent，直接 CLI 子命令
+- **Git 仓库依赖**：需要本地裸仓库（`file://`）模拟 marketplace 源
+- **manifest 结构敏感**：marketplace.json 的 plugins[].source 必填，否则 staging 跳过
+- **配置组合验证**：strict=true/false、auto-update=true/false 等需覆盖
+
+## 设计原则
+
+### 1. 测试仓库先行
+
+每个场景必须先搭建测试仓库。使用本地裸仓库（零网络依赖）：
+
+```markdown
+### 测试仓库结构
+
+work/
+├── .tfrobot-plugin/
+│   └── marketplace.json     # 必须有，plugins[].source 必填
+└── plugins/
+    └── hello/
+        └── skills/greet/SKILL.md
+```
+
+**marketplace.json 最小格式**：
+
+```json
+{"version": "1.0.0", "plugins": [{"name": "hello", "source": "./plugins/hello"}]}
+```
+
+> **常见踩坑**：`source` 字段缺失 → staging 跳过 → `skills: 0`。必须在场景中标注。
+
+### 2. 环境隔离必做
+
+所有命令使用独立的 `A2C_SKILL_HOME`：
+
+```bash
+A2C_SKILL_HOME=/tmp/a2c-uat-skill-home-$$
+```
+
+用 PID 后缀避免 zsh `rm -rf *` 确认弹窗。清理时直接 `rm -rf /tmp/a2c-uat-skill-home-*`。
+
+### 3. 退出码断言 + 输出断言双验证
+
+CLI 命令测试必须同时验证：
+
+| 验证维度 | 正向用例 | 反向用例 |
+| -------- | -------- | -------- |
+| 退出码 | 0 | 1（或非零） |
+| 输出内容 | JSON 包含预期字段 | JSON 包含 error 字段和具体错误信息 |
+
+**退出码获取**：tmux `get-command-result` 的 `exit code` 字段，或
+`capture-pane` 中的 `TMUX_MCP_DONE_$status`。
+
+### 4. CRUD 生命周期编排
+
+marketplace/plugin 场景按 CRUD 生命周期编排：
+
+```
+Phase 1: Create（add --trust → 验证 list 可见）
+Phase 2: Read（list → info → skill list）
+Phase 3: Update（refresh → set auto-update）
+Phase 4: Error Cases（重复添加 → 不带 trust → 无效 URL）
+Phase 5: Delete（remove → 验证 list 已无）
+```
+
+**状态复用**：Phase 1 的 add 结果直接用于 Phase 2/3，最后 Phase 5 清理。
+
+### 5. Strict 模式的组合覆盖
+
+strict 模式需要覆盖以下组合：
+
+| strict | entry.skills | plugin.json skills | 预期行为 |
+| ------ | ------------ | ------------------ | -------- |
+| true   | 有           | 有                 | entry 追加到 plugin |
+| true   | 无           | 有                 | 仅 plugin skills |
+| false  | 有           | 无                 | entry 替换全部 |
+| false  | 有           | 有                 | 硬错误（冲突） |
+
+每个组合是一个独立用例，需要不同的测试仓库。
+
+### 6. 幂等性保证
+
+每个场景的清理步骤必须保证：
+
+1. `marketplace remove` 清除所有添加的 marketplace
+2. `rm -rf $A2C_SKILL_HOME` 清除 clone 目录和物化文件
+3. 验证：再次 `marketplace list` 应为空
+
+## 验证清单补充项
+
+- [ ] 测试仓库搭建脚本完整且可复现
+- [ ] marketplace.json 的 source 字段已正确填写
+- [ ] A2C_SKILL_HOME 使用 PID 隔离
+- [ ] 每个用例同时验证退出码和输出内容
+- [ ] CRUD 生命周期编排合理（Create → Read → Update → Delete）
+- [ ] Strict 模式覆盖了关键组合
+- [ ] 清理步骤可恢复到初始状态

--- a/.claude/skills/uat-scenario/resources/guides/protocol-flow.md
+++ b/.claude/skills/uat-scenario/resources/guides/protocol-flow.md
@@ -1,0 +1,86 @@
+# 场景设计指南：协议流程类
+
+适用于涉及 Agent ↔ Server ↔ Computer 完整协议链路的 UAT 场景，如版本握手、
+tool_call 路由、SKILL 通知广播、断连守卫等。
+
+## 核心特征
+
+- **三进程协同**：需要 Server + Computer + Agent 三个真实进程在 tmux 中运行
+- **协议事件驱动**：通过 Socket.IO 事件进行通信，测试需验证事件路由和载荷格式
+- **端口动态分配**：每次测试分配随机端口，通过文件传递
+- **时序敏感**：连接/断连/超时等操作的时序影响测试结果
+
+## 设计原则
+
+### 1. 环境拓扑先于用例
+
+编写用例前，必须先明确 tmux 环境拓扑：
+
+```markdown
+### 环境拓扑
+
+tmux session: a2c-uat
+├── window: server     →  Server 进程（端口 → /tmp/a2c-uat-port）
+├── window: computer   →  a2c-computer run --url http://127.0.0.1:<PORT>
+└── window: agent      →  Agent Python 脚本
+```
+
+明确每个 window 的 pane ID，后续用例直接引用。
+
+### 2. 三端日志同步收集
+
+协议流程场景必须同时关注三端的输出：
+
+| 端 | 日志来源 | 关键观察点 |
+| -- | -------- | ---------- |
+| Server | server pane / server.log | 连接事件、路由日志、广播记录 |
+| Computer | computer pane / computer.log | MCP 调用、SKILL 上报、断连检测 |
+| Agent | agent pane / agent.log | 请求发出、响应接收、通知接收 |
+
+**每个用例执行后，三个 pane 都必须 capture-pane**。只看一端的输出会导致误判。
+
+### 3. 连接生命周期编排
+
+协议场景的用例编排应遵循连接生命周期：
+
+```
+Phase 1: 建立连接（Server 启动 → Computer 连接 → Agent 连接）
+Phase 2: 协议交互（join_office → tool_call → SKILL 通知）
+Phase 3: 异常场景（断连 → 重连 → 版本不兼容）
+Phase 4: 清理（断开 → kill 进程）
+```
+
+**状态复用**：Phase 1 的连接建立可被 Phase 2 的所有用例共享。
+
+### 4. 端口传递的验证
+
+动态端口通过文件传递是关键基础设施。必须在第一个用例中验证：
+
+1. Server 启动后端口文件存在
+2. 端口号可被 Computer/Agent 正确读取
+3. 端口可连通（curl 或 socket 连接测试）
+
+### 5. 时序等待策略
+
+协议交互有网络延迟，用例中需要合理的等待：
+
+| 操作 | 建议等待 | 等待方式 |
+| ---- | -------- | -------- |
+| Server 启动 | 2-3s | capture-pane 轮询 `SERVER_PORT=` |
+| Computer 连接 | 3-5s | capture-pane 轮询 `connected` |
+| Agent 连接 | 2-3s | capture-pane 轮询 `connected` |
+| tool_call 响应 | 3-5s | capture-pane 轮询结果输出 |
+| 断连检测 | 5-10s | capture-pane 轮询 disconnect 日志 |
+
+**轮询参数**：间隔 1-2 秒，最多 15 秒超时。
+
+## 验证清单补充项
+
+除通用验证清单外，协议流程场景还需确认：
+
+- [ ] 环境拓扑已明确（3 个 tmux window + pane ID）
+- [ ] 端口动态分配 + 文件传递机制已验证
+- [ ] 每个用例都收集了三端日志
+- [ ] 连接生命周期编排正确（Phase 1 → 2 → 3 → 4）
+- [ ] 时序等待策略合理（无硬编码 sleep，用轮询检查）
+- [ ] 断连/重连场景有独立的清理和重建步骤


### PR DESCRIPTION
## Summary

- 新增 UAT Skill（`.claude/skills/UAT/`），参照 TFRobotFrontPortal UAT 模式，将 Playwright 替换为 tmux MCP 工具，适配 CLI/SDK 项目的终端交互测试
- 包含 **marketplace-ops** 场景（CLI-only，8 个用例全部验证通过）和 **full-protocol** 场景（完整链路，Server+Computer+Agent 三进程）
- 提供完整的测试环境搭建指南、日志收集策略、测试仓库搭建脚本

### 验证结果（marketplace-ops 8/8 PASS）

| 用例 | 结果 |
|------|------|
| marketplace add --trust | ✅ |
| marketplace list | ✅ |
| marketplace info | ✅ |
| marketplace refresh | ✅ |
| marketplace set auto-update | ✅ |
| marketplace add 不带 --trust（应失败）| ✅ |
| marketplace remove | ✅ |
| marketplace add 重复（应失败）| ✅ |

### 文件结构

```
.claude/skills/UAT/
├── SKILL.md                              # 主技能文件
└── resources/
    ├── test-env-setup.md                 # 环境搭建指南
    └── scenarios/
        ├── marketplace-ops.md            # 场景1: marketplace CRUD
        └── full-protocol.md              # 场景2: 完整协议流程
```

## Test plan

- [x] 场景 1 marketplace-ops：8 个用例全部通过
- [ ] 场景 2 full-protocol：待后续补充验证
- [ ] 通过 `/uat marketplace-ops` 调用验证 Skill 可被正确加载执行

🤖 Generated with [Claude Code](https://claude.com/claude-code)