### PR TITLE
refactor(#116): Computer 概念瘦身——移除 active_workdir/registered_workdirs/${workspaceFolder}

### DIFF
--- a/.claude/skills/UAT/resources/scenarios/settings-scope.md
+++ b/.claude/skills/UAT/resources/scenarios/settings-scope.md
@@ -70,16 +70,17 @@ mkdir -p $A2C_SKILL_HOME
   - set 退出码 0，输出含 scope/key/value 信息
   - show --scope user 输出包含 strictKnownMarketplaces: true
 
-### G-05: settings set --scope project（需要 active workdir）
+### G-05: settings set --scope project（锚定进程 cwd，#116）
 
 - **优先级**: P1
 - **步骤**:
-  1. 执行：`A2C_SKILL_HOME=/tmp/a2c-uat-skill-home uv run a2c-computer settings set strictKnownMarketplaces true --scope project --json`
-  2. 捕获输出
+  1. 创建临时目录并切入：`mkdir -p /tmp/a2c-uat-proj && cd /tmp/a2c-uat-proj`
+  2. 执行：`A2C_SKILL_HOME=/tmp/a2c-uat-skill-home uv run --project <python-sdk 路径> a2c-computer settings set strictKnownMarketplaces true --scope project --json`
+  3. 捕获输出并检查 `/tmp/a2c-uat-proj/.tfrobot/settings.json`
 - **预期结果**:
-  - 退出码 1
-  - 输出包含 "requires an active workdir" 或类似错误信息
-  - project scope 需要 `--add-dir` 参数指定工作目录
+  - 退出码 0，输出含 scope/key/value 信息
+  - `<cwd>/.tfrobot/settings.json` 生成且包含 `"strictKnownMarketplaces": true`
+  - #116 起 project/local scope 无条件锚定进程 cwd（`--add-dir` 已移除，不再有 "requires an active workdir" 错误）
 
 ### G-06: scope merge 验证（覆盖后合并）
 

--- a/a2c_smcp/computer/cli/commands/__init__.py
+++ b/a2c_smcp/computer/cli/commands/__init__.py
@@ -81,13 +81,11 @@ def flag_value(args: list[str], flag: str) -> str | None:
 
 
 def resolved_settings(
-    registered_workdirs: Sequence[Path],
-    active_workdir: Path | None,
     env: Mapping[str, str] | None,
     *,
     flag_path: Path | None = None,
 ) -> dict[str, Any]:
-    """六层合并 settings（含 policy first-source-wins）/ Six-layer merged settings incl. policy。
+    """五层合并 settings（含 policy first-source-wins；#116 project/local 锚定进程 cwd）/ Merged settings incl. policy。
 
     plugin（``enabledPlugins`` / gc 声明视图）与 settings（merged show / get）共用。policy 层承载企业
     allowed/deniedMcpServers（POLICY_ONLY 字段，批准门控须读到），故统一注入。函数内 lazy import 沿用本仓
@@ -97,8 +95,6 @@ def resolved_settings(
     from a2c_smcp.computer.settings.scope import resolve_settings
 
     return resolve_settings(
-        registered_workdirs=registered_workdirs,
-        active_workdir=active_workdir,
         env=env,
         flag_settings_path=flag_path,
         policy_settings=resolve_policy_settings(env=env),

--- a/a2c_smcp/computer/cli/commands/plugin.py
+++ b/a2c_smcp/computer/cli/commands/plugin.py
@@ -454,7 +454,7 @@ async def repl_dispatch(comp: Any, parts: list[str], *, session: Any) -> None:
     json_output = "--json" in args
     pos = [a for a in args if not a.startswith("--")]
     cbs = build_mcp_callbacks(comp)
-    # #116：project/local scope 的 project_path 锚定进程 cwd（plugin enable/disable 写 enabledPlugins 落 cwd 单根）。
+    # #116：project/local scope 的 project_path 锚定进程 cwd（仅 install 分支消费；enable/disable 从 ledger 读 projectPath）。
     project_path = os.getcwd()
 
     if sub == "install":

--- a/a2c_smcp/computer/cli/commands/plugin.py
+++ b/a2c_smcp/computer/cli/commands/plugin.py
@@ -246,11 +246,9 @@ async def plugin_disable(
     return _ok(f"disabled {plugin_id!r} (whole plugin offline; enable to restore)")
 
 
-def _enabled_plugins_view(
-    home: Path, env: Mapping[str, str] | None, registered_workdirs: tuple[Path, ...], active_workdir: Path | None,
-) -> dict[str, Any]:
-    """六层合并视图的 ``enabledPlugins`` 映射（``id → bool``，缺省视为启用）/ Merged enabledPlugins map。"""
-    ep = resolved_settings(registered_workdirs, active_workdir, env).get("enabledPlugins")
+def _enabled_plugins_view(home: Path, env: Mapping[str, str] | None) -> dict[str, Any]:
+    """合并视图的 ``enabledPlugins`` 映射（``id → bool``，缺省视为启用）/ Merged enabledPlugins map。"""
+    ep = resolved_settings(env).get("enabledPlugins")
     return dict(ep) if isinstance(ep, Mapping) else {}
 
 
@@ -258,8 +256,6 @@ def plugin_list(
     home: Path,
     env: Mapping[str, str] | None,
     *,
-    registered_workdirs: tuple[Path, ...] = (),
-    active_workdir: Path | None = None,
     available: bool = False,
     json_output: bool = False,
 ) -> int:
@@ -267,7 +263,7 @@ def plugin_list(
     from a2c_smcp.computer.settings.store import load_installed_plugins
 
     installed = load_installed_plugins(home=home, env=env).get("plugins", {})
-    enabled_map = _enabled_plugins_view(home, env, registered_workdirs, active_workdir)
+    enabled_map = _enabled_plugins_view(home, env)
 
     rows: list[dict[str, Any]] = []
     for pid, records in installed.items():
@@ -304,15 +300,13 @@ def plugin_info(
     env: Mapping[str, str] | None,
     plugin_id: str,
     *,
-    registered_workdirs: tuple[Path, ...] = (),
-    active_workdir: Path | None = None,
     json_output: bool = False,
 ) -> int:
     """plugin 详情：scope / installPath / version / commitSha / enabled / bundledMcpServers / installedAt。"""
     records = _installed_records(home, env, plugin_id)
     if not records:
         return _err(f"plugin {plugin_id!r} not installed", json_output=json_output)
-    enabled = _enabled_plugins_view(home, env, registered_workdirs, active_workdir).get(plugin_id) is not False
+    enabled = _enabled_plugins_view(home, env).get(plugin_id) is not False
     info: dict[str, Any] = {"id": plugin_id, "enabled": enabled, "records": records}
     if json_output:
         console.print_json(data=info)
@@ -337,14 +331,12 @@ async def plugin_gc(
     home: Path,
     env: Mapping[str, str] | None,
     *,
-    registered_workdirs: tuple[Path, ...] = (),
-    active_workdir: Path | None = None,
     mcp_teardown: Callable[[list[str]], Awaitable[None]] | None = None,
     confirm: Callable[[list[str]], Awaitable[bool]] | None = None,
     json_output: bool = False,
 ) -> int:
     """清理孤儿 plugin（所有 scope 都不再声明 enabledPlugins[id]）/ GC orphan plugins。"""
-    declared = resolved_settings(registered_workdirs, active_workdir, env)
+    declared = resolved_settings(env)
     orphans = list_orphan_plugins(home, declared, env=env)
     if not orphans:
         if json_output:
@@ -390,10 +382,10 @@ async def run_mcp_approval(
     **不**喂 ``resolve_mcp_config(flag_config_path=)``（后者期望 ``{servers,inputs}``、schema 不符）；flag-scope
     **mcp.json 当前无 CLI 入口**（旧 ``--config`` 仅 ``_run_impl`` server 预加载、从不喂门控解析）。
     """
-    aw = comp.active_workdir
     env = os.environ
     # flag_config 是 settings.json（见 docstring）→ resolve_mcp_config 不收（避免 settings.json 当 mcp.json 误读）。
-    resolved = resolve_mcp_config(active_workdir=aw, env=env, flag_config_path=None)
+    # #116：project/local 层由 resolve_mcp_config 内部锚定进程 cwd。
+    resolved = resolve_mcp_config(env=env, flag_config_path=None)
 
     # 被 drop 的畸形 server/input 必须呈现（§5.6 / mcp_config 容错不静默，#69 Group B 风险 3）。
     for e in resolved.errors:
@@ -402,7 +394,7 @@ async def run_mcp_approval(
     if not resolved.servers:
         return
 
-    settings = resolved_settings(comp._registered_workdirs, aw, env, flag_path=flag_config)
+    settings = resolved_settings(env, flag_path=flag_config)
     bundled = bundled_mcp_server_names(comp.skill_home, env)
     statuses = gate_mcp_servers(resolved, settings, bundled)
 
@@ -440,14 +432,14 @@ async def run_mcp_approval(
             )
             ans = (await session.prompt_async(prompt)).strip().lower()
             if ans in {"a", "all"}:
-                approve_all_project_mcp(active_workdir=aw)
+                approve_all_project_mcp()
                 approved_all_session = True
                 await _mount(name)
             elif ans in {"y", "yes"}:
-                approve_mcp_server(name, active_workdir=aw)
+                approve_mcp_server(name)
                 await _mount(name)
             else:
-                deny_mcp_server(name, active_workdir=aw)
+                deny_mcp_server(name)
                 console.print(f"[dim]· denied MCP server {name!r} (written to local scope)[/dim]")
 
 
@@ -462,9 +454,8 @@ async def repl_dispatch(comp: Any, parts: list[str], *, session: Any) -> None:
     json_output = "--json" in args
     pos = [a for a in args if not a.startswith("--")]
     cbs = build_mcp_callbacks(comp)
-    aw = comp.active_workdir
-    # active workdir 作 project/local scope 的 project_path（plugin enable/disable 写 enabledPlugins 落 active 单根）。
-    project_path = str(aw) if aw is not None else None
+    # #116：project/local scope 的 project_path 锚定进程 cwd（plugin enable/disable 写 enabledPlugins 落 cwd 单根）。
+    project_path = os.getcwd()
 
     if sub == "install":
         if not pos:
@@ -524,16 +515,12 @@ async def repl_dispatch(comp: Any, parts: list[str], *, session: Any) -> None:
         if code == EXIT_OK:
             comp.mark_skills_dirty()
     elif sub == "list":
-        plugin_list(
-            home, env,
-            registered_workdirs=comp._registered_workdirs, active_workdir=aw,
-            available="--available" in args, json_output=json_output,
-        )
+        plugin_list(home, env, available="--available" in args, json_output=json_output)
     elif sub == "info":
         if not pos:
             console.print("[yellow]usage: plugin info <plugin>@<marketplace>[/yellow]")
             return
-        plugin_info(home, env, pos[0], registered_workdirs=comp._registered_workdirs, active_workdir=aw, json_output=json_output)
+        plugin_info(home, env, pos[0], json_output=json_output)
     elif sub == "gc":
 
         async def _confirm(orphans: list[str]) -> bool:
@@ -542,7 +529,6 @@ async def repl_dispatch(comp: Any, parts: list[str], *, session: Any) -> None:
 
         code = await plugin_gc(
             registry, home, env,
-            registered_workdirs=comp._registered_workdirs, active_workdir=aw,
             mcp_teardown=_batch_teardown(cbs.remove_server), confirm=_confirm, json_output=json_output,
         )
         if code == EXIT_OK:

--- a/a2c_smcp/computer/cli/commands/settings.py
+++ b/a2c_smcp/computer/cli/commands/settings.py
@@ -14,9 +14,9 @@
 写经 :func:`...scope.apply_write`（**数组整体替换**、``undefined`` 删键，§5.4）+ store 原子写/锁。
 
 - **scope**：``user`` / ``project`` / ``local`` 可写；``flag`` / ``policy`` **只读**（set/edit 拒绝，退出码 1）；
-  ``merged``（默认 show）= 六层合并视图。project/local 需 active workdir。
+  ``merged``（默认 show）= 五层合并视图。project/local 锚定进程 cwd（#116）。
 - settings.json **无 version 字段**（复刻 CC passthrough，§5）；写不注 version/保护头（``header=None``）。
-- ``edit`` 用 ``$EDITOR`` 打开该层文件，保存后经回调 reconcile（能力层对账 + 重跑 MCP 批准门控）。
+- ``edit`` 用 ``$EDITOR`` 打开该层文件，保存后经回调 reconcile（重跑 MCP 批准门控）。
 """
 
 from __future__ import annotations
@@ -108,7 +108,7 @@ def settings_show(
     if scope not in _READABLE:
         return _err(f"unknown scope {scope!r} (expected {'|'.join(_READABLE)})", json_output=json_output)
     data = _read_scope(scope, home, env, flag_path=flag_path)
-    if data is None:
+    if data is None:  # 防御性：_READABLE 前置拦截后不可达（#116 起 project/local 锚 cwd 恒可读）
         return _err(f"unknown scope {scope!r}", json_output=json_output)
     console.print_json(data=data)
     return EXIT_OK
@@ -127,7 +127,7 @@ def settings_get(
     if scope not in _READABLE:
         return _err(f"unknown scope {scope!r} (expected {'|'.join(_READABLE)})", json_output=json_output)
     data = _read_scope(scope, home, env, flag_path=flag_path)
-    if data is None:
+    if data is None:  # 防御性：_READABLE 前置拦截后不可达（#116 起 project/local 锚 cwd 恒可读）
         return _err(f"unknown scope {scope!r}", json_output=json_output)
     if key not in data:
         return _err(f"key {key!r} not set in scope {scope!r}", json_output=json_output)

--- a/a2c_smcp/computer/cli/commands/settings.py
+++ b/a2c_smcp/computer/cli/commands/settings.py
@@ -57,16 +57,15 @@ def _err(msg: str, *, json_output: bool) -> int:
     return EXIT_USER_ERROR
 
 
-def _writable_path(scope: str, active_workdir: Path | None, env: Mapping[str, str] | None) -> tuple[Path, SettingsScope]:
-    """解析可写 scope 的 settings.json 路径 + enum；flag/policy/unknown → ``ValueError``。"""
+def _writable_path(scope: str, env: Mapping[str, str] | None) -> tuple[Path, SettingsScope]:
+    """解析可写 scope 的 settings.json 路径 + enum（project/local 锚 cwd，#116）；flag/policy/unknown → ``ValueError``。"""
     if scope == "user":
         return user_settings_path(env), SettingsScope.USER
     if scope in ("project", "local"):
-        if active_workdir is None:
-            raise ValueError(f"scope {scope!r} requires an active workdir (use --add-dir at startup)")
+        cwd = Path(os.getcwd())
         if scope == "project":
-            return workdir_project_settings_path(active_workdir), SettingsScope.PROJECT
-        return workdir_local_settings_path(active_workdir), SettingsScope.LOCAL
+            return workdir_project_settings_path(cwd), SettingsScope.PROJECT
+        return workdir_local_settings_path(cwd), SettingsScope.LOCAL
     raise ValueError(f"scope {scope!r} is read-only (writable: user|project|local)")
 
 
@@ -75,19 +74,16 @@ def _read_scope(
     home: Path,
     env: Mapping[str, str] | None,
     *,
-    registered_workdirs: tuple[Path, ...],
-    active_workdir: Path | None,
     flag_path: Path | None,
 ) -> dict[str, Any] | None:
-    """读单 scope（或 merged）settings dict；scope 非法或缺 active workdir → ``None``（调用方报错）。"""
+    """读单 scope（或 merged）settings dict；scope 非法 → ``None``（调用方报错）。project/local 锚 cwd（#116）。"""
     if scope == "merged":
-        return resolved_settings(registered_workdirs, active_workdir, env, flag_path=flag_path)
+        return resolved_settings(env, flag_path=flag_path)
     if scope == "user":
         return load_settings_file(user_settings_path(env), SettingsScope.USER)[0]
     if scope in ("project", "local"):
-        if active_workdir is None:
-            return None
-        path = workdir_project_settings_path(active_workdir) if scope == "project" else workdir_local_settings_path(active_workdir)
+        cwd = Path(os.getcwd())
+        path = workdir_project_settings_path(cwd) if scope == "project" else workdir_local_settings_path(cwd)
         enum = SettingsScope.PROJECT if scope == "project" else SettingsScope.LOCAL
         return load_settings_file(path, enum)[0]
     if scope == "flag":
@@ -105,17 +101,15 @@ def settings_show(
     env: Mapping[str, str] | None,
     *,
     scope: str = "merged",
-    registered_workdirs: tuple[Path, ...] = (),
-    active_workdir: Path | None = None,
     flag_path: Path | None = None,
     json_output: bool = False,
 ) -> int:
     """展示某 scope 的 settings（默认 merged 合并视图）/ Show settings of a scope (default merged)。"""
     if scope not in _READABLE:
         return _err(f"unknown scope {scope!r} (expected {'|'.join(_READABLE)})", json_output=json_output)
-    data = _read_scope(scope, home, env, registered_workdirs=registered_workdirs, active_workdir=active_workdir, flag_path=flag_path)
+    data = _read_scope(scope, home, env, flag_path=flag_path)
     if data is None:
-        return _err(f"scope {scope!r} requires an active workdir (use --add-dir at startup)", json_output=json_output)
+        return _err(f"unknown scope {scope!r}", json_output=json_output)
     console.print_json(data=data)
     return EXIT_OK
 
@@ -126,17 +120,15 @@ def settings_get(
     key: str,
     *,
     scope: str = "merged",
-    registered_workdirs: tuple[Path, ...] = (),
-    active_workdir: Path | None = None,
     flag_path: Path | None = None,
     json_output: bool = False,
 ) -> int:
     """读取单字段（默认 merged 视图）/ Read a single field (default merged view)。"""
     if scope not in _READABLE:
         return _err(f"unknown scope {scope!r} (expected {'|'.join(_READABLE)})", json_output=json_output)
-    data = _read_scope(scope, home, env, registered_workdirs=registered_workdirs, active_workdir=active_workdir, flag_path=flag_path)
+    data = _read_scope(scope, home, env, flag_path=flag_path)
     if data is None:
-        return _err(f"scope {scope!r} requires an active workdir (use --add-dir at startup)", json_output=json_output)
+        return _err(f"unknown scope {scope!r}", json_output=json_output)
     if key not in data:
         return _err(f"key {key!r} not set in scope {scope!r}", json_output=json_output)
     console.print_json(data={key: data[key]})
@@ -150,7 +142,6 @@ def settings_set(
     value: str,
     *,
     scope: str = "user",
-    active_workdir: Path | None = None,
     json_output: bool = False,
 ) -> int:
     """写单字段（user|project|local；flag/policy 只读）/ Write a single field (flag/policy read-only)。
@@ -161,7 +152,7 @@ def settings_set(
     if scope not in _WRITABLE:
         return _err(f"scope {scope!r} is read-only (writable: {'|'.join(sorted(_WRITABLE))})", json_output=json_output)
     try:
-        path, enum = _writable_path(scope, active_workdir, env)
+        path, enum = _writable_path(scope, env)
     except ValueError as e:
         return _err(str(e), json_output=json_output)
 
@@ -187,7 +178,6 @@ def settings_edit(
     env: Mapping[str, str] | None,
     *,
     scope: str = "user",
-    active_workdir: Path | None = None,
     editor: str | None = None,
     reconcile_cb: Callable[[], Awaitable[None]] | None = None,
     json_output: bool = False,
@@ -200,7 +190,7 @@ def settings_edit(
     if scope not in _WRITABLE:
         return _err(f"scope {scope!r} is read-only (editable: {'|'.join(sorted(_WRITABLE))})", json_output=json_output), None
     try:
-        path, _enum = _writable_path(scope, active_workdir, env)
+        path, _enum = _writable_path(scope, env)
     except ValueError as e:
         return _err(str(e), json_output=json_output), None
 
@@ -228,22 +218,14 @@ async def repl_dispatch(comp: Any, parts: list[str], *, session: Any) -> None:
     json_output = "--json" in args
     pos = [a for a in args if not a.startswith("--")]
     scope = flag_value(args, "--scope")
-    registered = comp._registered_workdirs
-    aw = comp.active_workdir
 
     if sub == "show":
-        settings_show(
-            home, env, scope=scope or "merged",
-            registered_workdirs=registered, active_workdir=aw, json_output=json_output,
-        )
+        settings_show(home, env, scope=scope or "merged", json_output=json_output)
     elif sub == "get":
         if not pos:
             console.print("[yellow]usage: settings get <key> [--scope user|project|local|flag|policy|merged][/yellow]")
             return
-        settings_get(
-            home, env, pos[0], scope=scope or "merged",
-            registered_workdirs=registered, active_workdir=aw, json_output=json_output,
-        )
+        settings_get(home, env, pos[0], scope=scope or "merged", json_output=json_output)
     elif sub == "set":
         if len(pos) < 2:
             console.print("[yellow]usage: settings set <key> <value> [--scope user|project|local][/yellow]")
@@ -257,12 +239,12 @@ async def repl_dispatch(comp: Any, parts: list[str], *, session: Any) -> None:
                 break
             value_tokens.append(tok)
         value = " ".join(value_tokens)
-        code = settings_set(home, env, key, value, scope=scope or "user", active_workdir=aw, json_output=json_output)
+        code = settings_set(home, env, key, value, scope=scope or "user", json_output=json_output)
         _emit_keys = {"enabledPlugins", "enabledMcpjsonServers", "disabledMcpjsonServers", "enableAllProjectMcpServers"}
         if code == EXIT_OK and key in _emit_keys:
             comp.mark_skills_dirty()
     elif sub == "edit":
-        code, post_save = settings_edit(home, env, scope=scope or "user", active_workdir=aw, reconcile_cb=None, json_output=json_output)
+        code, post_save = settings_edit(home, env, scope=scope or "user", reconcile_cb=None, json_output=json_output)
         if code == EXIT_OK:
             comp.mark_skills_dirty()  # 编辑可能改 enabledPlugins/MCP 字段 → 触发去抖 emit
             if post_save is not None:

--- a/a2c_smcp/computer/cli/main.py
+++ b/a2c_smcp/computer/cli/main.py
@@ -52,12 +52,6 @@ app = typer.Typer(add_completion=False, help="A2C Computer CLI")
 # 使用全局 Console（引用模块属性，便于后续动态切换）
 console = console_util.console
 
-# ``--add-dir`` 是可重复 list 选项；提取为模块级 OptionInfo 单例规避 ruff B008（list 注解 + call-in-default），
-# 为 ruff 官方推荐做法。``_root`` 与 ``run`` 共用同一选项定义。/ module-level Option singleton to satisfy B008.
-_ADD_DIR_OPTION = typer.Option(
-    None, "--add-dir", help="注册工作目录（可重复；首个作 active-workdir）/ register a workdir (repeatable)",
-)
-
 
 # ------------------------------
 # 根级上下文（#97）：把根回调采集的全局 flag 透传给 settings 子命令
@@ -67,27 +61,13 @@ _ADD_DIR_OPTION = typer.Option(
 class _RootState:
     """根回调采集、供 ``settings`` 子命令读取的根级上下文（经 ``ctx.obj`` 在 Click 子上下文间继承）。
 
-    #97：``--settings`` / ``--add-dir`` 此前仅透传给 ``run`` 路径，``settings`` 子命令读不到 → flag scope
-    恒返回 ``{}``、project|local scope 缺 ``active_workdir`` 误报。统一收口到 ``ctx.obj``。
+    #97：``--settings`` 此前仅透传给 ``run`` 路径，``settings`` 子命令读不到 → flag scope
+    恒返回 ``{}``。统一收口到 ``ctx.obj``。#116：project/local scope 锚定进程 cwd，
+    不再有 ``--add-dir`` / workdir 状态。
     Root-level context gathered by the callback and read by `settings` subcommands via inherited ``ctx.obj``.
     """
 
     flag_path: Path | None = None
-    registered_workdirs: tuple[Path, ...] = ()
-    active_workdir: Path | None = None
-
-
-def _resolve_workdirs(add_dir: list[str] | None) -> tuple[tuple[Path, ...], Path | None]:
-    """``--add-dir`` → ``(registered_workdirs, active_workdir)``：绝对化、去重保序；``active`` 取首个（镜像
-    :attr:`Computer.active_workdir`）。直接调用 ``run()``（绕过 Typer）时 ``add_dir`` 可能泄漏 OptionInfo（非
-    list）→ isinstance 守卫为空（同 ``computer_factory`` 容错姿态）。/ Resolve ``--add-dir`` to workdirs。
-    """
-    registered: list[Path] = []
-    for d in add_dir if isinstance(add_dir, list) else []:
-        rp = Path(d).expanduser().resolve()
-        if rp not in registered:
-            registered.append(rp)
-    return tuple(registered), (registered[0] if registered else None)
 
 
 def _root_state(ctx: typer.Context) -> _RootState:
@@ -148,7 +128,6 @@ def _root(
     settings_file: str | None = typer.Option(
         None, "--settings", help="额外 settings.json（flag scope，最低优先级）/ extra settings.json (flag scope)",
     ),
-    add_dir: list[str] | None = _ADD_DIR_OPTION,
     approve_all_mcp: bool = typer.Option(
         False, "--approve-all-mcp", help="启动期全批 pending MCP server（仅本次、不落盘）/ approve all pending MCP (this run)",
     ),
@@ -165,13 +144,10 @@ def _root(
         # 重新绑定本地引用
         console = console_util.console
 
-    # #97：采集根级上下文（--settings flag scope 文件 + --add-dir 工作目录）存入 ctx.obj，供 settings 子命令读取。
+    # #97：采集根级上下文（--settings flag scope 文件）存入 ctx.obj，供 settings 子命令读取。
     # Click 子上下文默认继承父 ctx.obj，故无论是否带子命令都先填充（无子命令时 run 路径仍走显式参数）。
-    registered, active = _resolve_workdirs(add_dir)
     ctx.obj = _RootState(
         flag_path=Path(settings_file) if isinstance(settings_file, str) else None,
-        registered_workdirs=registered,
-        active_workdir=active,
     )
 
     if ctx.invoked_subcommand is None:
@@ -187,7 +163,6 @@ def _root(
             computer_factory=computer_factory,
             config=None,
             inputs=None,
-            add_dir=add_dir,
             approve_all_mcp=approve_all_mcp,
             settings_file=settings_file,
         )
@@ -227,7 +202,6 @@ def _run_impl(
     computer_factory: str | None,
     config: str | None,
     inputs: str | None,
-    add_dir: list[str] | None = None,
     approve_all_mcp: bool = False,
     settings_file: str | None = None,
 ) -> None:
@@ -235,9 +209,8 @@ def _run_impl(
     纯实现函数：不要在此处使用 Typer 的 Option 默认值，避免 OptionInfo 泄露到运行时。
     Both CLI (@app.command) 与回调 (@app.callback) 在需要时调用本函数。
 
-    add_dir / approve_all_mcp / settings_file 来自全局 flag ``--add-dir`` / ``--approve-all-mcp`` / ``--settings``
-    （#69 Group B/D）：``--add-dir`` 注册工作目录（→ ``registered_workdirs`` → ``active_workdir``，project/local
-    scope 与 ``${workspaceFolder}`` 的前置）；后两者透传启动期 MCP 批准框。
+    approve_all_mcp / settings_file 来自全局 flag ``--approve-all-mcp`` / ``--settings``
+    （#69 Group B/D）：透传启动期 MCP 批准框 / flag scope 文件。
     """
 
     async def _amain() -> None:
@@ -256,16 +229,12 @@ def _run_impl(
             console.print("[red]计算机构造目标不可调用，将回退到默认 Computer[/red]")
             comp_factory_obj = Computer
 
-        # --add-dir → registered_workdirs（能力发现并集 + active_workdir=首个）。解析复用 _resolve_workdirs（#97 DRY）。
-        registered_workdirs, _active_workdir = _resolve_workdirs(add_dir)
-
         comp = comp_factory_obj(
             name="friday_hands",
             inputs=set(),
             mcp_servers=set(),
             auto_connect=auto_connect,
             auto_reconnect=auto_reconnect,
-            registered_workdirs=registered_workdirs or None,
         )
         async with comp:
             init_client: SMCPComputerClient | None = None
@@ -322,7 +291,7 @@ def _run_impl(
                 except Exception as e:  # pragma: no cover
                     console.print(f"[red]加载 Servers 失败 / Failed to load servers: {e}[/red]")
 
-            # settings_file 直接调用 run() 时可能泄漏 OptionInfo → isinstance 守卫（同 add_dir / computer_factory 容错姿态）。
+            # settings_file 直接调用 run() 时可能泄漏 OptionInfo → isinstance 守卫（同 computer_factory 容错姿态）。
             await _interactive_loop(
                 comp,
                 init_client=init_client,
@@ -369,7 +338,6 @@ def run(
     settings_file: str | None = typer.Option(
         None, "--settings", help="额外 settings.json（flag scope，最低优先级）/ extra settings.json (flag scope)",
     ),
-    add_dir: list[str] | None = _ADD_DIR_OPTION,
     approve_all_mcp: bool = typer.Option(
         False, "--approve-all-mcp", help="启动期全批 pending MCP server（仅本次、不落盘）/ approve all pending MCP (this run)",
     ),
@@ -388,7 +356,6 @@ def run(
         computer_factory=computer_factory,
         config=config,
         inputs=inputs,
-        add_dir=add_dir,
         approve_all_mcp=approve_all_mcp,
         settings_file=settings_file,
     )
@@ -567,8 +534,8 @@ def _plugin_gc(json_output: bool = typer.Option(False, "--json")) -> None:
 
 
 # ── settings 子命令 / settings subcommands ────────────────────────────────────
-# 四个 settings 子命令经 ``ctx: typer.Context`` 取根状态（#97）：show/get 需 flag_path + workdirs 才能读 flag
-# scope 与 project|local；set/edit 需 active_workdir 才能写 project|local（flag/policy 本就只读，无 flag_path）。
+# 四个 settings 子命令经 ``ctx: typer.Context`` 取根状态（#97）：show/get 需 flag_path 才能读 flag scope；
+# project|local 锚定进程 cwd（#116），无需额外状态（flag/policy 本就只读，无 flag_path）。
 @settings_app.command("show")
 def _settings_show(
     ctx: typer.Context,
@@ -580,7 +547,6 @@ def _settings_show(
     raise typer.Exit(
         settings_cmd.settings_show(
             ensure_skill_home(), os.environ, scope=scope,
-            registered_workdirs=st.registered_workdirs, active_workdir=st.active_workdir,
             flag_path=st.flag_path, json_output=json_output,
         ),
     )
@@ -598,7 +564,6 @@ def _settings_get(
     raise typer.Exit(
         settings_cmd.settings_get(
             ensure_skill_home(), os.environ, key, scope=scope,
-            registered_workdirs=st.registered_workdirs, active_workdir=st.active_workdir,
             flag_path=st.flag_path, json_output=json_output,
         ),
     )
@@ -606,32 +571,28 @@ def _settings_get(
 
 @settings_app.command("set")
 def _settings_set(
-    ctx: typer.Context,
     key: str = typer.Argument(...),
     value: str = typer.Argument(..., help="JSON 优先，回退字面字符串 / JSON preferred, else literal"),
     scope: str = typer.Option("user", "--scope", help="user|project|local（flag/policy 只读）"),
     json_output: bool = typer.Option(False, "--json"),
 ) -> None:
     """写单字段（flag/policy 只读）/ Write a single field (flag/policy read-only)."""
-    st = _root_state(ctx)
     raise typer.Exit(
         settings_cmd.settings_set(
             ensure_skill_home(), os.environ, key, value, scope=scope,
-            active_workdir=st.active_workdir, json_output=json_output,
+            json_output=json_output,
         ),
     )
 
 
 @settings_app.command("edit")
 def _settings_edit(
-    ctx: typer.Context,
     scope: str = typer.Option("user", "--scope", help="user|project|local"),
     json_output: bool = typer.Option(False, "--json"),
 ) -> None:
     """用 $EDITOR 打开该层 settings.json（非交互无 reconcile）/ Open settings.json in $EDITOR."""
-    st = _root_state(ctx)
     code, _post = settings_cmd.settings_edit(
-        ensure_skill_home(), os.environ, scope=scope, active_workdir=st.active_workdir, json_output=json_output,
+        ensure_skill_home(), os.environ, scope=scope, json_output=json_output,
     )
     raise typer.Exit(code)
 

--- a/a2c_smcp/computer/computer.py
+++ b/a2c_smcp/computer/computer.py
@@ -31,7 +31,7 @@ import json
 import os
 import weakref
 from collections import deque
-from collections.abc import Callable, Sequence
+from collections.abc import Callable
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional
@@ -75,7 +75,6 @@ from a2c_smcp.computer.skills import (
     stage_mcp_skills,
     stage_user_skills,
     user_dropin_root,
-    workdir_skill_root,
 )
 from a2c_smcp.computer.types import ToolCallRecord
 from a2c_smcp.smcp import A2CSkillRef, Desktop, SMCPTool
@@ -109,7 +108,6 @@ class Computer(BaseComputer[PromptSession]):
         blob_resolvers: dict[str, BlobResolver] | None = None,
         blob_thresholds: BlobThresholds | None = None,
         skill_home: Path | None = None,
-        registered_workdirs: Sequence[Path] | None = None,
     ) -> None:
         """
         初始化 Computer 实例
@@ -141,11 +139,6 @@ class Computer(BaseComputer[PromptSession]):
                 ``A2C_SKILL_HOME`` → ``$XDG_DATA_HOME/a2c/skills`` → ``~/.a2c/skills`` 解析链。
                 mcp 源 ``skill://`` 物化落盘于 ``<home>/mcp/<server>/<skill>/``。
                 SKILL Home root override (test/deploy injection); defaults to the env resolution chain.
-            registered_workdirs (Sequence[Path] | None): v0.2.1 已登记工作目录（能力发现层，#60/#67）。
-                user 源 DropIn 跨 ``<home>/user/`` + 各 ``<workdir>/.tfrobot/skills/`` 全局并集就地发现，
-                并被文件 watcher 递归监控；**登记持久化由 CLI 工单维护，本类仅按注入参数消费**（默认空）。
-                Registered workdirs (capability layer): user-source DropIn discovery + file watcher span
-                these in place; persistence of the registration is owned by the CLI, consumed here as-is.
         """
         self.name = name
         self.mcp_manager: MCPServerManager | None = None
@@ -187,9 +180,8 @@ class Computer(BaseComputer[PromptSession]):
         self._skills_cache: set[str] = set()
 
         # v0.2.1 事件触发链（S14，#67，设计 §8）：多源 SKILL 变更 → 去抖器标脏 → 缓存失效 + 单次 emit。
-        # user 源 DropIn 文件 watcher 递归监控 user/ + 各登记 workdir/.tfrobot/skills/，SKILL.md 变更经去抖器汇聚。
+        # user 源 DropIn 文件 watcher 递归监控 <home>/user/（#116 起仅 home 单根；workdir 维度已下沉 MCP 服务）。
         # The debouncer coalesces multi-source SKILL changes into a single emit; the file watcher feeds user-source changes.
-        self._registered_workdirs: tuple[Path, ...] = tuple(registered_workdirs or ())
         self._skill_debouncer: SkillEventDebouncer = SkillEventDebouncer(
             self._emit_update_skills_now,
             invalidate=self._invalidate_user_skills,
@@ -574,8 +566,8 @@ class Computer(BaseComputer[PromptSession]):
         """
         缓存失效（文件源重扫）：就地重扫 user 源 DropIn 并对账孤儿 / Invalidate by rescanning user-source DropIn。
 
-        设计 §8.1「缓存失效」对**文件源**的落实——watcher/CLI 标脏后、emit 前重扫 ``<home>/user/`` +
-        各登记 ``<workdir>/.tfrobot/skills/``（``stage_user_skills`` 幂等 ``register_or_update``），并把本轮
+        设计 §8.1「缓存失效」对**文件源**的落实——watcher/CLI 标脏后、emit 前重扫 ``<home>/user/``
+        （``stage_user_skills`` 幂等 ``register_or_update``，#116 起仅 home 单根），并把本轮
         未发现的 user 源 SKILL 标孤儿（磁盘删除即从 ``get_skills`` 排除）。mcp 源由其 ``ResourceListChanged``
         处理器即时重物化，**不**在此重复。SKILL Home 未就绪 → no-op。
 
@@ -589,7 +581,7 @@ class Computer(BaseComputer[PromptSession]):
         if self._skill_home is None:
             return
         try:
-            discovered = stage_user_skills(self._skill_registry, self._skill_home, self._registered_workdirs)
+            discovered = stage_user_skills(self._skill_registry, self._skill_home)
             self._reconcile_orphans(set(discovered), lambda s: s == SOURCE_USER)
         except Exception as e:  # pragma: no cover — 防御性兜底（staging 内部已各自降级）
             logger.error(f"user 源重扫 / 对账失败 / user-source rescan failed: {e}", exc_info=True)
@@ -598,8 +590,8 @@ class Computer(BaseComputer[PromptSession]):
         """
         启动 user 源 DropIn 文件 watcher / Start the user-source DropIn file watcher。
 
-        监控根 = ``<home>/user/`` + 各登记 ``<workdir>/.tfrobot/skills/``（递归、过滤 ``SKILL.md``，**不**监
-        marketplace clone 树）。watchdog 回调在独立线程触发 → 经 ``loop.call_soon_threadsafe`` marshal 回事件
+        监控根 = ``<home>/user/``（递归、过滤 ``SKILL.md``，**不**监 marketplace clone 树；#116 起仅
+        home 单根）。watchdog 回调在独立线程触发 → 经 ``loop.call_soon_threadsafe`` marshal 回事件
         循环线程调去抖器 :meth:`mark_dirty`。已有 watcher → 先停。SKILL Home 未就绪 → no-op。
         """
         if self._skill_home is None:
@@ -616,8 +608,7 @@ class Computer(BaseComputer[PromptSession]):
                 pass
 
         watcher = SkillFileWatcher(_marshal, use_polling=self._skill_watch_polling)
-        roots = [user_dropin_root(self._skill_home), *(workdir_skill_root(wd) for wd in self._registered_workdirs)]
-        watcher.watch(roots)
+        watcher.watch([user_dropin_root(self._skill_home)])
         self._skill_watcher = watcher
 
     def mark_skill_internal_write(self, path: str | Path) -> None:
@@ -634,13 +625,10 @@ class Computer(BaseComputer[PromptSession]):
         """
         预定义渲染变量（对标 VS Code，§9.1）/ Predefined render variables (VS Code parity)。
 
-        ``workspaceFolder`` 取 active-workdir 单根（绑定当前任务，见 :attr:`active_workdir`），无则 ``os.getcwd()``；
         ``userHome``=用户主目录；``pathSeparator``=``os.sep``。``${env:VAR}`` 不在此（由 render 直接读
-        进程环境）。``workspaceFolder`` takes the active workdir (single bound root), else cwd.
+        进程环境）。#116：``${workspaceFolder}`` 已随 workdir 概念瘦身停产（按未知占位符原样保留）。
         """
-        workspace = str(self.active_workdir) if self.active_workdir else os.getcwd()
         return {
-            "workspaceFolder": workspace,
             "userHome": os.path.expanduser("~"),
             "pathSeparator": os.sep,
         }
@@ -650,7 +638,7 @@ class Computer(BaseComputer[PromptSession]):
         合并 ``envFile`` 的 ``KEY=VALUE`` 进 stdio server 的 ``env``（显式 env 胜，§9.1）/ Merge envFile into env。
 
         仅对 stdio（``server_parameters.env`` 存在）生效；sse/http 无 env 字段，原样返回。envFile **路径**
-        已在 :meth:`ConfigRender.arender` 渲染（``${workspaceFolder}`` 等已展开）。**显式 ``env`` 同名项覆盖
+        已在 :meth:`ConfigRender.arender` 渲染（``${input:}`` 等已展开）。**显式 ``env`` 同名项覆盖
         envFile**（显式胜）。本方法不改 ``envFile`` 字段本身（spawn 仅消费 ``server_parameters.env``）。
         """
         env_file = rendered.get("envFile") or rendered.get("env_file")
@@ -1302,17 +1290,6 @@ class Computer(BaseComputer[PromptSession]):
         if self._skill_home is None:
             self._skill_home = self._resolve_skill_home()
         return self._skill_home
-
-    @property
-    def active_workdir(self) -> Path | None:
-        """绑定当前任务的 active-workdir 单根（取首个已登记 workdir，空闲=None）/ The single active workdir (None when idle)。
-
-        北极星（#53）两层模型：本属性是 **project/local scope 来源**（``.tfrobot/settings[.local].json`` /
-        ``mcp.json``）与渲染 ``${workspaceFolder}`` 的**单一事实源**；而 :attr:`_registered_workdirs` 作能力发现
-        并集（DropIn 扫描 / watcher）跨全部目录、不随 active 跳变。``resolve_mcp_config`` / ``resolve_settings``
-        的 ``active_workdir`` 与 MCP 批准框写 local 均经此（#69 Group B/C）。
-        """
-        return self._registered_workdirs[0] if self._registered_workdirs else None
 
     def mark_skills_dirty(self) -> None:
         """标记 SKILL 集合变更 → 去抖器在窗口内合并触发单次 ``emit_update_skills``（CLI marketplace 变更后调）。

--- a/a2c_smcp/computer/inputs/render.py
+++ b/a2c_smcp/computer/inputs/render.py
@@ -8,11 +8,14 @@
 描述:
   中文: MCP 配置按需渲染器。识别占位符并替换，支持递归容器与深度限制。
         v0.2.1 #65（§9.1，对标 VS Code）：除 ``${input:<id>}``（经回调走解析链）外，新增
-        ``${env:<VAR>}``（进程环境变量，缺失→空串 + WARN）与预定义变量 ``${workspaceFolder}`` /
-        ``${userHome}`` / ``${pathSeparator}``。未知占位符保持原样（向后兼容）。
+        ``${env:<VAR>}``（进程环境变量，缺失→空串 + WARN）与预定义变量 ``${userHome}`` /
+        ``${pathSeparator}``。未知占位符保持原样（向后兼容）。
+        #116：``${workspaceFolder}`` 已随 workdir 概念瘦身移除（按未知占位符原样保留），
+        下游请改用 ``${input:<id>}`` 或绝对路径。
   English: On-demand renderer for MCP configs. v0.2.1 adds ``${env:VAR}`` (process env, missing → empty
-           + WARN) and predefined ``${workspaceFolder}`` / ``${userHome}`` / ``${pathSeparator}`` on top
-           of ``${input:id}``. Unknown placeholders are left untouched (backward compatible).
+           + WARN) and predefined ``${userHome}`` / ``${pathSeparator}`` on top of ``${input:id}``.
+           Unknown placeholders are left untouched (backward compatible). #116 removed
+           ``${workspaceFolder}``; use ``${input:<id>}`` or absolute paths instead.
 """
 
 from __future__ import annotations
@@ -34,7 +37,7 @@ def load_env_file(path: Path) -> dict[str, str]:
 
     解析规则：跳过空行与 ``#`` 注释；容忍前缀 ``export ``；去除值两端成对引号；无 ``=`` 的行跳过 + WARN。
     文件缺失 / 读失败 → ``{}`` + WARN（容错，不抛）。变量展开**不**在此发生——envFile 值按字面取，
-    占位符（如 ``${workspaceFolder}``）由调用方在渲染整份配置时（含 envFile **路径**）先行替换。
+    占位符（如 ``${input:<id>}``）由调用方在渲染整份配置时（含 envFile **路径**）先行替换。
     """
     try:
         text = path.read_text(encoding="utf-8")
@@ -69,7 +72,7 @@ def load_env_file(path: Path) -> dict[str, str]:
 # English: Match any ${...} placeholder; the inner token is dispatched by prefix in _aresolve_token.
 PLACEHOLDER_PATTERN = re.compile(r"\$\{([^}]+)}")
 
-_PREDEFINED_VARS = ("workspaceFolder", "userHome", "pathSeparator")
+_PREDEFINED_VARS = ("userHome", "pathSeparator")
 
 ResolveInput = Callable[[str], Awaitable[Any]]
 
@@ -96,7 +99,7 @@ class ConfigRender:
         中文: 递归渲染任意结构的数据，字符串中按需替换占位符。
         English: Recursively render arbitrary structured data, replacing placeholders in strings on demand.
 
-        :param variables: 预定义变量映射（workspaceFolder/userHome/pathSeparator）/ predefined variables.
+        :param variables: 预定义变量映射（userHome/pathSeparator）/ predefined variables.
         :param env: ``${env:VAR}`` 取值来源（默认 ``os.environ``，可注入便于测试）/ source for ``${env:VAR}``.
         """
         if _depth > self._max_depth:

--- a/a2c_smcp/computer/settings/__init__.py
+++ b/a2c_smcp/computer/settings/__init__.py
@@ -40,7 +40,6 @@ from a2c_smcp.computer.settings.policy import (
 )
 from a2c_smcp.computer.settings.schema import (
     BOOL_FIELDS,
-    CAPABILITY_FIELDS,
     POLICY_ONLY_FIELDS,
     STRING_ARRAY_FIELDS,
     ComputerSettings,
@@ -55,7 +54,6 @@ from a2c_smcp.computer.settings.scope import (
     DELETE,
     ResolvedSettings,
     apply_write,
-    filter_capability_fields,
     load_settings_file,
     merge_layers,
     merge_read,
@@ -104,7 +102,6 @@ from a2c_smcp.computer.settings.store import (
 __all__ = [
     # schema
     "BOOL_FIELDS",
-    "CAPABILITY_FIELDS",
     "POLICY_ONLY_FIELDS",
     "STRING_ARRAY_FIELDS",
     "ComputerSettings",
@@ -118,7 +115,6 @@ __all__ = [
     "DELETE",
     "ResolvedSettings",
     "apply_write",
-    "filter_capability_fields",
     "load_settings_file",
     "merge_layers",
     "merge_read",

--- a/a2c_smcp/computer/settings/__init__.py
+++ b/a2c_smcp/computer/settings/__init__.py
@@ -16,8 +16,8 @@ management UX.
 已落地模块 / Landed modules：
 - :mod:`a2c_smcp.computer.settings.schema` —— settings.json TypedDict + 字段级容错校验
   （passthrough / 无 version / policy-only 越权过滤）（S4，#56）
-- :mod:`a2c_smcp.computer.settings.scope`  —— 五级 scope 路径解析 + 读/写两套合并 customizer +
-  active-workdir 单根 / 能力层全局并集解析（S4，#56）
+- :mod:`a2c_smcp.computer.settings.scope`  —— 五级 scope 路径解析 + 读/写两套合并 customizer；
+  project/local 锚定进程 cwd（S4，#56；#116 瘦身）
 - :mod:`a2c_smcp.computer.settings.policy` —— policy 四子源 first-source-wins（remote stub + OS-MDM +
   managed-settings[+.d] + HKCU）（S4，#56）
 - :mod:`a2c_smcp.computer.settings.store`  —— 物化文件（known_marketplaces / installed_plugins）原子写 +

--- a/a2c_smcp/computer/settings/mcp_config.py
+++ b/a2c_smcp/computer/settings/mcp_config.py
@@ -23,7 +23,7 @@ SDK 设计 / Design: python-sdk docs/design-0.2.1-cli-marketplace-ux.md §9.1（
 This is the pure logic layer for MCP definitions/gating (no git / MCP manager / network).
 
 **显式划界 / Deferred boundaries**：
-- **取值渲染**（``envFile`` 加载 / ``${env:}`` / ``${workspaceFolder}`` / inputs 解析链 / keyring / 明文
+- **取值渲染**（``envFile`` 加载 / ``${env:}`` / inputs 解析链 / keyring / 明文
   state）归 **#65**：本模块产出**带占位符**的定义，``ResolvedMcpServer.ext``（``envFile`` 等 VS Code 扩展）
   + 未渲染占位符是交给 #65 的 handoff。**绝不在此渲染**（§9.1 安全铁律：值不离 Computer）。
 - **批准框 TTY 交互**（``[a]/[y]/[n]``）/ ``--approve-all-mcp`` flag / 非交互 pending→skip+WARN 接线归
@@ -43,6 +43,7 @@ This is the pure logic layer for MCP definitions/gating (no git / MCP manager / 
 from __future__ import annotations
 
 import json
+import os
 import sys
 from collections.abc import Mapping
 from dataclasses import dataclass, field
@@ -94,10 +95,6 @@ _TRUSTED_ORIGINS: frozenset[SettingsScope] = frozenset({SettingsScope.USER, Sett
 # 单点构造校验入口（照 manifest.py 范式）/ Single dict→model adapters.
 _MCP_SERVER_ADAPTER: TypeAdapter[MCPServerConfig] = TypeAdapter(MCPServerConfig)
 _MCP_INPUT_ADAPTER: TypeAdapter[MCPServerInput] = TypeAdapter(MCPServerInput)
-
-
-class McpConfigError(Exception):
-    """MCP 定义/批准写助手的契约违例（如批准写缺 active workdir）/ Contract violation in MCP config helpers."""
 
 
 class McpApprovalStatus(StrEnum):
@@ -265,7 +262,6 @@ def _validate_input(idef: Any, scope: SettingsScope, source: str | None) -> tupl
 # ---------------------------------------------------------------------------
 def resolve_mcp_config(
     *,
-    active_workdir: Path | None = None,
     env: Mapping[str, str] | None = None,
     flag_config_path: Path | None = None,
     managed_mcp_path: Path | None = None,
@@ -274,16 +270,16 @@ def resolve_mcp_config(
     """
     多 scope 加载合并 ``.tfrobot/mcp.json`` + 字段级校验 / Multi-scope load + merge + validate mcp.json。
 
-    合并顺序 low → high = ``[flag, user, active-project, active-local, policy]``（即优先级
+    合并顺序 low → high = ``[flag, user, project, local, policy]``（即优先级
     ``policy > local > project > user > flag``，§9.1/§5.5）；**无能力层并集**（敏感面隔离，区别于
-    settings.json）。``active_workdir is None`` → project/local 全空，仅 user + flag + policy + 默认。
+    settings.json）。#116：project/local 无条件锚定进程 ``os.getcwd()`` 的 ``.tfrobot/mcp[.local].json``
+    （cwd 恒存在；文件缺失 → 层不贡献）。
 
     - **servers**：按 name **整体替换**（高 scope 同名整体覆盖；server config 是原子单元、**非**深合并），
       ``origin`` = 最高定义 scope，``trusted_origin`` = origin ∈ {user, flag, policy}。
     - **inputs**：按 ``id`` 去重、高 scope 胜（缺 ``id`` 的条目各自保留以便逐条报错）。
     - 单 server / input 畸形 → drop + :class:`SettingsValidationError`，**不 abort**（§5.6 人编文件容错）。
 
-    :param active_workdir: 当前绑定任务的单根（project/local 来源）；``None`` = 空闲。
     :param env: 环境映射（解析 user config dir），默认 ``os.environ``。
     :param flag_config_path: ``--config @file`` 老接口文件（最低优先级，§5.5）。
     :param managed_mcp_path: policy scope ``managed-mcp.json`` 覆盖路径（缺省按平台推导；便于测试）。
@@ -291,14 +287,14 @@ def resolve_mcp_config(
     """
     managed_path = managed_mcp_path if managed_mcp_path is not None else managed_mcp_config_path(platform)
 
-    # (scope, path) 层，低优先级在前 / layers, lowest priority first.
+    # (scope, path) 层，低优先级在前；project/local 锚 cwd（#116）/ layers, lowest first; cwd-anchored.
+    cwd = Path(os.getcwd())
     layers: list[tuple[SettingsScope, Path]] = []
     if flag_config_path is not None:
         layers.append((SettingsScope.FLAG, Path(flag_config_path)))
     layers.append((SettingsScope.USER, user_mcp_config_path(env)))
-    if active_workdir is not None:
-        layers.append((SettingsScope.PROJECT, workdir_mcp_config_path(active_workdir)))
-        layers.append((SettingsScope.LOCAL, workdir_mcp_local_config_path(active_workdir)))
+    layers.append((SettingsScope.PROJECT, workdir_mcp_config_path(cwd)))
+    layers.append((SettingsScope.LOCAL, workdir_mcp_local_config_path(cwd)))
     layers.append((SettingsScope.POLICY, managed_path))
 
     errors: list[SettingsValidationError] = []
@@ -411,14 +407,12 @@ def bundled_mcp_server_names(home: Path | None = None, env: Mapping[str, str] | 
 # ---------------------------------------------------------------------------
 # 批准写助手（写 local scope）/ Approval write helpers (write to local scope)（§9.2）
 # ---------------------------------------------------------------------------
-def _require_active_workdir(active_workdir: Path | None) -> Path:
-    """批准写须落 local scope = active workdir；缺则 fail-fast（镜像 installer scope 守卫）/ local-scope guard。"""
-    if not active_workdir:
-        raise McpConfigError("MCP approval write requires an active workdir (local scope); none provided")
-    return Path(active_workdir)
+def _local_settings_write_path() -> Path:
+    """批准写落点：``<cwd>/.tfrobot/settings.local.json``（#116：cwd 恒存在，无 fail-fast）/ local write path。"""
+    return workdir_local_settings_path(Path(os.getcwd()))
 
 
-def _append_local_mcp_array(active_workdir: Path | None, field_name: str, name: str) -> None:
+def _append_local_mcp_array(field_name: str, name: str) -> None:
     """
     把 ``name`` 追加进 local ``settings.local.json`` 的某 MCP 数组字段（持锁原子 RMW + dedup）/ Append to a local array。
 
@@ -426,8 +420,7 @@ def _append_local_mcp_array(active_workdir: Path | None, field_name: str, name: 
     （数组**整体替换**写语义，§5.4）+ :func:`atomic_write_json`（``header=None``——人编意图层无写保护头/version）。
     锁内读-改-写杜绝并发丢更新。
     """
-    wd = _require_active_workdir(active_workdir)
-    path = workdir_local_settings_path(wd)
+    path = _local_settings_write_path()
     with file_lock(path):
         existing, _errors = load_settings_file(path, SettingsScope.LOCAL)
         current = [v for v in existing.get(field_name, []) if isinstance(v, str)]
@@ -437,20 +430,19 @@ def _append_local_mcp_array(active_workdir: Path | None, field_name: str, name: 
         atomic_write_json(path, updated)
 
 
-def approve_mcp_server(name: str, *, active_workdir: Path | None) -> None:
+def approve_mcp_server(name: str) -> None:
     """批准框 ``[y]es``：追加 ``enabledMcpjsonServers`` 到 local scope（§9.2）/ Approve: append to enabled list (local)。"""
-    _append_local_mcp_array(active_workdir, FIELD_ENABLED_MCPJSON_SERVERS, name)
+    _append_local_mcp_array(FIELD_ENABLED_MCPJSON_SERVERS, name)
 
 
-def deny_mcp_server(name: str, *, active_workdir: Path | None) -> None:
+def deny_mcp_server(name: str) -> None:
     """批准框 ``[n]o``：追加 ``disabledMcpjsonServers`` 到 local scope（§9.2）/ Deny: append to disabled list (local)。"""
-    _append_local_mcp_array(active_workdir, FIELD_DISABLED_MCPJSON_SERVERS, name)
+    _append_local_mcp_array(FIELD_DISABLED_MCPJSON_SERVERS, name)
 
 
-def approve_all_project_mcp(*, active_workdir: Path | None) -> None:
+def approve_all_project_mcp() -> None:
     """批准框 ``[a]ll``：``enableAllProjectMcpServers=true`` 写 local scope（§9.2）/ Approve-all: set the bool (local)。"""
-    wd = _require_active_workdir(active_workdir)
-    path = workdir_local_settings_path(wd)
+    path = _local_settings_write_path()
     with file_lock(path):
         existing, _errors = load_settings_file(path, SettingsScope.LOCAL)
         updated = apply_write(existing, {FIELD_ENABLE_ALL_PROJECT_MCP: True})

--- a/a2c_smcp/computer/settings/schema.py
+++ b/a2c_smcp/computer/settings/schema.py
@@ -76,9 +76,6 @@ FIELD_ALLOWED_MCP_SERVERS = "allowedMcpServers"
 FIELD_DENIED_MCP_SERVERS = "deniedMcpServers"
 FIELD_PERMISSIONS = "permissions"
 
-# 仅能在能力发现层取并集的字段（§5.0 (A) 层）/ Fields contributed by the capability layer.
-CAPABILITY_FIELDS: frozenset[str] = frozenset({FIELD_ENABLED_PLUGINS, FIELD_EXTRA_KNOWN_MARKETPLACES})
-
 # policy-only 字段：出现在非 policy scope → 过滤 + 记错（§5.6）。
 # Policy-only fields: filtered + recorded if seen outside the policy scope.
 POLICY_ONLY_FIELDS: frozenset[str] = frozenset({FIELD_ALLOWED_MCP_SERVERS, FIELD_DENIED_MCP_SERVERS})

--- a/a2c_smcp/computer/settings/schema.py
+++ b/a2c_smcp/computer/settings/schema.py
@@ -45,14 +45,10 @@ class SettingsScope(StrEnum):
     """
     settings 来源 scope（低 → 高，high 覆盖 low）/ Settings source scope (low → high)。
 
-    ``CAPABILITY`` 是 A2C 特有的**能力发现层**（最低优先级）：跨**全部登记工作目录**取
-    ``enabledPlugins`` / ``extraKnownMarketplaces`` 并集，让 Agent 能力面稳定、不随 active
-    workdir 跳变（§5.0/§5.1）。其余五级 = Claude Code 完整对齐（user/project/local/flag/policy）。
-    ``CAPABILITY`` is the A2C-specific capability-discovery layer (lowest); the other five align
-    with Claude Code.
+    五级与 Claude Code 完整对齐（user/project/local/flag/policy）；project/local 锚定进程 cwd（#116）。
+    Five levels aligned with Claude Code; project/local anchored at process cwd (#116).
     """
 
-    CAPABILITY = "capability"  # 能力发现层（最低）/ capability-discovery (lowest)
     USER = "user"
     PROJECT = "project"
     LOCAL = "local"

--- a/a2c_smcp/computer/settings/scope.py
+++ b/a2c_smcp/computer/settings/scope.py
@@ -5,8 +5,8 @@
 # @Email   : jqq1716@gmail.com
 # @Software: PyCharm
 """
-五级 scope 路径解析 + 读/写两套合并语义 + active-workdir / 能力层解析（v0.2.1）
-Five-level scope path resolution + read/write merge customizers + active-workdir / capability resolution.
+五级 scope 路径解析 + 读/写两套合并语义（v0.2.1；#116 起 project/local 锚定进程 cwd）
+Five-level scope path resolution + read/write merge customizers (project/local anchored at process cwd since #116).
 
 SDK 设计 / Design: python-sdk docs/design-0.2.1-cli-marketplace-ux.md §5.0 / §5.1 / §5.4。
 
@@ -23,9 +23,10 @@ SDK 设计 / Design: python-sdk docs/design-0.2.1-cli-marketplace-ux.md §5.0 / 
 - 删字段 → 写 :data:`DELETE`（= 删 key）/ deletion via the :data:`DELETE` sentinel.
 
 scope 分层（low → high）/ Scope layering (§5.1)：
-能力发现层（全部登记目录并集，仅 ``enabledPlugins`` / ``extraKnownMarketplaces``）< user（主）
-< project（active workdir 单根）< local（active workdir 单根）< flag < policy。
-**无 active workdir** 时 project/local 全空，仅 user + 能力层（+ flag/policy）。
+user（主）< project（``<cwd>/.tfrobot/settings.json``）< local（``<cwd>/.tfrobot/settings.local.json``）
+< flag < policy。#116：project/local 无条件锚定进程 ``os.getcwd()``（文件缺失 → 层为空）；
+原「能力发现层」（跨登记目录并集）随 ``registered_workdirs`` 概念一并移除——单 cwd 锚点下其贡献被
+更高优先级的 project/local 层（同文件超集）严格遮蔽，等价冗余。
 """
 
 from __future__ import annotations
@@ -38,7 +39,6 @@ from pathlib import Path
 from typing import Any
 
 from a2c_smcp.computer.settings.schema import (
-    CAPABILITY_FIELDS,
     SettingsScope,
     SettingsValidationError,
     validate_settings,
@@ -212,11 +212,6 @@ def load_settings_file(path: Path, scope: SettingsScope) -> tuple[dict[str, Any]
     return validate_settings(raw, scope, source_path=str(p))
 
 
-def filter_capability_fields(settings: Mapping[str, Any]) -> dict[str, Any]:
-    """只保留能力发现层字段（``enabledPlugins`` / ``extraKnownMarketplaces``）/ Keep only capability fields。"""
-    return {k: v for k, v in settings.items() if k in CAPABILITY_FIELDS}
-
-
 # ---------------------------------------------------------------------------
 # 解析编排 / Resolution orchestration
 # ---------------------------------------------------------------------------
@@ -235,63 +230,24 @@ class ResolvedSettings:
     errors: list[SettingsValidationError] = field(default_factory=list)
 
 
-def _build_capability_layer(
-    registered_workdirs: Sequence[Path],
-) -> tuple[dict[str, Any], list[SettingsValidationError]]:
-    """
-    能力发现层 (A)：跨**全部登记工作目录**取 ``enabledPlugins`` / ``extraKnownMarketplaces`` 并集。
-    Capability layer (A): union of capability fields across all registered workdirs。
-
-    单目录内 local 覆盖 project；跨目录按**登记顺序**后者覆盖前者并 WARN（§5.0「同名优先级」）。
-    Within a workdir local overrides project; across workdirs later registration wins + WARN.
-    """
-    errors: list[SettingsValidationError] = []
-    accumulated: dict[str, Any] = {}
-
-    def _on_conflict(path: str, old: Any, new: Any) -> None:
-        logger.warning(
-            "Capability-layer conflict on %r across registered workdirs: %r overridden by later registration %r",
-            path,
-            old,
-            new,
-        )
-
-    for workdir in registered_workdirs:
-        proj, proj_errors = load_settings_file(workdir_project_settings_path(workdir), SettingsScope.PROJECT)
-        local, local_errors = load_settings_file(workdir_local_settings_path(workdir), SettingsScope.LOCAL)
-        errors.extend(proj_errors)
-        errors.extend(local_errors)
-        # 单目录内：local 覆盖 project（仅能力字段）。
-        per_workdir = merge_read(filter_capability_fields(proj), filter_capability_fields(local))
-        accumulated = merge_read(accumulated, per_workdir, on_conflict=_on_conflict)
-
-    return accumulated, errors
-
-
 def _dedup_errors(errors: Sequence[SettingsValidationError]) -> list[SettingsValidationError]:
-    """按出现顺序去重（active workdir 文件在能力层 + B 层被读两次，错误天然重复）/ Order-preserving error dedup."""
+    """按出现顺序去重（防御性保留：各层独立读文件，正常不重复）/ Order-preserving error dedup."""
     return list(dict.fromkeys(errors))
 
 
 def resolve_settings(
     *,
-    registered_workdirs: Sequence[Path] = (),
-    active_workdir: Path | None = None,
     env: Mapping[str, str] | None = None,
     flag_settings_path: Path | None = None,
     policy_settings: Mapping[str, Any] | None = None,
 ) -> ResolvedSettings:
     """
-    解析六层 settings 视图（能力层 / user / project / local / flag / policy）/ Resolve the six-layer view。
+    解析五层 settings 视图（user / project / local / flag / policy）/ Resolve the five-layer view。
 
-    两层模型（访谈定稿，§5.0 / §5.1）/ Two-layer model:
-    - **(A) 能力发现层**：``enabledPlugins`` / ``extraKnownMarketplaces`` 跨**全部** ``registered_workdirs``
-      取并集、置最低优先级（稳定能力面、不随 active 跳变）。
-    - **(B) active-workdir 单根**：project/local **只取** ``active_workdir`` 的 ``.tfrobot/settings[.local].json``，
-      不跨目录并集；**``active_workdir is None`` 时 project/local 全空**（仅 user + 能力层 + flag/policy）。
+    #116：project/local 无条件锚定进程 ``os.getcwd()`` 的 ``.tfrobot/settings[.local].json``
+    （cwd 恒存在；文件缺失 → 层为空）。原「能力发现层 + active-workdir 单根」两层模型随
+    ``registered_workdirs`` / ``active_workdir`` 概念移除收敛为单 cwd 锚点。
 
-    :param registered_workdirs: workspace 持久登记的全部工作目录（能力层来源）/ all registered workdirs.
-    :param active_workdir: 当前绑定任务的单根（project/local 来源）；``None`` = 空闲 / no active task.
     :param env: 环境映射（解析 user config dir），默认 ``os.environ`` / env mapping for the user config dir.
     :param flag_settings_path: ``--settings <file>`` 指定文件 / the ``--settings`` flag file, if any.
     :param policy_settings: policy scope 原始 dict（来自 :mod:`a2c_smcp.computer.settings.policy`
@@ -299,22 +255,16 @@ def resolve_settings(
     """
     errors: list[SettingsValidationError] = []
 
-    # (A) 能力发现层（最低）/ capability layer (lowest)
-    capability_layer, cap_errors = _build_capability_layer(registered_workdirs)
-    errors.extend(cap_errors)
-
     # user（主）/ user (primary)
     user_layer, user_errors = load_settings_file(user_settings_path(env), SettingsScope.USER)
     errors.extend(user_errors)
 
-    # (B) active-workdir 单根 project/local / active-workdir single-root
-    if active_workdir is not None:
-        project_layer, proj_errors = load_settings_file(workdir_project_settings_path(active_workdir), SettingsScope.PROJECT)
-        local_layer, local_errors = load_settings_file(workdir_local_settings_path(active_workdir), SettingsScope.LOCAL)
-        errors.extend(proj_errors)
-        errors.extend(local_errors)
-    else:
-        project_layer, local_layer = {}, {}
+    # project/local：锚定进程 cwd / anchored at process cwd (#116)
+    cwd = Path(os.getcwd())
+    project_layer, proj_errors = load_settings_file(workdir_project_settings_path(cwd), SettingsScope.PROJECT)
+    local_layer, local_errors = load_settings_file(workdir_local_settings_path(cwd), SettingsScope.LOCAL)
+    errors.extend(proj_errors)
+    errors.extend(local_errors)
 
     # flag / flag (``--settings``)
     if flag_settings_path is not None:
@@ -327,5 +277,5 @@ def resolve_settings(
     policy_layer, policy_errors = validate_settings(dict(policy_settings or {}), SettingsScope.POLICY)
     errors.extend(policy_errors)
 
-    merged = merge_layers([capability_layer, user_layer, project_layer, local_layer, flag_layer, policy_layer])
+    merged = merge_layers([user_layer, project_layer, local_layer, flag_layer, policy_layer])
     return ResolvedSettings(settings=merged, errors=_dedup_errors(errors))

--- a/a2c_smcp/computer/settings/scope.py
+++ b/a2c_smcp/computer/settings/scope.py
@@ -231,7 +231,11 @@ class ResolvedSettings:
 
 
 def _dedup_errors(errors: Sequence[SettingsValidationError]) -> list[SettingsValidationError]:
-    """按出现顺序去重（防御性保留：各层独立读文件，正常不重复）/ Order-preserving error dedup."""
+    """按出现顺序去重 / Order-preserving error dedup。
+
+    防御性保留：#116 后各层读**不同文件**，当前无路径产生重复错误（原「能力层 + B 层双读
+    active workdir 文件」场景已随能力层移除消失）。
+    """
     return list(dict.fromkeys(errors))
 
 

--- a/a2c_smcp/computer/skills/__init__.py
+++ b/a2c_smcp/computer/skills/__init__.py
@@ -42,7 +42,6 @@ from a2c_smcp.computer.skills.home import (
     resolve_skill_home,
     user_dropin_root,
     user_skill_dir,
-    workdir_skill_root,
 )
 from a2c_smcp.computer.skills.naming import (
     MCP_SEGMENT,
@@ -112,7 +111,6 @@ __all__ = [
     "resolve_skill_home",
     "user_dropin_root",
     "user_skill_dir",
-    "workdir_skill_root",
     # naming
     "MCP_SEGMENT",
     "ParsedSkillName",

--- a/a2c_smcp/computer/skills/home.py
+++ b/a2c_smcp/computer/skills/home.py
@@ -58,9 +58,6 @@ XDG_DATA_HOME_ENV = "XDG_DATA_HOME"
 _A2C_DATA_SUBPATH = ("a2c", "skills")
 _DOTDIR_SUBPATH = (".a2c", "skills")
 
-# workspace 登记工作目录内的 user 源 DropIn 子路径 / Per-workdir user-source DropIn subpath。
-_WORKDIR_SKILL_SUBPATH = (".tfrobot", "skills")
-
 # 每用户私有目录权限 / Per-user-private directory mode（防御性写，隔离交给 OS）。
 SKILL_HOME_MODE = 0o700
 
@@ -142,17 +139,3 @@ def user_skill_dir(home: Path, skill: str) -> Path:
 def user_dropin_root(home: Path) -> Path:
     """SKILL Home 内的 user 源 DropIn 发现根 / Global user-source DropIn root：``<home>/user/``。"""
     return home / SOURCE_USER
-
-
-def workdir_skill_root(workdir: Path) -> Path:
-    """
-    workspace 登记工作目录的 user 源 DropIn 发现根 / Per-workdir user-source DropIn root。
-
-    ``<workdir>/.tfrobot/skills/``——**就地发现、不 staging 进 SKILL Home**（与 marketplace clone 树相反，
-    见 design-0.2.1-cli-marketplace-ux.md §5.0）。skill 属能力发现层：跨**全部已登记工作目录**全局并集、
-    置最低优先级、**不随 active workdir 切换**（§2.3/§5.1）。
-    ``<workdir>/.tfrobot/skills/`` — discovered **in place** (not staged into SKILL Home, unlike the
-    marketplace clone tree). User skills form a workspace-global capability set across all registered
-    workdirs (lowest precedence, independent of the active workdir).
-    """
-    return workdir.joinpath(*_WORKDIR_SKILL_SUBPATH)

--- a/a2c_smcp/computer/skills/staging.py
+++ b/a2c_smcp/computer/skills/staging.py
@@ -48,11 +48,10 @@ mcp 流程 / mcp flow：
 4. 合成 ``A2CSkillRef``（name = ``mcp:<normalized-server>:<frontmatter.name>``）→ 注册进 :class:`SkillRegistry`。
 
 user 流程 / user flow（与 mcp 的关键差异）：**就地发现、不复制进 SKILL Home**。扫描发现根
-``$A2C_SKILL_HOME/user/``（全局个人）+ **全部已登记工作目录** ``<workdir>/.tfrobot/skills/``（能力发现层、
-跨目录全局并集、不随 active workdir 切换）；发现单元 ``<root>/<skill>/SKILL.md``（根下**一级**）。
+``$A2C_SKILL_HOME/user/``（全局个人；#116 起仅 home 单根，workdir 维度 SKILL 已下沉 MCP 服务经
+``skill://`` 承载）；发现单元 ``<root>/<skill>/SKILL.md``（根下**一级**）。
 - **name = 目录 basename**（单段裸名，§5.0）——就地目录不可改名，与 sandbox 的 name 寻址（S2）一致；
   ``frontmatter.name`` 仅参考（不一致记 DEBUG）；basename 非严格 kebab → 跳过。
-- **优先级（低→高）**：``user/`` < 各 workdir（按登记序，**后者覆盖前者** + WARN）。
 - 深于一级的 ``SKILL.md``（``<root>/a/b/SKILL.md``）→ 忽略 + DEBUG（user 源单段命名，不嵌套）。
 - 重扫幂等：已注册 → ``update``（含孤儿恢复），否则 ``register``；磁盘删除项的孤儿标记交 reconciler（#62）/
   watcher（#67）按返回的发现 name 列表 diff，本函数不负责。

--- a/a2c_smcp/computer/skills/staging.py
+++ b/a2c_smcp/computer/skills/staging.py
@@ -89,7 +89,6 @@ from a2c_smcp.computer.skills.home import (
     marketplace_skill_dir,
     mcp_skill_dir,
     user_dropin_root,
-    workdir_skill_root,
 )
 from a2c_smcp.computer.skills.manifest import (
     PluginManifestError,
@@ -550,24 +549,6 @@ def _finalize_and_register(
 
 
 # ── user 源 DropIn（就地发现，不 staging）/ user-source in-place DropIn ────────
-def _user_dropin_roots(home: Path, workdirs: Sequence[Path]) -> list[Path]:
-    """
-    user 源 DropIn 发现根，按优先级**升序**（低→高，后者覆盖）+ 解析去重 / Ascending-priority deduped roots。
-
-    顺序 = ``[<home>/user]`` + ``[<workdir>/.tfrobot/skills ...]``（登记序）。``resolve()`` 后按路径去重保序，
-    避免同一目录被登记两次造成重复扫描 + 假 WARN（首次出现定其优先级槽位）。
-    """
-    ordered: list[Path] = [user_dropin_root(home).resolve()]
-    ordered.extend(workdir_skill_root(wd).resolve() for wd in workdirs)
-    seen: set[Path] = set()
-    deduped: list[Path] = []
-    for root in ordered:
-        if root not in seen:
-            seen.add(root)
-            deduped.append(root)
-    return deduped
-
-
 def _iter_user_skill_dirs(root: Path) -> Iterator[Path]:
     """
     枚举发现根下的 SKILL 目录 / Yield ``<root>/<skill>/`` whose ``<skill>/SKILL.md`` exists（根下**一级**）。
@@ -630,44 +611,32 @@ def _build_user_ref(name: str, skill_dir: Path) -> A2CSkillRef | None:
 def stage_user_skills(
     registry: SkillRegistry,
     home: Path,
-    workdirs: Sequence[Path] = (),
 ) -> list[str]:
     """
     枚举 user 源 DropIn 并注册进 Registry（**就地发现、不复制**）/ Discover user-source DropIn skills in place。
 
-    扫描 ``<home>/user/`` + 各 ``<workdir>/.tfrobot/skills/``（能力发现层全局并集，**不随 active workdir 切换**）；
-    发现单元 ``<root>/<skill>/SKILL.md``（根下一级），name = 目录 basename（单段裸名）。同名按发现根优先级
-    **后者覆盖前者**（``user/`` 最低 < 各 workdir 登记序），覆盖时记 WARN（便于诊断「为何我的 skill 不显示」）。
+    扫描 ``<home>/user/``（#116 起仅 home 单根；workdir 维度 SKILL 已下沉 MCP 服务经 ``skill://`` 承载）；
+    发现单元 ``<root>/<skill>/SKILL.md``（根下一级），name = 目录 basename（单段裸名）。
 
     :param registry: 目标 :class:`SkillRegistry`。
     :param home: SKILL Home 绝对根（见 :mod:`~a2c_smcp.computer.skills.home`）。
-    :param workdirs: workspace **已登记工作目录**（按登记序；调用方提供，本函数不耦合 workspace 登记模块）。
     :return: 本次发现并成功注册/刷新的 SKILL name 列表 / discovered & registered names（供 reconciler/watcher diff 孤儿）。
     """
-    winners: dict[str, tuple[A2CSkillRef, Path]] = {}  # name → (ref, 发现目录)；后者覆盖前者
-    for root in _user_dropin_roots(home, workdirs):
-        for skill_dir in _iter_user_skill_dirs(root):
-            basename = skill_dir.name
-            try:
-                name = synthesize_user_name(basename)  # 校验严格 kebab（§1.5 失败不入册）
-            except SkillNameError as e:
-                logger.error("user DropIn skill dir name invalid, skipped: %s (%s)", skill_dir, e.reason)
-                continue
-            ref = _build_user_ref(name, skill_dir)
-            if ref is None:
-                continue
-            prev = winners.get(name)
-            if prev is not None:
-                logger.warning(
-                    "user SKILL %r at %s shadows earlier DropIn at %s (later root wins)",
-                    name,
-                    skill_dir,
-                    prev[1],
-                )
-            winners[name] = (ref, skill_dir)
+    winners: dict[str, A2CSkillRef] = {}  # name → ref（单根下 basename 唯一，无跨根遮蔽）
+    for skill_dir in _iter_user_skill_dirs(user_dropin_root(home).resolve()):
+        basename = skill_dir.name
+        try:
+            name = synthesize_user_name(basename)  # 校验严格 kebab（§1.5 失败不入册）
+        except SkillNameError as e:
+            logger.error("user DropIn skill dir name invalid, skipped: %s (%s)", skill_dir, e.reason)
+            continue
+        ref = _build_user_ref(name, skill_dir)
+        if ref is None:
+            continue
+        winners[name] = ref
 
     registered: list[str] = []
-    for name, (ref, _) in winners.items():
+    for name, ref in winners.items():
         # 跨 run 既存（active 或 orphan）→ update（刷新 / 孤儿恢复）；否则 register。
         if registry.register_or_update(ref):
             registered.append(name)

--- a/a2c_smcp/computer/skills/watcher.py
+++ b/a2c_smcp/computer/skills/watcher.py
@@ -11,8 +11,8 @@ SKILL file watcher: watch user-source DropIn roots, SKILL.md change → debounce
 SDK 设计 / Design: python-sdk docs/design-0.2.1-cli-marketplace-ux.md §8.3。
 
 监控范围 / Scope（§8.3）：
-- 监控根（**递归**）= ``$A2C_SKILL_HOME/user/`` + **全部已登记** ``<workdir>/.tfrobot/skills/``（能力发现层、
-  全局并集、不随 active workdir 切换）；过滤器为 ``**/SKILL.md``。**绝不监** marketplace clone 树
+- 监控根（**递归**）= ``$A2C_SKILL_HOME/user/``（#116 起仅 home 单根，workdir 维度已下沉 MCP 服务）；
+  过滤器为 ``**/SKILL.md``。**绝不监** marketplace clone 树
   （``<home>/marketplace/<mp>/...``）——clone 树是物化产物，变更只经 CLI 操作发生（操作自调去抖标脏），
   监控它会引发 ``git pull`` 雪崩并破坏「意图层 / 物化层」单向同步边界（§8.3 三条理由）。
 - **监控范围 ≠ 发现单元**：watcher 监根递归子树并过滤 ``SKILL.md``；SKILL 的「发现单元」是

--- a/docs/design-0.2.1-cli-marketplace-ux.md
+++ b/docs/design-0.2.1-cli-marketplace-ux.md
@@ -1,5 +1,10 @@
 # 设计文档：0.2.1 — CLI Marketplace/Plugin/Skill 管理 UX
 
+> ⚠️ **部分内容已被 [#116](https://github.com/A2C-SMCP/python-sdk/issues/116) 取代（v0.2.2 workdir 概念瘦身）**：
+> `--add-dir` / `active_workdir` / `registered_workdirs` / `${workspaceFolder}` / 能力发现层（跨登记目录并集）
+> 已整体移除——workdir 范围 SKILL 下沉 IDE4AI 等 MCP 服务经 `skill://` Resource 承载；settings/mcp 的
+> project·local scope 锚定进程 cwd。本文涉及上述概念的章节（决策 #28、§5.0、§5.1、§9.1 等）仅作历史记录保留。
+
 > **性质**：python-sdk 的 **CLI 表面**设计（如何让用户在 `a2c-computer` 上管理 marketplace/plugin/skill）。**不是协议规范**，也不是内部模型规范（后者归 [`design-0.2.1-skill-computer-management.md`](design-0.2.1-skill-computer-management.md)）。
 > **范本**：Claude Code 的 marketplace/plugin/skill 三层模型 + 意图/物化两层 + reconciler；本文档逐项对齐，仅在 A2C 分布式架构（Agent ↔ Server ↔ Computer 三进程）下调整必要的事件机制。
 > **追踪**：GitHub Issue [#39](https://github.com/A2C-SMCP/python-sdk/issues/39) 拓展范围。原 #39 仅落 `computer/skills/` 内部六模块；本设计补 CLI 命令/REPL/settings.json/reconciler 表面 UX。

--- a/tests/integration_tests/computer/cli/test_main.py
+++ b/tests/integration_tests/computer/cli/test_main.py
@@ -280,20 +280,18 @@ def test_root_settings_flag_propagates_to_merged_show(tmp_path: Path, monkeypatc
     assert recorded.get("flag_path") == flag_file
 
 
-def test_root_add_dir_propagates_active_workdir_to_settings_set(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """`--add-dir <d> settings set <k> <v> --scope project` 应把 active_workdir 透传给 settings_set。"""
+# #116 概念瘦身：--add-dir 已移除 / #116 slimming: --add-dir removed
+def test_add_dir_option_removed(tmp_path: Path) -> None:
+    """#116: `--add-dir` 不再是合法选项，传入应报未知选项错误。"""
     runner = CliRunner()
-    wd = tmp_path / "wd"
-    wd.mkdir()
-    recorded: dict[str, Any] = {}
-    monkeypatch.setattr(cli_main.settings_cmd, "settings_set", _spy_handler(recorded), raising=True)
+    env = {**os.environ, "A2C_SKILL_HOME": str(tmp_path / "skill"), "XDG_CONFIG_HOME": str(tmp_path / "cfg")}
 
     result = runner.invoke(  # noqa: S603
-        cli_main.app, ["--add-dir", str(wd), "settings", "set", "k", "v", "--scope", "project"],
+        cli_main.app, ["--add-dir", str(tmp_path), "settings", "show"], env=env,
     )
 
-    assert result.exit_code == 0
-    assert recorded.get("active_workdir") == wd.resolve()  # 修前为 None（未透传）→ 红
+    assert result.exit_code != 0
+    assert "no such option" in result.output.lower()
 
 
 def test_root_settings_flag_scope_real_output(tmp_path: Path) -> None:

--- a/tests/integration_tests/computer/settings/test_mcp_config.py
+++ b/tests/integration_tests/computer/settings/test_mcp_config.py
@@ -23,6 +23,8 @@ import json
 import os
 from pathlib import Path
 
+import pytest
+
 from a2c_smcp.computer.settings.mcp_config import (
     McpApprovalStatus,
     approve_mcp_server,
@@ -60,15 +62,16 @@ def _home(tmp_path: Path) -> Path:
 
 
 # ── resolve + gate 全栈 ───────────────────────────────────────────────────────
-def test_resolve_and_gate_full_stack(tmp_path: Path) -> None:
+def test_resolve_and_gate_full_stack(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     env = _env(tmp_path)
     wd = tmp_path / "wd"
     managed_mcp = tmp_path / "managed-mcp.json"
 
-    # 跨 scope 铺 server 定义：user(trusted) / project(workspace) / policy(trusted)。
+    # 跨 scope 铺 server 定义：user(trusted) / project(workspace，锚 cwd，#116) / policy(trusted)。
     _write_json(tmp_path / "cfg" / "a2c" / "mcp.json", _mcp({"user-srv": _stdio()}))
     _write_json(wd / ".tfrobot" / "mcp.json", _mcp({"proj-srv": _stdio(), "blender": _stdio()}))
     _write_json(managed_mcp, _mcp({"policy-srv": _stdio()}))
+    monkeypatch.chdir(wd)
 
     # bundled 账本：plugin 携带 "blender" → 即使在 workspace mcp.json 出现，也免批准。
     save_installed_plugins(
@@ -79,10 +82,10 @@ def test_resolve_and_gate_full_stack(tmp_path: Path) -> None:
     # policy denies "policy-srv"（企业拒绝名单，policy scope）。
     policy = {"deniedMcpServers": ["policy-srv"]}
 
-    resolved = resolve_mcp_config(env=env, active_workdir=wd, managed_mcp_path=managed_mcp)
+    resolved = resolve_mcp_config(env=env, managed_mcp_path=managed_mcp)
     assert set(resolved.servers) == {"user-srv", "proj-srv", "blender", "policy-srv"}
 
-    settings = resolve_settings(active_workdir=wd, env=env, policy_settings=policy).settings
+    settings = resolve_settings(env=env, policy_settings=policy).settings
     bundled = bundled_mcp_server_names(env=env)
     statuses = gate_mcp_servers(resolved, settings, bundled)
 
@@ -94,37 +97,39 @@ def test_resolve_and_gate_full_stack(tmp_path: Path) -> None:
     }
 
 
-def test_approve_roundtrip_flips_pending_to_enabled(tmp_path: Path) -> None:
-    """pending workspace server → approve 写 local → resolve_settings 六层读回 → 重门控 enabled。"""
+def test_approve_roundtrip_flips_pending_to_enabled(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """pending workspace server → approve 写 local（cwd 锚，#116）→ resolve_settings 读回 → 重门控 enabled。"""
     env = _env(tmp_path)
     wd = tmp_path / "wd"
     managed_mcp = tmp_path / "absent-managed-mcp.json"
     _write_json(wd / ".tfrobot" / "mcp.json", _mcp({"figma": _stdio()}))
+    monkeypatch.chdir(wd)
 
-    resolved = resolve_mcp_config(env=env, active_workdir=wd, managed_mcp_path=managed_mcp)
+    resolved = resolve_mcp_config(env=env, managed_mcp_path=managed_mcp)
     bundled = bundled_mcp_server_names(env=env)
 
-    before = gate_mcp_servers(resolved, resolve_settings(active_workdir=wd, env=env).settings, bundled)
+    before = gate_mcp_servers(resolved, resolve_settings(env=env).settings, bundled)
     assert before == {"figma": McpApprovalStatus.PENDING}
 
-    # 批准框 [y]es：写 active-workdir local settings.local.json。
-    approve_mcp_server("figma", active_workdir=wd)
+    # 批准框 [y]es：写 cwd 的 local settings.local.json。
+    approve_mcp_server("figma")
 
-    after = gate_mcp_servers(resolved, resolve_settings(active_workdir=wd, env=env).settings, bundled)
+    after = gate_mcp_servers(resolved, resolve_settings(env=env).settings, bundled)
     assert after == {"figma": McpApprovalStatus.ENABLED}
 
 
-def test_scope_override_full_stack(tmp_path: Path) -> None:
-    """同名 server user(低) + local(高)：local 整体覆盖、origin=local、workspace 受门控（pending）。"""
+def test_scope_override_full_stack(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """同名 server user(低) + local(高，锚 cwd)：local 整体覆盖、origin=local、workspace 受门控（pending）。"""
     env = _env(tmp_path)
     wd = tmp_path / "wd"
     _write_json(tmp_path / "cfg" / "a2c" / "mcp.json", _mcp({"shared": {"type": "stdio", "server_parameters": {"command": "user-cmd"}}}))
     _write_json(wd / ".tfrobot" / "mcp.local.json", _mcp({"shared": {"type": "stdio", "server_parameters": {"command": "local-cmd"}}}))
+    monkeypatch.chdir(wd)
 
-    resolved = resolve_mcp_config(env=env, active_workdir=wd, managed_mcp_path=tmp_path / "absent.json")
+    resolved = resolve_mcp_config(env=env, managed_mcp_path=tmp_path / "absent.json")
     srv = resolved.servers["shared"]
     assert srv.config.server_parameters.command == "local-cmd"  # 高 scope 整体覆盖
     assert srv.trusted_origin is False  # origin=local → workspace 共享、受门控
 
-    statuses = gate_mcp_servers(resolved, resolve_settings(active_workdir=wd, env=env).settings, set())
+    statuses = gate_mcp_servers(resolved, resolve_settings(env=env).settings, set())
     assert statuses == {"shared": McpApprovalStatus.PENDING}

--- a/tests/unit_tests/computer/cli/test_mcp_approval.py
+++ b/tests/unit_tests/computer/cli/test_mcp_approval.py
@@ -70,9 +70,7 @@ class _Session:
 
 
 class _FakeComp:
-    def __init__(self, wd: Path | None, home: Path) -> None:
-        self.active_workdir = wd
-        self._registered_workdirs = (wd,) if wd is not None else ()
+    def __init__(self, home: Path) -> None:
         self.skill_home = home
         self.injected: list[Any] = []
         self.mounted: list[dict[str, Any]] = []
@@ -96,13 +94,14 @@ def _stdio() -> dict[str, Any]:
 
 # ── PENDING + TTY [y] → 写 local + 挂载 + 重启幂等 ──────────────────────────────
 @pytest.mark.asyncio
-async def test_pending_approve_yes_writes_local_and_mounts_then_idempotent(tmp_path: Path) -> None:
+async def test_pending_approve_yes_writes_local_and_mounts_then_idempotent(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     wd, home, env = tmp_path / "proj", tmp_path / "home", _env(tmp_path)
     wd.mkdir()
     home.mkdir()
     _project_mcp(wd, {"shared": _stdio()})  # project origin → 非 trusted → PENDING
+    monkeypatch.chdir(wd)  # #116：project/local 层锚定进程 cwd
 
-    comp = _FakeComp(wd, home)
+    comp = _FakeComp(home)
     sess = _Session(["y"])
     # run_mcp_approval 读 os.environ 派生 XDG → 用 monkeypatch env 注入
     import unittest.mock as _m
@@ -111,10 +110,10 @@ async def test_pending_approve_yes_writes_local_and_mounts_then_idempotent(tmp_p
         await run_mcp_approval(comp, sess, approve_all=False, flag_config=None)
     assert "shared" in _mounted_names(comp)  # [y] → 挂载
     local = json.loads(workdir_local_settings_path(wd).read_text(encoding="utf-8"))
-    assert local["enabledMcpjsonServers"] == ["shared"]  # 写 local scope
+    assert local["enabledMcpjsonServers"] == ["shared"]  # 写 local scope（cwd 单根）
 
     # 重启幂等：二次启动 gate 读到 local enabled → ENABLED 直挂、不再弹（session 无答案也不报错）
-    comp2 = _FakeComp(wd, home)
+    comp2 = _FakeComp(home)
     sess2 = _Session([])
     with _m.patch.dict(os.environ, env, clear=False):
         await run_mcp_approval(comp2, sess2, approve_all=False, flag_config=None)
@@ -124,12 +123,13 @@ async def test_pending_approve_yes_writes_local_and_mounts_then_idempotent(tmp_p
 
 # ── PENDING + 非 TTY → skip+WARN（不挂不写）；--approve-all-mcp → 挂载不落盘 ──────
 @pytest.mark.asyncio
-async def test_pending_non_tty_skips_and_does_not_write(tmp_path: Path) -> None:
+async def test_pending_non_tty_skips_and_does_not_write(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     wd, home, env = tmp_path / "proj", tmp_path / "home", _env(tmp_path)
     wd.mkdir()
     home.mkdir()
     _project_mcp(wd, {"shared": _stdio()})
-    comp = _FakeComp(wd, home)
+    monkeypatch.chdir(wd)
+    comp = _FakeComp(home)
     import unittest.mock as _m
 
     with _m.patch.dict(os.environ, env, clear=False):
@@ -139,12 +139,13 @@ async def test_pending_non_tty_skips_and_does_not_write(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
-async def test_pending_non_tty_approve_all_mounts_without_persist(tmp_path: Path) -> None:
+async def test_pending_non_tty_approve_all_mounts_without_persist(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     wd, home, env = tmp_path / "proj", tmp_path / "home", _env(tmp_path)
     wd.mkdir()
     home.mkdir()
     _project_mcp(wd, {"shared": _stdio()})
-    comp = _FakeComp(wd, home)
+    monkeypatch.chdir(wd)
+    comp = _FakeComp(home)
     import unittest.mock as _m
 
     with _m.patch.dict(os.environ, env, clear=False):
@@ -160,7 +161,7 @@ async def test_user_origin_mounts_without_box(tmp_path: Path) -> None:
     wd.mkdir()
     home.mkdir()
     _user_mcp(env, {"mine": _stdio()})  # user origin → trusted_origin → ENABLED、免批准
-    comp = _FakeComp(wd, home)
+    comp = _FakeComp(home)
     sess = _Session([])  # 不应被调用
     import unittest.mock as _m
 
@@ -178,7 +179,7 @@ async def test_envfile_ext_merged_into_mount_dict(tmp_path: Path) -> None:
     home.mkdir()
     envfile = str(wd / ".env")
     _user_mcp(env, {"mine": {**_stdio(), "envFile": envfile}})  # user origin → 直挂
-    comp = _FakeComp(wd, home)
+    comp = _FakeComp(home)
     import unittest.mock as _m
 
     with _m.patch.dict(os.environ, env, clear=False):
@@ -189,13 +190,16 @@ async def test_envfile_ext_merged_into_mount_dict(tmp_path: Path) -> None:
 
 # ── resolved.errors 呈现 WARN ──────────────────────────────────────────────────
 @pytest.mark.asyncio
-async def test_malformed_server_surfaces_warning(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+async def test_malformed_server_surfaces_warning(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch,
+) -> None:
     wd, home, env = tmp_path / "proj", tmp_path / "home", _env(tmp_path)
     wd.mkdir()
     home.mkdir()
     # 畸形 server（缺 type）→ drop + error；valid 同存
     _project_mcp(wd, {"bad": {"server_parameters": {}}, "good": _stdio()})
-    comp = _FakeComp(wd, home)
+    monkeypatch.chdir(wd)
+    comp = _FakeComp(home)
     import unittest.mock as _m
 
     with _m.patch.dict(os.environ, env, clear=False):

--- a/tests/unit_tests/computer/cli/test_settings.py
+++ b/tests/unit_tests/computer/cli/test_settings.py
@@ -66,9 +66,13 @@ def test_set_readonly_scopes_exit1(tmp_path: Path, scope: str) -> None:
     assert settings_cmd.settings_set(home, env, "deniedMcpServers", '["x"]', scope=scope, json_output=True) == 1
 
 
-def test_set_project_without_active_workdir_exit1(tmp_path: Path) -> None:
+def test_set_project_writes_cwd_anchor(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """#116: project scope 锚定进程 cwd，无 workdir 状态也可写（不再 exit 1）。"""
     home, env = _home(tmp_path), _env(tmp_path)
-    assert settings_cmd.settings_set(home, env, "foo", "1", scope="project", active_workdir=None, json_output=True) == 1
+    monkeypatch.chdir(tmp_path)
+    assert settings_cmd.settings_set(home, env, "strictKnownMarketplaces", "true", scope="project", json_output=True) == 0
+    data = json.loads((tmp_path / ".tfrobot" / "settings.json").read_text(encoding="utf-8"))
+    assert data["strictKnownMarketplaces"] is True
 
 
 # ── get / show ──────────────────────────────────────────────────────────────

--- a/tests/unit_tests/computer/inputs/test_envfile.py
+++ b/tests/unit_tests/computer/inputs/test_envfile.py
@@ -10,7 +10,8 @@ envFile 加载 + 合并单元测试（v0.2.1 #65，§9.1）/ envFile load + merg
 测试意图 / Test intentions:
 - ``load_env_file``：KEY=VALUE / 注释 / 引号 / export / 缺文件→{} / 无 '=' 行跳过；
 - ``Computer._apply_env_file``：stdio 合并、显式 env 胜、非 stdio（sse）原样、无 envFile 原样；
-- 端到端：envFile 路径含 ``${workspaceFolder}`` 经渲染后再加载（_arender_and_validate_server）。
+- 端到端：envFile 路径含 ``${userHome}`` 等占位符经渲染后再加载（_arender_and_validate_server；
+  #116 起 ``${workspaceFolder}`` 停产）。
 """
 
 from __future__ import annotations
@@ -52,20 +53,19 @@ def test_load_env_file_missing(tmp_path: Path) -> None:
     assert load_env_file(tmp_path / "nope.env") == {}
 
 
-def _comp(tmp_path: Path) -> Computer:
+def _comp() -> Computer:
     return Computer(
         name="t",
         inputs=set(),
         mcp_servers=set(),
         auto_connect=False,
         auto_reconnect=False,
-        registered_workdirs=[tmp_path],
     )
 
 
 def test_apply_env_file_explicit_wins(tmp_path: Path) -> None:
     (tmp_path / ".env").write_text("A=fromfile\nB=fromfile\n", encoding="utf-8")
-    comp = _comp(tmp_path)
+    comp = _comp()
     rendered = {
         "name": "s",
         "type": "stdio",
@@ -78,14 +78,14 @@ def test_apply_env_file_explicit_wins(tmp_path: Path) -> None:
 
 
 def test_apply_env_file_no_envfile_passthrough(tmp_path: Path) -> None:
-    comp = _comp(tmp_path)
+    comp = _comp()
     rendered = {"name": "s", "type": "stdio", "server_parameters": {"command": "node", "env": {"A": "1"}}}
     assert comp._apply_env_file(rendered) == rendered
 
 
 def test_apply_env_file_non_stdio_passthrough_and_warns(tmp_path: Path, caplog, attach_logger_to_caplog) -> None:
     caplog.set_level("WARNING", logger="a2c_smcp")
-    comp = _comp(tmp_path)
+    comp = _comp()
     rendered = {"name": "s", "type": "sse", "server_parameters": {"url": "http://x"}, "envFile": str(tmp_path / ".env")}
     # sse/http 填 envFile → 行为仍 passthrough（原样返回）+ 记一条 WARN（#65 fix-review #4）
     assert comp._apply_env_file(rendered) == rendered
@@ -93,14 +93,16 @@ def test_apply_env_file_non_stdio_passthrough_and_warns(tmp_path: Path, caplog, 
 
 
 @pytest.mark.asyncio
-async def test_render_then_envfile_with_workspacefolder(tmp_path: Path) -> None:
+async def test_render_then_envfile_with_env_placeholder(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """envFile 路径占位符经渲染后再加载（#116：${workspaceFolder} 停产，改用 ${env:}/绝对路径）。"""
     (tmp_path / ".env").write_text("FROM_FILE=yes\n", encoding="utf-8")
-    comp = _comp(tmp_path)  # registered_workdirs=[tmp_path] → ${workspaceFolder}=tmp_path
+    monkeypatch.setenv("WORK_DIR", str(tmp_path))
+    comp = _comp()
     raw = {
         "name": "s",
         "type": "stdio",
         "server_parameters": {"command": "node", "env": {"EXPLICIT": "v"}},
-        "envFile": "${workspaceFolder}/.env",
+        "envFile": "${env:WORK_DIR}/.env",
     }
     validated = await comp._arender_and_validate_server(raw)
     assert validated.server_parameters.env == {"EXPLICIT": "v", "FROM_FILE": "yes"}

--- a/tests/unit_tests/computer/inputs/test_render_vars.py
+++ b/tests/unit_tests/computer/inputs/test_render_vars.py
@@ -109,3 +109,20 @@ async def test_recursive_dict_and_list() -> None:
 async def test_single_env_placeholder_returns_string() -> None:
     out = await ConfigRender.arender_str("${env:X}", _noop_resolve, env={"X": "val"})
     assert out == "val"
+
+
+# ---------------------------------------------------------------------------
+# #116 概念瘦身：${workspaceFolder} 退出预定义变量 / #116: ${workspaceFolder} no longer predefined
+# ---------------------------------------------------------------------------
+def test_predefined_vars_slimmed_to_two() -> None:
+    """#116: 预定义变量仅剩 userHome / pathSeparator。"""
+    from a2c_smcp.computer.inputs.render import _PREDEFINED_VARS
+
+    assert _PREDEFINED_VARS == ("userHome", "pathSeparator")
+
+
+@pytest.mark.asyncio
+async def test_workspace_folder_left_verbatim_even_if_supplied() -> None:
+    """#116: 即便调用方在 variables 提供 workspaceFolder，也按未知占位符原样保留。"""
+    out = await ConfigRender.arender_str("${workspaceFolder}/x", _noop_resolve, variables={"workspaceFolder": "/work"})
+    assert out == "${workspaceFolder}/x"

--- a/tests/unit_tests/computer/inputs/test_render_vars.py
+++ b/tests/unit_tests/computer/inputs/test_render_vars.py
@@ -55,15 +55,15 @@ async def test_env_missing_empty_and_warn(caplog) -> None:
 
 @pytest.mark.asyncio
 async def test_predefined_vars() -> None:
-    vars_ = {"workspaceFolder": "/work", "userHome": "/home/u", "pathSeparator": ":"}
-    out = await ConfigRender.arender_str("${workspaceFolder}/x:${userHome}${pathSeparator}", _noop_resolve, variables=vars_)
-    assert out == "/work/x:/home/u:"
+    vars_ = {"userHome": "/home/u", "pathSeparator": ":"}
+    out = await ConfigRender.arender_str("${userHome}${pathSeparator}x", _noop_resolve, variables=vars_)
+    assert out == "/home/u:x"
 
 
 @pytest.mark.asyncio
 async def test_predefined_missing_empty_and_warn(caplog) -> None:
     caplog.set_level("WARNING", logger="a2c_smcp")
-    out = await ConfigRender.arender_str("${workspaceFolder}", _noop_resolve, variables={})
+    out = await ConfigRender.arender_str("${userHome}", _noop_resolve, variables={})
     assert out == ""
     assert any("预定义变量未提供" in rec.message for rec in caplog.records)
 
@@ -83,12 +83,12 @@ async def test_mixed_input_env_predefined() -> None:
         return "TOK"
 
     out = await ConfigRender.arender_str(
-        "${input:t}@${env:HOST}:${workspaceFolder}",
+        "${input:t}@${env:HOST}:${userHome}",
         resolver,
-        variables={"workspaceFolder": "/w"},
+        variables={"userHome": "/home/u"},
         env={"HOST": "localhost"},
     )
-    assert out == "TOK@localhost:/w"
+    assert out == "TOK@localhost:/home/u"
 
 
 @pytest.mark.asyncio
@@ -100,9 +100,9 @@ async def test_unknown_placeholder_left_as_is() -> None:
 @pytest.mark.asyncio
 async def test_recursive_dict_and_list() -> None:
     cr = ConfigRender()
-    data = {"env": {"LOG": "${env:LV}", "WS": "${workspaceFolder}"}, "args": ["${env:LV}"]}
-    out = await cr.arender(data, _noop_resolve, variables={"workspaceFolder": "/w"}, env={"LV": "info"})
-    assert out == {"env": {"LOG": "info", "WS": "/w"}, "args": ["info"]}
+    data = {"env": {"LOG": "${env:LV}", "HOME": "${userHome}"}, "args": ["${env:LV}"]}
+    out = await cr.arender(data, _noop_resolve, variables={"userHome": "/home/u"}, env={"LV": "info"})
+    assert out == {"env": {"LOG": "info", "HOME": "/home/u"}, "args": ["info"]}
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/computer/settings/test_mcp_config.py
+++ b/tests/unit_tests/computer/settings/test_mcp_config.py
@@ -369,3 +369,31 @@ def test_resolve_idless_and_non_object_inputs_dropped(tmp_path: Path) -> None:
     assert out.inputs == []  # 两者皆 drop、不崩
     unknown_errs = [e for e in out.errors if e.field == "inputs.<unknown>"]
     assert len(unknown_errs) == 2  # 各自独立报错 → <noid-N> key 不冲突（非互相覆盖）
+
+
+# ---------------------------------------------------------------------------
+# #116 概念瘦身：PROJECT/LOCAL 锚定进程 cwd / #116: PROJECT/LOCAL anchored at process cwd
+# ---------------------------------------------------------------------------
+def test_resolve_mcp_config_anchors_cwd(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """#116: PROJECT/LOCAL 层无条件锚定 cwd，`resolve_mcp_config` 不再有 active_workdir 形参。"""
+    env = _env(tmp_path)
+    _write_json(tmp_path / ".tfrobot" / "mcp.json", _mcp_doc(servers={"proj-srv": _stdio()}))
+    monkeypatch.chdir(tmp_path)
+
+    out = resolve_mcp_config(env=env, managed_mcp_path=tmp_path / "absent.json")
+    assert "proj-srv" in out.servers
+    assert out.servers["proj-srv"].origin == SettingsScope.PROJECT
+    assert out.servers["proj-srv"].trusted_origin is False  # project 非可信来源，语义不变
+
+
+def test_approval_writes_anchor_cwd_no_failfast(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """#116: 批准写盘锚定 cwd（`<cwd>/.tfrobot/settings.local.json`），不再因缺 workdir 而 fail-fast。"""
+    monkeypatch.chdir(tmp_path)
+    approve_mcp_server("figma")
+    deny_mcp_server("sketchy")
+    approve_all_project_mcp()
+
+    settings = _read_local_settings(tmp_path)
+    assert settings["enabledMcpjsonServers"] == ["figma"]
+    assert settings["disabledMcpjsonServers"] == ["sketchy"]
+    assert settings["enableAllProjectMcpServers"] is True

--- a/tests/unit_tests/computer/settings/test_mcp_config.py
+++ b/tests/unit_tests/computer/settings/test_mcp_config.py
@@ -31,7 +31,6 @@ from a2c_smcp.computer.mcp_clients.model import StdioServerConfig
 from a2c_smcp.computer.settings.mcp_config import (
     MANAGED_MCP_FILENAME,
     McpApprovalStatus,
-    McpConfigError,
     ResolvedMcpConfig,
     approve_all_project_mcp,
     approve_mcp_server,
@@ -123,53 +122,44 @@ def test_resolve_user_only_no_active(tmp_path: Path) -> None:
     assert srv.origin == SettingsScope.USER and srv.trusted_origin is True
 
 
-def test_resolve_no_active_ignores_workdir(tmp_path: Path) -> None:
-    """active_workdir=None → project/local 全不读（即使磁盘上有 .tfrobot/mcp.json 也不进）。"""
+def test_resolve_scope_priority_high_overrides(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """同名 server：local(高) 整体覆盖 user(低)，origin 记最高 scope（project/local 锚 cwd，#116）。"""
     env = _env(tmp_path)
-    wd = tmp_path / "wd"
-    _write_json(wd / ".tfrobot" / "mcp.json", _mcp_doc(servers={"proj-srv": _stdio()}))
-    out = resolve_mcp_config(env=env, active_workdir=None, managed_mcp_path=tmp_path / "absent.json")
-    assert "proj-srv" not in out.servers
-
-
-def test_resolve_scope_priority_high_overrides(tmp_path: Path) -> None:
-    """同名 server：local(高) 整体覆盖 user(低)，origin 记最高 scope。"""
-    env = _env(tmp_path)
-    wd = tmp_path / "wd"
     _write_json(_user_mcp(tmp_path), _mcp_doc(servers={"figma": _stdio("user-cmd")}))
-    _write_json(wd / ".tfrobot" / "mcp.local.json", _mcp_doc(servers={"figma": _stdio("local-cmd")}))
-    out = resolve_mcp_config(env=env, active_workdir=wd, managed_mcp_path=tmp_path / "absent.json")
+    _write_json(tmp_path / ".tfrobot" / "mcp.local.json", _mcp_doc(servers={"figma": _stdio("local-cmd")}))
+    monkeypatch.chdir(tmp_path)
+    out = resolve_mcp_config(env=env, managed_mcp_path=tmp_path / "absent.json")
     srv = out.servers["figma"]
     assert srv.origin == SettingsScope.LOCAL and srv.trusted_origin is False  # workspace-shared、受门控
     assert isinstance(srv.config, StdioServerConfig)
     assert srv.config.server_parameters.command == "local-cmd"  # 整体覆盖（高胜）
 
 
-def test_resolve_origins_partition_trust(tmp_path: Path) -> None:
-    """user/flag/policy → trusted；project/local → 受门控。"""
+def test_resolve_origins_partition_trust(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """user/flag/policy → trusted；project/local（锚 cwd）→ 受门控。"""
     env = _env(tmp_path)
-    wd = tmp_path / "wd"
     flag = tmp_path / "flag-mcp.json"
     managed = tmp_path / "managed-mcp.json"
     _write_json(flag, _mcp_doc(servers={"flag-srv": _stdio()}))
     _write_json(_user_mcp(tmp_path), _mcp_doc(servers={"user-srv": _stdio()}))
-    _write_json(wd / ".tfrobot" / "mcp.json", _mcp_doc(servers={"proj-srv": _stdio()}))
+    _write_json(tmp_path / ".tfrobot" / "mcp.json", _mcp_doc(servers={"proj-srv": _stdio()}))
     _write_json(managed, _mcp_doc(servers={"policy-srv": _stdio()}))
-    out = resolve_mcp_config(env=env, active_workdir=wd, flag_config_path=flag, managed_mcp_path=managed)
+    monkeypatch.chdir(tmp_path)
+    out = resolve_mcp_config(env=env, flag_config_path=flag, managed_mcp_path=managed)
     trust = {n: s.trusted_origin for n, s in out.servers.items()}
     assert trust == {"flag-srv": True, "user-srv": True, "proj-srv": False, "policy-srv": True}
 
 
-def test_resolve_inputs_dedup_by_id_high_wins(tmp_path: Path) -> None:
+def test_resolve_inputs_dedup_by_id_high_wins(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     env = _env(tmp_path)
-    wd = tmp_path / "wd"
     _write_json(_user_mcp(tmp_path), _mcp_doc(inputs=[{"id": "tok", "type": "promptString", "description": "user"}]))
     local_inputs = [
         {"id": "tok", "type": "promptString", "description": "local"},
         {"id": "other", "type": "promptString", "description": "x"},
     ]
-    _write_json(wd / ".tfrobot" / "mcp.local.json", _mcp_doc(inputs=local_inputs))
-    out = resolve_mcp_config(env=env, active_workdir=wd, managed_mcp_path=tmp_path / "absent.json")
+    _write_json(tmp_path / ".tfrobot" / "mcp.local.json", _mcp_doc(inputs=local_inputs))
+    monkeypatch.chdir(tmp_path)
+    out = resolve_mcp_config(env=env, managed_mcp_path=tmp_path / "absent.json")
     by_id = {i.id: i for i in out.inputs}
     assert set(by_id) == {"tok", "other"}
     assert by_id["tok"].description == "local"  # 高 scope 胜
@@ -270,12 +260,12 @@ def test_status_policy_allow_whitelist() -> None:
     assert mcp_server_status("x", settings=s2, bundled=set(), trusted_origin=False) == McpApprovalStatus.PENDING
 
 
-def test_gate_mcp_servers_maps_all(tmp_path: Path) -> None:
+def test_gate_mcp_servers_maps_all(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     env = _env(tmp_path)
-    wd = tmp_path / "wd"
     _write_json(_user_mcp(tmp_path), _mcp_doc(servers={"user-srv": _stdio()}))
-    _write_json(wd / ".tfrobot" / "mcp.json", _mcp_doc(servers={"proj-srv": _stdio()}))
-    out = resolve_mcp_config(env=env, active_workdir=wd, managed_mcp_path=tmp_path / "absent.json")
+    _write_json(tmp_path / ".tfrobot" / "mcp.json", _mcp_doc(servers={"proj-srv": _stdio()}))
+    monkeypatch.chdir(tmp_path)
+    out = resolve_mcp_config(env=env, managed_mcp_path=tmp_path / "absent.json")
     statuses = gate_mcp_servers(out, settings={}, bundled=set())
     assert statuses == {"user-srv": McpApprovalStatus.ENABLED, "proj-srv": McpApprovalStatus.PENDING}
 
@@ -303,46 +293,37 @@ def _read_local_settings(wd: Path) -> dict:
     return json.loads(workdir_local_settings_path(wd).read_text(encoding="utf-8"))
 
 
-def test_approve_writes_enabled_to_local(tmp_path: Path) -> None:
-    wd = tmp_path / "wd"
-    approve_mcp_server("figma", active_workdir=wd)
-    approve_mcp_server("figma", active_workdir=wd)  # dedup
-    settings = _read_local_settings(wd)
+def test_approve_writes_enabled_to_local(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    approve_mcp_server("figma")
+    approve_mcp_server("figma")  # dedup
+    settings = _read_local_settings(tmp_path)
     assert settings["enabledMcpjsonServers"] == ["figma"]
     assert "version" not in settings  # 人编层无 version
     # 无写保护头：首行即 JSON
-    assert workdir_local_settings_path(wd).read_text(encoding="utf-8").lstrip().startswith("{")
+    assert workdir_local_settings_path(tmp_path).read_text(encoding="utf-8").lstrip().startswith("{")
 
 
-def test_deny_writes_disabled_to_local(tmp_path: Path) -> None:
-    wd = tmp_path / "wd"
-    deny_mcp_server("sketchy", active_workdir=wd)
-    assert _read_local_settings(wd)["disabledMcpjsonServers"] == ["sketchy"]
+def test_deny_writes_disabled_to_local(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    deny_mcp_server("sketchy")
+    assert _read_local_settings(tmp_path)["disabledMcpjsonServers"] == ["sketchy"]
 
 
-def test_approve_all_sets_bool_local(tmp_path: Path) -> None:
-    wd = tmp_path / "wd"
-    approve_all_project_mcp(active_workdir=wd)
-    assert _read_local_settings(wd)["enableAllProjectMcpServers"] is True
+def test_approve_all_sets_bool_local(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    approve_all_project_mcp()
+    assert _read_local_settings(tmp_path)["enableAllProjectMcpServers"] is True
 
 
-def test_approve_then_resolve_settings_flips_status(tmp_path: Path) -> None:
+def test_approve_then_resolve_settings_flips_status(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """approve roundtrip：写 local enabled → 再判定 status 由 pending→enabled（接缝验证）。"""
-    wd = tmp_path / "wd"
+    monkeypatch.chdir(tmp_path)
     assert mcp_server_status("figma", settings={}, bundled=set(), trusted_origin=False) == McpApprovalStatus.PENDING
-    approve_mcp_server("figma", active_workdir=wd)
-    enabled = _read_local_settings(wd)["enabledMcpjsonServers"]
+    approve_mcp_server("figma")
+    enabled = _read_local_settings(tmp_path)["enabledMcpjsonServers"]
     after = mcp_server_status("figma", settings={"enabledMcpjsonServers": enabled}, bundled=set(), trusted_origin=False)
     assert after == McpApprovalStatus.ENABLED
-
-
-def test_approval_write_without_active_workdir_raises() -> None:
-    with pytest.raises(McpConfigError):
-        approve_mcp_server("x", active_workdir=None)
-    with pytest.raises(McpConfigError):
-        deny_mcp_server("x", active_workdir=None)
-    with pytest.raises(McpConfigError):
-        approve_all_project_mcp(active_workdir=None)
 
 
 def test_resolved_mcp_config_dataclass_defaults() -> None:

--- a/tests/unit_tests/computer/settings/test_scope.py
+++ b/tests/unit_tests/computer/settings/test_scope.py
@@ -20,12 +20,10 @@ SDK 设计 / Design: python-sdk docs/design-0.2.1-cli-marketplace-ux.md §5.0 / 
 """
 
 import json
-import logging
 from pathlib import Path
 
 import pytest
 
-import a2c_smcp.computer.settings.scope as scope_mod
 from a2c_smcp.computer.settings.scope import (
     DELETE,
     apply_write,
@@ -157,89 +155,17 @@ def test_workdir_paths(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
-# active-workdir / 能力层解析 / resolution
+# cwd 锚定解析（#116）/ cwd-anchored resolution
 # ---------------------------------------------------------------------------
 def _empty_user_env(tmp_path: Path) -> dict:
     # 指向无 settings.json 的隔离 config dir，确保 user 层为空。
     return {"XDG_CONFIG_HOME": str(tmp_path / "empty-config")}
 
 
-def test_no_active_workdir_project_local_empty(tmp_path: Path) -> None:
-    wd = tmp_path / "wd"
-    _write_json(workdir_project_settings_path(wd), {"strictKnownMarketplaces": True, "enabledPlugins": {"p@mp": True}})
-
+def test_policy_highest_priority_and_validated(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _write_json(workdir_project_settings_path(tmp_path), {"strictKnownMarketplaces": False})
+    monkeypatch.chdir(tmp_path)
     resolved = resolve_settings(
-        registered_workdirs=[wd],
-        active_workdir=None,  # 无 active
-        env=_empty_user_env(tmp_path),
-    )
-    # 标量 strictKnownMarketplaces 是 project（B 层）键，无 active → 不贡献。
-    assert "strictKnownMarketplaces" not in resolved.settings
-    # enabledPlugins 属能力层（A 层），跨登记目录并集 → 仍在。
-    assert resolved.settings["enabledPlugins"] == {"p@mp": True}
-
-
-def test_non_active_dir_contributes_capability_not_scalars(tmp_path: Path) -> None:
-    wd_active = tmp_path / "active"
-    wd_other = tmp_path / "other"
-    _write_json(workdir_project_settings_path(wd_active), {"enabledPlugins": {"a@mp": True}})
-    _write_json(
-        workdir_project_settings_path(wd_other),
-        {"strictKnownMarketplaces": True, "enabledPlugins": {"b@mp": True}, "trustedMarketplaces": ["x"]},
-    )
-
-    resolved = resolve_settings(
-        registered_workdirs=[wd_active, wd_other],
-        active_workdir=wd_active,
-        env=_empty_user_env(tmp_path),
-    )
-    # 非 active 的 wd_other：标量 strictKnownMarketplaces / 数组 trustedMarketplaces 不贡献。
-    assert "strictKnownMarketplaces" not in resolved.settings
-    assert "trustedMarketplaces" not in resolved.settings
-    # 能力层全局并集：两个目录的 enabledPlugins 都进。
-    assert resolved.settings["enabledPlugins"] == {"a@mp": True, "b@mp": True}
-
-
-def test_active_workdir_full_contribution(tmp_path: Path) -> None:
-    wd = tmp_path / "wd"
-    _write_json(workdir_project_settings_path(wd), {"strictKnownMarketplaces": True})
-    _write_json(workdir_local_settings_path(wd), {"strictKnownMarketplaces": False, "trustedMarketplaces": ["m"]})
-
-    resolved = resolve_settings(
-        registered_workdirs=[wd],
-        active_workdir=wd,
-        env=_empty_user_env(tmp_path),
-    )
-    # local 覆盖 project（高 scope 赢）。
-    assert resolved.settings["strictKnownMarketplaces"] is False
-    assert resolved.settings["trustedMarketplaces"] == ["m"]
-
-
-def test_capability_union_across_extra_marketplaces(tmp_path: Path) -> None:
-    wd1 = tmp_path / "wd1"
-    wd2 = tmp_path / "wd2"
-    _write_json(
-        workdir_project_settings_path(wd1),
-        {"extraKnownMarketplaces": {"mp1": {"source": {"type": "git", "url": "git@h:a.git"}}}},
-    )
-    _write_json(
-        workdir_project_settings_path(wd2),
-        {"extraKnownMarketplaces": {"mp2": {"source": {"type": "git", "url": "git@h:b.git"}}}},
-    )
-    resolved = resolve_settings(
-        registered_workdirs=[wd1, wd2],
-        active_workdir=None,
-        env=_empty_user_env(tmp_path),
-    )
-    assert set(resolved.settings["extraKnownMarketplaces"]) == {"mp1", "mp2"}
-
-
-def test_policy_highest_priority_and_validated(tmp_path: Path) -> None:
-    wd = tmp_path / "wd"
-    _write_json(workdir_project_settings_path(wd), {"strictKnownMarketplaces": False})
-    resolved = resolve_settings(
-        registered_workdirs=[wd],
-        active_workdir=wd,
         env=_empty_user_env(tmp_path),
         policy_settings={"strictKnownMarketplaces": True, "allowedMcpServers": ["srv"]},
     )
@@ -249,54 +175,33 @@ def test_policy_highest_priority_and_validated(tmp_path: Path) -> None:
     assert resolved.settings["allowedMcpServers"] == ["srv"]
 
 
-def test_corrupt_settings_file_yields_error_not_crash(tmp_path: Path) -> None:
-    wd = tmp_path / "wd"
-    p = workdir_project_settings_path(wd)
+def test_corrupt_settings_file_yields_error_not_crash(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    p = workdir_project_settings_path(tmp_path)
     p.parent.mkdir(parents=True, exist_ok=True)
     p.write_text("{not valid json", encoding="utf-8")
-    resolved = resolve_settings(registered_workdirs=[wd], active_workdir=wd, env=_empty_user_env(tmp_path))
+    monkeypatch.chdir(tmp_path)
+    resolved = resolve_settings(env=_empty_user_env(tmp_path))
     assert resolved.settings == {}  # 损坏文件回退空、不崩
     assert any(e.field == "<file>" for e in resolved.errors)
 
 
-def test_errors_deduped_when_active_dir_read_twice(tmp_path: Path) -> None:
-    # active workdir 文件在能力层 + B 层各读一次；同一错误应去重。
-    wd = tmp_path / "wd"
-    _write_json(workdir_project_settings_path(wd), {"strictKnownMarketplaces": "bad"})
-    resolved = resolve_settings(registered_workdirs=[wd], active_workdir=wd, env=_empty_user_env(tmp_path))
+def test_invalid_scalar_field_reported_once(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # 单层单文件的字段级错误只报一次（_dedup_errors 防御性保留）。
+    _write_json(workdir_project_settings_path(tmp_path), {"strictKnownMarketplaces": "bad"})
+    monkeypatch.chdir(tmp_path)
+    resolved = resolve_settings(env=_empty_user_env(tmp_path))
     scalar_errors = [e for e in resolved.errors if e.field == "strictKnownMarketplaces"]
     assert len(scalar_errors) == 1
 
 
-def test_capability_cross_workdir_conflict_warns(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
-    # 两登记目录对同一 enabledPlugins["foo@mp"] 给不同 bool → 后者(wd2)覆盖 + WARN（§5.4）。
-    wd1 = tmp_path / "wd1"
-    wd2 = tmp_path / "wd2"
-    _write_json(workdir_project_settings_path(wd1), {"enabledPlugins": {"foo@mp": True}})
-    _write_json(workdir_project_settings_path(wd2), {"enabledPlugins": {"foo@mp": False}})
-
-    # 项目 logger 关闭 propagate，直接挂 caplog handler（同 test_registry.py 范式）。
-    scope_mod.logger.addHandler(caplog.handler)
-    caplog.set_level(logging.WARNING)
-    try:
-        resolved = resolve_settings(registered_workdirs=[wd1, wd2], active_workdir=None, env=_empty_user_env(tmp_path))
-    finally:
-        scope_mod.logger.removeHandler(caplog.handler)
-
-    assert resolved.settings["enabledPlugins"] == {"foo@mp": False}  # 后者胜出
-    assert any("Capability-layer conflict" in r.getMessage() for r in caplog.records)
-
-
-def test_flag_layer_overrides_user_and_project(tmp_path: Path) -> None:
-    # flag 层（--settings <file>）优先级高于 project，仅低于 policy。
-    wd = tmp_path / "wd"
-    _write_json(workdir_project_settings_path(wd), {"strictKnownMarketplaces": False, "trustedMarketplaces": ["proj"]})
+def test_flag_layer_overrides_user_and_project(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # flag 层（--settings <file>）优先级高于 project，仅低于 policy。project 锚 cwd（#116）。
+    _write_json(workdir_project_settings_path(tmp_path), {"strictKnownMarketplaces": False, "trustedMarketplaces": ["proj"]})
     flag_file = tmp_path / "flag-settings.json"
     flag_file.write_text(json.dumps({"strictKnownMarketplaces": True, "trustedMarketplaces": ["flag"]}), encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
 
     resolved = resolve_settings(
-        registered_workdirs=[wd],
-        active_workdir=wd,
         env=_empty_user_env(tmp_path),
         flag_settings_path=flag_file,
     )

--- a/tests/unit_tests/computer/settings/test_scope.py
+++ b/tests/unit_tests/computer/settings/test_scope.py
@@ -303,3 +303,18 @@ def test_flag_layer_overrides_user_and_project(tmp_path: Path) -> None:
     assert resolved.settings["strictKnownMarketplaces"] is True  # flag 标量覆盖 project
     # 数组拼接去重（低 project 在前 + 高 flag 在后）。
     assert resolved.settings["trustedMarketplaces"] == ["proj", "flag"]
+
+
+# ---------------------------------------------------------------------------
+# #116 概念瘦身：project/local 锚定进程 cwd / #116: project/local anchored at process cwd
+# ---------------------------------------------------------------------------
+def test_resolve_settings_anchors_project_local_at_cwd(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """#116: project/local 层无条件锚定 cwd，`resolve_settings` 不再有 workdir 形参。"""
+    _write_json(workdir_project_settings_path(tmp_path), {"strictKnownMarketplaces": True, "enabledPlugins": {"p@mp": True}})
+    _write_json(workdir_local_settings_path(tmp_path), {"strictKnownMarketplaces": False, "trustedMarketplaces": ["m"]})
+    monkeypatch.chdir(tmp_path)
+
+    resolved = resolve_settings(env=_empty_user_env(tmp_path))
+    assert resolved.settings["strictKnownMarketplaces"] is False  # local 覆盖 project
+    assert resolved.settings["trustedMarketplaces"] == ["m"]
+    assert resolved.settings["enabledPlugins"] == {"p@mp": True}  # 能力字段随 project 层进（无需独立能力层）

--- a/tests/unit_tests/computer/settings/test_scope.py
+++ b/tests/unit_tests/computer/settings/test_scope.py
@@ -223,3 +223,20 @@ def test_resolve_settings_anchors_project_local_at_cwd(tmp_path: Path, monkeypat
     assert resolved.settings["strictKnownMarketplaces"] is False  # local 覆盖 project
     assert resolved.settings["trustedMarketplaces"] == ["m"]
     assert resolved.settings["enabledPlugins"] == {"p@mp": True}  # 能力字段随 project 层进（无需独立能力层）
+
+
+def test_extra_known_marketplaces_deep_merge_at_cwd(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """#116: extraKnownMarketplaces（dict）在 cwd project/local 层间深合并（键并集，同名叶子高层胜）。"""
+    _write_json(
+        workdir_project_settings_path(tmp_path),
+        {"extraKnownMarketplaces": {"mp1": {"source": {"type": "git", "url": "git@h:a.git"}}}},
+    )
+    _write_json(
+        workdir_local_settings_path(tmp_path),
+        {"extraKnownMarketplaces": {"mp2": {"source": {"type": "git", "url": "git@h:b.git"}}}},
+    )
+    monkeypatch.chdir(tmp_path)
+
+    resolved = resolve_settings(env=_empty_user_env(tmp_path))
+    assert set(resolved.settings["extraKnownMarketplaces"]) == {"mp1", "mp2"}  # 深合并键并集
+    assert resolved.settings["extraKnownMarketplaces"]["mp1"]["source"]["url"] == "git@h:a.git"

--- a/tests/unit_tests/computer/skills/test_staging.py
+++ b/tests/unit_tests/computer/skills/test_staging.py
@@ -345,53 +345,18 @@ def test_user_global_only_in_place(tmp_path: Path) -> None:
     assert ref["allowed_tools"] == ["read", "write"]
 
 
-def test_user_global_plus_multi_workdir_union(tmp_path: Path) -> None:
-    # 全局 + 多 workdir 全局并集；能力层不随 active workdir 切换——传入的全部 workdir 一律生效
+def test_user_home_only_no_workdir_dimension(tmp_path: Path) -> None:
+    # #116：user 源仅扫 <home>/user/ 单根；workdir 维度 SKILL 已下沉 MCP 服务（.tfrobot/skills 不再被发现）
     home = tmp_path / "home"
     _write_user_skill(home / "user", "global-skill")
-    wd1 = tmp_path / "ws1"
-    wd2 = tmp_path / "ws2"
-    _write_user_skill(wd1 / ".tfrobot" / "skills", "proj-a")
-    _write_user_skill(wd2 / ".tfrobot" / "skills", "proj-b")
-    reg = SkillRegistry()
-
-    names = stage_user_skills(reg, home, [wd1, wd2])
-
-    assert sorted(names) == ["global-skill", "proj-a", "proj-b"]
-    # workdir skill 就地发现于各自 .tfrobot/skills，未复制进 home
-    assert reg.resolve("proj-a")["path"] == str((wd1 / ".tfrobot" / "skills" / "proj-a").resolve())  # type: ignore[index]
-    assert not (home / "user" / "proj-a").exists()
-
-
-def test_workdir_overrides_user_home_with_warning(tmp_path: Path, staging_logs: pytest.LogCaptureFixture) -> None:
-    # 同名：workspace skill 覆盖 user-home 全局（§2.3「workspace skill 覆盖 user」）+ WARN
-    home = tmp_path / "home"
-    _write_user_skill(home / "user", "shared", description="from-home")
     wd = tmp_path / "ws"
-    _write_user_skill(wd / ".tfrobot" / "skills", "shared", description="from-workdir")
+    _write_user_skill(wd / ".tfrobot" / "skills", "proj-a")
     reg = SkillRegistry()
 
-    names = stage_user_skills(reg, home, [wd])
+    names = stage_user_skills(reg, home)
 
-    assert names == ["shared"]
-    assert reg.resolve("shared")["description"] == "from-workdir"  # workdir 胜  # type: ignore[index]
-    assert any(r.levelno == logging.WARNING and "shadows earlier" in r.getMessage() for r in staging_logs.records)
-
-
-def test_later_workdir_overrides_earlier_in_registration_order(tmp_path: Path, staging_logs: pytest.LogCaptureFixture) -> None:
-    # 登记目录间同名 → 按登记序后者覆盖前者 + WARN（验收第 1 条）
-    home = tmp_path / "home"
-    wd1 = tmp_path / "ws1"
-    wd2 = tmp_path / "ws2"
-    _write_user_skill(wd1 / ".tfrobot" / "skills", "dup", description="first")
-    _write_user_skill(wd2 / ".tfrobot" / "skills", "dup", description="second")
-    reg = SkillRegistry()
-
-    names = stage_user_skills(reg, home, [wd1, wd2])  # 登记序 wd1 → wd2
-
-    assert names == ["dup"]
-    assert reg.resolve("dup")["description"] == "second"  # 后登记者胜  # type: ignore[index]
-    assert any(r.levelno == logging.WARNING for r in staging_logs.records)
+    assert names == ["global-skill"]
+    assert reg.resolve("proj-a") is None  # workdir DropIn 不再进 user 源
 
 
 def test_user_basename_not_kebab_skipped(tmp_path: Path, staging_logs: pytest.LogCaptureFixture) -> None:
@@ -471,10 +436,10 @@ def test_user_rescan_idempotent_updates(tmp_path: Path) -> None:
 
 
 def test_user_missing_roots_tolerated(tmp_path: Path) -> None:
-    # 发现根不存在（home/user 与 workdir 都没建）→ 返回空、不抛
+    # 发现根不存在（home/user 没建）→ 返回空、不抛
     home = tmp_path / "nonexistent-home"
     reg = SkillRegistry()
-    names = stage_user_skills(reg, home, [tmp_path / "no-such-ws"])
+    names = stage_user_skills(reg, home)
     assert names == []
     assert len(reg) == 0
 
@@ -501,15 +466,15 @@ def test_user_skill_md_unreadable_skipped(tmp_path: Path, monkeypatch: pytest.Mo
     assert any(r.levelno == logging.ERROR and "unreadable" in r.getMessage() for r in staging_logs.records)
 
 
-def test_user_dropin_roots_dedup_no_spurious_warning(tmp_path: Path, staging_logs: pytest.LogCaptureFixture) -> None:
-    # 同一 workdir 登记两次 → _user_dropin_roots 按解析路径去重 → 只扫一次、不产生「shadows earlier」假 WARN
+def test_user_home_rescan_no_spurious_warning(tmp_path: Path, staging_logs: pytest.LogCaptureFixture) -> None:
+    # home 单根重复扫描（幂等 register_or_update）→ 不产生任何 WARN（#116 后无跨根遮蔽语义）
     home = tmp_path / "home"
-    wd = tmp_path / "ws"
-    _write_user_skill(wd / ".tfrobot" / "skills", "uniq")
+    _write_user_skill(home / "user", "uniq")
     reg = SkillRegistry()
 
-    names = stage_user_skills(reg, home, [wd, wd])
+    first = stage_user_skills(reg, home)
+    second = stage_user_skills(reg, home)
 
-    assert names == ["uniq"]
+    assert first == ["uniq"] and second == ["uniq"]
     assert len(reg) == 1
     assert not any(r.levelno == logging.WARNING for r in staging_logs.records)

--- a/tests/unit_tests/computer/test_computer_render_context.py
+++ b/tests/unit_tests/computer/test_computer_render_context.py
@@ -26,16 +26,21 @@ from a2c_smcp.computer.computer import Computer
 from a2c_smcp.computer.mcp_clients.model import MCPServerPromptStringInput
 
 
-def test_active_workdir_property(tmp_path: Path) -> None:
-    assert Computer(name="t").active_workdir is None  # 空闲
-    comp = Computer(name="t", registered_workdirs=[tmp_path, tmp_path / "b"])
-    assert comp.active_workdir == tmp_path  # 取首个（绑定任务单根）
+# ---------------------------------------------------------------------------
+# #116 概念瘦身：Computer 无 workdir 概念 / #116: Computer carries no workdir concept
+# ---------------------------------------------------------------------------
+def test_computer_rejects_workdir_concepts(tmp_path: Path) -> None:
+    """#116: `registered_workdirs` 构造参数与 `active_workdir` 属性均已移除。"""
+    with pytest.raises(TypeError):
+        Computer(name="t", registered_workdirs=[tmp_path])
+    assert not hasattr(Computer(name="t"), "active_workdir")
 
 
-def test_render_variables_uses_active_workdir(tmp_path: Path) -> None:
-    comp = Computer(name="t", registered_workdirs=[tmp_path])
-    assert comp._render_variables()["workspaceFolder"] == str(tmp_path)
-    assert Computer(name="t")._render_variables()["workspaceFolder"] == os.getcwd()  # 无 → cwd
+def test_render_variables_no_workspace_folder() -> None:
+    """#116: 渲染变量仅剩 userHome / pathSeparator（${workspaceFolder} 停产）。"""
+    variables = Computer(name="t")._render_variables()
+    assert set(variables) == {"userHome", "pathSeparator"}
+    assert variables["pathSeparator"] == os.sep
 
 
 _CFG = {"name": "s", "type": "stdio", "server_parameters": {"command": "node", "args": ["${input:token}"]}}


### PR DESCRIPTION
## Summary

落地 #116：把"工作目录（workspace）"概念整体移出 Computer 中立聚合层（净瘦身，**-338 行**）。

**协议先行已完成**：a2c-smcp-protocol#10 已合并（runtime-contract §2.2 `workdirs` 行删除，随 v0.2.3 发布）。

### 变更内容

| 域 | 变更 |
|---|---|
| inputs 渲染 | `${workspaceFolder}` 退出 `_PREDEFINED_VARS` → 按未知占位符**原样保留**；`${userHome}`/`${pathSeparator}`/`${input:}`/`${env:}` 不受影响 |
| SKILL | `stage_user_skills` 收敛 **home 单根**（`<home>/user/` 保留）；删 `workdir_skill_root`/`_user_dropin_roots`；watcher 仅监 home（模块零改动） |
| settings | 删能力发现层（单 cwd 锚点下被上方 project/local 层严格遮蔽，等价冗余）；`resolve_settings` 五层 `[user, project, local, flag, policy]`，project/local 无条件锚 `os.getcwd()`；删 `SettingsScope.CAPABILITY` 死枚举 |
| MCP 配置 | `resolve_mcp_config` 同锚 cwd（合并策略/8 档 gate 不变）；批准写盘落 `<cwd>/.tfrobot/settings.local.json`，**不再 fail-fast**（删 `_require_active_workdir`/`McpConfigError`） |
| CLI | 删 `--add-dir`；settings/plugin 命令与 REPL dispatcher 全链签名瘦身 |
| Computer | 删构造参数 `registered_workdirs` 与 `active_workdir` property |

### Breaking changes（SDK API，无协议变更）

- `Computer.__init__` 不再接受 `registered_workdirs`
- CLI `--add-dir` 移除（未知选项报错）
- `${workspaceFolder}` 停止渲染 → 下游 `mcp.json` 请迁移 `${input:}`/绝对路径

### 验证

- TDD：先提交 8 组红灯用例（e38e54e），实现后全部转绿
- 全量 **1723 passed** + `poe lint`（mypy 100 文件）绿
- 冒烟：`--help` 无 `--add-dir`；含 `.tfrobot/` 的临时目录中 `settings show --scope project` 正确 cwd 锚定
- 隔离 code-reviewer 审查：**无 🔴**；6🟡+2🔵 已全部落实（e4610dd）

### 后续

- rust-sdk 等价瘦身 Issue（互引，见 #116 验收标准）
- IDE4AI 承接 workdir→`skill://` Resource 暴露（独立仓库）

Closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)
