### PR TITLE
feat(#117): Computer.boot_up 补齐 plugin 治理启动恢复（协议 v0.2.3 §4.8）

### DIFF
--- a/a2c_smcp/computer/cli/commands/plugin.py
+++ b/a2c_smcp/computer/cli/commands/plugin.py
@@ -121,6 +121,41 @@ def _plugin_inject_inputs_cb(comp: Any, plugin: str, marketplace: str) -> Inject
     return _inject
 
 
+async def run_governance_remount(comp: Any, *, flag_config: Path | None = None) -> None:
+    """
+    启动期治理重挂（#117 设计 Y 的 client 接线参考实现）/ Boot-time governance remount (reference client wiring)。
+
+    boot_up 已恢复 bundled SKILL（skills-only，§4.8 #93 边界：SDK 不擅自拉 MCP 进程）；此处 CLI 作为
+    参考 client 经**公共 API** ``Computer.reconcile_governance(hooks)`` 显式重挂 enabled bundled MCP
+    server（外部 client / 未来 GUI 照抄本函数）。语义要点：
+
+    - declared 传 flag-aware 合并视图（补上 boot 内不可见的 ``--settings`` flag scope）；
+    - inputs 注入先于 register（bundled server 的 ``${input:}`` 经 D2 前缀回退解析，与 install/enable 流一致）；
+    - 与既有 server 同名 → reconcile_governance 内部 skip+WARN（用户配置胜）；bundled **免批准**（§5.10
+      不走 project 信任门），单点失败不阻断。
+    """
+    env = os.environ
+    declared = resolved_settings(env, flag_path=flag_config)
+
+    async def _register(cfg: Any, record: Any) -> None:
+        await comp.aadd_or_aupdate_server(cfg, plugin=record.plugin, marketplace=record.marketplace)
+        console.print(f"[green]✓ restored bundled MCP server {cfg.name!r} (plugin {record.plugin_id})[/green]")
+
+    async def _inject(record: Any) -> None:
+        inputs_json = record.install_path / MCP_SERVERS_SUBDIR / MCP_INPUTS_FILENAME
+        for inp in load_plugin_inputs(inputs_json, record.plugin, record.marketplace):
+            comp.add_or_update_input(inp)
+
+    report = await comp.reconcile_governance(
+        existing_server_names=lambda: {cfg.name for cfg in comp.mcp_servers},
+        register_server=_register,
+        inject_inputs=_inject,
+        declared=declared,
+    )
+    for marketplace in report.failed_marketplaces:
+        console.print(f"[yellow]⚠ marketplace {marketplace!r} degraded during governance recovery (skills/servers not restored)[/yellow]")
+
+
 # ── handlers ──────────────────────────────────────────────────────────────────
 async def plugin_install(
     registry: SkillRegistry,

--- a/a2c_smcp/computer/cli/commands/plugin.py
+++ b/a2c_smcp/computer/cli/commands/plugin.py
@@ -110,13 +110,18 @@ def _plugin_register_cb(comp: Any, plugin: str, marketplace: str) -> RegisterSer
     return _register
 
 
+def _inject_plugin_inputs(comp: Any, plugin_root: Path, plugin: str, marketplace: str) -> None:
+    """从 ``<plugin_root>/mcp-servers/inputs.json`` 读 plugin-scoped inputs、前缀化、逐条 add_or_update_input（DRY 单点）。"""
+    inputs_json = plugin_root / MCP_SERVERS_SUBDIR / MCP_INPUTS_FILENAME
+    for inp in load_plugin_inputs(inputs_json, plugin, marketplace):
+        comp.add_or_update_input(inp)
+
+
 def _plugin_inject_inputs_cb(comp: Any, plugin: str, marketplace: str) -> InjectInputs:
-    """注入 plugin-scoped inputs 入池：从 ``<plugin_root>/mcp-servers/inputs.json`` 读、前缀化、逐条 add_or_update_input。"""
+    """注入 plugin-scoped inputs 入池（install/enable 路径回调；闭包携 plugin/marketplace 上下文）。"""
 
     async def _inject(plugin_root: Path) -> None:
-        inputs_json = plugin_root / MCP_SERVERS_SUBDIR / MCP_INPUTS_FILENAME
-        for inp in load_plugin_inputs(inputs_json, plugin, marketplace):
-            comp.add_or_update_input(inp)
+        _inject_plugin_inputs(comp, plugin_root, plugin, marketplace)
 
     return _inject
 
@@ -129,10 +134,13 @@ async def run_governance_remount(comp: Any, *, flag_config: Path | None = None) 
     参考 client 经**公共 API** ``Computer.reconcile_governance(hooks)`` 显式重挂 enabled bundled MCP
     server（外部 client / 未来 GUI 照抄本函数）。语义要点：
 
-    - declared 传 flag-aware 合并视图（补上 boot 内不可见的 ``--settings`` flag scope）；
+    - declared 传 flag-aware 合并视图——注意其"补上 flag scope"**仅及于阶段二 server 重挂**（boot 从不挂
+      server）；bundled SKILL 已在 boot 期按无 flag 视图恢复且 additive-only 不撤销，flag-scope 的
+      ``enabledPlugins=false`` 对 skill 跨 boot 不生效（可靠 disable 请写 user scope）；
     - inputs 注入先于 register（bundled server 的 ``${input:}`` 经 D2 前缀回退解析，与 install/enable 流一致）；
-    - 与既有 server 同名 → reconcile_governance 内部 skip+WARN（用户配置胜）；bundled **免批准**（§5.10
-      不走 project 信任门），单点失败不阻断。
+    - ``existing_server_names`` **必传**（取自 ``comp.mcp_servers``）：与既有 server 同名 →
+      reconcile_governance 内部 skip+WARN（用户配置胜）；bundled **免批准**（§5.10 不走 project 信任门），
+      单点失败不阻断。
     """
     env = os.environ
     declared = resolved_settings(env, flag_path=flag_config)
@@ -142,9 +150,7 @@ async def run_governance_remount(comp: Any, *, flag_config: Path | None = None) 
         console.print(f"[green]✓ restored bundled MCP server {cfg.name!r} (plugin {record.plugin_id})[/green]")
 
     async def _inject(record: Any) -> None:
-        inputs_json = record.install_path / MCP_SERVERS_SUBDIR / MCP_INPUTS_FILENAME
-        for inp in load_plugin_inputs(inputs_json, record.plugin, record.marketplace):
-            comp.add_or_update_input(inp)
+        _inject_plugin_inputs(comp, record.install_path, record.plugin, record.marketplace)
 
     report = await comp.reconcile_governance(
         existing_server_names=lambda: {cfg.name for cfg in comp.mcp_servers},

--- a/a2c_smcp/computer/cli/interactive_impl.py
+++ b/a2c_smcp/computer/cli/interactive_impl.py
@@ -89,6 +89,14 @@ async def interactive_loop(
     except Exception as e:  # pragma: no cover - 批准框失败不阻断进入 REPL
         console.print(f"[yellow]⚠ MCP 批准门控初始化失败 / MCP approval init failed: {e}[/yellow]")
 
+    # #117 治理重挂（设计 Y client 接线）：boot 已恢复 bundled SKILL；CLI 作为参考 client 经公共 API
+    # reconcile_governance(hooks) 重挂 enabled bundled MCP server。时序刻意在批准框之后——mcp.json 的
+    # 显式用户配置先挂先占名（同名 bundled 被 skip，用户配置胜）；bundled 免批准（§5.10）。
+    try:
+        await plugin_cmd.run_governance_remount(comp, flag_config=mcp_flag_config)
+    except Exception as e:  # pragma: no cover - 重挂失败不阻断进入 REPL
+        console.print(f"[yellow]⚠ 治理重挂失败 / governance remount failed: {e}[/yellow]")
+
     while True:
         try:
             with patch_stdout_ctx(raw=True):

--- a/a2c_smcp/computer/computer.py
+++ b/a2c_smcp/computer/computer.py
@@ -31,7 +31,7 @@ import json
 import os
 import weakref
 from collections import deque
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable, Mapping
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional
@@ -64,6 +64,13 @@ from a2c_smcp.computer.inputs.render import ConfigRender, load_env_file
 from a2c_smcp.computer.inputs.resolver import InputNotFoundError, InputResolver
 from a2c_smcp.computer.mcp_clients.manager import MCPServerManager
 from a2c_smcp.computer.mcp_clients.model import MCPServerConfig, MCPServerInput
+from a2c_smcp.computer.settings.recovery import (
+    BundledServerRecord,
+    GovernanceRecoveryReport,
+    RegisterBundledServer,
+    collect_enabled_bundled_servers,
+    recover_marketplace_skills,
+)
 from a2c_smcp.computer.skills import (
     SOURCE_USER,
     SkillEventDebouncer,
@@ -325,13 +332,34 @@ class Computer(BaseComputer[PromptSession]):
 
         await self.mcp_manager.ainitialize(validated_servers)
 
-        # v0.2.1 SKILL 子系统启动初始化（设计 §5.1，#66）：解析 SKILL Home → 物化 mcp 源 skill:// →
-        # 填充 Registry → 初始化 skill:// 缓存。失败隔离：记 ERROR、**不**阻断 Computer 启动
-        # （skill.md §1.5：SKILL 通道对部分失败健壮）。marketplace/user 源 reconcile 见 #60/#61。
-        # SKILL subsystem boot init: resolve Home → materialize mcp-source skills → seed cache.
-        # Failure-isolated: log ERROR, never block Computer boot. marketplace/user sources land in #60/#61.
+        # v0.2.1 SKILL 子系统启动初始化（设计 §5.1，#66）：解析 SKILL Home → 治理启动恢复（#117）→
+        # 物化 mcp 源 skill:// → 填充 Registry → 初始化 skill:// 缓存。失败隔离：记 ERROR、**不**阻断
+        # Computer 启动（skill.md §1.5：SKILL 通道对部分失败健壮）。
+        # SKILL subsystem boot init: resolve Home → governance recovery (#117) → materialize mcp-source
+        # skills → seed cache. Failure-isolated: log ERROR, never block Computer boot.
         try:
             self._skill_home = self._resolve_skill_home()
+        except Exception as e:  # pragma: no cover — 防御性兜底
+            logger.error(f"SKILL Home 解析失败（不阻断 Computer 启动）/ SKILL Home resolve failed (non-blocking): {e}", exc_info=True)
+
+        # #117 治理启动恢复（协议 v0.2.3 §4.8.1，rust reconcile_governance 同位）：从双账本恢复
+        # enabled plugin 的 bundled SKILL。**skills-only**——bundled MCP server 不在 boot 拉进程
+        # （#93 client owns MCP config），client 经 reconcile_governance(hooks) 显式重挂（设计 Y）。
+        # Governance boot recovery (skills-only); bundled MCP servers stay client-driven via hooks.
+        if self._skill_home is not None:
+            try:
+                recovery_report = await self.reconcile_governance()
+                if recovery_report.restored_skills or recovery_report.failed_marketplaces:
+                    logger.info(
+                        "governance recovery: %d skills restored, %d plugins, %d marketplaces degraded",
+                        len(recovery_report.restored_skills),
+                        len(recovery_report.restored_plugins),
+                        len(recovery_report.failed_marketplaces),
+                    )
+            except Exception as e:  # pragma: no cover — 防御性兜底（recovery 内部已各自降级）
+                logger.error(f"治理启动恢复失败（不阻断启动）/ governance recovery failed (non-blocking): {e}", exc_info=True)
+
+        try:
             await self._restage_mcp_skills()
             self._skills_cache = await self._acollect_skill_refs()
         except Exception as e:  # pragma: no cover — 防御性兜底，正常路径已在内部各自降级
@@ -1297,6 +1325,81 @@ class Computer(BaseComputer[PromptSession]):
         Mark the SKILL set dirty so the debouncer coalesces a single emit (called after CLI marketplace mutations).
         """
         self._skill_debouncer.mark_dirty()
+
+    def _resolve_declared_settings(self) -> dict[str, Any]:
+        """治理恢复的 declared 合并视图（user/project/local/policy；无 flag——Computer 不持 ``--settings`` 知识）。
+
+        已知限制（与 rust 同构文档化）：flag scope 的 ``enabledPlugins`` 不在此视图；CLI 接线时经
+        ``reconcile_governance(declared=...)`` 显式传 flag-aware 视图。跨重启可靠 disable 请写 user scope。
+        The declared view for governance recovery (no flag scope at boot); pass flag-aware ``declared`` explicitly.
+        """
+        from a2c_smcp.computer.settings.policy import resolve_policy_settings
+        from a2c_smcp.computer.settings.scope import resolve_settings
+
+        return resolve_settings(policy_settings=resolve_policy_settings()).settings
+
+    async def reconcile_governance(
+        self,
+        *,
+        existing_server_names: Callable[[], set[str]] | None = None,
+        register_server: RegisterBundledServer | None = None,
+        inject_inputs: Callable[[BundledServerRecord], Awaitable[None]] | None = None,
+        declared: Mapping[str, Any] | None = None,
+    ) -> GovernanceRecoveryReport:
+        """
+        治理启动恢复公共入口（#117，协议 v0.2.3 §4.8；两 SDK 同构契约"设计 Y"）/ Governance recovery entry。
+
+        阶段一（恒执行）：从双账本恢复 enabled plugin 的 bundled SKILL 进当前 Registry（ledger 驱动、
+        additive-only、幂等、失败降级不抛——见 :mod:`~a2c_smcp.computer.settings.recovery`）。
+        阶段二（仅当给 ``register_server``）：client 显式重挂 bundled MCP server——逐 plugin 根先
+        ``inject_inputs(record)``（携归属上下文做 plugin inputs 前缀化注入，bundled server 的
+        ``${input:}`` D2 渲染前置；每 plugin 根仅一次），再逐 server 经 ``register_server(config, record)``
+        携归属上下文注册；与既有 server 同名 → **skip + WARN 不覆盖**（additive-only，用户配置胜）；
+        单 server 失败 → WARN 不阻断其余。
+
+        boot 默认（``boot_up`` 内无 hooks 调用）= skills-only：bundled MCP server 不在 boot 拉进程
+        （#93 client owns MCP config），仅经 :func:`collect_enabled_bundled_servers` 可查询；重挂永远是
+        client 的显式意志（CLI 为参考 client 实现，外部 GUI/client 调用同一入口）。
+
+        :param existing_server_names: 现存 server 名集合工厂（冲突判定；``None`` = 不判冲突）。
+        :param register_server: 重挂回调 ``(config, record) -> Awaitable``；``None`` = skills-only。
+        :param inject_inputs: plugin inputs 注入回调（入参含归属的 record）；每 plugin 根仅调一次。
+        :param declared: ``enabledPlugins`` 合并声明视图覆盖（``None`` = 现算 user/project/local/policy）。
+        :return: :class:`GovernanceRecoveryReport`（``remounted_servers`` 仅阶段二填充）。
+        """
+        home = self.skill_home
+        if declared is None:
+            declared = self._resolve_declared_settings()
+
+        report = await recover_marketplace_skills(self._skill_registry, home, declared)
+        if report.restored_skills:
+            self.mark_skills_dirty()
+
+        if register_server is None:
+            return report
+
+        existing = set(existing_server_names()) if existing_server_names is not None else set()
+        injected_roots: set[Path] = set()
+        for record in collect_enabled_bundled_servers(home, declared):
+            name = record.config.name
+            if name in existing:
+                logger.warning(
+                    "governance recovery: bundled server %r (plugin %s) conflicts with an existing server, skipped (existing wins)",
+                    name,
+                    record.plugin_id,
+                )
+                continue
+            try:
+                if inject_inputs is not None and record.install_path not in injected_roots:
+                    await inject_inputs(record)
+                    injected_roots.add(record.install_path)
+                await register_server(record.config, record)
+            except Exception as e:  # 单 server 失败隔离 / per-server failure isolation
+                logger.warning("governance recovery: failed to remount bundled server %r (plugin %s): %s", name, record.plugin_id, e)
+                continue
+            existing.add(name)
+            report.remounted_servers.append(name)
+        return report
 
     def get_skills(self) -> list[A2CSkillRef]:
         """当前已安装且可用 SKILL（排除孤儿；不排序、不去重）—— ``client:get_skills`` 数据源。

--- a/a2c_smcp/computer/computer.py
+++ b/a2c_smcp/computer/computer.py
@@ -1361,7 +1361,9 @@ class Computer(BaseComputer[PromptSession]):
         （#93 client owns MCP config），仅经 :func:`collect_enabled_bundled_servers` 可查询；重挂永远是
         client 的显式意志（CLI 为参考 client 实现，外部 GUI/client 调用同一入口）。
 
-        :param existing_server_names: 现存 server 名集合工厂（冲突判定；``None`` = 不判冲突）。
+        :param existing_server_names: 现存 server 名集合工厂（冲突判定）。⚠️ ``None`` = **不判冲突**，
+            同名 bundled server 会经 ``register_server`` 覆盖既有配置——client 重挂时**应当传入**
+            （如 CLI 取 ``comp.mcp_servers`` 名集），仅在明确无冲突面的受控场景省略。
         :param register_server: 重挂回调 ``(config, record) -> Awaitable``；``None`` = skills-only。
         :param inject_inputs: plugin inputs 注入回调（入参含归属的 record）；每 plugin 根仅调一次。
         :param declared: ``enabledPlugins`` 合并声明视图覆盖（``None`` = 现算 user/project/local/policy）。

--- a/a2c_smcp/computer/settings/__init__.py
+++ b/a2c_smcp/computer/settings/__init__.py
@@ -24,6 +24,9 @@ management UX.
   文件锁 + ``.corrupt-<ts>.bak`` 损坏恢复 + 写保护头（带 version）（S5，#58）
 - :mod:`a2c_smcp.computer.settings.reconciler` —— 启动对账（additive-only 四分支）+ 孤儿清理
   （marketplace prune / plugin gc）（S9，#62）
+- :mod:`a2c_smcp.computer.settings.recovery` —— 治理启动恢复（ledger 驱动：boot 恢复 enabled plugin 的
+  bundled SKILL + bundled MCP server 可查询/hooks 重挂）（#117，协议 v0.2.3 §4.8；与 reconciler/installer
+  同因**刻意不在此 re-export**——直接 ``from a2c_smcp.computer.settings.recovery import ...``）
 
 SDK 设计 / Design: python-sdk docs/design-0.2.1-cli-marketplace-ux.md §5 / §7。
 """

--- a/a2c_smcp/computer/settings/installer.py
+++ b/a2c_smcp/computer/settings/installer.py
@@ -28,11 +28,14 @@ gc/prune，本模块做**显式单 plugin** 增删启停，写 ``installed_plugi
 （§9.3，inputs 池消歧归 #65）。
 
 边界（文档化，非缺陷）/ Documented boundaries：
-- 本模块操作 **live session**（Computer.boot_up 当前不调 reconcile）：跨重启重挂 bundled server +
-  ``installed × enabled`` 交集归 reconcile 接线层（#68/#69）。
-- disable 的 skill orphan 为**内存态**（Registry 不落盘），同会话廉价复原；跨重启靠 reconcile 按
-  ``enabledPlugins`` 重建。uninstall 仅注销**活跃** SKILL（与 :func:`_unregister_marketplace_skills` 同限）；
-  先 disable（orphan）再 uninstall 会残留内存孤儿条目，进程重启即清。
+- 本模块操作 **live session**；跨重启恢复（``installed × enabled`` 交集）由治理启动恢复承担（#117）：
+  bundled SKILL 经 ``Computer.boot_up`` 内 :mod:`~a2c_smcp.computer.settings.recovery`（ledger 驱动）
+  自动重建；bundled MCP server 重挂由 client 显式经 ``Computer.reconcile_governance(hooks)`` 触发
+  （#93 client owns MCP config；CLI 启动序列即参考接线）。
+- disable 的 skill orphan 为**内存态**（Registry 不落盘），同会话廉价复原；跨重启由治理恢复按
+  ``enabledPlugins`` 门控重建（显式 false 不复活）。uninstall 仅注销**活跃** SKILL（与
+  :func:`_unregister_marketplace_skills` 同限）；先 disable（orphan）再 uninstall 会残留内存孤儿条目，
+  进程重启即清。
 """
 
 from __future__ import annotations

--- a/a2c_smcp/computer/settings/reconciler.py
+++ b/a2c_smcp/computer/settings/reconciler.py
@@ -28,6 +28,10 @@ SDK 设计 / Design: python-sdk docs/design-0.2.1-cli-marketplace-ux.md §7.1（
   （生产由 #63 写入、本工单测试直接 seed）。
 - bundled MCP server 的起停经 :func:`gc_plugins` 的 ``mcp_teardown`` 回调注入；真正接线（MCP manager）
   由 computer.py 集成承担，不在 #62。
+- **与治理启动恢复的分工（#117）**：本模块是**声明式**对账（declared 驱动，恢复不了"装即活跃"、未写
+  ``enabledPlugins`` 的命令式安装）；boot 恢复走 :mod:`~a2c_smcp.computer.settings.recovery`
+  （**ledger 驱动**：``installed_plugins.json`` 为"已安装"事实源 + ``enabledPlugins`` 仅作禁用门控），
+  两者 additive-only 语义一致、职责不同。
 
 并发 / Concurrency：:func:`reconcile` **串行** stage 各 marketplace（不 ``asyncio.gather``），遵守
 :func:`stage_marketplace_skills` 文档化的同步 ``file_lock`` 阻塞约束（store.py 同步设计的固有约束）。

--- a/a2c_smcp/computer/settings/recovery.py
+++ b/a2c_smcp/computer/settings/recovery.py
@@ -1,0 +1,226 @@
+# -*- coding: utf-8 -*-
+# filename: recovery.py
+# @Time    : 2026/07/06
+# @Author  : JQQ
+# @Email   : jqq1716@gmail.com
+# @Software: PyCharm
+"""
+治理启动恢复（#117，协议 v0.2.3 runtime-contract §4.8）/ Governance boot recovery。
+
+**ledger 驱动、additive-only、离线优先、enabled 门控**（与 rust-sdk ``settings/recovery.rs`` 同构）：
+从双账本（``installed_plugins.json`` + ``known_marketplaces.json``）重建 enabled plugin 的活跃集——
+bundled SKILL 经 :func:`~a2c_smcp.computer.skills.staging.stage_marketplace_skills`（``refresh=False``
+就地复用 clone 树）恢复进 Registry；bundled MCP server 经 :func:`collect_enabled_bundled_servers`
+纯函数**可查询**（含 plugin/marketplace 归属，§4.8.3），进程物化归 client（#93 client owns MCP config，
+§4.8 blockquote）——boot 默认不拉进程，重挂由 client 显式经
+:meth:`~a2c_smcp.computer.computer.Computer.reconcile_governance` 传 hooks 触发（设计 Y 同构契约）。
+
+为何不走声明式 :func:`~a2c_smcp.computer.settings.reconciler.reconcile`：命令式 ``install_plugin``
+**不写** ``enabledPlugins``（装即活跃），声明式对账恢复不了它；恢复以账本为"已安装"事实源、以
+``enabledPlugins`` 合并视图为启用门控（boot-active = installed ∧ ``enabledPlugins[pid] != False``，
+仅显式 false 禁用）。失败降级铁律：单 plugin / 单 marketplace / 单文件失败 → WARN + 记入报告，
+**不抛、不阻断 boot**（§3 degraded / §5.2）。
+
+已知限制（与 rust 同构文档化）：boot 内 declared 视图不含 ``--settings`` flag scope（Computer 无 flag
+知识；CLI 接线时可显式传 flag-aware ``declared``）——跨重启可靠 disable 请写 user scope。
+
+Ledger-driven, additive-only, offline-first governance recovery mirroring rust-sdk. Recovery reads the
+two ledgers as installed-facts, gates by the merged ``enabledPlugins`` view (only explicit ``false``
+disables), restores bundled SKILLs in place, and exposes enabled bundled MCP servers as a pure queryable
+function with ownership; process materialization stays with the client (#93).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from a2c_smcp.computer.mcp_clients.model import MCPServerConfig
+from a2c_smcp.computer.settings.store import load_installed_plugins, load_known_marketplaces
+from a2c_smcp.computer.skills.home import marketplace_skill_dir
+from a2c_smcp.computer.skills.manifest import PluginManifestError, load_bundled_servers
+from a2c_smcp.computer.skills.registry import SkillRegistry
+from a2c_smcp.computer.skills.staging import DEFAULT_GIT_TIMEOUT, stage_marketplace_skills
+from a2c_smcp.utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+@dataclass
+class GovernanceRecoveryReport:
+    """治理恢复报告（与 rust ``GovernanceRecoveryReport`` 同名同义，作观测 + 测试信号）/ Recovery report。
+
+    - ``restored_plugins``：clone 可达且已尝试 stage 的 plugin id（``<plugin>@<marketplace>``）；
+      **非**"保证注册了 SKILL"（manifest 损坏时 stage 内部降级，权威清单看 ``restored_skills``）。
+    - ``restored_skills``：本轮成功注册/刷新的 SKILL name 权威清单。
+    - ``remounted_servers``：阶段二经 hooks 成功重挂的 server name（由编排方填充；本模块函数留空）。
+    - ``failed_marketplaces``：源不可达 / clone 缺失且重建失败 / known 记录缺失（降级、不阻断）。
+    - ``skipped_disabled``：``enabledPlugins[pid] = false`` 刻意跳过的 plugin id。
+    """
+
+    restored_plugins: list[str] = field(default_factory=list)
+    restored_skills: list[str] = field(default_factory=list)
+    remounted_servers: list[str] = field(default_factory=list)
+    failed_marketplaces: list[str] = field(default_factory=list)
+    skipped_disabled: list[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True, slots=True)
+class BundledServerRecord:
+    """enabled bundled MCP server 的可查询记录（归属 = boot 纯函数输出，§4.8.3）/ Queryable bundled-server record。
+
+    ``config`` 从账本 ``installPath`` 经 :func:`load_bundled_servers` **每次 boot 重新解析**（不信任
+    存储态，§5.8 精神）；``plugin``/``marketplace`` 供 client 挂载时携带 D2 渲染上下文
+    （``Computer.aadd_or_aupdate_server(cfg, plugin=, marketplace=)``）。
+    """
+
+    plugin_id: str
+    plugin: str
+    marketplace: str
+    install_path: Path
+    config: MCPServerConfig
+
+
+# 阶段二重挂回调：携归属记录（供 client 带 plugin/marketplace 上下文注册，D2 ${input:} 前缀回退解析）。
+# Phase-2 remount callback carrying ownership context (unlike installer's context-free RegisterServer).
+RegisterBundledServer = Callable[[MCPServerConfig, BundledServerRecord], Awaitable[None]]
+
+
+def _plugin_boot_active(declared: Mapping[str, Any], pid: str) -> bool:
+    """boot-active 门控：仅显式 ``enabledPlugins[pid] = false`` 视为禁用（缺省/true 皆启用，与 rust 逐字一致）。"""
+    enabled = declared.get("enabledPlugins")
+    if isinstance(enabled, Mapping):
+        return enabled.get(pid) is not False
+    return True
+
+
+def _split_pid(pid: str) -> tuple[str, str] | None:
+    """``<plugin>@<marketplace>`` → (plugin, marketplace)；无 ``@``（本地-only 形态）→ None 跳过。"""
+    plugin, sep, marketplace = pid.partition("@")
+    if not sep or not plugin or not marketplace:
+        return None
+    return plugin, marketplace
+
+
+async def recover_marketplace_skills(
+    registry: SkillRegistry,
+    home: Path,
+    declared: Mapping[str, Any],
+    *,
+    env: Mapping[str, str] | None = None,
+    timeout: float = DEFAULT_GIT_TIMEOUT,
+) -> GovernanceRecoveryReport:
+    """
+    阶段一：从双账本恢复 enabled installed plugin 的 bundled SKILL（幂等、additive-only）/ Phase 1: restore skills。
+
+    按 marketplace 分组 → :func:`stage_marketplace_skills`（``refresh=False`` 离线优先：clone 在则就地复用重扫，
+    缺失才尝试 clone）。降级判定与 rust 同构：stage 内部吞错，事后 clone 树仍缺 → 该 marketplace 入
+    ``failed_marketplaces``；known_marketplaces 缺记录 → 同样降级。**绝不抛、不阻断其余**。
+
+    :param registry: 目标 :class:`SkillRegistry`（恢复注册进当前活跃集）。
+    :param home: SKILL Home 绝对根。
+    :param declared: ``enabledPlugins`` 合并声明视图（权威启用门控）。
+    :param env: 环境映射（账本路径解析 + git 子进程），默认 ``os.environ``。
+    :param timeout: 单次 git 操作超时（仅 clone 缺失重建时可能触发）。
+    """
+    report = GovernanceRecoveryReport()
+    installed = load_installed_plugins(home=home, env=env).get("plugins", {})
+    if not installed:
+        return report
+    known = load_known_marketplaces(home=home, env=env).get("marketplaces", {})
+
+    # enabled installed plugin 按 marketplace 分组 / group boot-active plugins by marketplace.
+    by_marketplace: dict[str, set[str]] = {}
+    for pid in installed:
+        split = _split_pid(pid)
+        if split is None:
+            logger.debug("governance recovery: plugin id %r has no '@marketplace' segment, skipped (local-only form)", pid)
+            continue
+        if not _plugin_boot_active(declared, pid):
+            report.skipped_disabled.append(pid)
+            continue
+        plugin, marketplace = split
+        by_marketplace.setdefault(marketplace, set()).add(plugin)
+
+    for marketplace, plugins in sorted(by_marketplace.items()):
+        record = known.get(marketplace)
+        source = record.get("source") if isinstance(record, Mapping) else None
+        if not isinstance(source, Mapping):
+            logger.warning(
+                "governance recovery: marketplace %r has no known_marketplaces record; its plugins %s degraded (not restored)",
+                marketplace,
+                sorted(plugins),
+            )
+            report.failed_marketplaces.append(marketplace)
+            continue
+        names = await stage_marketplace_skills(
+            marketplace,
+            source,
+            registry,
+            home,
+            plugin_filter=set(plugins),
+            refresh=False,  # 离线优先：clone 在则零 git / offline-first
+            timeout=timeout,
+            env=env,
+        )
+        # 降级代理判定（rust 同构）：stage 失败降级不抛；事后 clone 树仍缺 = 源不可达且无本地物化。
+        if not marketplace_skill_dir(home, marketplace).is_dir():
+            logger.warning("governance recovery: marketplace %r clone missing and rebuild failed, degraded", marketplace)
+            report.failed_marketplaces.append(marketplace)
+            continue
+        report.restored_skills.extend(names)
+        report.restored_plugins.extend(sorted(f"{plugin}@{marketplace}" for plugin in plugins))
+
+    return report
+
+
+def collect_enabled_bundled_servers(
+    home: Path,
+    declared: Mapping[str, Any],
+    *,
+    env: Mapping[str, str] | None = None,
+) -> list[BundledServerRecord]:
+    """
+    阶段二输入（纯读、无锁、无副作用）：枚举 enabled installed plugin 的 bundled MCP server / Phase-2 pure collect。
+
+    协议 §4.8 blockquote 的"SDK MUST 使 enabled bundled server 可查询"落点：client 据此物化进自己的
+    MCP 配置模型，或经 :meth:`Computer.reconcile_governance` 传 hooks 显式重挂。跨 plugin/scope 同名
+    server **首见保留去重**（账本插入序，与 rust 一致）；``installPath`` 缺失 / bundled JSON 损坏 →
+    WARN 跳过该记录，不阻断其余、不抛。
+
+    :param home: SKILL Home 绝对根。
+    :param declared: ``enabledPlugins`` 合并声明视图。
+    :param env: 环境映射（账本路径解析），默认 ``os.environ``。
+    """
+    out: list[BundledServerRecord] = []
+    seen: set[str] = set()
+    installed = load_installed_plugins(home=home, env=env).get("plugins", {})
+    for pid, records in installed.items():
+        split = _split_pid(pid)
+        if split is None:
+            continue
+        if not _plugin_boot_active(declared, pid):
+            continue
+        plugin, marketplace = split
+        for record in records:
+            install_path = record.get("installPath") if isinstance(record, Mapping) else None
+            if not install_path or not isinstance(install_path, str):
+                logger.warning("governance recovery: plugin %r record has no installPath, bundled servers skipped", pid)
+                continue
+            root = Path(install_path)
+            try:
+                configs = load_bundled_servers(root)
+            except PluginManifestError as e:
+                logger.warning("governance recovery: plugin %r bundled servers unparsable at %s, skipped: %s", pid, root, e)
+                continue
+            for config in configs:
+                if config.name in seen:
+                    logger.debug("governance recovery: bundled server %r duplicated across plugins/scopes, first seen wins", config.name)
+                    continue
+                seen.add(config.name)
+                out.append(
+                    BundledServerRecord(plugin_id=pid, plugin=plugin, marketplace=marketplace, install_path=root, config=config),
+                )
+    return out

--- a/tests/unit_tests/computer/cli/test_plugin.py
+++ b/tests/unit_tests/computer/cli/test_plugin.py
@@ -320,3 +320,119 @@ async def test_repl_list_and_unknown_subcommand_no_raise(tmp_path: Path, monkeyp
     await plugin_cmd.repl_dispatch(comp, ["plugin", "list"], session=None)  # 空 → 无错
     await plugin_cmd.repl_dispatch(comp, ["plugin", "bogus"], session=None)  # 未知子命令 → no-op
     assert comp.dirty == 0
+
+
+# ── run_governance_remount（#117 设计 Y CLI 参考接线）/ boot-time governance remount ──
+def _seed_recovery_home(home: Path, *, servers: list[str], skills: list[str]) -> Path:
+    """预置治理恢复态：catalog 树（acme/audit，含 mcp-servers/ + skills/）+ 双账本。返回 plugin 根。"""
+    catalog = marketplace_skill_dir(home, "acme")
+    _write_json(
+        catalog / ".tfrobot-plugin" / "marketplace.json",
+        {
+            "name": "acme",
+            "owner": {"name": "X"},
+            "metadata": {"pluginRoot": "./plugins"},
+            "plugins": [{"name": "audit", "source": "audit", "version": "1.2.0"}],
+        },
+    )
+    plugin_root = catalog / "plugins" / "audit"
+    plugin_root.mkdir(parents=True, exist_ok=True)
+    for sname in servers:
+        _write_json(plugin_root / "mcp-servers" / f"{sname}.json", _stdio(sname))
+    for sk in skills:
+        p = plugin_root / "skills" / sk / "SKILL.md"
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(f"---\nname: {sk}\ndescription: d\n---\nbody\n", encoding="utf-8")
+    save_known_marketplaces(
+        {"version": 1, "marketplaces": {"acme": {"source": _SRC, "installLocation": str(catalog.resolve())}}},
+        home=home,
+    )
+    save_installed_plugins(
+        {
+            "version": 1,
+            "plugins": {
+                "audit@acme": [
+                    {"scope": "user", "installPath": str(plugin_root), "version": "1.2.0", "bundledMcpServers": list(servers)},
+                ],
+            },
+        },
+        home=home,
+    )
+    return plugin_root
+
+
+def _isolate_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "cfg"))
+    monkeypatch.chdir(tmp_path)
+
+
+@pytest.mark.asyncio
+async def test_run_governance_remount_wires_ownership_context(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """CLI 接线断言：register 经 comp.aadd_or_aupdate_server 携正确 plugin/marketplace 归属上下文。"""
+    from a2c_smcp.computer.computer import Computer
+
+    _isolate_env(tmp_path, monkeypatch)
+    home = _home(tmp_path)
+    _seed_recovery_home(home, servers=["figma-mcp"], skills=["lint"])
+
+    async with Computer(name="t", skill_home=home) as comp:
+        recorded: list[tuple[str, str | None, str | None]] = []
+
+        async def fake_register(server: Any, *, session: Any = None, plugin: str | None = None, marketplace: str | None = None) -> None:
+            recorded.append((server.name, plugin, marketplace))
+
+        monkeypatch.setattr(comp, "aadd_or_aupdate_server", fake_register)
+        await plugin_cmd.run_governance_remount(comp)
+
+        assert recorded == [("figma-mcp", "audit", "acme")]
+
+
+@pytest.mark.asyncio
+async def test_run_governance_remount_flag_declared_disables(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """flag-aware declared 生效于阶段二：``--settings`` 文件里 enabledPlugins=false → 不重挂。"""
+    from a2c_smcp.computer.computer import Computer
+
+    _isolate_env(tmp_path, monkeypatch)
+    home = _home(tmp_path)
+    _seed_recovery_home(home, servers=["figma-mcp"], skills=["lint"])
+    flag_file = tmp_path / "flag-settings.json"
+    flag_file.write_text(json.dumps({"enabledPlugins": {"audit@acme": False}}), encoding="utf-8")
+
+    async with Computer(name="t", skill_home=home) as comp:
+        recorded: list[str] = []
+
+        async def fake_register(server: Any, *, session: Any = None, plugin: str | None = None, marketplace: str | None = None) -> None:
+            recorded.append(server.name)
+
+        monkeypatch.setattr(comp, "aadd_or_aupdate_server", fake_register)
+        await plugin_cmd.run_governance_remount(comp, flag_config=flag_file)
+
+        assert recorded == []
+
+
+@pytest.mark.asyncio
+async def test_run_governance_remount_existing_from_comp_servers(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """existing_server_names 取自 comp.mcp_servers：同名已存在 → skip 不覆盖（用户配置胜）。"""
+    from pydantic import TypeAdapter
+
+    from a2c_smcp.computer.computer import Computer
+    from a2c_smcp.computer.mcp_clients.model import MCPServerConfig
+
+    _isolate_env(tmp_path, monkeypatch)
+    home = _home(tmp_path)
+    _seed_recovery_home(home, servers=["figma-mcp"], skills=["lint"])
+
+    async with Computer(name="t", skill_home=home) as comp:
+        # 用户已有同名 server（仅入配置集，不挂载进程）/ pre-existing user config, no process spawn
+        user_cfg = TypeAdapter(MCPServerConfig).validate_python(_stdio("figma-mcp"))
+        comp._mcp_servers.add(user_cfg)
+
+        recorded: list[str] = []
+
+        async def fake_register(server: Any, *, session: Any = None, plugin: str | None = None, marketplace: str | None = None) -> None:
+            recorded.append(server.name)
+
+        monkeypatch.setattr(comp, "aadd_or_aupdate_server", fake_register)
+        await plugin_cmd.run_governance_remount(comp)
+
+        assert recorded == []

--- a/tests/unit_tests/computer/settings/test_recovery.py
+++ b/tests/unit_tests/computer/settings/test_recovery.py
@@ -1,0 +1,265 @@
+# -*- coding: utf-8 -*-
+# filename: test_recovery.py
+# @Time    : 2026/07/06
+# @Author  : JQQ
+# @Email   : jqq1716@gmail.com
+# @Software: PyCharm
+"""
+治理启动恢复单元测试（#117，协议 v0.2.3 §4.8）/ Governance boot-recovery unit tests。
+
+镜像 rust-sdk recovery.rs 的 hermetic 套件（无 git、无网络：预置 catalog clone 树 + ``refresh=False``
+就地复用）。测试意图 / Test intentions:
+- ``recover_marketplace_skills``：enabled installed plugin 的 bundled SKILL 恢复 + 幂等；
+  ``enabledPlugins=false`` 跳过不复活（disable 负向）；账本无记录不恢复（uninstall 负向）；
+  known_marketplaces 缺记录 / clone 缺失且源不可达 → ``failed_marketplaces`` 降级不抛；空 home noop。
+- ``collect_enabled_bundled_servers``：含归属（plugin/marketplace）纯函数输出（§4.8.3）；
+  跨 plugin 同名 server 首见去重；installPath 缺失 / JSON 损坏 → WARN 跳过不阻断。
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import Sequence
+from pathlib import Path
+
+import pytest
+
+from a2c_smcp.computer.settings.recovery import (
+    collect_enabled_bundled_servers,
+    recover_marketplace_skills,
+)
+from a2c_smcp.computer.settings.store import save_installed_plugins, save_known_marketplaces
+from a2c_smcp.computer.skills.home import marketplace_skill_dir
+from a2c_smcp.computer.skills.registry import SkillRegistry
+
+_SRC = {"type": "git", "url": "https://example.com/acme.git"}
+
+
+# ── 辅助 / helpers ───────────────────────────────────────────────────────────
+def _home(tmp_path: Path) -> Path:
+    h = tmp_path / "skill-home"
+    h.mkdir()
+    return h
+
+
+def _env(tmp_path: Path) -> dict[str, str]:
+    """重定向 XDG_CONFIG_HOME → tmp（隔离 user settings 读写）。"""
+    return {**os.environ, "XDG_CONFIG_HOME": str(tmp_path / "cfg")}
+
+
+def _write_json(path: Path, obj: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(obj), encoding="utf-8")
+
+
+def _stdio(name: str, command: str = "node") -> dict:
+    return {"name": name, "type": "stdio", "server_parameters": {"command": command}}
+
+
+def _skill_md(name: str, description: str = "a skill") -> str:
+    return f"---\nname: {name}\ndescription: {description}\nlicense: MIT\n---\n# {name}\nbody\n"
+
+
+def _setup_catalog(
+    home: Path,
+    mp: str,
+    plugin: str,
+    *,
+    servers: Sequence[str] = (),
+    skills: Sequence[str] = (),
+    seed_known: bool = True,
+) -> Path:
+    """预置 catalog clone 树（marketplace.json + plugin 的 mcp-servers/ + skills/）+ 可选 seed known_marketplaces。
+
+    返回 plugin 根 ``<catalog>/plugins/<plugin>``。``refresh=False`` 下真实 staging 就地复用此树（零 git）。
+    """
+    catalog = marketplace_skill_dir(home, mp)
+    manifest = {
+        "name": mp,
+        "owner": {"name": "X"},
+        "metadata": {"pluginRoot": "./plugins"},
+        "plugins": [{"name": plugin, "source": plugin, "version": "1.2.0"}],
+    }
+    _write_json(catalog / ".tfrobot-plugin" / "marketplace.json", manifest)
+    plugin_root = catalog / "plugins" / plugin
+    plugin_root.mkdir(parents=True, exist_ok=True)
+    for sname in servers:
+        _write_json(plugin_root / "mcp-servers" / f"{sname}.json", _stdio(sname))
+    for sk in skills:
+        p = plugin_root / "skills" / sk / "SKILL.md"
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(_skill_md(sk), encoding="utf-8")
+    if seed_known:
+        save_known_marketplaces(
+            {"version": 1, "marketplaces": {mp: {"source": _SRC, "installLocation": str(catalog.resolve()), "commitSha": "abc123"}}},
+            home=home,
+        )
+    return plugin_root
+
+
+def _seed_installed(home: Path, plugins: dict[str, list[dict]]) -> None:
+    save_installed_plugins({"version": 1, "plugins": plugins}, home=home)
+
+
+def _record(plugin_root: Path, *, scope: str = "user", servers: Sequence[str] = ()) -> dict:
+    return {
+        "scope": scope,
+        "installPath": str(plugin_root),
+        "version": "1.2.0",
+        "commitSha": "abc123",
+        "installedAt": "2026-07-06T00:00:00Z",
+        "bundledMcpServers": list(servers),
+    }
+
+
+# ── recover_marketplace_skills ────────────────────────────────────────────────
+@pytest.mark.asyncio
+async def test_recover_restages_enabled_installed_plugin_and_idempotent(tmp_path: Path) -> None:
+    """enabled（缺省即启用）installed plugin → bundled SKILL 恢复进 Registry；二次调用幂等。"""
+    home = _home(tmp_path)
+    root = _setup_catalog(home, "acme", "audit", skills=["lint"])
+    _seed_installed(home, {"audit@acme": [_record(root)]})
+    reg = SkillRegistry()
+
+    report = await recover_marketplace_skills(reg, home, {"enabledPlugins": {}}, env=_env(tmp_path))
+
+    assert "audit@acme" in report.restored_plugins
+    assert "audit:lint" in report.restored_skills
+    assert reg.resolve("audit:lint") is not None
+    assert report.failed_marketplaces == [] and report.skipped_disabled == []
+
+    # 幂等：显式 true 亦启用；registry 不重复注册
+    report2 = await recover_marketplace_skills(reg, home, {"enabledPlugins": {"audit@acme": True}}, env=_env(tmp_path))
+    assert "audit:lint" in report2.restored_skills
+    assert len(reg) == 1
+
+
+@pytest.mark.asyncio
+async def test_recover_skips_disabled_plugin_and_collect_skips(tmp_path: Path) -> None:
+    """enabledPlugins=false → skipped_disabled、SKILL 不复活、collect 同步跳过（disable 负向）。"""
+    home = _home(tmp_path)
+    root = _setup_catalog(home, "acme", "audit", servers=["figma"], skills=["lint"])
+    _seed_installed(home, {"audit@acme": [_record(root, servers=["figma"])]})
+    reg = SkillRegistry()
+    declared = {"enabledPlugins": {"audit@acme": False}}
+
+    report = await recover_marketplace_skills(reg, home, declared, env=_env(tmp_path))
+
+    assert report.skipped_disabled == ["audit@acme"]
+    assert report.restored_skills == [] and report.restored_plugins == []
+    assert reg.resolve("audit:lint") is None
+    assert collect_enabled_bundled_servers(home, declared, env=_env(tmp_path)) == []
+
+
+@pytest.mark.asyncio
+async def test_recover_without_ledger_record_is_noop(tmp_path: Path) -> None:
+    """账本无记录（uninstall 后）→ 即使 catalog 树仍在也不恢复（uninstall 负向；ledger 驱动）。"""
+    home = _home(tmp_path)
+    _setup_catalog(home, "acme", "audit", skills=["lint"])  # 树在、账本空
+    reg = SkillRegistry()
+
+    report = await recover_marketplace_skills(reg, home, {}, env=_env(tmp_path))
+
+    assert report.restored_plugins == [] and report.restored_skills == []
+    assert len(reg) == 0
+
+
+@pytest.mark.asyncio
+async def test_recover_degrades_when_marketplace_record_absent(tmp_path: Path) -> None:
+    """known_marketplaces 缺该 marketplace 记录 → failed_marketplaces 降级、不抛、不阻断。"""
+    home = _home(tmp_path)
+    root = _setup_catalog(home, "acme", "audit", skills=["lint"], seed_known=False)
+    _seed_installed(home, {"audit@acme": [_record(root)]})
+    reg = SkillRegistry()
+
+    report = await recover_marketplace_skills(reg, home, {}, env=_env(tmp_path))
+
+    assert report.failed_marketplaces == ["acme"]
+    assert report.restored_skills == []
+
+
+@pytest.mark.asyncio
+async def test_recover_degrades_when_clone_missing_and_unreachable(tmp_path: Path) -> None:
+    """clone 树缺失且源不可达（file:// 不存在路径，git 快速失败离线安全）→ failed_marketplaces 降级。"""
+    home = _home(tmp_path)
+    save_known_marketplaces(
+        {"version": 1, "marketplaces": {"acme": {"source": {"type": "git", "url": f"file://{tmp_path}/no-such-repo"}}}},
+        home=home,
+    )
+    _seed_installed(home, {"audit@acme": [_record(tmp_path / "gone")]})
+    reg = SkillRegistry()
+
+    report = await recover_marketplace_skills(reg, home, {}, env=_env(tmp_path))
+
+    assert report.failed_marketplaces == ["acme"]
+    assert report.restored_skills == []
+
+
+@pytest.mark.asyncio
+async def test_recover_empty_home_is_noop(tmp_path: Path) -> None:
+    """空 home（双账本皆无）→ 空报告 noop。"""
+    home = _home(tmp_path)
+    reg = SkillRegistry()
+
+    report = await recover_marketplace_skills(reg, home, {}, env=_env(tmp_path))
+
+    assert report.restored_plugins == []
+    assert report.restored_skills == []
+    assert report.failed_marketplaces == []
+    assert report.skipped_disabled == []
+    assert len(reg) == 0
+
+
+# ── collect_enabled_bundled_servers ──────────────────────────────────────────
+def test_collect_returns_enabled_bundled_servers_with_ownership(tmp_path: Path) -> None:
+    """enabled plugin 的 bundled server 可查询，且归属（plugin/marketplace/installPath）为纯函数输出（§4.8.3）。"""
+    home = _home(tmp_path)
+    root = _setup_catalog(home, "acme", "audit", servers=["figma", "blender"])
+    _seed_installed(home, {"audit@acme": [_record(root, servers=["figma", "blender"])]})
+
+    records = collect_enabled_bundled_servers(home, {}, env=_env(tmp_path))
+
+    assert {r.config.name for r in records} == {"figma", "blender"}
+    for r in records:
+        assert r.plugin_id == "audit@acme"
+        assert r.plugin == "audit" and r.marketplace == "acme"
+        assert r.install_path == root
+
+
+def test_collect_dedupes_same_server_name_across_plugins(tmp_path: Path) -> None:
+    """跨 plugin 同名 server → 首见保留去重（与 rust 一致）。"""
+    home = _home(tmp_path)
+    root_a = _setup_catalog(home, "acme", "audit", servers=["shared"])
+    root_b = _setup_catalog(home, "beta", "fmt", servers=["shared"])
+    _seed_installed(
+        home,
+        {"audit@acme": [_record(root_a, servers=["shared"])], "fmt@beta": [_record(root_b, servers=["shared"])]},
+    )
+
+    records = collect_enabled_bundled_servers(home, {}, env=_env(tmp_path))
+
+    assert len(records) == 1
+    assert records[0].config.name == "shared"
+
+
+def test_collect_skips_missing_install_path_and_corrupt_json(tmp_path: Path) -> None:
+    """installPath 缺失 / mcp-servers JSON 损坏 → WARN 跳过该 plugin，不阻断其余、不抛。"""
+    home = _home(tmp_path)
+    good_root = _setup_catalog(home, "acme", "audit", servers=["figma"])
+    corrupt_root = _setup_catalog(home, "beta", "fmt")
+    (corrupt_root / "mcp-servers").mkdir(parents=True, exist_ok=True)
+    (corrupt_root / "mcp-servers" / "bad.json").write_text("{not json", encoding="utf-8")
+    no_path_record = {"scope": "user", "version": "1.0.0"}  # 无 installPath
+    _seed_installed(
+        home,
+        {
+            "audit@acme": [_record(good_root, servers=["figma"])],
+            "fmt@beta": [_record(corrupt_root)],
+            "ghost@acme": [no_path_record],
+        },
+    )
+
+    records = collect_enabled_bundled_servers(home, {}, env=_env(tmp_path))
+
+    assert {r.config.name for r in records} == {"figma"}

--- a/tests/unit_tests/computer/settings/test_recovery.py
+++ b/tests/unit_tests/computer/settings/test_recovery.py
@@ -197,6 +197,39 @@ async def test_recover_degrades_when_clone_missing_and_unreachable(tmp_path: Pat
 
 
 @pytest.mark.asyncio
+async def test_local_only_pid_without_at_is_skipped(tmp_path: Path) -> None:
+    """账本 pid 无 ``@marketplace`` 段（本地-only 形态）→ 恢复与 collect 均静默跳过、不炸、不误纳入。"""
+    home = _home(tmp_path)
+    root = _setup_catalog(home, "acme", "audit", servers=["figma"], skills=["lint"])
+    _seed_installed(home, {"localplugin": [_record(root, servers=["figma"])]})
+    reg = SkillRegistry()
+
+    report = await recover_marketplace_skills(reg, home, {}, env=_env(tmp_path))
+
+    assert report.restored_plugins == [] and report.restored_skills == []
+    assert report.skipped_disabled == [] and report.failed_marketplaces == []
+    assert len(reg) == 0
+    assert collect_enabled_bundled_servers(home, {}, env=_env(tmp_path)) == []
+
+
+@pytest.mark.asyncio
+async def test_recover_revives_orphaned_skill(tmp_path: Path) -> None:
+    """已 orphan 的 bundled SKILL（同会话 disable 内存态）经 recover 重扫复活回活跃集（register_or_update 语义）。"""
+    home = _home(tmp_path)
+    root = _setup_catalog(home, "acme", "audit", skills=["lint"])
+    _seed_installed(home, {"audit@acme": [_record(root)]})
+    reg = SkillRegistry()
+    await recover_marketplace_skills(reg, home, {}, env=_env(tmp_path))
+    assert reg.mark_orphan("audit:lint") is True
+    assert reg.resolve("audit:lint") is None  # 孤儿不可解析
+
+    report = await recover_marketplace_skills(reg, home, {}, env=_env(tmp_path))
+
+    assert "audit:lint" in report.restored_skills
+    assert reg.resolve("audit:lint") is not None  # 复活
+
+
+@pytest.mark.asyncio
 async def test_recover_empty_home_is_noop(tmp_path: Path) -> None:
     """空 home（双账本皆无）→ 空报告 noop。"""
     home = _home(tmp_path)
@@ -228,7 +261,7 @@ def test_collect_returns_enabled_bundled_servers_with_ownership(tmp_path: Path) 
 
 
 def test_collect_dedupes_same_server_name_across_plugins(tmp_path: Path) -> None:
-    """跨 plugin 同名 server → 首见保留去重（与 rust 一致）。"""
+    """跨 plugin 同名 server → 首见保留去重且**归属为首见者**（账本插入序，与 rust "first seen wins" 一致）。"""
     home = _home(tmp_path)
     root_a = _setup_catalog(home, "acme", "audit", servers=["shared"])
     root_b = _setup_catalog(home, "beta", "fmt", servers=["shared"])
@@ -241,6 +274,34 @@ def test_collect_dedupes_same_server_name_across_plugins(tmp_path: Path) -> None
 
     assert len(records) == 1
     assert records[0].config.name == "shared"
+    assert records[0].plugin_id == "audit@acme"  # 首见胜：归属锁定账本序首个
+    assert records[0].install_path == root_a
+
+
+def test_collect_enumerates_multi_scope_records_with_dedup(tmp_path: Path) -> None:
+    """单 pid 多 scope record（user + project 不同 installPath）→ 逐 record 枚举 + 跨 record 同名首见去重。"""
+    home = _home(tmp_path)
+    root_user = _setup_catalog(home, "acme", "audit", servers=["figma"])
+    root_proj = home / "alt-install" / "audit"
+    _write_json(root_proj / "mcp-servers" / "figma.json", _stdio("figma"))
+    _write_json(root_proj / "mcp-servers" / "extra.json", _stdio("extra"))
+    _seed_installed(
+        home,
+        {
+            "audit@acme": [
+                _record(root_user, servers=["figma"]),
+                _record(root_proj, scope="project", servers=["figma", "extra"]),
+            ],
+        },
+    )
+
+    records = collect_enabled_bundled_servers(home, {}, env=_env(tmp_path))
+
+    assert {r.config.name for r in records} == {"figma", "extra"}
+    figma = next(r for r in records if r.config.name == "figma")
+    assert figma.install_path == root_user  # 首见（user record 在前）胜
+    extra = next(r for r in records if r.config.name == "extra")
+    assert extra.install_path == root_proj
 
 
 def test_collect_skips_missing_install_path_and_corrupt_json(tmp_path: Path) -> None:

--- a/tests/unit_tests/computer/test_computer_governance_recovery.py
+++ b/tests/unit_tests/computer/test_computer_governance_recovery.py
@@ -56,7 +56,8 @@ def _seed_home(tmp_path: Path, *, servers: Sequence[str] = (), skills: Sequence[
     plugin_root = catalog / "plugins" / "audit"
     plugin_root.mkdir(parents=True, exist_ok=True)
     for sname in servers:
-        _write_json(plugin_root / "mcp-servers" / f"{sname}.json", {"name": sname, "type": "stdio", "server_parameters": {"command": "node"}})
+        server_def = {"name": sname, "type": "stdio", "server_parameters": {"command": "node"}}
+        _write_json(plugin_root / "mcp-servers" / f"{sname}.json", server_def)
     for sk in skills:
         p = plugin_root / "skills" / sk / "SKILL.md"
         p.parent.mkdir(parents=True, exist_ok=True)
@@ -129,8 +130,8 @@ async def test_reconcile_governance_remounts_via_hooks_and_idempotent(tmp_path: 
     async def register(cfg, record: BundledServerRecord) -> None:
         calls.append((cfg.name, record.plugin, record.marketplace))
 
-    async def inject(path: Path) -> None:
-        injected.append(path)
+    async def inject(record: BundledServerRecord) -> None:
+        injected.append(record.install_path)
 
     async with Computer(name="t", skill_home=home) as comp:
         report = await comp.reconcile_governance(

--- a/tests/unit_tests/computer/test_computer_governance_recovery.py
+++ b/tests/unit_tests/computer/test_computer_governance_recovery.py
@@ -154,6 +154,33 @@ async def test_reconcile_governance_remounts_via_hooks_and_idempotent(tmp_path: 
 
 
 @pytest.mark.asyncio
+async def test_reconcile_governance_injects_once_per_plugin_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """同一 plugin 根下多个 bundled server → inject_inputs 仅调一次，所有 server 均重挂。"""
+    _isolate_declared_env(tmp_path, monkeypatch)
+    home, plugin_root = _seed_home(tmp_path, servers=["blender", "figma"], skills=["lint"])
+
+    mounted: list[str] = []
+    injected: list[Path] = []
+
+    async def register(cfg, record) -> None:
+        mounted.append(cfg.name)
+
+    async def inject(record) -> None:
+        injected.append(record.install_path)
+
+    async with Computer(name="t", skill_home=home) as comp:
+        report = await comp.reconcile_governance(
+            existing_server_names=lambda: set(),
+            register_server=register,
+            inject_inputs=inject,
+            declared={},
+        )
+        assert sorted(mounted) == ["blender", "figma"]
+        assert sorted(report.remounted_servers) == ["blender", "figma"]
+        assert injected == [plugin_root]  # 每 plugin 根仅一次
+
+
+@pytest.mark.asyncio
 async def test_reconcile_governance_register_failure_non_blocking(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """register 抛错 → 不阻断（不抛出），失败 server 不入 remounted，skills 恢复不受影响。"""
     _isolate_declared_env(tmp_path, monkeypatch)

--- a/tests/unit_tests/computer/test_computer_governance_recovery.py
+++ b/tests/unit_tests/computer/test_computer_governance_recovery.py
@@ -1,0 +1,192 @@
+# -*- coding: utf-8 -*-
+# filename: test_computer_governance_recovery.py
+# @Time    : 2026/07/06
+# @Author  : JQQ
+# @Email   : jqq1716@gmail.com
+# @Software: PyCharm
+"""
+Computer 级治理启动恢复测试（#117，协议 v0.2.3 §4.8）/ Computer-level governance recovery tests。
+
+测试意图 / Test intentions（hermetic：预置 catalog clone 树 + 双账本，零 git 零网络）:
+- ``boot_up`` 从既有 skill_home 恢复 enabled plugin 的 bundled SKILL（§4.8.1/2；conformance §2.4 重启恢复）；
+- ``reconcile_governance(hooks)`` 显式重挂：register 收到含归属上下文的调用 + 幂等（设计 Y client 契约）；
+- register 抛错不阻断其余（失败隔离）；existing 名冲突 skip 不覆盖（additive-only，用户配置胜）。
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Sequence
+from pathlib import Path
+
+import pytest
+
+from a2c_smcp.computer.computer import Computer
+from a2c_smcp.computer.settings.recovery import BundledServerRecord
+from a2c_smcp.computer.settings.store import save_installed_plugins, save_known_marketplaces
+from a2c_smcp.computer.skills.home import marketplace_skill_dir
+
+_SRC = {"type": "git", "url": "https://example.com/acme.git"}
+
+
+# ── fixture 辅助（与 test_recovery.py 同构）/ helpers ─────────────────────────
+def _write_json(path: Path, obj: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(obj), encoding="utf-8")
+
+
+def _skill_md(name: str) -> str:
+    return f"---\nname: {name}\ndescription: a skill\nlicense: MIT\n---\n# {name}\nbody\n"
+
+
+def _seed_home(tmp_path: Path, *, servers: Sequence[str] = (), skills: Sequence[str] = ()) -> tuple[Path, Path]:
+    """预置 skill_home：catalog 树（acme/audit）+ known_marketplaces + installed 账本。返回 (home, plugin_root)。"""
+    home = tmp_path / "skill-home"
+    home.mkdir()
+    catalog = marketplace_skill_dir(home, "acme")
+    _write_json(
+        catalog / ".tfrobot-plugin" / "marketplace.json",
+        {
+            "name": "acme",
+            "owner": {"name": "X"},
+            "metadata": {"pluginRoot": "./plugins"},
+            "plugins": [{"name": "audit", "source": "audit", "version": "1.2.0"}],
+        },
+    )
+    plugin_root = catalog / "plugins" / "audit"
+    plugin_root.mkdir(parents=True, exist_ok=True)
+    for sname in servers:
+        _write_json(plugin_root / "mcp-servers" / f"{sname}.json", {"name": sname, "type": "stdio", "server_parameters": {"command": "node"}})
+    for sk in skills:
+        p = plugin_root / "skills" / sk / "SKILL.md"
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(_skill_md(sk), encoding="utf-8")
+    save_known_marketplaces(
+        {"version": 1, "marketplaces": {"acme": {"source": _SRC, "installLocation": str(catalog.resolve()), "commitSha": "abc123"}}},
+        home=home,
+    )
+    save_installed_plugins(
+        {
+            "version": 1,
+            "plugins": {
+                "audit@acme": [
+                    {
+                        "scope": "user",
+                        "installPath": str(plugin_root),
+                        "version": "1.2.0",
+                        "commitSha": "abc123",
+                        "installedAt": "2026-07-06T00:00:00Z",
+                        "bundledMcpServers": list(servers),
+                    },
+                ],
+            },
+        },
+        home=home,
+    )
+    return home, plugin_root
+
+
+def _isolate_declared_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """隔离 declared 视图来源：XDG → tmp、cwd → tmp（防读真实 user/project settings）。"""
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "cfg"))
+    monkeypatch.chdir(tmp_path)
+
+
+# ── boot_up 恢复（skills-only，设计 Y）────────────────────────────────────────
+@pytest.mark.asyncio
+async def test_boot_up_restores_bundled_skills_from_ledger(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """同一 skill_home 重建 Computer → boot 后 bundled SKILL 重现于 get_skills（conformance §2.4 重启恢复正向）。"""
+    _isolate_declared_env(tmp_path, monkeypatch)
+    home, _ = _seed_home(tmp_path, skills=["lint"])
+
+    async with Computer(name="t", skill_home=home) as comp:
+        names = {ref["name"] for ref in comp.get_skills()}
+        assert "audit:lint" in names
+
+
+@pytest.mark.asyncio
+async def test_boot_up_does_not_restore_disabled_plugin(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """user scope enabledPlugins=false → boot 不复活（disable 负向 + scope 门控）。"""
+    _isolate_declared_env(tmp_path, monkeypatch)
+    home, _ = _seed_home(tmp_path, skills=["lint"])
+    _write_json(tmp_path / "cfg" / "a2c" / "settings.json", {"enabledPlugins": {"audit@acme": False}})
+
+    async with Computer(name="t", skill_home=home) as comp:
+        names = {ref["name"] for ref in comp.get_skills()}
+        assert "audit:lint" not in names
+
+
+# ── reconcile_governance(hooks) 显式重挂（client 契约）────────────────────────
+@pytest.mark.asyncio
+async def test_reconcile_governance_remounts_via_hooks_and_idempotent(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """hooks 重挂：register 收到 (config, 归属记录)；inject_inputs 先于 register；二次调用幂等。"""
+    _isolate_declared_env(tmp_path, monkeypatch)
+    home, plugin_root = _seed_home(tmp_path, servers=["figma"], skills=["lint"])
+
+    calls: list[tuple[str, str, str]] = []
+    injected: list[Path] = []
+
+    async def register(cfg, record: BundledServerRecord) -> None:
+        calls.append((cfg.name, record.plugin, record.marketplace))
+
+    async def inject(path: Path) -> None:
+        injected.append(path)
+
+    async with Computer(name="t", skill_home=home) as comp:
+        report = await comp.reconcile_governance(
+            existing_server_names=lambda: set(),
+            register_server=register,
+            inject_inputs=inject,
+            declared={},
+        )
+        assert report.remounted_servers == ["figma"]
+        assert calls == [("figma", "audit", "acme")]
+        assert injected == [plugin_root]
+
+        report2 = await comp.reconcile_governance(
+            existing_server_names=lambda: set(),
+            register_server=register,
+            inject_inputs=inject,
+            declared={},
+        )
+        assert report2.remounted_servers == ["figma"]  # 幂等：结果一致
+
+
+@pytest.mark.asyncio
+async def test_reconcile_governance_register_failure_non_blocking(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """register 抛错 → 不阻断（不抛出），失败 server 不入 remounted，skills 恢复不受影响。"""
+    _isolate_declared_env(tmp_path, monkeypatch)
+    home, _ = _seed_home(tmp_path, servers=["figma"], skills=["lint"])
+
+    async def register(cfg, record) -> None:
+        raise RuntimeError("mount boom")
+
+    async with Computer(name="t", skill_home=home) as comp:
+        report = await comp.reconcile_governance(
+            existing_server_names=lambda: set(),
+            register_server=register,
+            declared={},
+        )
+        assert report.remounted_servers == []
+        assert "audit:lint" in report.restored_skills
+
+
+@pytest.mark.asyncio
+async def test_reconcile_governance_conflict_skips_existing_name(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """existing 已有同名 server → skip 不覆盖（additive-only，用户配置胜），register 不被调用。"""
+    _isolate_declared_env(tmp_path, monkeypatch)
+    home, _ = _seed_home(tmp_path, servers=["figma"], skills=["lint"])
+
+    calls: list[str] = []
+
+    async def register(cfg, record) -> None:
+        calls.append(cfg.name)
+
+    async with Computer(name="t", skill_home=home) as comp:
+        report = await comp.reconcile_governance(
+            existing_server_names=lambda: {"figma"},
+            register_server=register,
+            declared={},
+        )
+        assert calls == []
+        assert report.remounted_servers == []


### PR DESCRIPTION
## Summary

落地 #117：`Computer.boot_up` 补齐 plugin 治理启动恢复（对齐已发布协议 **v0.2.3** `runtime-contract.md` §4.8；修复 rust-sdk#96 同构缺口）。

### 设计（两 SDK 同构契约"设计 Y"，与用户共同裁决）

- **ledger 驱动**（非声明式 `reconcile()`）：命令式 `install_plugin` 不写 `enabledPlugins`（装即活跃），声明式对账恢复不了它；恢复读双账本，`enabledPlugins` 合并视图仅作禁用门控
- **boot-active** = `pid ∈ installed_plugins.json ∧ enabledPlugins[pid] != false`（与 rust `recovery.rs` 逐字一致）
- **boot 默认 skills-only + inventory 可查询**；bundled MCP server 重挂永远是 client 显式调公共 API `reconcile_governance(hooks)`（§4.8 blockquote / #93 client owns MCP config）——忘接线=功能缺失可见可修，优于默认自挂的"行为入侵"
- **CLI 为参考 client 接线**（`run_governance_remount`，批准框后、mcp.json 先挂先占名、bundled 免批准 §5.10）；未来 GUI / 外部 client 照抄同一公共 API
- 超出 rust 现状两点（协议有据，rust 后续对齐）：collect 输出含 plugin/marketplace **归属**（§4.8.3 MUST）；remount 臂**注入 plugin inputs**（`${input:}` D2 渲染前置）

### 变更

| 文件 | 内容 |
|---|---|
| `settings/recovery.py`（新） | `recover_marketplace_skills` + `collect_enabled_bundled_servers` + `GovernanceRecoveryReport`（与 rust 同名同义）；失败降级铁律（单点 WARN 不抛不阻断） |
| `computer.py` | 公共 API `reconcile_governance(hooks)`（两阶段：skills 恒恢复 + hooks 时重挂，同名冲突 skip 用户配置胜）；`boot_up` 接线（skills-only，失败隔离） |
| `cli/` | `run_governance_remount` 参考接线 + interactive 启动序列调用 |
| docstring | installer/reconciler/settings.`__init__` 分工更新（声明式对账 vs ledger 恢复） |

### 验证

- TDD：红灯先行（模块不存在→14 组失败）→ 实现转绿 → 审查后增至 **20 组专测**
- 全量 **1745 passed** + lint（mypy 101 文件）绿
- CLI 冒烟：预置治理态 → 重启 `a2c-computer run` → `governance recovery: 1 skills restored` + `✓ restored bundled MCP server` + `status` 显示 connected
- 隔离审查：**无 🔴**；6🟡+2🔵 已全部落实

### 已知限制（有意，与 rust 同构文档化）

boot 内 declared 视图无 `--settings` flag scope（CLI 阶段二已补 flag-aware）；跨重启可靠 disable 请写 user scope。

Closes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)
