### PR TITLE
test(skills): AS-40 FastMCP Skills Provider 可注册性集成测试覆盖

### DIFF
--- a/.claude/skills/UAT/resources/scenarios/mcp-fastmcp-skill.md
+++ b/.claude/skills/UAT/resources/scenarios/mcp-fastmcp-skill.md
@@ -1,0 +1,69 @@
+# 场景：mcp-fastmcp-skill
+
+## 测试目标
+
+验证 FastMCP-style Skills Provider 经 MCP `skill://` 资源暴露的 skill，能否被 smcp-computer 的
+`restage_mcp_skills` 物化注册并经 `Computer.get_skills()` 收集。守护 AS-40 的两条契约：
+
+- **MF-01 可注册形状**：provider 暴露 `_meta.source=resources` 根 + 子资源（`SKILL.md`/`reference.md`）→
+  current SDK **无需改码**即注册为 `mcp:<server>:<skill>`。
+- **MF-02 裸 FastMCP 布局**：裸 `skill://<name>/SKILL.md`（无 `_meta.source` 根）当前**不注册**，
+  由 provider 侧适配解决（暴露可注册形状）。SDK 应**静默跳过**，不误报 invalid/skipped。
+
+> 依据 / Basis: AS-40 comment 13849。`_meta.source` 是 A2C 自家协议（`skill.md §3`）的物化标记，
+> **不是** MCP 标准；FastMCP 的 `skill://<name>/SKILL.md`+`_manifest` 是另一套约定。两者均建于标准
+> MCP `resources/list` + `resources/read` 之上。
+
+## 类型
+
+集成测试（gated）—— **非 CLI/tmux 可观测**，见下方局限说明。
+
+## ⚠️ CLI / tmux 局限说明（为何不是 CLI-only 用例）
+
+`restage_mcp_skills` 仅在 Computer `boot_up` 时触发；而 MCP server 的批准/连接发生在 boot **之后**。
+故非交互 CLI（`a2c-computer skill list --source mcp`）在 boot 时尚无活跃 MCP 连接，**观测不到** live
+MCP skill 注册（与 `skill-discovery.md` D-03「非交互模式返回空列表」一致）。因此本场景的可注册性验证
+落在 Python 集成测试，而非 tmux 终端交互。
+
+## 验证载体（单一真源）
+
+| 类型 | 路径 |
+|------|------|
+| stdio fixture | `tests/integration_tests/computer/mcp_servers/fastmcp_skill_stdio_server.py` |
+| 集成测试 | `tests/integration_tests/computer/skills/test_fastmcp_skills_integration.py` |
+| UAT seed 索引 | `.claude/skills/UAT/resources/seeds/mcp/fastmcp-skill-server/README.md` |
+
+一台 fixture 同时暴露 MF-01 可注册形状（`skill://fastmcp.demo.example/fastmcp-demo` + 子资源）与
+MF-02 裸布局（`skill://bare-demo/SKILL.md`），用一次 boot 守护两个契约。
+
+## 测试用例
+
+### MF-01: 可注册形状被 get_skills 收集
+
+- **优先级**: P0
+- **步骤**:
+  1. 经真 stdio fixture 启动 `MCPServerManager`（server 名 `fastmcp-skill-test`）
+  2. 注入 Computer，调用 `await comp._restage_mcp_skills()`
+  3. 读取 `comp.get_skills()`
+- **预期结果**:
+  - `registered` 含 `mcp:fastmcp-skill-test:fastmcp-demo`
+  - `get_skills()` 名单含同名 skill；`source == "mcp:fastmcp-skill-test"`，`version == "1.0.0"`
+  - 物化包根落盘 `SKILL.md` 与 `reference.md`（子资源逐个 `resources/read` 还原）
+
+### MF-02: 裸 FastMCP 布局不注册（当前契约）
+
+- **优先级**: P0
+- **步骤**: 同 MF-01 boot；检查裸 `skill://bare-demo/SKILL.md` 的处理
+- **预期结果**:
+  - `registered` 与 `get_skills()` 均**不含**任何 `bare-demo` 变体
+  - 裸布局仅静默跳过，**不**误报 invalid/skipped；可注册形状（MF-01）仍正常入册，未被连累
+
+## 执行
+
+```bash
+uv run pytest tests/integration_tests/computer/skills/test_fastmcp_skills_integration.py -v
+```
+
+## 清理
+
+集成测试使用 `tmp_path`，自动清理；fixture 仅占 stdin/stdout，astop_all 后子进程退出，无残留。

