### PR TITLE
fix(mcp-manager): alias 反映到 Agent 暴露面 + forbidden 工具不再触发重名冲突 (#106)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,6 +89,11 @@ Socket.IO 事件遵循以下前缀：
 2. 相关命名空间/客户端类中的处理方法
 3. 测试中的 Mock 服务器事件处理器
 
+**工具暴露名语义 (#106)**：`client:get_tools` 暴露给 Agent 的 `SMCPTool.name` 为 **display_name**
+（`tool_meta.alias` 优先，无 alias 时回退 MCP 原始名），由 `manager.available_tools()` 改写。Agent 即以此名
+寻址（`aexecute_tool` 经 `_alias_mapping` 解析回原始名）。故含连字符 / 冲突的原始工具名可借 alias 重命名以适配
+下游命名约束。被 `forbidden_tools` 禁用的工具**不出现在暴露面**（不可见且不可调用），且不参与跨 server 重名冲突检测。
+
 ### v0.2 协议新增 (a2c-smcp-protocol v0.2.0 GA)
 
 - **`client:get_resources`** (`GET_RESOURCES_EVENT`): Agent → Computer，透明转发 MCP

--- a/a2c_smcp/computer/mcp_clients/manager.py
+++ b/a2c_smcp/computer/mcp_clients/manager.py
@@ -310,17 +310,23 @@ class MCPServerManager:
 
                     # 确定最终显示的工具名（优先使用别名）
                     display_name: str = tool_meta.alias if tool_meta and tool_meta.alias else original_tool_name
+
+                    # 检查是否为禁用工具 (根据配置，但此时需要注意如果原始名称在禁用列表中，也应该禁用，因为此处的禁用列表是归属于某个
+                    # ServerConfig的，不存在重复名称的情况，用户有可能配置了alias，但是使用原始名称禁用。)
+                    # 禁用判定必须**先于** tool_sources 收集：被禁用的工具不暴露、不路由、也不应参与跨 server
+                    # 重名冲突检测（#106）——否则「禁用了仍触发 ToolNameDuplicatedError」，用户无法靠 forbid 一方规避重名。
+                    # The forbidden check must precede tool_sources collection: a disabled tool is neither exposed nor
+                    # routed, and must not participate in cross-server duplicate detection (#106).
+                    if display_name in (config.forbidden_tools or []) or original_tool_name in (config.forbidden_tools or []):
+                        self._disabled_tools.add(display_name)
+                        continue
+
                     # 如果使用提别名，则更新别名映射
                     if display_name != original_tool_name:
                         self._alias_mapping[display_name] = (server_name, original_tool_name)
 
                     # 将工具添加到映射
                     tool_sources[display_name].append(server_name)
-
-                    # 检查是否为禁用工具 (根据配置，但此时需要注意如果原始名称在禁用列表中，也应该禁用，因为此处的禁用列表是归属于某个
-                    # ServerConfig的，不存在重复名称的情况，用户有可能配置了alias，但是使用原始名称禁用。)
-                    if display_name in (config.forbidden_tools or []) or original_tool_name in (config.forbidden_tools or []):
-                        self._disabled_tools.add(display_name)
             except Exception as e:
                 logger.error(f"Error listing tools for {server_name}: {e}", exc_info=True)
 
@@ -334,6 +340,12 @@ class MCPServerManager:
                 )
                 raise ToolNameDuplicatedError(f"Tool '{tool}' exists in multiple servers: {sources}\n{suggestion}")
             self._tool_mapping[tool] = sources[0]
+
+        # 跨 server 误伤对账（#106）：_disabled_tools 按全局 display_name 索引，若某名被某 server forbid，
+        # 但同名工具由其它 server 正常提供（已进入 _tool_mapping），应以**存活方为准**，否则 avalidate_tool_call
+        # 会因 _disabled_tools 命中而误拒可用工具。单 server 独有工具被 forbid（无其它提供方）则仍保留禁用语义。
+        # Cross-server reconciliation: a name forbidden on one server but live on another must keep the live one.
+        self._disabled_tools.difference_update(self._tool_mapping.keys())
 
     async def avalidate_tool_call(self, tool_name: TOOL_NAME, parameters: dict) -> tuple[SERVER_NAME, TOOL_NAME]:
         """
@@ -516,12 +528,16 @@ class MCPServerManager:
                 tool = next((t for t in tools if t.name == original_tool_name), None)
                 if tool:
                     a2c_meta = self._merged_tool_meta(config, original_tool_name)
+                    # 对外暴露 display_name（alias 优先，无 alias 时即原始名）作为 Tool.name（#106）：Agent 按此名寻址，
+                    # 含连字符 / 冲突的原始名才能借 alias 适配下游命名约束。tool_name 即 _tool_mapping 的 key（display_name）。
+                    # 产出名字改写后的**副本**，避免原地 mutate 缓存对象（servers_cached_tools 按原始名复用，原地改名会破坏后续查找）。
+                    # Expose display_name as Tool.name (#106); yield a renamed copy to avoid mutating the cached tool object.
+                    update: dict[str, Any] = {"name": tool_name}
                     if a2c_meta:
-                        if tool.meta is None:
-                            tool.meta = {A2C_TOOL_META: a2c_meta}
-                        else:
-                            tool.meta.update({A2C_TOOL_META: a2c_meta})
-                    yield tool
+                        merged_meta = dict(tool.meta) if tool.meta else {}
+                        merged_meta[A2C_TOOL_META] = a2c_meta
+                        update["meta"] = merged_meta
+                    yield tool.model_copy(update=update)
 
     async def list_windows(self, window_uri: str | None = None) -> list[tuple[SERVER_NAME, Resource]]:
         """

--- a/tests/unit_tests/computer/mcp_clients/test_manager.py
+++ b/tests/unit_tests/computer/mcp_clients/test_manager.py
@@ -45,10 +45,10 @@ class MockMCPClient:
 
 
 def create_mock_tool(name: str, meta: dict | None = None) -> Tool:
-    tool = MagicMock(name=name, spec=Tool)
-    tool.name = name
-    tool.meta = meta
-    return tool
+    # 使用真实 Tool（pydantic 模型）而非 MagicMock：available_tools 经 model_copy 改写暴露名（#106），
+    # 而 MagicMock 的 model_copy 不具备 pydantic 语义（返回 mock，.name 非真实字符串）会失真。
+    # Use a real Tool so model_copy (used to rename the exposed tool, #106) behaves faithfully.
+    return Tool(name=name, inputSchema={"type": "object"}, _meta=meta)
 
 
 # 模拟client_factory函数
@@ -224,6 +224,11 @@ async def test_disabled_tool(manager):
     # 尝试执行禁用工具
     with pytest.raises(PermissionError):
         await manager.aexecute_tool("tool2", {})
+
+    # #106 契约：禁用工具不应再出现在对外暴露面（不可见且不可调用），钉死避免被无意改回。
+    # Contract (#106): a disabled tool must not appear in the exposed tool list either.
+    names = [tool.name async for tool in manager.available_tools()]
+    assert "tool2" not in names
 
 
 @pytest.mark.asyncio
@@ -638,7 +643,9 @@ async def test_aadd_or_aupdate_server_with_duplicate_tool(manager, monkeypatch):
     # 验证服务器仍然保持原状
     assert manager._active_clients["server1"].list_tools.return_value[0].name == "tool1"
     tools_list = [tool async for tool in manager.available_tools()]
-    assert any(tool.name == "tool1" and tool.meta["a2c_tool_meta"].alias == "new_alias" for tool in tools_list) and any(
+    # #106：alias 须反映到对外暴露的 Tool.name。server1 的 tool1 别名为 new_alias → 暴露名 new_alias；
+    # server2 的 tool1 无别名 → 暴露名 tool1。二者借 alias 不再同名冲突（正是本修复要达成的效果）。
+    assert any(tool.name == "new_alias" and tool.meta["a2c_tool_meta"].alias == "new_alias" for tool in tools_list) and any(
         tool.name == "tool1" and not tool.meta for tool in tools_list
     )
 
@@ -839,3 +846,93 @@ async def test_acall_tool_vrl_with_nested_parameters(manager, monkeypatch):
     assert transformed["user_info"]["name"] == "Alice"
     assert transformed["options"]["enabled"] is True
     assert transformed["options"]["timeout"] == 30
+
+
+# ── #106 回归：alias 必须反映到对外暴露的工具名 / alias must surface as the exposed tool name ──
+@pytest.mark.asyncio
+async def test_available_tools_exposes_alias_as_name(manager):
+    """#106 复现：配置 alias 后，available_tools 暴露的 Tool.name 应为 display_name（alias），而非原始名。
+
+    Repro for #106: once an alias is configured, available_tools must expose the display_name (alias)
+    as Tool.name, not the original name. Downstream agents address tools by this name, so含连字符 /
+    冲突的原始名才能借 alias 适配下游命名约束。
+    """
+    tool_meta = {"tool5": ToolMeta(alias="aliased_tool")}
+    servers = [create_server_config("alias_server", tool_meta=tool_meta)]
+    await manager.ainitialize(servers)
+    await manager.astart_all()
+
+    names = [tool.name async for tool in manager.available_tools()]
+    # 暴露面应为 alias，原始名不得出现 / exposed name must be the alias, never the original
+    assert "aliased_tool" in names
+    assert "tool5" not in names
+
+
+@pytest.mark.asyncio
+async def test_forbidden_tool_excluded_from_duplicate_detection(manager, monkeypatch):
+    """#106 附带缺陷复现：被 forbid 的工具不应再参与跨 server 重名冲突检测。
+
+    Repro for #106 secondary defect: a forbidden tool must not participate in cross-server duplicate
+    detection. 两个 server 都原生暴露同名 ``tool1``，其中一侧 forbid 之后，应能消除 ToolNameDuplicatedError。
+    """
+
+    def both_expose_tool1(config: MCPServerConfig, message_handler=None) -> Any:
+        return MockMCPClient([create_mock_tool("tool1")], message_handler=message_handler)
+
+    monkeypatch.setattr("a2c_smcp.computer.mcp_clients.manager.client_factory", both_expose_tool1)
+
+    # server1 forbid tool1，server2 正常暴露 tool1 → 不应再冲突
+    servers = [
+        create_server_config("server1", forbidden_tools=["tool1"]),
+        create_server_config("server2"),
+    ]
+    await manager.ainitialize(servers)
+    await manager.astart_all()
+
+    # 冲突被消除：tool1 仅来自 server2 / conflict resolved: tool1 routes to server2 only
+    assert manager._tool_mapping["tool1"] == "server2"
+    # 存活侧（server2）的 tool1 仍可寻址；不被另一 server 的 forbid 误伤
+    # The surviving tool1 (server2) stays addressable; a forbid on another server must not disable it.
+    assert "tool1" not in manager._disabled_tools
+    server_name, original = await manager.avalidate_tool_call("tool1", {})
+    assert (server_name, original) == ("server2", "tool1")
+    # 暴露面只出现一次 tool1（server1 那份被禁用、不暴露）/ tool1 exposed exactly once
+    names = [tool.name async for tool in manager.available_tools()]
+    assert names.count("tool1") == 1
+
+
+@pytest.mark.asyncio
+async def test_forbidden_original_name_suppresses_alias(manager):
+    """#106 边界：对原始名 forbid 时，即便该工具配了 alias，alias 也不应暴露（forbid 优先于 alias）。
+
+    Boundary (#106): forbidding by the original name suppresses an aliased exposure too — forbid wins over alias,
+    so an aliased tool cannot be used to bypass a forbid on its underlying tool.
+    """
+    tool_meta = {"tool5": ToolMeta(alias="aliased_tool")}
+    servers = [create_server_config("alias_server", tool_meta=tool_meta, forbidden_tools=["tool5"])]
+    await manager.ainitialize(servers)
+    await manager.astart_all()
+
+    # alias 与原始名都不暴露、不路由 / neither the alias nor the original is exposed/routed
+    names = [tool.name async for tool in manager.available_tools()]
+    assert "aliased_tool" not in names
+    assert "tool5" not in names
+    assert "aliased_tool" not in manager._tool_mapping
+    assert "tool5" not in manager._tool_mapping
+
+
+@pytest.mark.asyncio
+async def test_forbidden_tool_without_provider_stays_disabled(manager):
+    """forbid 单 server 独有工具时，仍应保留 PermissionError 语义（_disabled_tools 命中）。
+
+    When the forbidden tool is not provided by any other server, it stays in _disabled_tools so a call
+    raises PermissionError (regression guard for the existing single-server forbid behavior).
+    """
+    servers = [create_server_config("server1", forbidden_tools=["tool2"])]
+    await manager.ainitialize(servers)
+    await manager.astart_all()
+
+    assert "tool2" in manager._disabled_tools
+    assert "tool2" not in manager._tool_mapping
+    with pytest.raises(PermissionError):
+        await manager.aexecute_tool("tool2", {})


### PR DESCRIPTION
## 背景

Fixes #106。含连字符的 MCP 工具（如 `tmux-mcp` 的 `execute-command`）在 Agent 端（`client:get_tools`）全部丢失——Agent 侧工具名仅接受 `[A-Za-z0-9_]`，连字符被过滤。期望用 `tool_meta.alias` 重命名规避，但 **alias 从未反映到暴露给 Agent 的工具名**。

## 根因（已实证复现）

1. **主缺陷**：`manager.available_tools()` yield 的是原始 `Tool`，`.name` 仍为原始名；`computer.convert_tool` 用 `SMCPTool(name=t.name)` 序列化。alias 只写进内部路由表 `_tool_mapping` / `_alias_mapping`，从未反映到对外暴露名。
2. **附带缺陷**：`_arefresh_tool_mapping()` 在 forbidden 判定**之前**就把工具 append 进 `tool_sources`，导致被禁用的工具仍参与跨 server 重名冲突检测（`ToolNameDuplicatedError`），无法靠 forbid 一方规避重名。

## 修复

- `available_tools()`：经 `tool.model_copy(update={"name": display_name, ...})` 把对外暴露名改为 **display_name（alias 优先，无 alias 时回退原始名）**；顺手消除旧代码原地 mutate `list_tools()` 缓存对象的副作用，幂等性更强。
- `_arefresh_tool_mapping()`：把 forbidden 判定提前到 append `tool_sources` 之前并 `continue`（禁用工具不暴露、不路由、不参与重名检测）；建表后 `self._disabled_tools.difference_update(self._tool_mapping.keys())` 做**跨 server 误伤对账**——某名被 A server forbid 但由 B server 正常提供时以存活方为准。
- `CLAUDE.md`：记录 `client:get_tools` 暴露名语义与「禁用工具不暴露」契约。

## 行为契约变更

- `client:get_tools` 返回的 `SMCPTool.name` 由「MCP 原始名」变为 **display_name（alias 优先）**。Agent 仍以此名寻址（`aexecute_tool` 经 `_alias_mapping` 解析回原始名）。
- 被 `forbidden_tools` 禁用的工具**不再出现在暴露面**（旧行为：可见但调用时 `PermissionError`；新行为：不可见且不可调用）。

## 测试

| 测试 | 说明 |
|---|---|
| `test_available_tools_exposes_alias_as_name` | alias 后暴露名为 alias，原始名不出现 |
| `test_forbidden_tool_excluded_from_duplicate_detection` | 两 server 同名，forbid 一侧后不再冲突，存活侧仍可寻址 |
| `test_forbidden_original_name_suppresses_alias` | forbid 原始名时 alias 也被抑制（forbid 优先于 alias） |
| `test_forbidden_tool_without_provider_stays_disabled` | 单 server 独有工具被 forbid 仍 `PermissionError` |
| `test_disabled_tool`（增强） | 禁用工具不出现在 `available_tools` 暴露面 |

`create_mock_tool` 从 `MagicMock(spec=Tool)` 改为真实 `Tool`（MagicMock 的 `model_copy` 不具 pydantic 语义会失真），并更正了一个编码旧 buggy 行为的断言。

## 验证

- 复现测试：修复前 3 FAIL → 修复后全 PASS
- 全量：**1700 passed, 2 skipped, 4 xfailed**
- Lint + typecheck：**All checks passed / no issues in 99 source files**
- 隔离上下文复审（code-reviewer）：APPROVE，零阻塞项

🤖 Generated with [Claude Code](https://claude.com/claude-code)