### PR TITLE
fix(blob): drain_blob 双端对齐 — 并行确定性 fatal>drift>range 分派 + max_retries 夹取≥1 (#101)

### DIFF
--- a/a2c_smcp/utils/blob.py
+++ b/a2c_smcp/utils/blob.py
@@ -126,7 +126,9 @@ async def drain_blob(
         blob_handle: 来自某生产者通道的不透明句柄.
         concurrency: 并发度；``1`` 串行（保守默认），``>1`` 启用并行模式.
         chunk_size: 客户建议单块上限；缺省 :data:`DEFAULT_CHUNK_SIZE`（Computer 会 clamp）.
-        max_retries: 串行重读上限（应对源漂移 / 全量 sha256 不一致）.
+        max_retries: 串行重读上限（应对源漂移 / 全量 sha256 不一致）；入口夹取至 ``max(1, ...)``——
+            显式传 ``0`` 仍至少尝试一次，不会「零次循环直接 max_retries_exceeded」.
+            Clamped to ``max(1, ...)`` at entry: an explicit ``0`` still attempts once.
 
     Returns:
         ``(payload_bytes, mime_type)``: 完整字节内容 + 内容 MIME.
@@ -136,13 +138,17 @@ async def drain_blob(
             或 ``max_retries`` 仍未通过 ``sha256`` 校验.
     """
     effective_chunk = chunk_size or DEFAULT_CHUNK_SIZE
+    # 夹取至 ≥1：显式 max_retries=0 不应「零次循环、一个 call 都不发」即报 max_retries_exceeded（脚枪）。
+    # Clamp to ≥1: an explicit max_retries=0 must still attempt once, never short-circuit to
+    # max_retries_exceeded without a single call.
+    effective_retries = max(1, max_retries)
     if concurrency <= 1:
-        return await _drain_serial_async(call, computer, blob_handle, effective_chunk, max_retries)
+        return await _drain_serial_async(call, computer, blob_handle, effective_chunk, effective_retries)
     try:
-        return await _drain_parallel_async(call, computer, blob_handle, effective_chunk, concurrency, max_retries)
+        return await _drain_parallel_async(call, computer, blob_handle, effective_chunk, concurrency, effective_retries)
     except (_RecoverableDrift, _RecoverableRange) as e:
         logger.info(f"drain_blob: parallel → serial fallback (reason: {type(e).__name__})")
-        return await _drain_serial_async(call, computer, blob_handle, effective_chunk, max_retries)
+        return await _drain_serial_async(call, computer, blob_handle, effective_chunk, effective_retries)
 
 
 def drain_blob_sync(
@@ -161,13 +167,16 @@ def drain_blob_sync(
     Parallel branch uses ``ThreadPoolExecutor``; error coordination matrix mirrors async exactly.
     """
     effective_chunk = chunk_size or DEFAULT_CHUNK_SIZE
+    # 夹取至 ≥1：与 async 入口一致，显式 max_retries=0 仍至少尝试一次（脚枪防御）。
+    # Clamp to ≥1: mirrors the async entry; an explicit max_retries=0 still attempts once.
+    effective_retries = max(1, max_retries)
     if concurrency <= 1:
-        return _drain_serial_sync(call, computer, blob_handle, effective_chunk, max_retries)
+        return _drain_serial_sync(call, computer, blob_handle, effective_chunk, effective_retries)
     try:
-        return _drain_parallel_sync(call, computer, blob_handle, effective_chunk, concurrency, max_retries)
+        return _drain_parallel_sync(call, computer, blob_handle, effective_chunk, concurrency, effective_retries)
     except (_RecoverableDrift, _RecoverableRange) as e:
         logger.info(f"drain_blob_sync: parallel → serial fallback (reason: {type(e).__name__})")
-        return _drain_serial_sync(call, computer, blob_handle, effective_chunk, max_retries)
+        return _drain_serial_sync(call, computer, blob_handle, effective_chunk, effective_retries)
 
 
 # ── 串行实现 / Serial implementations ────────────────────────────────────
@@ -298,66 +307,63 @@ async def _drain_parallel_async(
     offsets = list(range(first_chunk_len, total_size, chunk_size))
     sem = asyncio.Semaphore(concurrency)
 
-    async def fetch(off: int) -> tuple[int, Mapping[str, Any]]:
+    async def fetch(off: int) -> tuple[str, int, Mapping[str, Any] | None]:
         async with sem:
             ret = await call(computer, blob_handle, off, chunk_size)
-        # 单块协议错误就地抛 → TaskGroup 自动取消其他在飞任务
-        # Per-chunk protocol errors raised in-place → TaskGroup auto-cancels others
-        _raise_for_blob_error(ret)
-        # 漂移就地抛 → 与协议错误一并进入 TaskGroup except* 分支
-        # Drift raised in-place → joins protocol errors in the TaskGroup except* dispatch
+        # 可恢复信号（range / 漂移）返回 marker、**不 raise** → 不触发 TaskGroup 取消（镜像 sync：
+        # recoverable 永不早退，收集到结束再分派）。仅 fatal（非 range 的 4018）就地 raise → TaskGroup
+        # fail-fast 取消其余在飞。如此 fatal 永不被「先完成的 range」经 TaskGroup-cancel 掩盖。
+        # Recoverable signals (range / drift) return a marker instead of raising — they do NOT trigger
+        # TaskGroup cancellation (mirrors sync: recoverable never short-circuits). Only fatal raises
+        # in-place → TaskGroup fail-fast cancels the rest, so a fatal can never be masked by a racing
+        # range that finished first (the prior in-place-raise behavior had exactly that leak).
+        try:
+            _raise_for_blob_error(ret)
+        except BlobTransferError as e:
+            if e.reason == "range":
+                return ("range", off, None)
+            raise
         if str(ret["sha256"]) != expected_sha or int(ret["total_size"]) != total_size:
-            raise _RecoverableDrift()
-        return off, ret
+            return ("drift", off, None)
+        return ("ok", off, ret)
 
-    # 步骤 3 / Step 3: TaskGroup 结构化并发；首个失败 → 自动取消所有在飞
-    # TaskGroup gives us structured cancellation: first failure auto-cancels all pending
-    #
-    # 合并为单个 except* BaseException 集中分派 / Unified except* dispatcher:
-    # 双分支 raise（如 ``except* BlobTransferError`` + ``except* _RecoverableDrift`` 各自 raise）
-    # 在 race 下会让 fallback-able (range / drift) 与 fatal (invalid_handle / forbidden / gone)
-    # 并存时被重新包成 ExceptionGroup，外层 ``except (_RecoverableDrift, _RecoverableRange)``
-    # 不接 group 而漏走 serial fallback。集中扁平化处理消除该 race 漏洞。
-    # When two except* branches each raise, a race that produces both fatal and recoverable
-    # exceptions re-wraps them into a group that the outer plain-except cannot match; flattening
-    # the exception group eliminates that leak.
+    # 步骤 3 / Step 3: TaskGroup 结构化并发；**仅 fatal** 触发 fail-fast 取消，recoverable 收集到结束再分派。
+    # 与 _drain_parallel_sync 完全一致：收集全部 outcome 后按 fatal > drift > range 分派，fatal 永不被
+    # race 中先完成的 range 掩盖（旧实现 range 就地抛 → TaskGroup 取消在飞 fatal → group 仅余 range，
+    # 在「快 range + 慢 fatal」竞态下错误降级成 range；marker-collect 消除该漏洞）。
+    # Only fatal triggers fail-fast cancellation; recoverable markers are collected and dispatched
+    # after the group completes — exactly mirroring _drain_parallel_sync (fatal > drift > range).
     try:
         async with asyncio.TaskGroup() as tg:
             tasks = [tg.create_task(fetch(off)) for off in offsets]
     except BaseExceptionGroup as eg:
+        # recoverable 不再 raise → group 内只可能是 fatal（或 call 自身抛的未知异常）。
+        # Recoverable no longer raises → the group can only carry a fatal (or an unknown exc from call).
         flat = _flatten_exception_group(eg)
-        # 优先级 / Priority: fatal (invalid_handle / forbidden / gone) > range fallback > drift reread.
-        # 不可恢复的 fatal 必须先于可恢复信号抛出（否则隐藏了 4018 的真实原因）。
-        # Fatal must surface before recoverable signals to avoid hiding the true 4018 cause.
-        fatal: BlobTransferError | None = None
-        has_range = False
-        has_drift = False
-        for sub in flat:
-            if isinstance(sub, BlobTransferError):
-                if sub.reason == "range":
-                    has_range = True
-                else:
-                    # 任一非 range 的 BlobTransferError 即为 fatal
-                    # Any non-range BlobTransferError is fatal
-                    fatal = fatal or sub
-            elif isinstance(sub, _RecoverableDrift):
-                has_drift = True
+        fatal = next((sub for sub in flat if isinstance(sub, BlobTransferError)), None)
         if fatal is not None:
             raise fatal from eg
-        if has_drift:
-            # drift 优先于 range：sha256/total_size 漂移说明源被改写，从 0 重读最稳妥
-            # drift wins over range: source was rewritten, restart from 0 is the safest
-            raise _RecoverableDrift() from eg
-        if has_range:
-            raise _RecoverableRange() from eg
         # 未识别的异常 group → 原样抛 / Unrecognized group → re-raise
         raise
 
-    # 步骤 4 / Step 4: 聚合（每块已在 fetch 内校验协议错误 + 漂移）
-    # Step 4: collect (each chunk already validated inside fetch)
+    # 步骤 4 / Step 4: 无 fatal——收集 marker，按 drift > range 分派（fatal 已在 except 优先抛出）
+    # Step 4: no fatal — collect markers, dispatch drift > range (fatal already surfaced above)
+    has_drift = False
+    has_range = False
     for t in tasks:
-        off, ret = t.result()
-        chunks[off] = base64.b64decode(ret["blob"])
+        kind, off, ret = t.result()
+        if kind == "drift":
+            has_drift = True  # 漂移：源被改写，从 0 串行重读最稳妥 / drift: source rewritten, serial reread
+        elif kind == "range":
+            has_range = True
+        else:  # "ok"
+            assert ret is not None  # marker 不变式：kind=="ok" ⟺ ret 非空 / invariant: ok ⟺ ret present
+            chunks[off] = base64.b64decode(ret["blob"])
+    if has_drift:
+        # drift 优先于 range / drift wins over range
+        raise _RecoverableDrift()
+    if has_range:
+        raise _RecoverableRange()
 
     # 步骤 5 / Step 5: 按 offset 重组 + 全量 sha256 自证
     full = b"".join(chunks[off] for off in sorted(chunks))
@@ -390,13 +396,22 @@ def _drain_parallel_sync(
     first_chunk_len = len(chunks[0])
     offsets = list(range(first_chunk_len, total_size, chunk_size))
 
-    # 步骤 2-3 / Steps 2-3: ThreadPoolExecutor 并发拉取；按 **完成顺序** 收集（``as_completed``）
-    # 而非提交顺序——与 async TaskGroup 「首个失败即可见」语义对齐，兑现协议 §3 并行红利。
-    # Collect by **completion order** via ``as_completed`` (not submit order) — aligns with the
-    # async TaskGroup "first failure visible immediately" semantics and realizes the protocol §3
-    # parallel-fail-fast dividend.
+    # 步骤 2-3 / Steps 2-3: ThreadPoolExecutor 并发拉取；按 **完成顺序**（``as_completed``）收集**全部**
+    # 已完成 outcome 后再按 ``fatal > drift > range`` 分派——**镜像 async** ``_drain_parallel_async``
+    # 的 ``_flatten_exception_group`` 分派，而非「遇首个错误即 break」。
+    #
+    # 为何不 break-on-first-error：并发态下若一个 ``range`` 块先于一个 fatal（``invalid_handle`` /
+    # ``forbidden`` / ``gone``）块完成，先 break → ``_RecoverableRange`` → 串行 fallback → 串行态再遇
+    # ``range`` 即 fatal → **对外报 range，掩盖真实 forbidden/gone**（不可重试错误被降级成貌似瞬态）。
+    # 那会让 ``drain_blob``(async) 报 forbidden、``drain_blob_sync``(sync) 报 range —— 双端对同一服务端
+    # 状况给出不一致诊断。收集全部 outcome 后分派即消除该 race。
+    # Collect ALL completed outcomes, then dispatch by fatal > drift > range — mirroring the async
+    # path. Breaking on the first error would let a racing ``range`` mask a concurrent fatal,
+    # diverging from drain_blob (async). Recoverable signals never break; only fatal stops early.
     results: dict[int, Mapping[str, Any]] = {}
-    first_error: BaseException | None = None
+    fatal: BlobTransferError | None = None
+    has_drift = False
+    has_range = False
     with ThreadPoolExecutor(max_workers=concurrency) as executor:
         futures = {executor.submit(call, computer, blob_handle, off, chunk_size): off for off in offsets}
         for fut in as_completed(futures):
@@ -405,24 +420,27 @@ def _drain_parallel_sync(
                 ret = fut.result()
                 _raise_for_blob_error(ret)
                 if str(ret["sha256"]) != expected_sha or int(ret["total_size"]) != total_size:
-                    first_error = _RecoverableDrift()
-                    break
+                    has_drift = True  # 漂移：不 break，继续收集（让并存 fatal 必被发现）/ drift: keep collecting
+                    continue
                 results[off] = ret
             except BlobTransferError as e:
-                first_error = e
-                break
-            except _RecoverableDrift as e:  # pragma: no cover — already wrapped above
-                first_error = e
-                break
+                if e.reason == "range":
+                    has_range = True  # range：不 break，继续收集 / range: keep collecting
+                else:
+                    fatal = fatal or e  # 仅 fatal 记录并停止；运行中 future 无法真正取消，等其自然完成
+                    break
         # 取消其余 future（best-effort，ThreadPoolExecutor 无法真正终止已运行任务）
         # Cancel remaining (best-effort; ThreadPoolExecutor cannot terminate in-flight work)
         for fut in futures:
             if not fut.done():
                 fut.cancel()
-    if first_error is not None:
-        if isinstance(first_error, BlobTransferError) and first_error.reason == "range":
-            raise _RecoverableRange() from first_error
-        raise first_error
+    # 分派优先级与 async 完全一致：fatal > drift > range / Same priority as async: fatal > drift > range
+    if fatal is not None:
+        raise fatal
+    if has_drift:
+        raise _RecoverableDrift()
+    if has_range:
+        raise _RecoverableRange()
 
     chunks.update({off: base64.b64decode(r["blob"]) for off, r in results.items()})
     full = b"".join(chunks[off] for off in sorted(chunks))

--- a/docs/blob-drain-parity-recommendations.md
+++ b/docs/blob-drain-parity-recommendations.md
@@ -1,0 +1,107 @@
+# Blob `drain_blob` 双端对齐建议（Rust → Python）
+
+> 来源：Rust SDK 实现 `crates/smcp/src/utils/blob.rs`（对标 Python `a2c_smcp/utils/blob.py`）+ `/code-review` 跟进。
+> 状态：**Rust + Python 双端均已实施**（Python 侧 issue #101 / 分支 `feature/blob-drain-parity`）。
+> 下列两项均**非语言限制**、是设计选择，不改协议线格式、不影响 happy-path、`PROTOCOL_VERSION` 不变。
+>
+> 实施补记（Python `/fix-review`）：R1 落地时实测发现 **async 路径在「快 range + 慢 fatal」竞态下同样会
+> 掩盖 fatal**（见 R1「现状」修正），故 sync **与** async **一并**改为「收集全部 outcome 后按
+> `fatal > drift > range` 分派」，达成双端确定性 fatal-wins。
+
+---
+
+## R1 — sync 并行：让 `fatal > recoverable` 优先级确定性成立（永不隐藏 fatal）
+
+### 现状（Python）
+
+- `_drain_parallel_async`（`asyncio.TaskGroup`）：原实现首个异常即取消其余，收集异常组后经
+  `_flatten_exception_group` 按 `fatal > drift > range` 分派。**曾误以为**已保证 fatal 不被 range 掩盖
+  ⚠️ —— 实测**不成立**：`fetch()` 对 range **就地 raise** → TaskGroup fail-fast 取消其余在飞任务；当
+  range 比 fatal **先完成**，在飞的 fatal 被取消（`CancelledError` **不进** ExceptionGroup）→ group 仅余
+  range → `_RecoverableRange` → 串行 fallback → 串行撞低 offset range 即 fatal → **对外报 range，掩盖
+  真实 fatal**。
+- `_drain_parallel_sync`（`ThreadPoolExecutor` + `as_completed`）：原实现**遇首个错误即 `break`**
+  （`first_error`），随后 `if reason == "range" → _RecoverableRange`，同样会以先完成的 range 掩盖 fatal。
+
+### 问题
+
+并发态下若一个 `range` 块先于一个 `fatal` 块（如 `invalid_handle` / `forbidden` / `gone`）完成，
+sync 路径会以 `range` 先 `break` → `_RecoverableRange` → 串行 fallback → 串行态再遇 `range` 即 fatal →
+**最终对外报 `range`，掩盖了真实的 `forbidden`/`gone`**。
+
+即：**同一服务端状况，错误被降级成貌似瞬态的 `range`**（forbidden/gone 语义是"不可重试/无权限"，被
+掩盖）。实测确认 sync（break-on-first）与 async（in-place raise + TaskGroup-cancel）**两条路径都有此掩盖**，
+race 触发条件不同而已。
+
+### 建议（sync **与** async 一并改）
+
+**两条并行路径**均改为「收集所有已完成 outcome 后再分派」：`range`/drift **不**早退（sync 不 `break` /
+async 不就地 raise，改返回 marker），**仅** fatal 早退（sync `break` / async 就地 raise 触发 TaskGroup
+fail-fast）。收集结束后按 `fatal > drift > range` 优先级分派。sync 伪代码（async 同理，`fetch()` 改为返回
+`("range"|"drift"|"ok", off, ret)` marker、仅 fatal raise）：
+
+```python
+# 伪代码（替换 break-on-first-error）
+recoverable = False
+fatal: BlobTransferError | None = None
+for fut in as_completed(futures):
+    try:
+        ret = fut.result()
+        _raise_for_blob_error(ret)
+        if str(ret["sha256"]) != expected_sha or int(ret["total_size"]) != total_size:
+            recoverable = True            # drift：不 break，继续收集
+            continue
+        results[futures[fut]] = ret
+    except BlobTransferError as e:
+        if e.reason == "range":
+            recoverable = True            # range：不 break，继续收集（让并存 fatal 必被发现）
+        else:
+            fatal = fatal or e            # 仅 fatal 记录；可停止提交新任务
+            break
+# 分派：fatal 优先于 recoverable
+if fatal is not None:
+    raise fatal
+if recoverable:
+    raise _RecoverableRange()
+```
+
+代价：recoverable 路径会多等若干在飞块完成再回退串行（原本就要串行重读，开销有界且仅错误路径）。
+
+### Rust 对照
+
+Rust `drain_parallel_sync` 的 recoverable 分支（`Ok(None)` 漂移 / `ChunkErr::Range`）**不置 stop/break**，
+仅 fatal 触发 `stop`+`break`；drain 完后 `fatal` 优先、其次 `recoverable → Fallback`。与 async 路径完全一致。
+对应测试：`parallel_sync_fatal_beats_recoverable`、`parallel_async_fatal_beats_recoverable`。
+
+Python 对应测试：`test_parallel_sync_fatal_beats_range`、`test_parallel_async_fatal_beats_range`，
+另补 `test_parallel_sync_range_fallback` / `test_parallel_sync_drift_fallback` /
+`test_parallel_sync_full_sha_mismatch_rereads` 覆盖 sync 并行 recoverable→fallback 分支。
+
+---
+
+## R2 — `max_retries == 0` 脚枪：夹取至 ≥ 1
+
+### 现状（Python）
+
+`_drain_serial_async` / `_drain_serial_sync`：`for attempt in range(max_retries): ...`。
+`max_retries == 0` → **零次循环**、一个 `call` 都不发 → 直接
+`raise BlobTransferError(reason="max_retries_exceeded")`。`drain_blob(..., max_retries=0)` 显式传 0
+即得此反直觉结果（默认值安全，但显式 0 是合法入参）。
+
+### 建议
+
+入口夹取或入参校验：`effective_retries = max(1, max_retries)`（至少尝试一次），并在 docstring 注明。
+
+### Rust 对照
+
+`drain_blob` / `drain_blob_sync` 入口：`let max_retries = opts.max_retries.max(1);`。
+对应测试：`serial_async_zero_retries_still_attempts_once`。
+
+---
+
+## 备注
+
+- 两项不改变协议线格式、不影响 happy-path 行为，纯属错误路径的稳健性 / 一致性加固。
+- **已落地** `a2c_smcp/utils/blob.py`（issue #101 / 分支 `feature/blob-drain-parity`）：R1 双端 marker-collect
+  分派 + R2 入口 `max(1, max_retries)` 夹取，附 6 项单测；`ruff` / `mypy` 净、`drain_blob` 全测试零回归。
+- 代价（双端一致）：recoverable 路径会多等若干在飞块完成再回退串行——原本就要串行重读，开销有界且仅错误路径。

--- a/tests/unit_tests/utils/test_blob.py
+++ b/tests/unit_tests/utils/test_blob.py
@@ -18,8 +18,11 @@
 
 from __future__ import annotations
 
+import asyncio
 import base64
 import hashlib
+import threading
+import time
 from collections.abc import Mapping
 from typing import Any
 
@@ -279,7 +282,11 @@ class TestParallelAsync:
                 if offset == 200:
                     parallel_done["v"] = True  # 触发漂移后即切换到 serial 阶段
                     return _make_ret(
-                        payload=payload, chunk_offset=offset, end=end, total_size=600, sha256_hex=bad_sha,
+                        payload=payload,
+                        chunk_offset=offset,
+                        end=end,
+                        total_size=600,
+                        sha256_hex=bad_sha,
                     )
                 return _make_ret(payload=payload, chunk_offset=offset, end=end, total_size=600, sha256_hex=good_sha)
             return _make_ret(payload=payload, chunk_offset=offset, end=end, total_size=600, sha256_hex=good_sha)
@@ -379,6 +386,32 @@ class TestParallelAsync:
         # fatal 必须暴露真实原因，而不是被 drift 掩盖 / fatal must surface, not be masked by drift
         assert exc_info.value.reason == "gone"
 
+    @pytest.mark.asyncio
+    async def test_parallel_async_fatal_beats_range(self) -> None:
+        """混合 race（快 range + 慢 fatal）：fatal 必须暴露，不被先完成的 range 经 TaskGroup-cancel 掩盖.
+
+        回归：旧实现 range 就地 raise → TaskGroup 取消在飞 fatal（CancelledError 不进 group）→ group 仅余
+        range → fallback → 串行撞 range 即 fatal → 对外报 range。marker-collect 后 fatal 永不被掩盖。
+        Mirrors Rust ``parallel_async_fatal_beats_recoverable``: a racing fast ``range`` must not mask a
+        slow concurrent fatal.
+        """
+        payload = b"x" * 600
+        good_sha = hashlib.sha256(payload).hexdigest()
+
+        async def call(comp: str, handle: str, offset: int, max_chunk: int) -> Mapping[str, Any]:
+            end = min(offset + 200, 600)
+            if offset == 0:
+                return _make_ret(payload=payload, chunk_offset=0, end=end, total_size=600, sha256_hex=good_sha)
+            if offset == 200:
+                return _make_blob_error("range")  # 快可恢复，先完成 / fast recoverable, completes first
+            await asyncio.sleep(0.05)  # 慢 fatal，让 range 先完成 / slow fatal so range wins the race
+            return _make_blob_error("forbidden")
+
+        with pytest.raises(BlobTransferError) as exc_info:
+            await drain_blob(call, "c", "h", concurrency=4, chunk_size=200)
+        # fatal 必须暴露，而非被先完成的 range 掩盖 / fatal must surface, not be masked by the racing range
+        assert exc_info.value.reason == "forbidden"
+
 
 # ── Sync 镜像 / Sync mirror ──────────────────────────────────────────────
 
@@ -432,6 +465,124 @@ class TestSyncMirror:
         with pytest.raises(BlobTransferError) as exc_info:
             drain_blob_sync(call, "c", "h")
         assert exc_info.value.reason == "gone"
+
+    def test_parallel_sync_fatal_beats_range(self) -> None:
+        """sync 并行：低 offset ``range`` 块先完成 + 高 offset ``forbidden`` 块后完成 → 必报 fatal(forbidden).
+
+        回归 break-on-first-error：旧实现遇 ``range`` 先 break → 串行 fallback → 串行态先撞低 offset 的
+        ``range`` 即 fatal → 对外报 range，**掩盖** offset=400 的 forbidden（永不抵达）。新实现收集全部
+        outcome 后按 ``fatal > drift > range`` 分派，fatal 永不被掩盖——与 ``drain_blob``(async) 一致。
+        Mirrors Rust ``parallel_sync_fatal_beats_recoverable``: a racing lower-offset ``range`` must
+        not mask a concurrent higher-offset fatal in the sync parallel path.
+        """
+        payload = b"x" * 600
+        good_sha = hashlib.sha256(payload).hexdigest()
+
+        def call(comp: str, handle: str, offset: int, max_chunk: int) -> Mapping[str, Any]:
+            end = min(offset + 200, 600)
+            if offset == 0:
+                return _make_ret(payload=payload, chunk_offset=0, end=end, total_size=600, sha256_hex=good_sha)
+            if offset == 200:
+                # 可恢复信号，立即返回 → 在并发态先于 fatal 完成（旧实现据此误 break 成 range）
+                # recoverable, returns immediately → completes before the fatal in parallel
+                return _make_blob_error("range")
+            # offset == 400: fatal，故意延迟让 range 先完成 / fatal, delayed so range wins the race
+            time.sleep(0.05)
+            return _make_blob_error("forbidden")
+
+        with pytest.raises(BlobTransferError) as exc_info:
+            drain_blob_sync(call, "c", "h", concurrency=4, chunk_size=200)
+        # fatal 必须暴露，而非被先完成的 range 掩盖 / fatal must surface, not be masked by the racing range
+        assert exc_info.value.reason == "forbidden"
+
+    def test_parallel_sync_range_fallback(self) -> None:
+        """sync 并行纯 ``range`` → 取消 + 串行 fallback 成功还原（覆盖 sync range 分派）.
+        Sync parallel pure ``range`` → serial fallback restores payload (covers sync range dispatch)."""
+        payload = b"x" * 600
+        good_sha = hashlib.sha256(payload).hexdigest()
+        phase = {"parallel": True}
+
+        def call(comp: str, handle: str, offset: int, max_chunk: int) -> Mapping[str, Any]:
+            end = min(offset + 200, 600)
+            if phase["parallel"] and offset == 200:
+                phase["parallel"] = False  # 触发 fallback 后切到 serial 阶段（全部一致）/ switch to serial phase
+                return _make_blob_error("range")
+            return _make_ret(payload=payload, chunk_offset=offset, end=end, total_size=600, sha256_hex=good_sha)
+
+        data, _ = drain_blob_sync(call, "c", "h", concurrency=4, chunk_size=200)
+        assert data == payload
+
+    def test_parallel_sync_drift_fallback(self) -> None:
+        """sync 并行纯 drift（某块 sha256 漂移）→ 串行 fallback 还原（覆盖 sync drift 分派）.
+        Sync parallel pure drift → serial fallback restores payload (covers sync drift dispatch)."""
+        payload = b"a" * 600
+        good_sha = hashlib.sha256(payload).hexdigest()
+        bad_sha = "0" * 64
+        parallel_done = {"v": False}
+
+        def call(comp: str, handle: str, offset: int, max_chunk: int) -> Mapping[str, Any]:
+            end = min(offset + 200, 600)
+            if not parallel_done["v"] and offset == 200:
+                parallel_done["v"] = True  # 漂移触发 fallback 后切 serial 阶段 / switch to serial after drift
+                return _make_ret(payload=payload, chunk_offset=offset, end=end, total_size=600, sha256_hex=bad_sha)
+            return _make_ret(payload=payload, chunk_offset=offset, end=end, total_size=600, sha256_hex=good_sha)
+
+        data, _ = drain_blob_sync(call, "c", "h", concurrency=4, chunk_size=200, max_retries=3)
+        assert data == payload
+
+    def test_parallel_sync_full_sha_mismatch_rereads(self) -> None:
+        """sync 并行：各块 per-chunk sha 字段正确但字节损坏 → 重组后全量自证失败 → 串行 fallback 还原.
+
+        覆盖并行重组后的 `_RecoverableDrift` 自证分支（per-chunk 一致但整体 sha 不符）。计数切相：前一轮
+        并行尝试（首块 + 2 并发块 = 3 次调用）返回损坏字节，之后串行 fallback 返回真字节——与完成顺序无关。
+        Covers the post-reassembly whole-blob self-check; first parallel attempt (3 calls) returns
+        corrupt bytes, serial fallback returns real bytes — order-independent via a locked counter."""
+        payload = b"b" * 600
+        good_sha = hashlib.sha256(payload).hexdigest()
+        corrupt = b"Z" * 600  # 同长不同字节，每块 sha 字段仍报 good_sha / same length, different bytes
+        lock = threading.Lock()
+        count = {"n": 0}
+
+        def call(comp: str, handle: str, offset: int, max_chunk: int) -> Mapping[str, Any]:
+            with lock:
+                count["n"] += 1
+                n = count["n"]
+            end = min(offset + 200, 600)
+            # 前 3 次（并行尝试：首块 + 2 并发块）→ 损坏字节 + 正确 sha 字段 → 全量自证必失败
+            # serial fallback（第 4 次起）→ 真字节
+            src = corrupt if n <= 3 else payload
+            return _make_ret(payload=src, chunk_offset=offset, end=end, total_size=600, sha256_hex=good_sha)
+
+        data, _ = drain_blob_sync(call, "c", "h", concurrency=4, chunk_size=200, max_retries=3)
+        assert data == payload
+
+
+# ── max_retries=0 脚枪：夹取至 ≥1 / max_retries=0 footgun: clamp to ≥1 ──────
+
+
+class TestZeroRetriesAttemptsOnce:
+    """``max_retries=0`` 仍至少尝试一次（入口夹取 ``max(1, ...)``）——对标 Rust ``serial_*_zero_retries_still_attempts_once``.
+
+    显式传 ``0`` 不应「零次循环、一个 call 都不发」直接 ``max_retries_exceeded``；夹取后实发一次并成功。
+    An explicit ``max_retries=0`` must still attempt once (not short-circuit to max_retries_exceeded).
+    """
+
+    @pytest.mark.asyncio
+    async def test_async_zero_retries_still_attempts_once(self) -> None:
+        payload = b"hello"
+        sha = hashlib.sha256(payload).hexdigest()
+        call = _AsyncMockCall([_make_ret(payload=payload, chunk_offset=0, end=5, total_size=5, sha256_hex=sha)])
+        data, _ = await drain_blob(call, "c", "h", max_retries=0)
+        assert data == payload
+        assert len(call.calls) == 1  # 夹取至 1 → 实发一次 / clamped to 1 → exactly one real call
+
+    def test_sync_zero_retries_still_attempts_once(self) -> None:
+        payload = b"hello"
+        sha = hashlib.sha256(payload).hexdigest()
+        call = _SyncMockCall([_make_ret(payload=payload, chunk_offset=0, end=5, total_size=5, sha256_hex=sha)])
+        data, _ = drain_blob_sync(call, "c", "h", max_retries=0)
+        assert data == payload
+        assert len(call.calls) == 1
 
 
 # ── docstring 「并行安全」断言（无意中删除即报）/ docstring "parallel-safe" assertion ──


### PR DESCRIPTION
## 概述

`drain_blob` 双端对齐（Rust → Python parity），两项错误路径加固，**不触协议**（wire 格式 / `4018` reason / `PROTOCOL_VERSION` 不变，happy-path 不变）。Closes #101 · 父 #42 · follow-up to #38。

## R1 — 并行确定性 `fatal > drift > range` 分派（永不掩盖 fatal）

并发态下，先完成的 recoverable（`range`/drift）会经串行 fallback 把并存的 fatal（`forbidden`/`gone`/`invalid_handle`）降级成貌似瞬态的 `range`。**sync 与 async 两条路径都有此掩盖**，race 触发条件不同：

- **`_drain_parallel_sync`**：原 break-on-first-error → 先撞 `range` 即 `break` → fallback → 串行撞低 offset `range` 即 fatal → 报 `range`。
- **`_drain_parallel_async`**：原 `fetch()` 对 `range` 就地 raise → `TaskGroup` fail-fast 取消在飞 fatal 任务（`CancelledError` 不进 `ExceptionGroup`）→ group 仅余 `range` → 同样报 `range`。（`/fix-review` 实测 race 确认：旧 async 报 `range`，新 sync 报 `forbidden` — 一度反向不一致。）

**修复**：两条路径统一「recoverable 不早退、仅 fatal fail-fast、收集全部 outcome 后按 `fatal > drift > range` 分派」。async 的 `fetch()` 改为返回 `("range"|"drift"|"ok", off, ret)` marker、仅 fatal raise。双端现确定性 fatal-wins，对齐 Rust `parallel_{sync,async}_fatal_beats_recoverable`。

## R2 — `max_retries == 0` 脚枪：夹取至 ≥ 1

`drain_blob` / `drain_blob_sync` 入口 `effective_retries = max(1, max_retries)`；显式传 `0` 仍至少尝试一次，不再「零次循环直接 `max_retries_exceeded`」。

## 测试（新增 7 项）

- `test_parallel_sync_fatal_beats_range` / `test_parallel_async_fatal_beats_range` — fatal 永不被先完成的 range 掩盖（对标 Rust）。
- `test_async/sync_zero_retries_still_attempts_once` — R2 回归。
- `test_parallel_sync_range_fallback` / `_drift_fallback` / `_full_sha_mismatch_rereads` — sync 并行 recoverable→串行 fallback 分支覆盖。

## 验证

- `uv run --no-sync ruff check` 净 · `ruff format` 净 · `mypy a2c_smcp` 净（98 files）
- blob 单测 **31 passed** · computer-side + 集成 wire **共 64 passed**，零回归

🤖 Generated with [Claude Code](https://claude.com/claude-code)