--- a/.claude/skills/UAT/resources/seeds/mcp/fastmcp-skill-server/README.md
+++ b/.claude/skills/UAT/resources/seeds/mcp/fastmcp-skill-server/README.md
@@ -1,0 +1,41 @@
+# seed: `fastmcp-skill-server` — FastMCP-style Skills Provider（AS-40）
+
+> **单一真源 / single source of truth**：本 seed **不**复制 fixture 脚本，直接指向集成测试 fixture，
+> 避免两处 stdio server 实现漂移。
+
+## 指向
+
+| 类型 | 路径 |
+|------|------|
+| stdio server fixture | [`tests/integration_tests/computer/mcp_servers/fastmcp_skill_stdio_server.py`](../../../../../../tests/integration_tests/computer/mcp_servers/fastmcp_skill_stdio_server.py) |
+| 集成测试（验收方法） | [`tests/integration_tests/computer/skills/test_fastmcp_skills_integration.py`](../../../../../../tests/integration_tests/computer/skills/test_fastmcp_skills_integration.py) |
+| UAT 场景 | [`scenarios/mcp-fastmcp-skill.md`](../../scenarios/mcp-fastmcp-skill.md) |
+
+## 暴露形状
+
+一台 stdio server（名 `fastmcp-skill-test`）同时暴露：
+
+```
+# MF-01 可注册形状 / registrable（_meta.source=resources 根 + 子资源）
+skill://fastmcp.demo.example/fastmcp-demo            _meta.source=resources, version=1.0.0
+skill://fastmcp.demo.example/fastmcp-demo/SKILL.md
+skill://fastmcp.demo.example/fastmcp-demo/reference.md
+
+# MF-02 裸 FastMCP 布局 / bare（无 _meta.source 根，当前不注册）
+skill://bare-demo/SKILL.md
+```
+
+## 验收方法（可执行）
+
+```bash
+uv run pytest tests/integration_tests/computer/skills/test_fastmcp_skills_integration.py -v
+```
+
+- MF-01 → `get_skills()` 收集 `mcp:fastmcp-skill-test:fastmcp-demo`（current SDK 无需改码）
+- MF-02 → 裸布局不注册、不误报；由 provider 侧适配（暴露可注册形状）解决
+
+## 背景
+
+AS-40 / comment 13849：`_meta.source` 为 A2C 自家协议物化标记（非 MCP 标准）；FastMCP 的
+`skill://<name>/SKILL.md`+`_manifest` 为另一套约定。结论是 **provider 侧适配到可注册形状**，
+SDK 侧仅新增测试守护契约，零 src 改动。

