### PR TITLE
feat(auth)!: AS-38 连接面鉴权迁移至 Socket.IO auth dict（字段 token，退役 HTTP-header 鉴权）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,40 @@ and this project adheres to [PEP 440](https://peps.python.org/pep-0440/) version
 > `0.2.0` is performed separately at release cut. Tracking issue:
 > [#8](https://github.com/A2C-SMCP/python-sdk/issues/8).
 
+### Breaking Changes
+- **Connection-plane auth moved from HTTP header to the Socket.IO `auth` dict**
+  (#112 / Jira AS-38; Epic TFRM-153). A2C-SMCP is auth-agnostic — **no protocol
+  change**; `token` is an SDK/deployment convention aligned with rust-sdk /
+  tfrobot-client / TFRS Provider. The credential now travels in the connection
+  `auth` dict's `token` field; **HTTP headers no longer authenticate** (routing
+  headers such as `X-TF-*` are still passed through, unrelated to auth). This
+  **supersedes** the [0.1.5a1] `x-api-key`→`access_token` header default.
+  - Constant `DEFAULT_AUTH_HEADER_NAME` → **`DEFAULT_AUTH_FIELD_NAME`** (default
+    value `access_token` → **`token`**) in `a2c_smcp.agent` and `a2c_smcp.server`;
+    **removed** from `a2c_smcp.computer` (the Computer client holds no credential).
+  - `DefaultAgentAuthProvider`: kwarg `api_key_header=` → **`auth_field_name=`**;
+    `api_key` is now injected into the connection `auth` dict under `auth_field_name`
+    (default `token`) and merged with `auth_data`; `get_connection_headers()` returns
+    routing-only headers (no credential).
+  - `DefaultAuthenticationProvider` / `DefaultSyncAuthenticationProvider`:
+    `authenticate()` reads the credential from the connection `auth` dict
+    (`api_key_name`, default `token`) instead of HTTP headers; auth failure rejects
+    the connection (`ConnectionRefusedError`).
+  - `a2c_smcp.computer.SMCPComputerClient`: **removed** the `auth_header_name=`
+    constructor kwarg and the `auth_header_name` property. The connection `auth`
+    dict is supplied by the caller via `connect(url, auth=...)` (CLI injects via
+    `--auth 'token:...'`).
+  - **Migration**: put the credential in the connection `auth` dict under `token`
+    — Agent: `DefaultAgentAuthProvider(api_key=...)`; Computer CLI: `--auth 'token:...'`.
+    To keep a custom field name, pass `auth_field_name=` (Agent) / `api_key_name=`
+    (Server). JWKS/JWT verification is performed by the Server's custom
+    `AuthenticationProvider` (e.g. TFRS), not by the SDK default provider.
+  - Added `smcp.ConnectAuth` TypedDict (`role` required + `token` `NotRequired`) as a
+    protocol-reference type. Note: default providers do **not** inject `role` at
+    connect (role is established via `EnterOfficeReq`/`join_office`, consistent with
+    rust-sdk); full role-at-connect wiring is a pre-existing protocol-vs-impl
+    divergence deferred to a separate protocol-first effort.
+
 ### Added
 - **Connection protocol-version handshake** (#17 / #18). Clients (Agent + Computer,
   async + sync) auto-append `a2c_version` to the Socket.IO connect URL query;

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,22 @@ Socket.IO 事件遵循以下前缀：
 - **DPE 已整体移除**: A2C-SMCP 控制面不再涉及 `client:get_dpe` / `dpe://` 解析；DPE 迁出至独立
   [dpe-protocol](https://github.com/A2C-SMCP/dpe-protocol) 仓库。修改时勿重新引入 DPE 事件/类型。
 
+### 连接面鉴权字段契约 (#112 / AS-38，Epic TFRM-153)
+
+**连接面鉴权统一走 Socket.IO CONNECT `auth` dict，凭据字段名 = `token`**（A2C-SMCP auth-agnostic，
+**无协议规范变更**——`token` 为 SDK/部署约定，与 rust-sdk / tfrobot-client / TFRS Provider 四处对齐）。
+HTTP header **不再参与连接面鉴权**（路由 header 如 `X-TF-*` 仍由传输层透传，与鉴权无关）：
+
+- 客户端：`DefaultAgentAuthProvider(api_key=...)` 把凭据注入 `auth` dict 的 `token` 字段
+  （`auth_field_name` 可覆盖）；`get_connection_headers()` 仅承载路由 header。Computer 经 CLI `--auth 'token:...'` 注入。
+- Server：`DefaultAuthenticationProvider`（含同步版）从 `auth` dict 读 `api_key_name`（默认 `token`）；
+  鉴权失败 `on_connect` 抛 `ConnectionRefusedError` 真正拒连。**JWT 仅 TFRobotServer 后端验签**，SDK 只携带——
+  JWKS 验签由 TFRS 自定义 `AuthenticationProvider` 子类实现（抽象 `authenticate(..., auth, ...)` 已透传 auth dict）。
+- 类型：`smcp.ConnectAuth`（`role` 必需 + `token` NotRequired，为协议参考类型——默认 provider 不在连接注入
+  `role`，`role` 经 `join_office` 建立，与 rust-sdk 一致）；常量 `DEFAULT_AUTH_FIELD_NAME = "token"`
+  （server / agent 两处；computer 客户端不持凭据，不再定义该常量）。
+- 范围外（Phase 2 协议先行）：事件级 `authorize_event` hook + claims 入 session。
+
 ## 测试结构
 
 测试目录结构与 `a2c_smcp/` 源码结构保持一致：

--- a/a2c_smcp/agent/__init__.py
+++ b/a2c_smcp/agent/__init__.py
@@ -13,7 +13,7 @@ A2C-SMCP Agent module
 Provides Agent-side SMCP protocol client implementation, including both synchronous and asynchronous modes
 """
 
-from a2c_smcp.agent.auth import DEFAULT_AUTH_HEADER_NAME, AgentAuthProvider, DefaultAgentAuthProvider
+from a2c_smcp.agent.auth import DEFAULT_AUTH_FIELD_NAME, AgentAuthProvider, DefaultAgentAuthProvider
 from a2c_smcp.agent.base import BaseAgentClient
 from a2c_smcp.agent.client import AsyncSMCPAgentClient
 from a2c_smcp.agent.errors import SMCPProtocolError
@@ -34,7 +34,7 @@ from a2c_smcp.agent.types import (
 
 __all__ = [
     # 常量 / Constants
-    "DEFAULT_AUTH_HEADER_NAME",
+    "DEFAULT_AUTH_FIELD_NAME",
     # 认证相关 / Authentication related
     "AgentAuthProvider",
     "DefaultAgentAuthProvider",

--- a/a2c_smcp/agent/auth.py
+++ b/a2c_smcp/agent/auth.py
@@ -13,9 +13,13 @@ from typing import Any
 
 from a2c_smcp.agent.types import AgentConfig
 
-# 默认鉴权 HTTP header 名（SDK 侧默认，可由调用方覆盖）
-# Default auth HTTP header name for the SDK (consumers may override)
-DEFAULT_AUTH_HEADER_NAME = "access_token"
+# 默认鉴权字段名（Socket.IO CONNECT ``auth`` dict 内的键）/ Default auth field name within the
+# Socket.IO CONNECT ``auth`` dict.
+#
+# #112(AS-38)：连接面鉴权统一走 Socket.IO ``auth`` dict（不再用 HTTP header）。A2C-SMCP auth-agnostic，
+# 默认 ``token``（对齐 server 默认与 TFRS token-exchange 契约），可由调用方覆盖。
+# #112(AS-38): connection auth lives in the Socket.IO ``auth`` dict (no HTTP header); defaults to ``token``.
+DEFAULT_AUTH_FIELD_NAME = "token"
 
 
 class AgentAuthProvider(ABC):
@@ -80,7 +84,7 @@ class DefaultAgentAuthProvider(AgentAuthProvider):
         agent_id: str,
         office_id: str,
         api_key: str | None = None,
-        api_key_header: str = DEFAULT_AUTH_HEADER_NAME,
+        auth_field_name: str = DEFAULT_AUTH_FIELD_NAME,
         extra_headers: dict[str, str] | None = None,
         auth_data: dict[str, Any] | None = None,
     ) -> None:
@@ -91,15 +95,20 @@ class DefaultAgentAuthProvider(AgentAuthProvider):
         Args:
             agent_id (str): Agent唯一标识 / Agent unique identifier
             office_id (str): 办公室ID / Office ID
-            api_key (str | None): API密钥 / API key
-            api_key_header (str): API密钥请求头名称 / API key header name
-            extra_headers (dict[str, str] | None): 额外请求头 / Extra headers
-            auth_data (dict[str, Any] | None): 额外认证数据 / Extra auth data
+            api_key (str | None): API密钥；#112(AS-38) 注入 Socket.IO ``auth`` dict 的 ``auth_field_name``
+                字段（默认 ``token``）/ API key; injected into the Socket.IO ``auth`` dict under
+                ``auth_field_name`` (default ``token``)
+            auth_field_name (str): auth dict 内密钥字段名，默认 ``token`` / Key field name within the
+                ``auth`` dict, defaults to ``token``
+            extra_headers (dict[str, str] | None): 额外（路由）请求头，#112(AS-38) 起不再承载鉴权凭据 /
+                Extra (routing) headers; no longer carry auth credentials since #112(AS-38)
+            auth_data (dict[str, Any] | None): 额外认证数据，与 api_key 合并进 ``auth`` dict /
+                Extra auth data, merged with api_key into the ``auth`` dict
         """
         self._agent_id = agent_id
         self._office_id = office_id
         self._api_key = api_key
-        self._api_key_header = api_key_header
+        self._auth_field_name = auth_field_name
         self._extra_headers = extra_headers or {}
         self._auth_data = auth_data or {}
 
@@ -112,26 +121,29 @@ class DefaultAgentAuthProvider(AgentAuthProvider):
 
     def get_connection_auth(self) -> dict[str, Any] | None:
         """
-        获取连接认证信息
-        Get connection authentication info
+        获取连接认证信息（Socket.IO ``auth`` dict）
+        Get connection authentication info (Socket.IO ``auth`` dict)
+
+        #112(AS-38)：连接面鉴权走 ``auth`` dict —— 把 ``api_key`` 注入 ``auth_field_name`` 字段
+        （默认 ``token``），并与用户传入的 ``auth_data`` 合并。无任何字段时返回 ``None``。
+        #112(AS-38): connection auth lives in the ``auth`` dict — the api_key is injected under
+        ``auth_field_name`` (default ``token``) and merged with the user-supplied ``auth_data``.
         """
-        if not self._auth_data:
-            return None
-        return self._auth_data.copy()
+        auth: dict[str, Any] = self._auth_data.copy()
+
+        # 把 API 密钥注入 auth dict（默认字段 token）
+        # Inject the API key into the auth dict (default field token)
+        if self._api_key:
+            auth[self._auth_field_name] = self._api_key
+
+        return auth or None
 
     def get_connection_headers(self) -> dict[str, str]:
         """
-        获取连接请求头
-        Get connection headers
+        获取连接请求头（仅路由，#112(AS-38) 起不再承载鉴权凭据）
+        Get connection (routing-only) headers; no auth credentials since #112(AS-38)
         """
-        headers = self._extra_headers.copy()
-
-        # 添加API密钥到请求头
-        # Add API key to headers
-        if self._api_key:
-            headers[self._api_key_header] = self._api_key
-
-        return headers
+        return self._extra_headers.copy()
 
     def get_agent_config(self) -> AgentConfig:
         """

--- a/a2c_smcp/computer/__init__.py
+++ b/a2c_smcp/computer/__init__.py
@@ -5,6 +5,6 @@
 # @Email   : jqq1716@gmail.com
 # @Software: PyCharm
 from a2c_smcp.computer.computer import Computer
-from a2c_smcp.computer.socketio.client import DEFAULT_AUTH_HEADER_NAME, SMCPComputerClient
+from a2c_smcp.computer.socketio.client import SMCPComputerClient
 
-__all__ = ["DEFAULT_AUTH_HEADER_NAME", "Computer", "SMCPComputerClient"]
+__all__ = ["Computer", "SMCPComputerClient"]

--- a/a2c_smcp/computer/socketio/client.py
+++ b/a2c_smcp/computer/socketio/client.py
@@ -80,10 +80,6 @@ from a2c_smcp.utils.logger import get_logger
 
 logger = get_logger(__name__)
 
-# 默认鉴权 HTTP header 名（SDK 侧默认，可由调用方覆盖）
-# Default auth HTTP header name for the SDK (consumers may override)
-DEFAULT_AUTH_HEADER_NAME = "access_token"
-
 
 def _to_a2c_resource(res: Resource) -> A2CResource:
     """
@@ -136,7 +132,6 @@ class SMCPComputerClient(AsyncClient):
         *args: Any,
         computer: Computer,
         namespace: str = SMCP_NAMESPACE,
-        auth_header_name: str = DEFAULT_AUTH_HEADER_NAME,
         **kwargs: Any,
     ) -> None:  # noqa: E112
         """
@@ -146,16 +141,17 @@ class SMCPComputerClient(AsyncClient):
         Args:
             computer (Computer): 绑定的Computer实例 / Bound Computer instance
             namespace (str): Socket.IO命名空间，默认 ``/smcp`` / Socket.IO namespace, default ``/smcp``
-            auth_header_name (str): 鉴权 HTTP header 名，默认 ``access_token``。
-                连接时若通过 headers 传入该字段，将作为鉴权凭据转发给 Server。/
-                Auth HTTP header name, default ``access_token``. When present in headers at connect time,
-                it is forwarded as credential to the Server.
+
+        Note:
+            #112(AS-38)：连接面鉴权走 Socket.IO ``auth`` dict（字段 ``token``）。Computer 侧的 ``auth`` dict
+            由调用方在 ``connect(url, auth=...)`` 时提供（CLI 经 ``--auth`` 注入），本客户端不持有凭据、
+            不构造 ``auth``。/ The connection ``auth`` dict (field ``token``) is supplied by the caller at
+            ``connect(url, auth=...)`` (CLI injects via ``--auth``); this client holds no credential.
         """
         super().__init__(*args, **kwargs)
         self.computer = computer
         # 实例级握手配置 / Per-instance handshake config
         self._namespace = namespace
-        self._auth_header_name = auth_header_name
         # 将客户端以 weakref 方式绑定回 Computer，避免循环强引用
         self.computer.socketio_client = self
         self.on(TOOL_CALL_EVENT, self.on_tool_call, namespace=self._namespace)
@@ -179,14 +175,6 @@ class SMCPComputerClient(AsyncClient):
         Return the Socket.IO namespace used by this instance
         """
         return self._namespace
-
-    @property
-    def auth_header_name(self) -> str:
-        """
-        返回当前实例使用的鉴权 HTTP header 名
-        Return the auth HTTP header name used by this instance
-        """
-        return self._auth_header_name
 
     async def connect(self, url: str, *args: Any, **kwargs: Any) -> None:
         """

--- a/a2c_smcp/server/__init__.py
+++ b/a2c_smcp/server/__init__.py
@@ -8,7 +8,7 @@
 * 描述: A2C-SMCP Server模块导出 / A2C-SMCP Server module exports
 """
 
-from .auth import DEFAULT_AUTH_HEADER_NAME, AuthenticationProvider, DefaultAuthenticationProvider
+from .auth import DEFAULT_AUTH_FIELD_NAME, AuthenticationProvider, DefaultAuthenticationProvider
 from .base import BaseNamespace
 from .middleware import (
     DEFAULT_SOCKETIO_PATH,
@@ -29,7 +29,7 @@ from .utils import (
 
 __all__ = [
     # 常量 / Constants
-    "DEFAULT_AUTH_HEADER_NAME",
+    "DEFAULT_AUTH_FIELD_NAME",
     # 认证相关 / Authentication related
     "AuthenticationProvider",
     "DefaultAuthenticationProvider",

--- a/a2c_smcp/server/auth.py
+++ b/a2c_smcp/server/auth.py
@@ -12,9 +12,14 @@ from abc import ABC, abstractmethod
 
 from socketio import AsyncServer
 
-# 默认鉴权 HTTP header 名（SDK 侧默认，可由调用方覆盖）
-# Default auth HTTP header name for the SDK (consumers may override)
-DEFAULT_AUTH_HEADER_NAME = "access_token"
+# 默认鉴权字段名（Socket.IO CONNECT ``auth`` dict 内的键）/ Default auth field name within the
+# Socket.IO CONNECT ``auth`` dict.
+#
+# #112(AS-38)：连接面鉴权统一走 Socket.IO ``auth`` dict（不再用 HTTP header）。A2C-SMCP 协议
+# auth-agnostic，部署方可显式覆盖 ``api_key_name``；默认 ``token``，对齐 client 侧 auth dict 注入与
+# TuringFocus/TFRS token-exchange 契约（Epic TFRM-153）。
+# #112(AS-38): connection auth lives in the Socket.IO ``auth`` dict (no HTTP header); defaults to ``token``.
+DEFAULT_AUTH_FIELD_NAME = "token"
 
 
 class AuthenticationProvider(ABC):
@@ -47,34 +52,31 @@ class DefaultAuthenticationProvider(AuthenticationProvider):
     Default authentication provider, provides basic authentication logic implementation
     """
 
-    def __init__(self, admin_secret: str | None = None, api_key_name: str = DEFAULT_AUTH_HEADER_NAME) -> None:
+    def __init__(self, admin_secret: str | None = None, api_key_name: str = DEFAULT_AUTH_FIELD_NAME) -> None:
         """
         初始化默认认证提供者
         Initialize default authentication provider
 
         Args:
             admin_secret (str | None): 管理员密钥 / Admin secret
-            api_key_name (str): API密钥字段名 / API key field name
+            api_key_name (str): auth dict 内密钥字段名，默认 ``token`` / Key field name within the
+                Socket.IO CONNECT ``auth`` dict, defaults to ``token``
         """
         self.admin_secret = admin_secret
         self.api_key_name = api_key_name
 
     async def authenticate(self, sio: AsyncServer, environ: dict, auth: dict | None, headers: list) -> bool:
         """
-        默认认证逻辑：从headers中提取API密钥进行认证
-        Default authentication logic: extract API key from headers for authentication
-        """
-        # 从headers中提取API密钥
-        # Extract API key from headers
-        api_key = None
-        for header in headers:
-            if isinstance(header, (list, tuple)) and len(header) >= 2:
-                header_name = header[0].decode("utf-8").lower() if isinstance(header[0], bytes) else str(header[0]).lower()
-                header_value = header[1].decode("utf-8") if isinstance(header[1], bytes) else str(header[1])
+        默认认证逻辑：从 Socket.IO CONNECT ``auth`` dict 提取密钥进行认证。
+        Default authentication logic: extract the API key from the Socket.IO CONNECT ``auth`` dict.
 
-                if header_name == self.api_key_name.lower():
-                    api_key = header_value
-                    break
+        #112(AS-38)：连接面鉴权走 ``auth`` dict（字段 ``api_key_name``，默认 ``token``）；HTTP header 不再
+        参与鉴权（路由 header 仍由传输层透传，与鉴权无关）。
+        #112(AS-38): connection auth reads the ``auth`` dict; HTTP headers no longer authenticate.
+        """
+        # 从 auth dict 提取密钥（字段 api_key_name，默认 token）
+        # Extract the API key from the auth dict (field api_key_name, default token)
+        api_key = auth.get(self.api_key_name) if isinstance(auth, dict) else None
 
         if not api_key:
             return False

--- a/a2c_smcp/server/sync_auth.py
+++ b/a2c_smcp/server/sync_auth.py
@@ -12,7 +12,7 @@ from abc import ABC, abstractmethod
 
 from socketio import Server
 
-from a2c_smcp.server.auth import DEFAULT_AUTH_HEADER_NAME
+from a2c_smcp.server.auth import DEFAULT_AUTH_FIELD_NAME
 
 
 class SyncAuthenticationProvider(ABC):
@@ -45,33 +45,31 @@ class DefaultSyncAuthenticationProvider(SyncAuthenticationProvider):
     Default sync authentication provider
     """
 
-    def __init__(self, admin_secret: str | None = None, api_key_name: str = DEFAULT_AUTH_HEADER_NAME) -> None:
+    def __init__(self, admin_secret: str | None = None, api_key_name: str = DEFAULT_AUTH_FIELD_NAME) -> None:
         """
         初始化默认同步认证提供者
         Initialize default sync authentication provider
 
         Args:
             admin_secret (str | None): 管理员密钥 / Admin secret
-            api_key_name (str): API密钥字段名 / API key field name
+            api_key_name (str): auth dict 内密钥字段名，默认 ``token`` / Key field name within the
+                Socket.IO CONNECT ``auth`` dict, defaults to ``token``
         """
         self.admin_secret = admin_secret
         self.api_key_name = api_key_name
 
     def authenticate(self, sio: Server, environ: dict, auth: dict | None, headers: list) -> bool:
         """
-        默认认证逻辑：从headers中提取API密钥进行认证
-        Default authentication logic: extract API key from headers for authentication
+        默认认证逻辑：从 Socket.IO CONNECT ``auth`` dict 提取密钥进行认证。
+        Default authentication logic: extract the API key from the Socket.IO CONNECT ``auth`` dict.
+
+        #112(AS-38)：连接面鉴权走 ``auth`` dict（字段 ``api_key_name``，默认 ``token``）；HTTP header 不再
+        参与鉴权（路由 header 仍由传输层透传，与鉴权无关）。
+        #112(AS-38): connection auth reads the ``auth`` dict; HTTP headers no longer authenticate.
         """
-        # 从headers中提取API密钥
-        # Extract API key from headers
-        api_key = None
-        for header in headers:
-            if isinstance(header, (list, tuple)) and len(header) >= 2:
-                header_name = header[0].decode("utf-8").lower() if isinstance(header[0], bytes) else str(header[0]).lower()
-                header_value = header[1].decode("utf-8") if isinstance(header[1], bytes) else str(header[1])
-                if header_name == self.api_key_name.lower():
-                    api_key = header_value
-                    break
+        # 从 auth dict 提取密钥（字段 api_key_name，默认 token）
+        # Extract the API key from the auth dict (field api_key_name, default token)
+        api_key = auth.get(self.api_key_name) if isinstance(auth, dict) else None
         if not api_key:
             return False
 

--- a/a2c_smcp/smcp.py
+++ b/a2c_smcp/smcp.py
@@ -93,6 +93,32 @@ class GetToolsRet(TypedDict):
     req_id: str
 
 
+class ConnectAuth(TypedDict):
+    """
+    中文: Socket.IO 连接握手阶段的 ``auth`` 对象（业务层）。协议唯一规范要求是 ``role``；其余字段
+        （如 ``token``）是否存在、如何校验由业务层（Server 实现方）自决。
+        #112(AS-38)：连接面鉴权凭据统一走 ``token`` 字段（SDK / 部署约定，与 rust-sdk / tfrobot-client /
+        TFRS Provider 四处对齐，Epic TFRM-153）；JWT 仅 TFRobotServer 后端验签，SDK 只负责携带。
+    英文: The Socket.IO handshake ``auth`` object (business layer). The only protocol requirement is
+        ``role``; other fields (e.g. ``token``) are business-defined. Since #112(AS-38) the
+        connection-auth credential travels in the ``token`` field (SDK / deployment convention).
+    协议依据 / Protocol: a2c-smcp-protocol data-structures.md#auth-对象业务层connectauth。
+
+    !!! note "role 字段的接线现状（#112/AS-38 范围说明）"
+        本类型忠实镜像协议文档（``role`` 标为 MUST）。但 SDK 默认 provider **不在连接 ``auth`` 注入 role**：
+        ``DefaultAgentAuthProvider.get_connection_auth()`` 仅产出 ``{token: ...}``，Computer 经 CLI ``--auth``
+        注入的也只有 ``token``；服务端 role 仍经 ``EnterOfficeReq`` / ``join_office`` 建立（与 rust-sdk 行为一致）。
+        因此 ``ConnectAuth`` 在 SDK 内是**协议参考类型**，``get_connection_auth()`` 返回裸 ``dict``、不以此为标注。
+        「role-at-connect 全面接线」是既有的协议文档-实现分歧（全生态未实现），非本次范围，留待独立 protocol-first 对齐。
+        The default providers do NOT inject ``role`` at connect (consistent with rust-sdk); role is
+        established via ``EnterOfficeReq`` / ``join_office``. Full role-at-connect wiring is a pre-existing
+        protocol-vs-impl divergence deferred to a separate protocol-first effort.
+    """
+
+    role: Literal["computer", "agent"]  # 协议 MUST：客户端角色 / protocol MUST: client role
+    token: NotRequired[str]  # #112(AS-38) 连接面鉴权凭据字段 / connection-auth credential field
+
+
 class EnterOfficeReq(TypedDict):
     role: Literal["computer", "agent"]
     name: str

--- a/docs/guides/agent-guide.md
+++ b/docs/guides/agent-guide.md
@@ -78,15 +78,17 @@ from a2c_smcp.agent import DefaultAgentAuthProvider
 auth = DefaultAgentAuthProvider(
     agent_id="my_agent",           # Agent 唯一标识
     office_id="my_office",         # 房间 ID
-    api_key="your_api_key",        # API 密钥
-    api_key_header="x-api-key",    # API 密钥请求头名称
-    extra_headers={                # 额外请求头
+    api_key="your_api_key",        # 凭据：注入 Socket.IO 连接 auth dict 的 token 字段（#112 / AS-38）
+    auth_field_name="token",       # auth dict 内凭据字段名（默认 token，可覆盖）
+    extra_headers={                # 额外路由请求头（非鉴权；不再承载凭据）
         "User-Agent": "MyAgent/1.0"
     },
-    auth_data={                    # 额外认证数据
-        "token": "auth_token"
+    auth_data={                    # 额外业务认证数据，与 api_key 合并进 auth dict
+        "tenant_id": "t1"
     }
 )
+# 上述配置产生的连接 auth dict：{"tenant_id": "t1", "token": "your_api_key"}
+# 连接面鉴权统一走 auth dict（HTTP header 不再参与鉴权）
 ```
 
 ### 自定义认证提供者

--- a/tests/integration_tests/agent/test_auth.py
+++ b/tests/integration_tests/agent/test_auth.py
@@ -7,6 +7,9 @@
 """
 中文：Agent 认证提供者（AgentAuthProvider）的集成测试。
 English: Integration tests for AgentAuthProvider.
+
+#112(AS-38)：连接面鉴权改走 Socket.IO ``auth`` dict（字段默认 ``token``）；api_key 注入 auth dict、
+不再进 HTTP header；header 仅承载路由。
 """
 
 from a2c_smcp.agent.auth import DefaultAgentAuthProvider
@@ -15,8 +18,8 @@ from a2c_smcp.agent.types import AgentConfig
 
 def test_default_agent_auth_provider_basic():
     """
-    中文：验证默认认证提供者的基本功能。
-    English: Verify basic functionality of DefaultAgentAuthProvider.
+    中文：验证默认认证提供者的基本功能（api_key 进 auth dict token 字段）。
+    English: Verify basic functionality of DefaultAgentAuthProvider (api_key → auth dict token field).
     """
     agent_id = "test-agent-123"
     office_id = "test-office-456"
@@ -31,13 +34,13 @@ def test_default_agent_auth_provider_basic():
     # 验证 agent_id
     assert auth.get_agent_id() == agent_id
 
-    # 验证连接认证信息
+    # #112(AS-38)：api_key 进 auth dict 的 token 字段
     auth_data = auth.get_connection_auth()
-    assert auth_data is None  # 默认无额外认证数据
+    assert auth_data == {"token": api_key}
 
-    # 验证连接请求头
+    # #112(AS-38)：header 仅承载路由，不含凭据
     headers = auth.get_connection_headers()
-    assert headers["access_token"] == api_key
+    assert headers == {}
 
     # 验证 Agent 配置
     config = auth.get_agent_config()
@@ -47,15 +50,15 @@ def test_default_agent_auth_provider_basic():
 
 def test_default_agent_auth_provider_with_custom_headers():
     """
-    中文：验证默认认证提供者支持自定义请求头。
-    English: Verify DefaultAgentAuthProvider supports custom headers.
+    中文：验证默认认证提供者支持自定义（路由）请求头，且凭据走 auth dict 而非 header。
+    English: Verify custom (routing) headers are supported while credential goes to the auth dict.
     """
     agent_id = "test-agent-custom"
     office_id = "test-office-custom"
     api_key = "custom-api-key"
     extra_headers = {
         "X-Custom-Header": "custom-value",
-        "Authorization": "Bearer token123",
+        "X-TF-Route": "route-1",
     }
 
     auth = DefaultAgentAuthProvider(
@@ -65,44 +68,44 @@ def test_default_agent_auth_provider_with_custom_headers():
         extra_headers=extra_headers,
     )
 
+    # #112(AS-38)：凭据在 auth dict
+    assert auth.get_connection_auth() == {"token": api_key}
+
+    # header 仅承载路由头，且不含凭据
     headers = auth.get_connection_headers()
-
-    # 验证 API 密钥头
-    assert headers["access_token"] == api_key
-
-    # 验证自定义头
-    assert headers["X-Custom-Header"] == "custom-value"
-    assert headers["Authorization"] == "Bearer token123"
+    assert headers == extra_headers
+    assert "access_token" not in headers
+    assert api_key not in headers.values()
 
 
-def test_default_agent_auth_provider_with_custom_api_key_header():
+def test_default_agent_auth_provider_with_custom_field_name():
     """
-    中文：验证默认认证提供者支持自定义 API 密钥请求头名称。
-    English: Verify DefaultAgentAuthProvider supports custom API key header name.
+    中文：验证默认认证提供者支持自定义 auth dict 密钥字段名。
+    English: Verify DefaultAgentAuthProvider supports a custom auth-dict field name.
     """
     agent_id = "test-agent-header"
     office_id = "test-office-header"
-    api_key = "header-api-key"
-    custom_header_name = "X-API-TOKEN"
+    api_key = "field-api-key"
+    custom_field_name = "x-api-token"
 
     auth = DefaultAgentAuthProvider(
         agent_id=agent_id,
         office_id=office_id,
         api_key=api_key,
-        api_key_header=custom_header_name,
+        auth_field_name=custom_field_name,
     )
 
-    headers = auth.get_connection_headers()
-
-    # 验证使用自定义头名称
-    assert headers[custom_header_name] == api_key
-    assert "access_token" not in headers
+    connection_auth = auth.get_connection_auth()
+    assert connection_auth is not None
+    assert connection_auth == {custom_field_name: api_key}
+    assert "token" not in connection_auth
+    assert auth.get_connection_headers() == {}
 
 
 def test_default_agent_auth_provider_with_auth_data():
     """
-    中文：验证默认认证提供者支持额外认证数据。
-    English: Verify DefaultAgentAuthProvider supports extra auth data.
+    中文：验证默认认证提供者支持额外认证数据（无 api_key 时原样承载）。
+    English: Verify DefaultAgentAuthProvider supports extra auth data (carried as-is without api_key).
     """
     agent_id = "test-agent-auth"
     office_id = "test-office-auth"
@@ -121,6 +124,7 @@ def test_default_agent_auth_provider_with_auth_data():
     connection_auth = auth.get_connection_auth()
 
     # 验证认证数据
+    assert connection_auth is not None
     assert connection_auth == auth_data
     assert connection_auth["username"] == "testuser"
     assert connection_auth["password"] == "testpass"
@@ -141,9 +145,9 @@ def test_default_agent_auth_provider_no_api_key():
         # 不提供 api_key
     )
 
+    # 无 api_key、无 auth_data → auth dict 为 None，header 为空
+    assert auth.get_connection_auth() is None
     headers = auth.get_connection_headers()
-
-    # 验证没有 API 密钥头
     assert "access_token" not in headers
     assert len(headers) == 0
 

--- a/tests/integration_tests/server/test_auth_connection.py
+++ b/tests/integration_tests/server/test_auth_connection.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+"""
+中文：#112(AS-38) 连接面鉴权端到端契约集成测试。
+English: #112(AS-38) connection-auth end-to-end contract integration test.
+
+对标 rust-sdk ``crates/smcp-server-core/tests/auth_connection_test.rs`` /
+``crates/smcp-computer/tests/auth_dict_injection_test.rs``：
+
+验证 **客户端 AuthProvider 注入的 auth dict** 恰好能被 **服务端 on_connect → Default provider** 验签通过，
+即四处对齐的 ``token`` 字段契约在 SDK 内端到端闭环（client 产出 → server 消费）。HTTP header 不再参与鉴权。
+"""
+
+from __future__ import annotations
+
+import pytest
+from socketio import AsyncServer, Server
+
+from a2c_smcp.agent.auth import DefaultAgentAuthProvider
+from a2c_smcp.server.auth import DefaultAuthenticationProvider
+from a2c_smcp.server.namespace import SMCPNamespace
+from a2c_smcp.server.sync_auth import DefaultSyncAuthenticationProvider
+from a2c_smcp.server.sync_namespace import SyncSMCPNamespace
+
+SHARED_SECRET = "shared-secret-123"
+
+
+def _client_auth_dict(api_key: str | None) -> dict | None:
+    """客户端 AuthProvider 实际产出的 auth dict / the auth dict actually produced by the client provider."""
+    return DefaultAgentAuthProvider(agent_id="agent-1", office_id="office-1", api_key=api_key).get_connection_auth()
+
+
+@pytest.mark.asyncio
+async def test_async_client_auth_dict_round_trips_to_server_accept_reject() -> None:
+    # 客户端注入凭据 → auth dict 字段名恰为 token / client injects credential under the token field
+    auth = _client_auth_dict(SHARED_SECRET)
+    assert auth == {"token": SHARED_SECRET}
+
+    sio = AsyncServer(async_mode="asgi")
+    ns = SMCPNamespace(auth_provider=DefaultAuthenticationProvider(SHARED_SECRET))
+    sio.register_namespace(ns)
+
+    # 客户端真实产出的 auth dict 被服务端接受 / the client-produced auth dict is accepted
+    assert await ns.on_connect("sid-ok", {}, auth) is True
+
+    # 错误凭据 / 缺失 auth dict / 旧 header 路径 → 拒连
+    with pytest.raises(ConnectionRefusedError):
+        await ns.on_connect("sid-wrong", {}, {"token": "nope"})
+    with pytest.raises(ConnectionRefusedError):
+        await ns.on_connect("sid-none", {}, None)
+    with pytest.raises(ConnectionRefusedError):
+        await ns.on_connect("sid-header", {"asgi.scope": {"headers": [(b"access_token", SHARED_SECRET.encode())]}}, None)
+
+
+def test_sync_client_auth_dict_round_trips_to_server_accept_reject() -> None:
+    auth = _client_auth_dict(SHARED_SECRET)
+    assert auth == {"token": SHARED_SECRET}
+
+    sio = Server()
+    ns = SyncSMCPNamespace(auth_provider=DefaultSyncAuthenticationProvider(SHARED_SECRET))
+    sio.register_namespace(ns)
+
+    assert ns.on_connect("sid-ok", {}, auth) is True
+
+    with pytest.raises(ConnectionRefusedError):
+        ns.on_connect("sid-wrong", {}, {"token": "nope"})
+    with pytest.raises(ConnectionRefusedError):
+        ns.on_connect("sid-none", {}, None)
+    with pytest.raises(ConnectionRefusedError):
+        ns.on_connect("sid-header", {"asgi.scope": {"headers": [(b"access_token", SHARED_SECRET.encode())]}}, None)
+
+
+def test_client_no_credential_yields_none_auth_rejected_by_server() -> None:
+    # 无凭据时客户端 auth dict 为 None；服务端据此拒连
+    assert _client_auth_dict(None) is None

--- a/tests/unit_tests/agent/test_auth.py
+++ b/tests/unit_tests/agent/test_auth.py
@@ -2,16 +2,24 @@
 * 文件名: test_auth
 * 作者: JQQ
 * 创建日期: 2025/9/30
-* 最后修改日期: 2025/9/30
+* 最后修改日期: 2026/6/19
 * 版权: 2023 JQQ. All rights reserved.
 * 依赖: pytest
 * 描述: Agent认证模块测试用例 / Agent authentication module test cases
+
+  #112(AS-38)：连接面鉴权改走 Socket.IO ``auth`` dict（字段默认 ``token``）；api_key 注入 auth dict、
+  不再进 HTTP header；header 仅承载路由。
 """
 
 import pytest
 
-from a2c_smcp.agent.auth import AgentAuthProvider, DefaultAgentAuthProvider
+from a2c_smcp.agent.auth import DEFAULT_AUTH_FIELD_NAME, AgentAuthProvider, DefaultAgentAuthProvider
 from a2c_smcp.agent.types import AgentConfig
+
+
+def test_default_auth_field_name_is_token() -> None:
+    """#112(AS-38)：默认鉴权字段名为 ``token`` / default auth field is ``token``."""
+    assert DEFAULT_AUTH_FIELD_NAME == "token"
 
 
 class TestAgentAuthProvider:
@@ -45,23 +53,22 @@ class TestDefaultAgentAuthProvider:
             agent_id="test_agent",
             office_id="test_office",
             api_key="test_key",
-            api_key_header="Authorization",
             extra_headers={"Custom-Header": "custom_value"},
-            auth_data={"token": "test_token"},
+            auth_data={"tenant_id": "t1"},
         )
 
         assert provider.get_agent_id() == "test_agent"
 
-        # 测试认证数据
-        # Test authentication data
+        # #112(AS-38)：api_key 注入 auth dict 的 token 字段，与 auth_data 合并
+        # api_key is injected into the auth dict's token field, merged with auth_data
         auth_data = provider.get_connection_auth()
-        assert auth_data == {"token": "test_token"}
+        assert auth_data == {"tenant_id": "t1", "token": "test_key"}
 
-        # 测试请求头
-        # Test headers
+        # #112(AS-38)：header 仅承载路由，不含 api_key
+        # headers carry routing only, no api_key
         headers = provider.get_connection_headers()
-        assert headers["Authorization"] == "test_key"
-        assert headers["Custom-Header"] == "custom_value"
+        assert headers == {"Custom-Header": "custom_value"}
+        assert "test_key" not in headers.values()
 
     def test_get_connection_auth_empty(self) -> None:
         """测试空认证数据 / Test empty authentication data"""
@@ -73,16 +80,29 @@ class TestDefaultAgentAuthProvider:
         auth_data = provider.get_connection_auth()
         assert auth_data is None
 
-    def test_get_connection_headers_with_api_key(self) -> None:
-        """测试带API密钥的请求头 / Test headers with API key"""
+    def test_api_key_injected_into_auth_dict_token(self) -> None:
+        """#112(AS-38)：仅 api_key 时 → auth dict 含 token / api_key only → auth dict has token."""
         provider = DefaultAgentAuthProvider(
             agent_id="test_agent",
             office_id="test_office",
             api_key="secret_key",
         )
 
+        assert provider.get_connection_auth() == {"token": "secret_key"}
+
+    def test_get_connection_headers_routing_only(self) -> None:
+        """#112(AS-38)：api_key 不再进 header，header 仅路由 / api_key never in headers."""
+        provider = DefaultAgentAuthProvider(
+            agent_id="test_agent",
+            office_id="test_office",
+            api_key="secret_key",
+            extra_headers={"X-TF-Route": "r1"},
+        )
+
         headers = provider.get_connection_headers()
-        assert headers["access_token"] == "secret_key"
+        assert headers == {"X-TF-Route": "r1"}
+        assert "access_token" not in headers
+        assert "secret_key" not in headers.values()
 
     def test_get_connection_headers_without_api_key(self) -> None:
         """测试不带API密钥的请求头 / Test headers without API key"""
@@ -92,7 +112,7 @@ class TestDefaultAgentAuthProvider:
         )
 
         headers = provider.get_connection_headers()
-        assert "access_token" not in headers
+        assert headers == {}
 
     def test_get_agent_config(self) -> None:
         """测试获取Agent配置 / Test get Agent configuration"""
@@ -108,15 +128,26 @@ class TestDefaultAgentAuthProvider:
         }
         assert config == expected_config
 
-    def test_custom_api_key_header(self) -> None:
-        """测试自定义API密钥请求头 / Test custom API key header"""
+    def test_custom_auth_field_name(self) -> None:
+        """测试自定义 auth dict 密钥字段名 / Test custom auth-dict field name"""
         provider = DefaultAgentAuthProvider(
             agent_id="test_agent",
             office_id="test_office",
             api_key="test_key",
-            api_key_header="X-Custom-Auth",
+            auth_field_name="x-custom-auth",
         )
 
-        headers = provider.get_connection_headers()
-        assert headers["X-Custom-Auth"] == "test_key"
-        assert "access_token" not in headers
+        assert provider.get_connection_auth() == {"x-custom-auth": "test_key"}
+        # 默认 token 字段在自定义字段名下不存在
+        assert provider.get_connection_headers() == {}
+
+    def test_api_key_overrides_auth_data_token(self) -> None:
+        """显式 api_key 在 token 字段上优先于 auth_data / explicit api_key wins on the token field."""
+        provider = DefaultAgentAuthProvider(
+            agent_id="test_agent",
+            office_id="test_office",
+            api_key="new_token",
+            auth_data={"token": "old_token", "tenant_id": "t1"},
+        )
+
+        assert provider.get_connection_auth() == {"token": "new_token", "tenant_id": "t1"}

--- a/tests/unit_tests/agent/test_handshake_config.py
+++ b/tests/unit_tests/agent/test_handshake_config.py
@@ -3,17 +3,19 @@
 中文：Agent 客户端握手配置测试（对齐 Rust handshake_config_test 精神）。
 English: Handshake config tests for the Agent-side client.
 
+#112(AS-38)：连接面鉴权改走 Socket.IO ``auth`` dict（字段默认 ``token``）；api_key 注入 auth dict、不再进 header。
+
 覆盖场景 / Covered scenarios:
-  1. ``DEFAULT_AUTH_HEADER_NAME`` 常量对外暴露为 ``access_token``
-  2. ``DefaultAgentAuthProvider`` 默认把 API key 写到 ``access_token`` header
-  3. 自定义 ``api_key_header`` 能覆盖默认名
+  1. ``DEFAULT_AUTH_FIELD_NAME`` 常量对外暴露为 ``token``
+  2. ``DefaultAgentAuthProvider`` 默认把 API key 注入 ``auth`` dict 的 ``token`` 字段（不进 header）
+  3. 自定义 ``auth_field_name`` 能覆盖默认名
   4. Async / Sync Agent 客户端默认 namespace 为 ``/smcp``，自定义 namespace 会贯穿事件注册
   5. getter 返回构造器传入的真实值
 """
 
 from __future__ import annotations
 
-from a2c_smcp.agent import DEFAULT_AUTH_HEADER_NAME, DefaultAgentAuthProvider
+from a2c_smcp.agent import DEFAULT_AUTH_FIELD_NAME, DefaultAgentAuthProvider
 from a2c_smcp.agent.client import AsyncSMCPAgentClient
 from a2c_smcp.agent.sync_client import SMCPAgentClient
 from a2c_smcp.smcp import (
@@ -34,36 +36,37 @@ EXPECTED_NOTIFY_EVENTS = {
 }
 
 
-def test_agent_default_auth_header_name_is_access_token() -> None:
-    """Agent 模块导出的默认 header 名为 ``access_token`` / exported default header is ``access_token``"""
-    assert DEFAULT_AUTH_HEADER_NAME == "access_token"
+def test_agent_default_auth_field_name_is_token() -> None:
+    """Agent 模块导出的默认鉴权字段名为 ``token`` / exported default auth field is ``token``"""
+    assert DEFAULT_AUTH_FIELD_NAME == "token"
 
 
-def test_default_agent_auth_provider_uses_access_token_by_default() -> None:
-    """``DefaultAgentAuthProvider`` 默认把 API key 写到 ``access_token`` header"""
+def test_default_agent_auth_provider_injects_token_by_default() -> None:
+    """``DefaultAgentAuthProvider`` 默认把 API key 注入 ``auth`` dict 的 ``token`` 字段（不进 header）"""
     provider = DefaultAgentAuthProvider(
         agent_id="agent-1",
         office_id="office-1",
         api_key="secret",
     )
 
-    headers = provider.get_connection_headers()
-    assert headers["access_token"] == "secret"
-    assert "x-api-key" not in headers
+    assert provider.get_connection_auth() == {"token": "secret"}
+    # api_key 不再进 header；header 仅承载路由
+    assert provider.get_connection_headers() == {}
 
 
-def test_default_agent_auth_provider_custom_header_overrides_default() -> None:
-    """自定义 ``api_key_header`` 能覆盖默认名 / custom api_key_header overrides the default"""
+def test_default_agent_auth_provider_custom_field_overrides_default() -> None:
+    """自定义 ``auth_field_name`` 能覆盖默认名 / custom auth_field_name overrides the default"""
     provider = DefaultAgentAuthProvider(
         agent_id="agent-2",
         office_id="office-2",
         api_key="secret",
-        api_key_header="x-tf-token",
+        auth_field_name="x-tf-token",
     )
 
-    headers = provider.get_connection_headers()
-    assert headers["x-tf-token"] == "secret"
-    assert "access_token" not in headers
+    connection_auth = provider.get_connection_auth()
+    assert connection_auth is not None
+    assert connection_auth == {"x-tf-token": "secret"}
+    assert "token" not in connection_auth
 
 
 def test_async_agent_client_default_namespace() -> None:

--- a/tests/unit_tests/computer/socketio/test_handshake_config.py
+++ b/tests/unit_tests/computer/socketio/test_handshake_config.py
@@ -1,14 +1,16 @@
 # -*- coding: utf-8 -*-
 """
-中文：Computer 客户端握手配置测试（对齐 Rust ``crates/smcp-computer/tests/handshake_config_test.rs``）。
-English: Handshake config tests for the Computer-side client (mirrors Rust SDK 0.1.15).
+中文：Computer 客户端握手配置测试（对齐 Rust ``crates/smcp-computer/tests/handshake_config_test.rs`` #86 变更）。
+English: Handshake config tests for the Computer-side client.
+
+#112(AS-38)：连接面鉴权改走 Socket.IO ``auth`` dict（字段 ``token``）。Computer 客户端**不持有凭据、
+不构造 auth**——auth dict 由调用方在 ``connect(url, auth=...)`` 提供（CLI 经 ``--auth`` 注入）。
+故本客户端不再有 ``auth_field_name``/header 鉴权配置项，仅保留 ``namespace`` 握手配置。
 
 覆盖场景 / Covered scenarios:
-  1. 默认鉴权 header 名为 ``access_token``
-  2. 自定义鉴权 header 名透传到 getter
-  3. 自定义 namespace 贯穿所有事件处理器注册
-  4. getter 返回构造器传入的真实值
-  5. 向后兼容：未显式指定时默认落在 ``/smcp`` 与 ``access_token``
+  1. 自定义 namespace 贯穿所有事件处理器注册
+  2. namespace getter 返回构造器传入的真实值
+  3. 未显式指定时默认落在 ``/smcp``
 """
 
 from __future__ import annotations
@@ -17,7 +19,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from a2c_smcp.computer.socketio.client import DEFAULT_AUTH_HEADER_NAME, SMCPComputerClient
+from a2c_smcp.computer.socketio.client import SMCPComputerClient
 from a2c_smcp.smcp import (
     CANCEL_TOOL_CALL_NOTIFICATION,
     GET_BLOB_EVENT,
@@ -32,28 +34,10 @@ from a2c_smcp.smcp import (
 )
 
 
-def test_default_auth_header_name_is_access_token() -> None:
-    """默认鉴权 header 名为 ``access_token`` / Default auth header is ``access_token``"""
-    assert DEFAULT_AUTH_HEADER_NAME == "access_token"
-
-
 def test_computer_client_default_handshake_config() -> None:
-    """未显式指定时，Computer 客户端应落在 ``/smcp`` 与 ``access_token`` / Defaults fall back to ``/smcp`` and ``access_token``"""
+    """未显式指定时，Computer 客户端默认 namespace 为 ``/smcp`` / default namespace is ``/smcp``"""
     client = SMCPComputerClient(computer=MagicMock())
 
-    assert client.namespace == SMCP_NAMESPACE
-    assert client.auth_header_name == "access_token"
-
-
-def test_computer_client_custom_auth_header_name() -> None:
-    """构造器传入的自定义 header 名应能从 getter 读回 / Custom header name is exposed via getter"""
-    client = SMCPComputerClient(
-        computer=MagicMock(),
-        auth_header_name="x-custom-auth",
-    )
-
-    assert client.auth_header_name == "x-custom-auth"
-    # 默认 namespace 不应被误改 / Namespace must stay on default when not overridden
     assert client.namespace == SMCP_NAMESPACE
 
 
@@ -109,14 +93,12 @@ async def test_computer_client_emit_uses_instance_namespace() -> None:
     assert captured["event"] == "server:some_event"
 
 
-def test_computer_client_full_custom_handshake() -> None:
-    """namespace + header 同时自定义时两者独立生效 / Custom namespace and header propagate independently"""
+def test_computer_client_custom_namespace_propagates() -> None:
+    """自定义 namespace 独立生效并贯穿处理器注册 / custom namespace propagates to handler registration"""
     client = SMCPComputerClient(
         computer=MagicMock(),
         namespace="/custom",
-        auth_header_name="x-tf-token",
     )
 
     assert client.namespace == "/custom"
-    assert client.auth_header_name == "x-tf-token"
     assert "/custom" in client.handlers

--- a/tests/unit_tests/server/test_auth.py
+++ b/tests/unit_tests/server/test_auth.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 """
 测试 a2c_smcp/server/auth.py
+
+#112(AS-38)：连接面鉴权改走 Socket.IO CONNECT ``auth`` dict（字段默认 ``token``），HTTP header 不再参与鉴权。
 """
 
 from __future__ import annotations
@@ -9,10 +11,15 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from a2c_smcp.server.auth import DefaultAuthenticationProvider
+from a2c_smcp.server.auth import DEFAULT_AUTH_FIELD_NAME, DefaultAuthenticationProvider
 
 # get_agent_id 方法已被移除，不再需要测试
 # get_agent_id method has been removed, no longer need to test
+
+
+def test_default_auth_field_name_is_token():
+    """#112(AS-38)：默认鉴权字段名为 auth dict 内的 ``token`` / default auth field is ``token``."""
+    assert DEFAULT_AUTH_FIELD_NAME == "token"
 
 
 @pytest.mark.asyncio
@@ -20,21 +27,43 @@ async def test_authenticate_admin_ok_and_missing_or_wrong_key():
     prov = DefaultAuthenticationProvider("admin_secret")
     sio = AsyncMock()
     environ = {}
+    headers: list = []  # #112(AS-38)：headers 不再参与鉴权
 
-    # 正确 key
-    headers = [(b"access_token", b"admin_secret")]
-    ok = await prov.authenticate(sio, environ, None, headers)
+    # 正确 token（在 auth dict 内）
+    ok = await prov.authenticate(sio, environ, {"token": "admin_secret"}, headers)
     assert ok is True
 
-    # 缺失 key
-    headers = []
+    # 缺失 auth dict（None）
     ok2 = await prov.authenticate(sio, environ, None, headers)
     assert ok2 is False
 
-    # 错误 key
-    headers = [(b"access_token", b"wrong")]
-    ok3 = await prov.authenticate(sio, environ, None, headers)
+    # auth dict 无 token 字段
+    ok2b = await prov.authenticate(sio, environ, {}, headers)
+    assert ok2b is False
+
+    # 错误 token
+    ok3 = await prov.authenticate(sio, environ, {"token": "wrong"}, headers)
     assert ok3 is False
+
+
+@pytest.mark.asyncio
+async def test_authenticate_ignores_http_header():
+    """#112(AS-38)：凭据放在 HTTP header（旧路径）必须被忽略 / credential in header must be ignored."""
+    prov = DefaultAuthenticationProvider("admin_secret")
+    sio = AsyncMock()
+    # 旧 header 路径携带正确密钥，但 auth dict 为空 → 仍拒绝
+    headers = [(b"access_token", b"admin_secret")]
+    assert await prov.authenticate(sio, {}, None, headers) is False
+
+
+@pytest.mark.asyncio
+async def test_authenticate_custom_field_name():
+    """自定义 ``api_key_name`` 字段名必须真实生效 / custom field name must take effect."""
+    prov = DefaultAuthenticationProvider("admin_secret", api_key_name="x-legacy-key")
+    sio = AsyncMock()
+    assert await prov.authenticate(sio, {}, {"x-legacy-key": "admin_secret"}, []) is True
+    # 默认 token 字段在自定义字段名下无效
+    assert await prov.authenticate(sio, {}, {"token": "admin_secret"}, []) is False
 
 
 # has_admin_permission 方法已被移除，管理员权限检查已集成到 authenticate 方法中
@@ -50,11 +79,9 @@ async def test_admin_permission_integrated_in_authenticate():
     # 无管理员密钥配置的提供者
     # Provider without admin secret configured
     prov1 = DefaultAuthenticationProvider(None)
-    headers = [(b"access_token", b"any_key")]
-    assert await prov1.authenticate(sio, environ, None, headers) is False
+    assert await prov1.authenticate(sio, environ, {"token": "any_key"}, []) is False
 
     # 有管理员密钥配置的提供者
     # Provider with admin secret configured
     prov2 = DefaultAuthenticationProvider("admin_secret")
-    headers = [(b"access_token", b"admin_secret")]
-    assert await prov2.authenticate(sio, environ, None, headers) is True
+    assert await prov2.authenticate(sio, environ, {"token": "admin_secret"}, []) is True

--- a/tests/unit_tests/server/test_handshake_config.py
+++ b/tests/unit_tests/server/test_handshake_config.py
@@ -1,13 +1,15 @@
 # -*- coding: utf-8 -*-
 """
-中文：Server 侧握手配置测试（对齐 Rust ``smcp-server-core/src/auth.rs`` 默认值变更）。
+中文：Server 侧握手配置测试（对齐 Rust ``smcp-server-core/src/auth.rs`` #86 默认值变更）。
 English: Handshake config tests for the Server-side auth providers.
 
+#112(AS-38)：连接面鉴权改走 Socket.IO CONNECT ``auth`` dict（字段默认 ``token``），HTTP header 不再参与鉴权。
+
 覆盖场景 / Covered scenarios:
-  1. ``DEFAULT_AUTH_HEADER_NAME`` 导出为 ``access_token``
-  2. async / sync ``DefaultAuthenticationProvider`` 默认 ``api_key_name`` 为 ``access_token``
-  3. 默认 provider 能识别 ``access_token`` header 完成鉴权
-  4. 自定义 ``api_key_name`` 生效
+  1. ``DEFAULT_AUTH_FIELD_NAME`` 导出为 ``token``
+  2. async / sync ``DefaultAuthenticationProvider`` 默认 ``api_key_name`` 为 ``token``
+  3. 默认 provider 能从 ``auth`` dict 的 ``token`` 字段完成鉴权
+  4. 自定义 ``api_key_name`` 生效；旧 HTTP header 路径被忽略
 """
 
 from __future__ import annotations
@@ -17,60 +19,60 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from a2c_smcp.server import (
-    DEFAULT_AUTH_HEADER_NAME,
+    DEFAULT_AUTH_FIELD_NAME,
     DefaultAuthenticationProvider,
     DefaultSyncAuthenticationProvider,
 )
 
 
-def test_server_default_auth_header_name_is_access_token() -> None:
-    """Server 模块导出的默认 header 名为 ``access_token``"""
-    assert DEFAULT_AUTH_HEADER_NAME == "access_token"
+def test_server_default_auth_field_name_is_token() -> None:
+    """Server 模块导出的默认鉴权字段名为 ``token``"""
+    assert DEFAULT_AUTH_FIELD_NAME == "token"
 
 
 def test_async_default_auth_provider_default_api_key_name() -> None:
-    """Async 默认 provider 的 ``api_key_name`` 默认值为 ``access_token``"""
+    """Async 默认 provider 的 ``api_key_name`` 默认值为 ``token``"""
     provider = DefaultAuthenticationProvider(admin_secret="adm")
-    assert provider.api_key_name == "access_token"
+    assert provider.api_key_name == "token"
 
 
 def test_sync_default_auth_provider_default_api_key_name() -> None:
-    """Sync 默认 provider 的 ``api_key_name`` 默认值为 ``access_token``"""
+    """Sync 默认 provider 的 ``api_key_name`` 默认值为 ``token``"""
     provider = DefaultSyncAuthenticationProvider(admin_secret="adm")
-    assert provider.api_key_name == "access_token"
+    assert provider.api_key_name == "token"
 
 
 @pytest.mark.asyncio
-async def test_async_default_auth_provider_authenticates_access_token_header() -> None:
-    """默认 provider 能识别 ``access_token`` header 并完成管理员鉴权"""
+async def test_async_default_auth_provider_authenticates_auth_dict_token() -> None:
+    """默认 provider 能从 ``auth`` dict 的 ``token`` 字段完成管理员鉴权"""
     provider = DefaultAuthenticationProvider(admin_secret="adm")
     sio = AsyncMock()
 
-    headers_ok = [(b"access_token", b"adm")]
-    assert await provider.authenticate(sio, {}, None, headers_ok) is True
+    assert await provider.authenticate(sio, {}, {"token": "adm"}, []) is True
+    assert await provider.authenticate(sio, {}, {"token": "wrong"}, []) is False
+    # 旧 HTTP header 路径携带正确密钥 → 必须被忽略
+    assert await provider.authenticate(sio, {}, None, [(b"access_token", b"adm")]) is False
 
-    headers_bad = [(b"access_token", b"wrong")]
-    assert await provider.authenticate(sio, {}, None, headers_bad) is False
 
-
-def test_sync_default_auth_provider_authenticates_access_token_header() -> None:
-    """Sync 默认 provider 能识别 ``access_token`` header"""
+def test_sync_default_auth_provider_authenticates_auth_dict_token() -> None:
+    """Sync 默认 provider 能从 ``auth`` dict 的 ``token`` 字段完成鉴权"""
     provider = DefaultSyncAuthenticationProvider(admin_secret="adm")
     sio = MagicMock()
 
-    assert provider.authenticate(sio, {}, None, [(b"access_token", b"adm")]) is True
-    assert provider.authenticate(sio, {}, None, [(b"access_token", b"wrong")]) is False
+    assert provider.authenticate(sio, {}, {"token": "adm"}, []) is True
+    assert provider.authenticate(sio, {}, {"token": "wrong"}, []) is False
+    assert provider.authenticate(sio, {}, None, [(b"access_token", b"adm")]) is False
 
 
 @pytest.mark.asyncio
 async def test_async_default_auth_provider_custom_api_key_name() -> None:
-    """自定义 ``api_key_name`` 生效，默认 header 不应再通过"""
+    """自定义 ``api_key_name`` 生效，默认 ``token`` 字段不应再通过"""
     provider = DefaultAuthenticationProvider(admin_secret="adm", api_key_name="x-tf-token")
 
     sio = AsyncMock()
     assert provider.api_key_name == "x-tf-token"
 
-    # 自定义 header 可通过 / Custom header passes
-    assert await provider.authenticate(sio, {}, None, [(b"x-tf-token", b"adm")]) is True
-    # 旧默认 header 不再能通过 / Former default header no longer authenticates
-    assert await provider.authenticate(sio, {}, None, [(b"access_token", b"adm")]) is False
+    # 自定义字段可通过 / Custom field passes
+    assert await provider.authenticate(sio, {}, {"x-tf-token": "adm"}, []) is True
+    # 默认 token 字段不再能通过 / Default token field no longer authenticates
+    assert await provider.authenticate(sio, {}, {"token": "adm"}, []) is False

--- a/tests/unit_tests/server/test_smcp_namespace.py
+++ b/tests/unit_tests/server/test_smcp_namespace.py
@@ -441,12 +441,11 @@ class TestDefaultAuthenticationProvider:
 
     @pytest.mark.asyncio
     async def test_admin_authentication(self):
-        """测试管理员认证 / Test admin authentication"""
+        """测试管理员认证 / Test admin authentication（#112(AS-38)：凭据走 auth dict 的 token）"""
         provider = DefaultAuthenticationProvider("admin_secret")
         mock_sio = AsyncMock()
 
-        headers = [(b"access_token", b"admin_secret")]
-        result = await provider.authenticate(mock_sio, "agent_123", None, headers)
+        result = await provider.authenticate(mock_sio, {}, {"token": "admin_secret"}, [])
         assert result is True
 
     @pytest.mark.asyncio
@@ -455,19 +454,19 @@ class TestDefaultAuthenticationProvider:
         provider = DefaultAuthenticationProvider("admin_secret")
         mock_sio = AsyncMock()
 
-        headers = [(b"access_token", b"wrong_secret")]
-        result = await provider.authenticate(mock_sio, "agent_123", None, headers)
+        result = await provider.authenticate(mock_sio, {}, {"token": "wrong_secret"}, [])
         assert result is False
 
     @pytest.mark.asyncio
     async def test_no_api_key(self):
-        """测试无API密钥的情况 / Test no API key scenario"""
+        """测试无API密钥的情况 / Test no API key scenario（#112(AS-38)：auth dict 缺失/无 token）"""
         provider = DefaultAuthenticationProvider("admin_secret")
         mock_sio = AsyncMock()
 
-        headers = []  # 空的headers列表
-        result = await provider.authenticate(mock_sio, "agent_123", None, headers)
-        assert result is False
+        # auth dict 为 None / 无 token 字段 / 旧 header 路径均不应通过
+        assert await provider.authenticate(mock_sio, {}, None, []) is False
+        assert await provider.authenticate(mock_sio, {}, {}, []) is False
+        assert await provider.authenticate(mock_sio, {}, None, [(b"access_token", b"admin_secret")]) is False
 
     @pytest.mark.asyncio
     async def test_enter_room_computer_duplicate_name_raises_error(self, smcp_namespace, mock_server):

--- a/tests/unit_tests/server/test_sync_auth.py
+++ b/tests/unit_tests/server/test_sync_auth.py
@@ -1,16 +1,22 @@
 # -*- coding: utf-8 -*-
 """
 测试 a2c_smcp/server/sync_auth.py
+
+#112(AS-38)：连接面鉴权改走 Socket.IO CONNECT ``auth`` dict（字段默认 ``token``），HTTP header 不再参与鉴权。
 """
 
 from __future__ import annotations
 
 from unittest.mock import MagicMock
 
-from a2c_smcp.server.sync_auth import DefaultSyncAuthenticationProvider
+from a2c_smcp.server.sync_auth import DEFAULT_AUTH_FIELD_NAME, DefaultSyncAuthenticationProvider
 
 # get_agent_id 方法已被移除，不再需要测试
 # get_agent_id method has been removed, no longer need to test
+
+
+def test_sync_default_auth_field_name_is_token():
+    assert DEFAULT_AUTH_FIELD_NAME == "token"
 
 
 def test_sync_authenticate_variants():
@@ -18,11 +24,23 @@ def test_sync_authenticate_variants():
     sio = MagicMock()
     environ = {}
 
-    ok = prov.authenticate(sio, environ, None, [(b"access_token", b"adm")])
-    assert ok is True
+    # 正确 token（在 auth dict 内）
+    assert prov.authenticate(sio, environ, {"token": "adm"}, []) is True
 
+    # 缺失 / 无 token / 错误 token
     assert prov.authenticate(sio, environ, None, []) is False
-    assert prov.authenticate(sio, environ, None, [(b"access_token", b"wrong")]) is False
+    assert prov.authenticate(sio, environ, {}, []) is False
+    assert prov.authenticate(sio, environ, {"token": "wrong"}, []) is False
+
+    # 旧 HTTP header 路径携带正确密钥 → 必须被忽略
+    assert prov.authenticate(sio, environ, None, [(b"access_token", b"adm")]) is False
+
+
+def test_sync_custom_field_name():
+    prov = DefaultSyncAuthenticationProvider("adm", api_key_name="x-legacy-key")
+    sio = MagicMock()
+    assert prov.authenticate(sio, {}, {"x-legacy-key": "adm"}, []) is True
+    assert prov.authenticate(sio, {}, {"token": "adm"}, []) is False
 
 
 # has_admin_permission 方法已被移除，管理员权限检查已集成到 authenticate 方法中
@@ -37,9 +55,9 @@ def test_sync_admin_permission_integrated_in_authenticate():
     # 无管理员密钥配置的提供者
     # Provider without admin secret configured
     prov1 = DefaultSyncAuthenticationProvider(None)
-    assert prov1.authenticate(sio, environ, None, [(b"access_token", b"any_key")]) is False
+    assert prov1.authenticate(sio, environ, {"token": "any_key"}, []) is False
 
     # 有管理员密钥配置的提供者
     # Provider with admin secret configured
     prov2 = DefaultSyncAuthenticationProvider("adm")
-    assert prov2.authenticate(sio, environ, None, [(b"access_token", b"adm")]) is True
+    assert prov2.authenticate(sio, environ, {"token": "adm"}, []) is True


### PR DESCRIPTION
## 概述

把 python-sdk 的**连接面鉴权从 HTTP header 统一迁移到 Socket.IO CONNECT `auth` dict**，凭据字段名 `token`，**退役 header 鉴权面**。对标 rust-sdk 已发布的对位实现（#85+#86，commit `2c4efb3` @ v0.2.3）。

- **协议门控**：**无协议变更**。A2C-SMCP auth-agnostic；协议 `data-structures.md` §ConnectAuth 早有 `auth={"role","token"}` 业务层示例；rust-sdk 对位提交亦声明「无协议规范变更，`token` 为 SDK/部署约定」。
- **北极星（Epic TFRM-153 Phase 1）**：token 按传输分流（Socket.IO→auth dict `token`；HTTP/A2A→Bearer）；**JWT 仅 TFRobotServer 后端验签**，SDK 只负责携带 + 暴露可插拔 `AuthenticationProvider` 钩子。
- ⚠️ **破坏性 SDK API 变更**（Epic flag-day 无线上用户，可硬切）。

## 变更

**Server**（`server/auth.py` + `sync_auth.py`）
- `DEFAULT_AUTH_HEADER_NAME` → `DEFAULT_AUTH_FIELD_NAME`（默认值 `access_token` → `token`）
- `Default(Sync)AuthenticationProvider.authenticate()` 从 `auth` dict 读 `api_key_name`（默认 `token`），不再扫 header；失败 `ConnectionRefusedError` 拒连
- `on_connect` 早已透传 auth dict（无 rust 的 extensions 旁路缺口），改动精准落在 provider 层

**Agent**（`agent/auth.py`）
- `DefaultAgentAuthProvider`：`api_key_header=` → `auth_field_name=`；`api_key` 注入 `auth` dict 的 `token` 字段并与 `auth_data` 合并；`get_connection_headers()` 仅承载路由 header

**Computer**（`computer/socketio/client.py`）
- 移除 vestigial `auth_header_name` 参数/属性/`DEFAULT_AUTH_FIELD_NAME` 常量/导出（Computer 无 auth provider 抽象，`auth` dict 由调用方 `connect(url, auth=...)` / CLI `--auth 'token:...'` 提供）

**类型 / 文档**
- 新增 `smcp.ConnectAuth`（`role` 必需 + `token` NotRequired，协议参考类型）
- `CHANGELOG.md` Breaking Changes 条目（含迁移指引、supersede 0.1.5a1）；`CLAUDE.md` 契约登记；`agent-guide.md` 示例修正

**测试**
- 双端单测改 auth-dict `token` 路径 + 「旧 header 路径必被忽略」回归断言
- 新增 `tests/integration_tests/server/test_auth_connection.py`：client `DefaultAgentAuthProvider` 产出的 auth dict 恰被 server `on_connect → Default provider` 接受的端到端契约（含错误/None/旧 header 三态拒连）

## 门控
- ✅ `uv run poe lint`（ruff + mypy，100 files，0 issue）
- ✅ `uv run poe test`（1723 passed / 2 skipped / 4 xfailed）
- ✅ Step 7 隔离 code-reviewer 复审：0 🔴；两轮 🟡 全消化

## 范围外（Phase 2，未触碰）
事件级 `authorize_event` hook + claims 入 session。

## 已知后续（非本 PR）
`role-at-connect` 分歧：协议文档称 `role` MUST 进连接 auth，但 python+rust+TFRS 全经 `join_office` 建立 role —— **既有协议↔实现分歧**，非本 PR 引入；`ConnectAuth` docstring 已注明现状，待独立 protocol-first 对齐。

Closes #112
关联：Jira AS-38 · Epic TFRM-153 · rust-sdk #85 / #86（`2c4efb3`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
