### PR TITLE
fix(e2e): conftest 测试 Server 包裹协议版本握手中间件，修复 UAT F-05 (#93)

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,8 @@ python -m a2c_smcp.computer.cli.main run \
 ```python
 from fastapi import FastAPI
 import socketio
-from a2c_smcp.server import SMCPNamespace, DefaultAuthenticationProvider
+from a2c_smcp import PROTOCOL_VERSION
+from a2c_smcp.server import A2CProtocolVersionASGIMiddleware, SMCPNamespace, DefaultAuthenticationProvider
 
 app = FastAPI()
 
@@ -134,8 +135,15 @@ smcp_ns = SMCPNamespace(auth)
 sio = socketio.AsyncServer(cors_allowed_origins="*")
 sio.register_namespace(smcp_ns)
 
-socket_app = socketio.ASGIApp(sio, app)
+# 用 A2C 中间件包裹以启用协议版本握手（不包裹则 a2c_version 校验不生效）
+socket_app = socketio.ASGIApp(sio, other_asgi_app=app, socketio_path="/socket.io")
+socket_app = A2CProtocolVersionASGIMiddleware(socket_app, socketio_path="/socket.io", server_version=PROTOCOL_VERSION)
 ```
+
+> **启用握手**：`socketio.ASGIApp` / `WSGIApp` 本身不做版本校验，**必须**再用
+> `A2CProtocolVersionASGIMiddleware` / `A2CProtocolVersionWSGIMiddleware` 包裹一层，
+> 上文「Server MUST 返回 HTTP 400 + 4008」才会真正生效。裸 ASGI/WSGI、FastAPI 集成与验证方法见
+> [`docs/guides/server-version-handshake.md`](docs/guides/server-version-handshake.md)。
 
 同步版本、会话查询与自定义认证示例请参考 `docs/server.md`。
 

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -113,8 +113,10 @@ asyncio.run(main())
 ```python
 from fastapi import FastAPI
 import socketio
-from a2c_smcp.server import SMCPNamespace, DefaultAuthenticationProvider
+from a2c_smcp import PROTOCOL_VERSION
+from a2c_smcp.server import A2CProtocolVersionASGIMiddleware, SMCPNamespace, DefaultAuthenticationProvider
 
+SOCKETIO_PATH = "/socket.io"
 app = FastAPI()
 
 # 1. 创建认证提供者
@@ -130,11 +132,15 @@ smcp_ns = SMCPNamespace(auth)
 sio = socketio.AsyncServer(cors_allowed_origins="*")
 sio.register_namespace(smcp_ns)
 
-# 4. 挂载到 FastAPI
-socket_app = socketio.ASGIApp(sio, app)
+# 4. 挂载到 FastAPI，并用 A2C 中间件包裹以启用协议版本握手
+socket_app = socketio.ASGIApp(sio, other_asgi_app=app, socketio_path=SOCKETIO_PATH)
+socket_app = A2CProtocolVersionASGIMiddleware(socket_app, socketio_path=SOCKETIO_PATH, server_version=PROTOCOL_VERSION)
 
 # 运行: uvicorn main:socket_app
 ```
+
+> ⚠️ 不用 `A2CProtocolVersionASGIMiddleware` 包裹，协议版本握手（`a2c_version` → HTTP 400 + `4008`）
+> 不会生效。部署细节见 [Server 协议版本握手部署指南](server-version-handshake.md)。
 
 **下一步**: 阅读 [Server 使用指南](server-guide.md)
 
@@ -196,14 +202,17 @@ asyncio.run(main())
 # server_app.py
 from fastapi import FastAPI
 import socketio
-from a2c_smcp.server import SMCPNamespace, DefaultAuthenticationProvider
+from a2c_smcp import PROTOCOL_VERSION
+from a2c_smcp.server import A2CProtocolVersionASGIMiddleware, SMCPNamespace, DefaultAuthenticationProvider
 
 app = FastAPI()
 auth = DefaultAuthenticationProvider(admin_secret="secret")
 smcp_ns = SMCPNamespace(auth)
 sio = socketio.AsyncServer(cors_allowed_origins="*")
 sio.register_namespace(smcp_ns)
-socket_app = socketio.ASGIApp(sio, app)
+socket_app = socketio.ASGIApp(sio, other_asgi_app=app, socketio_path="/socket.io")
+# A2C 中间件包裹以启用协议版本握手（详见 server-version-handshake.md）
+socket_app = A2CProtocolVersionASGIMiddleware(socket_app, socketio_path="/socket.io", server_version=PROTOCOL_VERSION)
 
 # uvicorn server_app:socket_app --port 8000
 ```

--- a/docs/guides/server-guide.md
+++ b/docs/guides/server-guide.md
@@ -96,8 +96,10 @@ from a2c_smcp.server import (
 import asyncio
 from fastapi import FastAPI
 import socketio
-from a2c_smcp.server import SMCPNamespace, DefaultAuthenticationProvider
+from a2c_smcp import PROTOCOL_VERSION
+from a2c_smcp.server import A2CProtocolVersionASGIMiddleware, SMCPNamespace, DefaultAuthenticationProvider
 
+SOCKETIO_PATH = "/socket.io"
 app = FastAPI()
 
 # 1. 创建认证提供者
@@ -113,17 +115,26 @@ smcp_namespace = SMCPNamespace(auth_provider)
 sio = socketio.AsyncServer(cors_allowed_origins="*")
 sio.register_namespace(smcp_namespace)
 
-# 4. 挂载到 FastAPI
-socket_app = socketio.ASGIApp(sio, app)
+# 4. 挂载到 FastAPI，并用 A2C 中间件包裹以启用协议版本握手
+#    ⚠️ 不包裹中间件，a2c_version 校验（HTTP 400 + 4008）不会生效。详见 server-version-handshake.md
+socket_app = socketio.ASGIApp(sio, other_asgi_app=app, socketio_path=SOCKETIO_PATH)
+socket_app = A2CProtocolVersionASGIMiddleware(socket_app, socketio_path=SOCKETIO_PATH, server_version=PROTOCOL_VERSION)
 
 # 运行: uvicorn main:socket_app
 ```
+
+> **协议版本握手**：用 `A2CProtocolVersionASGIMiddleware` 包裹后，不兼容的 `a2c_version` 客户端会在
+> 传输层被拒（HTTP 400 + Socket.IO `4008`）。完整部署形态（裸 ASGI/WSGI、FastAPI 集成、验证方法）见
+> [Server 协议版本握手部署指南](server-version-handshake.md)。
 
 ### 同步版本（Flask/WSGI）
 
 ```python
 from socketio import Server, WSGIApp
-from a2c_smcp.server import SyncSMCPNamespace, DefaultSyncAuthenticationProvider
+from a2c_smcp import PROTOCOL_VERSION
+from a2c_smcp.server import A2CProtocolVersionWSGIMiddleware, SyncSMCPNamespace, DefaultSyncAuthenticationProvider
+
+SOCKETIO_PATH = "/socket.io"
 
 # 1. 创建同步认证提供者
 auth_provider = DefaultSyncAuthenticationProvider(
@@ -138,8 +149,9 @@ smcp_namespace = SyncSMCPNamespace(auth_provider)
 sio = Server(cors_allowed_origins="*")
 sio.register_namespace(smcp_namespace)
 
-# 4. 在 WSGI 框架中使用
-app = WSGIApp(sio)
+# 4. 在 WSGI 框架中使用，并用 A2C 中间件包裹以启用协议版本握手
+app = WSGIApp(sio, socketio_path=SOCKETIO_PATH)
+app = A2CProtocolVersionWSGIMiddleware(app, socketio_path=SOCKETIO_PATH, server_version=PROTOCOL_VERSION)
 
 # 运行: gunicorn -k geventwebsocket.gunicorn.workers.GeventWebSocketWorker main:app
 ```

--- a/docs/guides/server-version-handshake.md
+++ b/docs/guides/server-version-handshake.md
@@ -1,0 +1,223 @@
+# Server 协议版本握手部署指南 / Enabling the Protocol Version Handshake
+
+> 适用范围：**部署 A2C-SMCP Server** 的工程师。本指南说明如何在你的部署形态中启用「连接版本握手」
+> （`a2c_version` 协商 / HTTP 400 + Socket.IO `4008`），覆盖 **裸 Socket.IO Server（ASGI / WSGI）**
+> 与 **FastAPI + Socket.IO 集成** 两类场景。
+>
+> 协议依据：[a2c-smcp-protocol `versioning.md`](https://github.com/A2C-SMCP/a2c-smcp-protocol)。
+
+---
+
+## 1. 背景：握手不是自动生效的
+
+SDK 把协议版本握手实现为一层**传输层中间件**（`a2c_smcp/server/middleware.py`），它在请求进入
+Socket.IO `connect` handler **之前**于 HTTP 传输层校验 URL query 中的 `a2c_version`，不兼容直接
+返回 `HTTP 400 + 4008`。这是协议唯一规范的校验时机——即使业务 handler 有 bug 也无法绕过。
+
+**关键事实：这层中间件不会自动套上。** `socketio.ASGIApp(...)` / `socketio.WSGIApp(...)` 本身
+不做版本校验。如果你**只**创建了 socketio app 而没有用 A2C 中间件包裹它，那么：
+
+- 任意 `a2c_version`（甚至 `99.0.0` 或完全缺失）都会被放行，连接照常建立（HTTP 200）；
+- 协议 MUST 要求的「不兼容连接被拒、绝不建立」**被静默跳过**，且不会有任何报错——
+  这正是 [python-sdk #93](https://github.com/A2C-SMCP/python-sdk/issues/93) 暴露的问题。
+
+> 一句话：**创建 socketio app 后，必须再用 A2C 中间件包一层，握手才真正生效。**
+
+---
+
+## 2. 中间件总览
+
+`a2c_smcp.server` 导出两个对称的中间件类：
+
+| 类 | 运行栈 | 包裹对象 |
+|----|--------|---------|
+| `A2CProtocolVersionASGIMiddleware` | ASGI（uvicorn / hypercorn，FastAPI/Starlette/Sanic 等） | `socketio.ASGIApp(...)` |
+| `A2CProtocolVersionWSGIMiddleware` | WSGI（gunicorn / werkzeug，Flask 等） | `socketio.WSGIApp(...)` |
+
+构造参数（两者一致）：
+
+```python
+A2CProtocolVersionASGIMiddleware(
+    app,                              # 下游 socketio app（必填，位置参数）
+    *,
+    socketio_path="/socket.io",       # MUST 与 socketio app 的 socketio_path 完全一致
+    server_version=PROTOCOL_VERSION,  # Server 实现的协议版本，默认 SDK 内置常量
+)
+```
+
+设计要点：
+
+- **路径作用域**：中间件**只**校验命中 `socketio_path` 前缀的请求；其它路由（你的 REST API、
+  健康检查等）原样透传，互不影响。
+- **`server_version` 默认即 `a2c_smcp.PROTOCOL_VERSION`**，绝大多数部署无需显式传入；仅在你需要
+  对外宣称一个不同的协议版本（例如灰度 / 测试不兼容）时才覆盖。
+- v0.x 阶段严格匹配 `MAJOR.MINOR`，`PATCH` 任意。即客户端 `X.Y.Z` 仅与 Server 区间
+  `[X.Y.0, X.Y.999]` 兼容。
+
+导入方式：
+
+```python
+from a2c_smcp import PROTOCOL_VERSION
+from a2c_smcp.server import (
+    A2CProtocolVersionASGIMiddleware,
+    A2CProtocolVersionWSGIMiddleware,
+)
+```
+
+---
+
+## 3. 场景 A：裸 Socket.IO ASGI Server（uvicorn）
+
+最常见的异步部署：用 uvicorn 直接跑一个 socketio ASGI app。
+
+```python
+import socketio
+from a2c_smcp import PROTOCOL_VERSION
+from a2c_smcp.server import A2CProtocolVersionASGIMiddleware, SMCPNamespace, DefaultAuthenticationProvider
+
+SOCKETIO_PATH = "/socket.io"
+
+sio = socketio.AsyncServer(async_mode="asgi", cors_allowed_origins="*")
+sio.register_namespace(SMCPNamespace(DefaultAuthenticationProvider(admin_secret="secret")))
+
+# 1) 先建 socketio ASGI app
+asgi_app = socketio.ASGIApp(sio, socketio_path=SOCKETIO_PATH)
+
+# 2) 再用 A2C 中间件包裹 —— 握手在此生效
+app = A2CProtocolVersionASGIMiddleware(asgi_app, socketio_path=SOCKETIO_PATH, server_version=PROTOCOL_VERSION)
+
+# 运行: uvicorn main:app --host 0.0.0.0 --port 8000
+```
+
+---
+
+## 4. 场景 B：裸 Socket.IO WSGI Server（Flask / gunicorn）
+
+同步部署完全对称，换用 WSGI 中间件即可。
+
+```python
+from socketio import Server, WSGIApp
+from a2c_smcp import PROTOCOL_VERSION
+from a2c_smcp.server import A2CProtocolVersionWSGIMiddleware, SyncSMCPNamespace, DefaultSyncAuthenticationProvider
+
+SOCKETIO_PATH = "/socket.io"
+
+sio = Server(cors_allowed_origins="*")
+sio.register_namespace(SyncSMCPNamespace(DefaultSyncAuthenticationProvider(admin_secret="secret")))
+
+# 1) 先建 socketio WSGI app
+wsgi_app = WSGIApp(sio, socketio_path=SOCKETIO_PATH)
+
+# 2) 再用 A2C 中间件包裹
+app = A2CProtocolVersionWSGIMiddleware(wsgi_app, socketio_path=SOCKETIO_PATH, server_version=PROTOCOL_VERSION)
+
+# 运行: gunicorn -k geventwebsocket.gunicorn.workers.GeventWebSocketWorker main:app
+```
+
+---
+
+## 5. 场景 C：FastAPI + Socket.IO 集成
+
+FastAPI（Starlette）本身是 ASGI 应用。和 Socket.IO 集成时，**推荐用 `socketio.ASGIApp` 的
+`other_asgi_app` 把 FastAPI 作为「非 socketio 路由」的回落**，然后把整体再交给 A2C 中间件包裹。
+因为中间件按路径作用域工作，FastAPI 的业务路由会原样透传，只有 `/socket.io/*` 走版本校验。
+
+```python
+import socketio
+from fastapi import FastAPI
+from a2c_smcp import PROTOCOL_VERSION
+from a2c_smcp.server import A2CProtocolVersionASGIMiddleware, SMCPNamespace, DefaultAuthenticationProvider
+
+SOCKETIO_PATH = "/socket.io"
+
+fastapi_app = FastAPI()
+
+@fastapi_app.get("/health")  # 你的普通 REST 路由：不受握手影响，正常透传
+async def health() -> dict:
+    return {"ok": True}
+
+sio = socketio.AsyncServer(async_mode="asgi", cors_allowed_origins="*")
+sio.register_namespace(SMCPNamespace(DefaultAuthenticationProvider(admin_secret="secret")))
+
+# 1) socketio app 以 FastAPI 作为非 socketio 请求的回落（other_asgi_app）
+asgi_app = socketio.ASGIApp(sio, other_asgi_app=fastapi_app, socketio_path=SOCKETIO_PATH)
+
+# 2) A2C 中间件包在最外层：只拦 /socket.io 握手，/health 等 FastAPI 路由透传
+app = A2CProtocolVersionASGIMiddleware(asgi_app, socketio_path=SOCKETIO_PATH, server_version=PROTOCOL_VERSION)
+
+# 运行: uvicorn main:app --host 0.0.0.0 --port 8000
+```
+
+> **通用原则（适用于任何挂载方式）**：A2C 中间件必须位于**最外层**，即所有 `/socket.io` 握手
+> 请求进入 engine.io 之前都会先经过它；且其 `socketio_path` 必须等于 engine.io 实际接收请求的
+> 完整路径。若你改用 `fastapi_app.mount("/socket.io", socketio.ASGIApp(sio))` 的挂载方式，则把
+> A2C 中间件包在 `fastapi_app` 外层、并保持 `socketio_path="/socket.io"` 一致即可。
+
+---
+
+## 6. 强约束：`socketio_path` 必须三处一致
+
+握手能否命中，取决于路径匹配。下面三者**必须完全一致**，否则中间件要么拦不到握手（形同未启用），
+要么误伤其它路由：
+
+1. `socketio.ASGIApp(sio, socketio_path=...)` / `socketio.WSGIApp(sio, socketio_path=...)`
+2. `A2CProtocolVersionASGIMiddleware(app, socketio_path=...)` / WSGI 同理
+3. 客户端连接时的 `socketio_path`（SDK 客户端默认 `/socket.io`）
+
+默认值均为 `/socket.io`，保持默认即可；一旦自定义，请三处同步修改。
+
+---
+
+## 7. WebSocket-only 与 transports 注意
+
+- ASGI 中间件同时校验 `http`（polling 握手）与 `websocket`（直连 WS 握手）两类 scope。对 WS-only
+  不兼容客户端：运行栈支持 ASGI WebSocket Denial Response（uvicorn ≥ 0.21 / hypercorn / daphne）时，
+  回与 polling 路径**字节一致**的 `HTTP 400 + 4008`；否则以 WebSocket close code `4900` 关闭握手。
+- WSGI 不区分 http / websocket scope（WS 握手起始即普通 HTTP GET），天然走同一 `400/4008` 路径。
+- **客户端侧**：A2C SDK 客户端强制 polling-first 握手（显式 `transports=["websocket"]` 会被护栏
+  纠正），以确保 `4008` 拒因可被还原归一为 `ProtocolVersionError`。**部署 Server 时无需为此做额外
+  配置**，但请勿在反向代理层屏蔽 polling 握手路径。
+
+---
+
+## 8. 验证握手是否生效
+
+部署后用裸 HTTP 探测 polling 握手端点即可验证（无需真实客户端）：
+
+```bash
+# 不兼容版本 → 期望 HTTP 400 + 4008
+curl -i "http://127.0.0.1:8000/socket.io/?EIO=4&transport=polling&a2c_version=99.0.0"
+# 预期：HTTP/1.1 400 Bad Request
+#       X-A2C-Error-Code: 4008
+#       {"code":4008,"message":"Protocol version mismatch","server_version":"0.2.0",
+#        "client_version":"99.0.0","min_supported":"0.2.0","max_supported":"0.2.999"}
+
+# 缺失 a2c_version → 期望 HTTP 400（无 4008 header）
+curl -i "http://127.0.0.1:8000/socket.io/?EIO=4&transport=polling"
+
+# 兼容版本 → 期望 HTTP 200（透传给 engine.io，返回 open 包）
+curl -i "http://127.0.0.1:8000/socket.io/?EIO=4&transport=polling&a2c_version=0.2.0"
+
+# 非 socketio 路由不受影响 → 期望正常响应
+curl -i "http://127.0.0.1:8000/health"
+```
+
+若不兼容版本仍返回 `200`，说明中间件没有套上（参见 §1）。
+
+---
+
+## 9. 检查清单
+
+- [ ] 创建 `socketio.ASGIApp` / `WSGIApp` 后，**用 A2C 中间件包裹**再交给 uvicorn / gunicorn
+- [ ] 中间件、socketio app、客户端三处 `socketio_path` 一致（默认 `/socket.io`）
+- [ ] `server_version` 一般保持默认 `PROTOCOL_VERSION`，仅在灰度/测试时覆盖
+- [ ] 反向代理未屏蔽 polling 握手路径
+- [ ] 用 §8 的 `curl` 探测确认 `99.0.0 → 400/4008`、`0.2.0 → 200`
+
+---
+
+## 相关文档
+
+- [Server 使用指南](server-guide.md) — 命名空间、认证、事件处理
+- [快速开始](getting-started.md) — 三方协作最小示例
+- 协议规范：a2c-smcp-protocol `docs/specification/versioning.md`、`error-handling.md`

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,6 +8,7 @@
 
 - [快速开始](guides/getting-started.md) - 快速上手
 - [Server 指南](guides/server-guide.md) - 搭建信令服务器
+- [Server 协议版本握手部署指南](guides/server-version-handshake.md) - 启用 `a2c_version` 握手（裸 ASGI/WSGI、FastAPI 集成）
 - [Agent 指南](guides/agent-guide.md) - 开发 Agent 客户端
 - [Computer 指南](guides/computer-guide.md) - 管理 MCP 服务
 - [CLI 指南](guides/cli-guide.md) - 命令行工具使用

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -27,7 +27,9 @@ import socketio
 from socketio import Namespace, Server, WSGIApp
 from werkzeug.serving import make_server
 
+from a2c_smcp import PROTOCOL_VERSION
 from a2c_smcp.server import SyncSMCPNamespace
+from a2c_smcp.server.middleware import A2CProtocolVersionASGIMiddleware, A2CProtocolVersionWSGIMiddleware
 from a2c_smcp.server.sync_auth import SyncAuthenticationProvider
 
 # ============================================================================
@@ -49,8 +51,16 @@ class LocalSyncSMCPNamespace(SyncSMCPNamespace):
         super().__init__(auth_provider=_PassSyncAuth())
 
 
-def create_local_sync_server() -> tuple[Server, Namespace, WSGIApp]:
-    """中文: 创建同步 Socket.IO Server 并注册本地命名空间 / English: Create sync Socket.IO Server with local namespace"""
+def create_local_sync_server() -> tuple[Server, Namespace, A2CProtocolVersionWSGIMiddleware]:
+    """中文: 创建同步 Socket.IO Server 并注册本地命名空间 / English: Create sync Socket.IO Server with local namespace
+
+    中文: 返回的 app 包裹 ``A2CProtocolVersionWSGIMiddleware``，与生产部署等价——在 HTTP 传输层
+        校验 ``a2c_version`` query，不兼容客户端被拒（HTTP 400 + 4008）。否则 UAT F-05（版本不兼容
+        拒绝）会被静默跳过（#93）。SDK 客户端经 build_handshake_url 自动携带兼容版本，故正常连接不受影响。
+    English: The returned app wraps ``A2CProtocolVersionWSGIMiddleware`` (production-equivalent),
+        validating ``a2c_version`` at the HTTP transport layer; incompatible clients get HTTP 400 +
+        4008. Without it the protocol version gate is skipped and UAT F-05 silently passes (#93).
+    """
     sio = Server(
         cors_allowed_origins="*",
         ping_timeout=5,  # 中文: 测试环境使用较短超时 / English: Use shorter timeout for testing
@@ -60,7 +70,8 @@ def create_local_sync_server() -> tuple[Server, Namespace, WSGIApp]:
     )
     ns = LocalSyncSMCPNamespace()
     sio.register_namespace(ns)
-    app = WSGIApp(sio, socketio_path="/socket.io")
+    wsgi_app = WSGIApp(sio, socketio_path="/socket.io")
+    app = A2CProtocolVersionWSGIMiddleware(wsgi_app, socketio_path="/socket.io", server_version=PROTOCOL_VERSION)
     return sio, ns, app
 
 
@@ -206,8 +217,11 @@ def mcp_server_config_path(tmp_path: Path) -> Path:
 
 def create_local_async_server() -> tuple[socketio.AsyncServer, socketio.AsyncNamespace, Any]:
     """
-    中文: 创建本地异步 SMCP 服务器，用于测试。
-    English: Create local async SMCP server for testing.
+    中文: 创建本地异步 SMCP 服务器，用于测试。返回的 app 包裹 ``A2CProtocolVersionASGIMiddleware``，
+        与生产等价——HTTP/WebSocket 传输层校验 ``a2c_version``，不兼容客户端被拒（#93）。
+    English: Create local async SMCP server for testing. The returned app wraps
+        ``A2CProtocolVersionASGIMiddleware`` (production-equivalent), validating ``a2c_version`` at the
+        transport layer so incompatible clients are rejected (#93).
     """
     from a2c_smcp.server import SMCPNamespace
     from a2c_smcp.server.auth import AuthenticationProvider
@@ -236,7 +250,8 @@ def create_local_async_server() -> tuple[socketio.AsyncServer, socketio.AsyncNam
     sio.eio.start_service_task = False
     ns = LocalAsyncSMCPNamespace()
     sio.register_namespace(ns)
-    app = socketio.ASGIApp(sio, socketio_path="/socket.io")
+    asgi_app = socketio.ASGIApp(sio, socketio_path="/socket.io")
+    app = A2CProtocolVersionASGIMiddleware(asgi_app, socketio_path="/socket.io", server_version=PROTOCOL_VERSION)
     return sio, ns, app
 
 

--- a/tests/e2e/test_version_handshake_conftest_server.py
+++ b/tests/e2e/test_version_handshake_conftest_server.py
@@ -1,0 +1,109 @@
+# -*- coding: utf-8 -*-
+# filename: test_version_handshake_conftest_server.py
+# @Author  : JQQ
+# @Software: PyCharm
+"""
+中文: E2E conftest 测试 Server 协议版本握手回归测试（#93）。
+
+    UAT full-protocol 场景 F-05 经 ``tests/e2e/conftest.py::_run_server_process`` →
+    ``create_local_sync_server()`` 启动 Server。若该工厂返回裸 ``WSGIApp`` 而未包裹
+    ``A2CProtocolVersionWSGIMiddleware``，则协议版本握手闸门在 HTTP 传输层被完全跳过，
+    ``a2c_version=99.0.0`` 的不兼容客户端不会被拒（HTTP 200），F-05 失效。
+
+    本测试用进程内 WSGI/ASGI test client 直接断言两个工厂返回的 app 已套上版本握手中间件
+    （确定性，零多进程 flakiness）。断言风格镜像
+    ``tests/integration_tests/test_version_handshake_server.py``。
+
+English: Regression test (#93) ensuring the E2E conftest test servers wrap the protocol
+    version handshake middleware. UAT F-05 launches the Server via
+    ``create_local_sync_server()``; without the middleware the ``a2c_version`` gate is
+    skipped at the transport layer and an incompatible client connects (HTTP 200). We assert
+    in-process (werkzeug WSGI client / httpx ASGI transport) that both factories' apps reject
+    incompatible versions and pass compatible ones through.
+
+协议依据 / Protocol: a2c-smcp-protocol docs/specification/versioning.md (§连接握手 / §错误码 4008)
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+from werkzeug.test import Client
+
+from a2c_smcp import PROTOCOL_VERSION
+from tests.e2e.conftest import create_local_async_server, create_local_sync_server
+
+_INCOMPATIBLE = "99.0.0"  # 与 SDK PROTOCOL_VERSION(0.2.0) MINOR 不匹配 / MINOR mismatch vs 0.2.0
+
+
+def _poll_path(version: str) -> str:
+    """polling 握手 URL（query 含 a2c_version）/ polling handshake URL carrying a2c_version."""
+    return f"/socket.io/?EIO=4&transport=polling&a2c_version={version}"
+
+
+def _assert_4008_body(body: dict) -> None:
+    """断言 4008 flat ErrorPayload 四字段 / assert the four 4008 flat-ErrorPayload fields."""
+    assert body["code"] == 4008
+    assert body["message"] == "Protocol version mismatch"
+    assert body["server_version"] == PROTOCOL_VERSION
+    assert body["client_version"] == _INCOMPATIBLE
+    assert body["min_supported"] == "0.2.0"
+    assert body["max_supported"] == "0.2.999"
+
+
+# ============================================================================
+# 中文: 同步 WSGI 工厂 / English: sync WSGI factory
+# ============================================================================
+
+
+def test_sync_conftest_server_rejects_incompatible() -> None:
+    """中文: create_local_sync_server() 返回的 app 必须以 400 + 4008 拒绝不兼容版本。"""
+    _sio, _ns, app = create_local_sync_server()
+    client = Client(app)
+    resp = client.get(_poll_path(_INCOMPATIBLE))
+
+    assert resp.status_code == 400
+    assert resp.headers.get("X-A2C-Error-Code") == "4008"
+    _assert_4008_body(json.loads(resp.get_data(as_text=True)))
+
+
+def test_sync_conftest_server_accepts_compatible() -> None:
+    """中文: 兼容版本必须被透传给 socketio（非 400、无错误头）。"""
+    _sio, _ns, app = create_local_sync_server()
+    client = Client(app)
+    resp = client.get(_poll_path(PROTOCOL_VERSION))
+
+    assert resp.status_code != 400
+    assert "X-A2C-Error-Code" not in resp.headers
+
+
+# ============================================================================
+# 中文: 异步 ASGI 工厂 / English: async ASGI factory
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_async_conftest_server_rejects_incompatible() -> None:
+    """中文: create_local_async_server() 返回的 app 必须以 400 + 4008 拒绝不兼容版本。"""
+    _sio, _ns, app = create_local_async_server()
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as c:
+        resp = await c.get(_poll_path(_INCOMPATIBLE))
+
+    assert resp.status_code == 400
+    assert resp.headers.get("X-A2C-Error-Code") == "4008"
+    _assert_4008_body(resp.json())
+
+
+@pytest.mark.asyncio
+async def test_async_conftest_server_accepts_compatible() -> None:
+    """中文: 兼容版本必须被透传给 socketio（非 400、无错误头）。"""
+    _sio, _ns, app = create_local_async_server()
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as c:
+        resp = await c.get(_poll_path(PROTOCOL_VERSION))
+
+    assert resp.status_code != 400
+    assert "X-A2C-Error-Code" not in resp.headers


### PR DESCRIPTION
## 背景

UAT full-protocol 场景 **F-05** 失败：Agent 携带 `a2c_version=99.0.0` 连接测试 Server 时连接未被拒（HTTP 200），预期 HTTP 400 + 错误码 `4008`。

## 根因

UAT 启动 Server 走 `tests/e2e/conftest.py::_run_server_process → create_local_sync_server()`，该工厂返回**裸 `WSGIApp`**，未包裹 `A2CProtocolVersionWSGIMiddleware`，导致协议版本握手闸门在 HTTP 传输层被**静默跳过**。`create_local_async_server()` 存在同种潜在缺陷。

**归属**：测试基础设施缺陷 —— 中间件本身（`a2c_smcp/server/middleware.py`）实现正确，已有集成测试 `test_version_handshake_server.py` 验证；缺陷仅在 conftest 测试 Server 未套用与生产等价的中间件。**未改协议、未改生产代码。**

## 变更

| 文件 | 变更 |
|------|------|
| `tests/e2e/conftest.py` | `create_local_sync_server()` 包裹 `A2CProtocolVersionWSGIMiddleware`；`create_local_async_server()` 包裹 `A2CProtocolVersionASGIMiddleware`（`server_version=PROTOCOL_VERSION`） |
| `tests/e2e/test_version_handshake_conftest_server.py`（新增） | 4 个 TDD 回归用例，进程内 WSGI/ASGI test client 直接断言两工厂的 app 已套握手中间件 |
| `docs/guides/server-version-handshake.md`（新增） | Server 部署启用握手的权威指南：裸 ASGI/WSGI、FastAPI 集成、`curl` 验证 |
| `README.md` / `docs/guides/{getting-started,server-guide}.md` / `docs/index.md` | 修正此前**遗漏中间件**的 FastAPI/WSGI 示例（会教错部署姿势），并交叉引用新指南 |

## 安全前提（零回归）

所有 SDK 客户端经 `build_handshake_url` 自动携带 `a2c_version=0.2.0`（与 Server 兼容），故包裹中间件后正常连接不受影响。

## 验证

- ✅ **红→绿**：复现测试修复前 `200 == 400` 失败，修复后通过
- ✅ **回归**：`uv run poe test-e2e` → 60 passed / 0 failed
- ✅ **质量门**：ruff + format 干净、`mypy a2c_smcp` 通过

Fixes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)