--- a/tests/integration_tests/computer/mcp_servers/fastmcp_skill_stdio_server.py
+++ b/tests/integration_tests/computer/mcp_servers/fastmcp_skill_stdio_server.py
@@ -1,0 +1,103 @@
+# -*- coding: utf-8 -*-
+# filename: fastmcp_skill_stdio_server.py
+"""
+中文: 最小 stdio MCP server fixture，模拟 FastMCP-style Skills Provider，用于 AS-40 集成测试。
+英文: Minimal stdio MCP server fixture emulating a FastMCP-style Skills Provider, for the AS-40
+      integration test.
+
+背景 / Background (AS-40 comment 13849):
+    FastMCP Skills Provider 暴露 ``skill://<name>/SKILL.md`` / ``_manifest`` / ``reference.md``。
+    其中**裸布局** ``skill://<name>/SKILL.md``（无 ``_meta.source`` 根）当前 SDK 不收（设计如此，
+    由 provider 侧适配解决）；只要 provider 暴露**可注册形状**（``_meta.source=resources`` 根 +
+    子资源），current SDK **无需改码**即可物化注册。本 fixture 同时暴露两者，用一台 server 守护
+    两个契约：
+
+      ┌ MF-01 可注册形状（registrable）──────────────────────────────────────┐
+      │ skill://fastmcp.demo.example/fastmcp-demo            _meta.source=resources │
+      │ skill://fastmcp.demo.example/fastmcp-demo/SKILL.md        （子资源）        │
+      │ skill://fastmcp.demo.example/fastmcp-demo/reference.md    （子资源）        │
+      └──────────────────────────────────────────────────────────────────────────┘
+      ┌ MF-02 裸 FastMCP 布局（bare，当前不注册）──────────────────────────────────┐
+      │ skill://bare-demo/SKILL.md                          无 _meta.source 根       │
+      └──────────────────────────────────────────────────────────────────────────┘
+
+启动 / Run: python fastmcp_skill_stdio_server.py  （仅 stdin/stdout，不监听端口）
+"""
+
+from __future__ import annotations
+
+import anyio
+import mcp.types as types
+from mcp.server.lowlevel.server import Server
+from mcp.server.stdio import stdio_server
+
+# ── MF-01 可注册形状 / registrable shape ─────────────────────────────────────
+SKILL_HOST = "fastmcp.demo.example"
+REG_ROOT = f"skill://{SKILL_HOST}/fastmcp-demo"
+
+_REG_SKILL_MD = (
+    "---\n"
+    "name: fastmcp-demo\n"
+    "description: FastMCP-style demo skill exposed as registrable resources\n"
+    "license: MIT\n"
+    "---\n"
+    "# FastMCP Demo\n\n"
+    "中文: FastMCP 可注册形状演示 SKILL。英文: registrable-shape demo skill.\n"
+)
+_REG_REFERENCE_MD = "# Reference\n\n中文: 附带参考文件。英文: supporting reference file.\n"
+
+# ── MF-02 裸 FastMCP 布局 / bare layout（无 _meta.source 根，当前 SDK 跳过）─────
+BARE_ROOT = "skill://bare-demo"
+_BARE_SKILL_MD = "---\nname: bare-demo\ndescription: bare FastMCP layout without a _meta.source root\n---\n# Bare Demo\n"
+
+# uri -> resources/read 文本内容 / uri -> read content
+_CONTENT: dict[str, str] = {
+    f"{REG_ROOT}/SKILL.md": _REG_SKILL_MD,
+    f"{REG_ROOT}/reference.md": _REG_REFERENCE_MD,
+    f"{BARE_ROOT}/SKILL.md": _BARE_SKILL_MD,
+}
+
+
+def build_resources() -> list[types.Resource]:
+    """枚举 MF-01 根+子资源 与 MF-02 裸 SKILL.md。"""
+    return [
+        # MF-01 根（带 _meta.source=resources）/ registrable root
+        types.Resource.model_validate(
+            {
+                "uri": REG_ROOT,
+                "name": "fastmcp-demo",
+                "mimeType": "inode/directory",
+                "_meta": {"source": "resources", "version": "1.0.0"},
+            },
+        ),
+        # MF-01 子资源（不带 _meta.source）/ sub-resources
+        types.Resource.model_validate({"uri": f"{REG_ROOT}/SKILL.md", "name": "SKILL.md", "mimeType": "text/markdown"}),
+        types.Resource.model_validate(
+            {"uri": f"{REG_ROOT}/reference.md", "name": "reference.md", "mimeType": "text/markdown"},
+        ),
+        # MF-02 裸 FastMCP 入口（无根、无 _meta.source）/ bare entry
+        types.Resource.model_validate({"uri": f"{BARE_ROOT}/SKILL.md", "name": "SKILL.md", "mimeType": "text/markdown"}),
+    ]
+
+
+async def run() -> None:
+    server = Server(name="fastmcp-skill-test", version="0.0.1", instructions="AS-40 fastmcp skills fixture")
+
+    @server.list_resources()
+    async def _list_resources() -> list[types.Resource]:
+        return build_resources()
+
+    @server.read_resource()
+    async def _read_resource(uri: types.AnyUrl) -> str:
+        key = str(uri)
+        if key not in _CONTENT:
+            raise FileNotFoundError(f"resource not found: {key}")
+        return _CONTENT[key]
+
+    async with stdio_server() as (read_stream, write_stream):
+        init_opts = server.create_initialization_options()
+        await server.run(read_stream, write_stream, init_opts)
+
+
+if __name__ == "__main__":
+    anyio.run(run)

--- a/tests/integration_tests/computer/skills/test_fastmcp_skills_integration.py
+++ b/tests/integration_tests/computer/skills/test_fastmcp_skills_integration.py
@@ -1,0 +1,94 @@
+# -*- coding: utf-8 -*-
+# filename: test_fastmcp_skills_integration.py
+"""
+AS-40 集成测试：FastMCP-style Skills Provider 经真 stdio MCP server 的可注册性。
+Integration test for AS-40: registrability of a FastMCP-style Skills Provider over a real stdio MCP server.
+
+依据 / Basis: AS-40 comment 13849 —— 「FastMCP 资源已能被 smcp-computer 注册，前提是 provider 用
+可注册形状（``_meta.source=resources`` 根 + 子资源）；裸 ``skill://<name>/SKILL.md`` 由 provider 侧适配解决。」
+本测试**不改 src**，只新增覆盖：真 stdio server → boot manager → ``_restage_mcp_skills`` → ``Computer.get_skills()``。
+
+为什么落在集成测试而非 CLI/tmux UAT / Why integration test, not CLI UAT:
+    ``_restage_mcp_skills`` 仅在 ``boot_up`` 触发，而 MCP server 的批准/连接发生在 boot 之后——
+    非交互 CLI 无法观测 live MCP skill 注册（见 scenarios/mcp-fastmcp-skill.md 的 CLI 局限说明）。
+    故可注册性的自动化验证落在此 gated 集成测试。
+
+覆盖 / Coverage:
+    - MF-01: 可注册形状被 ``get_skills()`` 收集为 ``mcp:fastmcp-skill-test:fastmcp-demo``
+    - MF-02: 裸 ``skill://bare-demo/SKILL.md`` **不**注册（当前契约），且不误报 invalid/skipped
+"""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+import pytest
+from mcp import StdioServerParameters
+
+from a2c_smcp.computer.computer import Computer
+from a2c_smcp.computer.mcp_clients.manager import MCPServerManager
+from a2c_smcp.computer.mcp_clients.model import StdioServerConfig
+
+_FIXTURE = Path(__file__).resolve().parents[1] / "mcp_servers" / "fastmcp_skill_stdio_server.py"
+_SERVER_NAME = "fastmcp-skill-test"
+_EXPECTED_SKILL = "mcp:fastmcp-skill-test:fastmcp-demo"
+
+
+@asynccontextmanager
+async def _booted_computer(tmp_path: Path) -> AsyncIterator[Computer]:
+    """启动真 stdio fixture 的 manager，注入 Computer，重物化后产出可查询 get_skills 的 Computer。"""
+    assert _FIXTURE.exists(), f"fixture missing: {_FIXTURE}"
+    params = StdioServerParameters(command=sys.executable, args=[str(_FIXTURE)])
+    cfg = StdioServerConfig(name=_SERVER_NAME, server_parameters=params)
+
+    manager = MCPServerManager(auto_connect=False)
+    await manager.ainitialize([cfg])
+    await manager.astart_all()
+
+    comp = Computer(name="comp-fastmcp-itest", skill_home=tmp_path / "home", auto_connect=False, auto_reconnect=False)
+    comp.mcp_manager = manager  # type: ignore[assignment]
+    comp._skill_home = tmp_path / "home"
+    comp._skill_home.mkdir(parents=True, exist_ok=True)
+    try:
+        yield comp
+    finally:
+        await manager.astop_all()
+
+
+@pytest.mark.anyio
+async def test_mf01_registrable_shape_collected_by_get_skills(tmp_path: Path) -> None:
+    """MF-01: 可注册形状（_meta.source=resources 根 + SKILL.md/reference.md 子资源）→ 入 get_skills。"""
+    async with _booted_computer(tmp_path) as comp:
+        registered = await comp._restage_mcp_skills()
+        assert _EXPECTED_SKILL in registered
+
+        names = [s["name"] for s in comp.get_skills()]
+        assert _EXPECTED_SKILL in names
+
+        # 物化产物落盘：包根含 SKILL.md 与 reference.md（子资源被逐个 read 还原）
+        ref = comp.get_skill_ref(_EXPECTED_SKILL)
+        assert ref is not None
+        pkg = Path(ref["path"])
+        assert (pkg / "SKILL.md").is_file()
+        assert (pkg / "reference.md").is_file()
+        assert ref["source"] == f"mcp:{_SERVER_NAME}"
+        assert ref["version"] == "1.0.0"
+
+
+@pytest.mark.anyio
+async def test_mf02_bare_layout_not_registered(tmp_path: Path) -> None:
+    """MF-02: 裸 skill://bare-demo/SKILL.md（无 _meta.source 根）当前不注册——provider 侧适配解决。
+
+    同时守护「不误报」：裸布局只是静默跳过，不应污染可注册形状的注册结果。
+    """
+    async with _booted_computer(tmp_path) as comp:
+        registered = await comp._restage_mcp_skills()
+        # 裸布局任何命名变体都不应出现
+        assert not any("bare-demo" in n for n in registered)
+        names = [s["name"] for s in comp.get_skills()]
+        assert not any("bare-demo" in n for n in names)
+        # 可注册形状仍正常入册（裸布局未连累）
+        assert _EXPECTED_SKILL in names


### PR DESCRIPTION
## 背景

[AS-40](https://turingfocus.atlassian.net/browse/AS-40) — 让 smcp-computer 的 skill staging 识别 FastMCP Skills Provider 暴露的 skill。

依据 **AS-40 comment 13849** 的本地验证结论：FastMCP 资源**已能**被 smcp-computer 注册，**前提是 provider 用「可注册形状」**（`_meta.source=resources` 的 skill 根 + 子资源）；裸 `skill://<name>/SKILL.md` 由 **provider 侧适配**解决。因此 SDK 侧**撤销所有代码改动**，只新增测试覆盖此场景 —— 与 Rust SDK 参照同一份标准，避免两端实现漂移。

## 关键技术发现

CLI/tmux UAT **无法观测 live MCP skill 注册** —— `restage_mcp_skills` 仅在 `boot_up` 触发，而 MCP server 的批准/连接发生在 boot 之后。故可注册性的自动化验证落在集成测试。

## 交付物（4 文件，零 `src` 改动）

| 文件 | 说明 |
|------|------|
| `tests/integration_tests/computer/mcp_servers/fastmcp_skill_stdio_server.py` | 最小 stdio MCP server fixture，一台同时暴露 **MF-01 可注册形状**（`_meta.source=resources` 根 + `SKILL.md`/`reference.md` 子资源）与 **MF-02 裸布局**（`skill://bare-demo/SKILL.md`） |
| `tests/integration_tests/computer/skills/test_fastmcp_skills_integration.py` | 集成测试：boot manager → 注入 Computer → `_restage_mcp_skills` → `get_skills()`，断言收集 `mcp:fastmcp-skill-test:fastmcp-demo`；裸布局不注册、不误报 |
| `.claude/skills/UAT/resources/scenarios/mcp-fastmcp-skill.md` | UAT 场景（MF-01 / MF-02 契约 + CLI/tmux 局限说明） |
| `.claude/skills/UAT/resources/seeds/mcp/fastmcp-skill-server/README.md` | UAT seed 索引（单一真源，指向 tests/ fixture，不复制脚本） |

## 验证

- ✅ 新集成测试 **4 passed**（`test_mf01_*` / `test_mf02_*`，asyncio + trio 各一）—— current SDK 无需改码即通过，证明「可注册形状」有效。
- ✅ 新文件 `py_compile` 通过、`ruff check` All passed、`ruff format` clean。

## 与 Rust SDK 的一致性

两端参照同一标准：provider 侧适配到可注册形状，SDK 侧零 src 改动 + 仅新增测试守护契约；同一 fixture 形状、同一断言（`get_skills()` 收集 `mcp:fastmcp-skill-test:fastmcp-demo`）、同一 CLI 局限说明。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[AS-40]: https://turingfocus.atlassian.net/browse/AS-40?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