### PR TITLE
feat(#121): Computer.list_mcp_servers_with_metadata 归属 + 活跃 inventory 查询（对齐 rust-sdk #97）

### DIFF
--- a/a2c_smcp/computer/computer.py
+++ b/a2c_smcp/computer/computer.py
@@ -1415,15 +1415,16 @@ class Computer(BaseComputer[PromptSession]):
 
         合并两个来源（去重按 server 名，运行期条目优先）：
 
-        1. 运行期已物化集 ``self.mcp_servers``——用户配置 server，或 client 经 ``reconcile_governance(hooks)``
-           物化的 plugin bundled server；名字命中 ledger 派生 bundled 集 → ``managedBy=plugin``，否则
-           ``managedBy=user``。
+        1. 运行期活跃配置集——manager 已建时取 ``MCPServerManager.server_configs()`` 快照（构造期声明经
+           boot 物化项 + ``aadd_or_aupdate_server`` 动态挂载项 + client 经 ``reconcile_governance(hooks)``
+           重挂的 plugin bundled 项）；manager 未建（pre-boot）回退构造期声明集 ``self._mcp_servers``。
+           名字命中 ledger 派生 bundled 集 → ``managedBy=plugin``，否则 ``managedBy=user``。
         2. ledger 派生的**已启用但尚未物化**的 plugin bundled server（boot 默认 ``register_server=None`` 后
            即此态）——补入 inventory 并标 ``managedBy=plugin``，满足 §4.8「进程未拉起也可观测」（client 据此
            物化或引导 Marketplace）。
 
-        结果按 server 名排序（``self._mcp_servers`` 为 set，排序保证稳定可测输出）。**不**含运行期「进程是否
-        已启动」状态——那由 ``MCPServerManager.get_server_status`` 单独提供。
+        结果按 server 名排序（保证稳定可测输出）。**不**含运行期「进程是否已启动」状态——那由
+        ``MCPServerManager.get_server_status`` 单独提供。
 
         归属 join key = server 名（限制与非目标，rust #97 同文档化）：同名冲突会退化——用户配置一个与某启用
         plugin bundled server **同名**的 server 会被标 ``plugin``（只读）；两个 plugin 的同名 bundled server 经
@@ -1442,8 +1443,10 @@ class Computer(BaseComputer[PromptSession]):
         out: list[McpServerWithMetadata] = []
         materialized: set[str] = set()
 
-        # 来源一：运行期已物化 server。命中 ledger bundled 集 → plugin，否则 user。
-        for cfg in self._mcp_servers:
+        # 来源一：运行期活跃配置集。manager 已建 = 权威（含动态挂载/重挂项；`_mcp_servers` 仅构造期声明快照，
+        # 此后不回写）；未建（pre-boot）回退构造集。命中 ledger bundled 集 → plugin，否则 user。
+        active_configs = self.mcp_manager.server_configs() if self.mcp_manager is not None else tuple(self._mcp_servers)
+        for cfg in active_configs:
             materialized.add(cfg.name)
             record = bundled.get(cfg.name)
             managed_by: McpOwnership = plugin_ownership(record) if record is not None else McpUserOwnership()

--- a/a2c_smcp/computer/computer.py
+++ b/a2c_smcp/computer/computer.py
@@ -62,6 +62,7 @@ from a2c_smcp.computer.blob import (
 from a2c_smcp.computer.desktop.organize import organize_desktop
 from a2c_smcp.computer.inputs.render import ConfigRender, load_env_file
 from a2c_smcp.computer.inputs.resolver import InputNotFoundError, InputResolver
+from a2c_smcp.computer.inventory import McpOwnership, McpPluginOwnership, McpServerWithMetadata, McpUserOwnership
 from a2c_smcp.computer.mcp_clients.manager import MCPServerManager
 from a2c_smcp.computer.mcp_clients.model import MCPServerConfig, MCPServerInput
 from a2c_smcp.computer.settings.recovery import (
@@ -1402,6 +1403,59 @@ class Computer(BaseComputer[PromptSession]):
             existing.add(name)
             report.remounted_servers.append(name)
         return report
+
+    def list_mcp_servers_with_metadata(self) -> list[McpServerWithMetadata]:
+        """列出 MCP 服务器 + 归属 / 生命周期元数据（活跃 inventory，#121 对齐 rust-sdk #97）/ inventory query。
+
+        面向 client（如 ``tfrobot-client``）Skill / MCP tab：一次拿到「当前 Computer 有哪些 MCP server + 每条
+        归谁（user vs plugin，含 marketplace / plugin / pluginId）+ 能否从普通 MCP tab 编辑 / 启停」，**无需**读
+        SDK ledger、**无需**解析 plugin manifest、**无需**持内存 ownership map。协议依据 a2c-smcp-protocol
+        v0.2.3 §4.8（归属 = boot 纯函数、每次可复现；enabled bundled server 进程未拉起也须可查询）。元数据类型
+        见 :mod:`~a2c_smcp.computer.inventory`，**SDK-facing、不进** Agent-facing ``client:*`` wire。
+
+        合并两个来源（去重按 server 名，运行期条目优先）：
+
+        1. 运行期已物化集 ``self.mcp_servers``——用户配置 server，或 client 经 ``reconcile_governance(hooks)``
+           物化的 plugin bundled server；名字命中 ledger 派生 bundled 集 → ``managedBy=plugin``，否则
+           ``managedBy=user``。
+        2. ledger 派生的**已启用但尚未物化**的 plugin bundled server（boot 默认 ``register_server=None`` 后
+           即此态）——补入 inventory 并标 ``managedBy=plugin``，满足 §4.8「进程未拉起也可观测」（client 据此
+           物化或引导 Marketplace）。
+
+        结果按 server 名排序（``self._mcp_servers`` 为 set，排序保证稳定可测输出）。**不**含运行期「进程是否
+        已启动」状态——那由 ``MCPServerManager.get_server_status`` 单独提供。
+
+        归属 join key = server 名（限制与非目标，rust #97 同文档化）：同名冲突会退化——用户配置一个与某启用
+        plugin bundled server **同名**的 server 会被标 ``plugin``（只读）；两个 plugin 的同名 bundled server 经
+        首见去重、后者身份不出现。这符合协议「name = 能力身份」语义，且**可靠的冲突拦截是安装期职责**（install
+        hook ``existing_server_names`` 冲突门），非本只读投影的职责。调用方若需强冲突保证，应经带 hooks 的安装
+        路径拦截，而非依赖本查询。
+        """
+        home = self.skill_home
+        # ledger 派生的已启用 bundled server（归属纯函数，与 reconcile_governance 同解析视图）。
+        declared = self._resolve_declared_settings()
+        bundled = {record.config.name: record for record in collect_enabled_bundled_servers(home, declared)}
+
+        def plugin_ownership(record: BundledServerRecord) -> McpPluginOwnership:
+            return McpPluginOwnership(marketplace=record.marketplace, plugin=record.plugin, plugin_id=record.plugin_id)
+
+        out: list[McpServerWithMetadata] = []
+        materialized: set[str] = set()
+
+        # 来源一：运行期已物化 server。命中 ledger bundled 集 → plugin，否则 user。
+        for cfg in self._mcp_servers:
+            materialized.add(cfg.name)
+            record = bundled.get(cfg.name)
+            managed_by: McpOwnership = plugin_ownership(record) if record is not None else McpUserOwnership()
+            out.append(McpServerWithMetadata.assemble(cfg.name, disabled=cfg.disabled, managed_by=managed_by))
+
+        # 来源二：已启用但尚未物化的 bundled server（不在运行期集 → 补入，标 plugin；§4.8 可观测）。
+        for name, record in bundled.items():
+            if name not in materialized:
+                out.append(McpServerWithMetadata.assemble(name, disabled=record.config.disabled, managed_by=plugin_ownership(record)))
+
+        out.sort(key=lambda entry: entry.name)
+        return out
 
     def get_skills(self) -> list[A2CSkillRef]:
         """当前已安装且可用 SKILL（排除孤儿；不排序、不去重）—— ``client:get_skills`` 数据源。

--- a/a2c_smcp/computer/inventory.py
+++ b/a2c_smcp/computer/inventory.py
@@ -1,0 +1,125 @@
+# -*- coding: utf-8 -*-
+# filename: inventory.py
+# @Time    : 2026/07/06
+# @Author  : JQQ
+# @Email   : jqq1716@gmail.com
+# @Software: PyCharm
+"""
+Computer 级 MCP server 归属 + 活跃 inventory 查询的 SDK-facing 元数据类型（#121，对齐 rust-sdk #97）。
+SDK-facing ownership + active-inventory metadata for MCP servers (#121, mirrors rust-sdk #97).
+
+这些类型是 **SDK-facing、不进 Agent-facing ``client:*`` wire**。
+
+协议依据 / Protocol: a2c-smcp-protocol **v0.2.3** ``computer-management/runtime-contract.md`` §4.8
+（#93 client-owns-MCP-config 边界）。§4.8 要求：重建后的能力归属元数据 MUST 为 boot 的**纯函数**输出
+（意图 + resolved location + manifest 重推导，每次 boot 可复现，**不**依赖任何调用方持有的内存 ownership
+map）；且 enabled bundled server **即使进程未拉起**也 MUST **可查询**。本模块的类型正是该「可查询归属」的
+载体，供 client（如 ``tfrobot-client``）的 Skill / MCP tab 直接消费——判定某 server 是否可从普通 MCP tab
+编辑 / 启停，无需读 SDK ledger、无需解析 plugin manifest、无需持内存 ownership map。
+
+**刻意不进协议 wire**：归属 / 生命周期字段仅在 SDK 表面（:meth:`Computer.list_mcp_servers_with_metadata`），
+**不**加入 ``client:*`` 事件数据结构——Agent 侧协议表面与能力归属无关（Agent-User 能力等价，不给协议加角色
+门控字段）。序列化 camelCase 对齐 rust #96 JSON 示例（``managedBy`` / ``pluginId`` / ``canEditFromMcpTab`` …），
+与 rust serde ``rename_all = "camelCase"`` 逐字一致（``serialize_by_alias`` 令 ``model_dump*`` 默认即 camelCase）。
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, ClassVar, Literal, TypeAlias
+
+from pydantic import BaseModel, ConfigDict, Field
+from pydantic.alias_generators import to_camel
+
+
+class _InventoryModel(BaseModel):
+    """camelCase 序列化基类：wire 形态 camelCase（对齐 rust serde），Python 侧仍 snake_case 构造/访问。"""
+
+    model_config: ClassVar[ConfigDict] = ConfigDict(
+        alias_generator=to_camel,
+        populate_by_name=True,
+        serialize_by_alias=True,
+        frozen=True,
+    )
+
+
+class McpLifecycle(_InventoryModel):
+    """面向 UI 入口权限的生命周期能力 / lifecycle capabilities for UI entry gating。
+
+    由归属纯函数派生（:meth:`McpUserOwnership.lifecycle` / :meth:`McpPluginOwnership.lifecycle`），client 据此
+    决定 MCP tab 能否编辑 / 启停：user server 可从 MCP tab 全权管理；plugin bundled server 只读展示、引导到
+    Marketplace 管理。
+    """
+
+    # 管理入口常量 / manage-from constants（与 rust ``McpLifecycle`` 关联常量同名同义）。
+    MANAGE_FROM_MCP: ClassVar[str] = "mcp"
+    MANAGE_FROM_MARKETPLACE: ClassVar[str] = "marketplace"
+
+    can_edit_from_mcp_tab: bool = Field(description="是否可在普通 MCP tab 编辑 / 删除 / can edit from the MCP tab")
+    can_start_from_mcp_tab: bool = Field(description="是否可在普通 MCP tab 启停 / can start-stop from the MCP tab")
+    manage_from: str = Field(description='管理入口："mcp"（用户）/ "marketplace"（插件）/ where this server is managed from')
+
+
+class McpUserOwnership(_InventoryModel):
+    """用户配置 / client 传入的 MCP server（配置态权威在 client 用户配置）/ user-owned。"""
+
+    type: Literal["user"] = "user"
+
+    def lifecycle(self) -> McpLifecycle:
+        """user → 全权（可编辑 / 可启停，入口 ``mcp``）/ full control from the MCP tab。"""
+        return McpLifecycle(
+            can_edit_from_mcp_tab=True,
+            can_start_from_mcp_tab=True,
+            manage_from=McpLifecycle.MANAGE_FROM_MCP,
+        )
+
+
+class McpPluginOwnership(_InventoryModel):
+    """已启用 marketplace plugin 派生的 bundled MCP server / plugin-owned bundled server。
+
+    ``plugin_id`` = ``<plugin>@<marketplace>``（与 ``installed_plugins.json`` 的 map 键、
+    :class:`~a2c_smcp.computer.settings.recovery.BundledServerRecord` 严格同构）。归属为 ledger + manifest 的
+    纯函数推导（§4.8.3），不含运行期状态。
+    """
+
+    type: Literal["plugin"] = "plugin"
+    marketplace: str = Field(description="marketplace 名 / marketplace name")
+    plugin: str = Field(description="plugin 名 / plugin name")
+    plugin_id: str = Field(description="plugin id：<plugin>@<marketplace> / plugin id")
+
+    def lifecycle(self) -> McpLifecycle:
+        """plugin → 只读（禁编辑 / 禁启停，入口 ``marketplace``）/ read-only, managed from Marketplace。"""
+        return McpLifecycle(
+            can_edit_from_mcp_tab=False,
+            can_start_from_mcp_tab=False,
+            manage_from=McpLifecycle.MANAGE_FROM_MARKETPLACE,
+        )
+
+
+# 判别联合，对齐 rust ``#[serde(tag = "type")]`` / #96 示例 ``managedBy``：
+# user → {"type":"user"}；plugin → {"type":"plugin","marketplace":…,"plugin":…,"pluginId":…}。
+McpOwnership: TypeAlias = Annotated[McpUserOwnership | McpPluginOwnership, Field(discriminator="type")]
+
+
+class McpServerWithMetadata(_InventoryModel):
+    """一条 MCP server 的**活跃 inventory** 条目 + 归属 / 生命周期元数据 / one active-inventory entry。
+
+    :meth:`Computer.list_mcp_servers_with_metadata` 的返回元素。合并两个来源（client 无需自己拼）：
+
+    - 运行期已物化的 server（``Computer.mcp_servers``）——用户配置 or client 经 hooks 物化的 plugin bundled；
+    - ledger 派生的**已启用但尚未物化**的 plugin bundled server（§4.8：进程未拉起也须可观测）。
+
+    ``disabled`` 取自 server 配置本身（:class:`~a2c_smcp.computer.mcp_clients.model.BaseMCPServerConfig`
+    ``disabled`` 旗）；``managed_by`` 决定 ``lifecycle``。**不**含运行期「进程是否已启动」状态——那由
+    ``MCPServerManager.get_server_status`` 单独提供，本 inventory 只承载「有哪些 + 归谁 + 能否从 MCP tab 管」
+    这一稳定归属视图（对齐 #96 示例四字段）。
+    """
+
+    name: str = Field(description="server 名（inventory 主键）/ server name")
+    disabled: bool = Field(description="是否禁用（配置态）/ disabled flag from config")
+    managed_by: McpOwnership = Field(description="归属：用户 vs 插件 / ownership")
+    lifecycle: McpLifecycle = Field(description="由归属派生的生命周期能力 / lifecycle capabilities derived from ownership")
+
+    @classmethod
+    def assemble(cls, name: str, *, disabled: bool, managed_by: McpOwnership) -> McpServerWithMetadata:
+        """由 ``name`` + ``disabled`` + 归属组装（``lifecycle`` 从归属派生）/ assemble; lifecycle derived from ownership。"""
+        return cls(name=name, disabled=disabled, managed_by=managed_by, lifecycle=managed_by.lifecycle())

--- a/a2c_smcp/computer/inventory.py
+++ b/a2c_smcp/computer/inventory.py
@@ -30,6 +30,14 @@ from typing import Annotated, ClassVar, Literal, TypeAlias
 from pydantic import BaseModel, ConfigDict, Field
 from pydantic.alias_generators import to_camel
 
+__all__ = [
+    "McpLifecycle",
+    "McpOwnership",
+    "McpPluginOwnership",
+    "McpServerWithMetadata",
+    "McpUserOwnership",
+]
+
 
 class _InventoryModel(BaseModel):
     """camelCase 序列化基类：wire 形态 camelCase（对齐 rust serde），Python 侧仍 snake_case 构造/访问。"""
@@ -105,7 +113,8 @@ class McpServerWithMetadata(_InventoryModel):
 
     :meth:`Computer.list_mcp_servers_with_metadata` 的返回元素。合并两个来源（client 无需自己拼）：
 
-    - 运行期已物化的 server（``Computer.mcp_servers``）——用户配置 or client 经 hooks 物化的 plugin bundled；
+    - 运行期活跃配置集（``MCPServerManager.server_configs()``，含动态挂载项）——用户配置 server or client
+      经 hooks 物化的 plugin bundled server；
     - ledger 派生的**已启用但尚未物化**的 plugin bundled server（§4.8：进程未拉起也须可观测）。
 
     ``disabled`` 取自 server 配置本身（:class:`~a2c_smcp.computer.mcp_clients.model.BaseMCPServerConfig`

--- a/a2c_smcp/computer/mcp_clients/manager.py
+++ b/a2c_smcp/computer/mcp_clients/manager.py
@@ -73,6 +73,10 @@ class MCPServerManager:
         """通过名称获取服务配置"""
         return self._servers_config[server_name]
 
+    def server_configs(self) -> tuple[MCPServerConfig, ...]:
+        """全部服务配置的不可变快照（运行期活跃配置集，含动态挂载/重挂项）/ snapshot of all active server configs。"""
+        return tuple(self._servers_config.values())
+
     def get_tool_meta(self, server_name: SERVER_NAME, tool_name: TOOL_NAME) -> ToolMeta | None:
         """
         中文: 获取指定服务器下某工具合并后的元数据（优先具体 tool_meta，缺失字段回落 default_tool_meta）。

--- a/tests/unit_tests/computer/test_computer_inventory.py
+++ b/tests/unit_tests/computer/test_computer_inventory.py
@@ -42,7 +42,13 @@ def _write_json(path: Path, obj: object) -> None:
     path.write_text(json.dumps(obj), encoding="utf-8")
 
 
-def _seed_home(tmp_path: Path, *, servers: Sequence[str] = (), pid: str = "audit@acme") -> tuple[Path, Path]:
+def _seed_home(
+    tmp_path: Path,
+    *,
+    servers: Sequence[str] = (),
+    disabled_servers: Sequence[str] = (),
+    pid: str = "audit@acme",
+) -> tuple[Path, Path]:
     """预置 skill_home：catalog 树（acme/audit）+ known_marketplaces + installed 账本。返回 (home, plugin_root)。"""
     home = tmp_path / "skill-home"
     home.mkdir()
@@ -58,8 +64,9 @@ def _seed_home(tmp_path: Path, *, servers: Sequence[str] = (), pid: str = "audit
     )
     plugin_root = catalog / "plugins" / "audit"
     plugin_root.mkdir(parents=True, exist_ok=True)
-    for sname in servers:
-        server_def = {"name": sname, "type": "stdio", "server_parameters": {"command": "node"}}
+    all_servers = [*servers, *disabled_servers]
+    for sname in all_servers:
+        server_def = {"name": sname, "type": "stdio", "server_parameters": {"command": "node"}, "disabled": sname in disabled_servers}
         _write_json(plugin_root / "mcp-servers" / f"{sname}.json", server_def)
     save_known_marketplaces(
         {"version": 1, "marketplaces": {"acme": {"source": _SRC, "installLocation": str(catalog.resolve()), "commitSha": "abc123"}}},
@@ -76,7 +83,7 @@ def _seed_home(tmp_path: Path, *, servers: Sequence[str] = (), pid: str = "audit
                         "version": "1.2.0",
                         "commitSha": "abc123",
                         "installedAt": "2026-07-06T00:00:00Z",
-                        "bundledMcpServers": list(servers),
+                        "bundledMcpServers": all_servers,
                     },
                 ],
             },
@@ -181,3 +188,55 @@ async def test_inventory_merge_dedupes_by_name_runtime_entry_wins(tmp_path: Path
         assert len(inv) == 1, "同名去重：运行期条目优先，不重复补入"
         assert inv[0].disabled, "disabled 应取运行期配置（运行期条目优先）"
         assert isinstance(inv[0].managed_by, McpPluginOwnership), "name 命中 bundled 集 → 标 plugin（文档化退化）"
+
+
+@pytest.mark.asyncio
+async def test_inventory_includes_dynamically_added_user_server(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """boot 后经 ``aadd_or_aupdate_server`` 动态挂载的 user server 必须出现（CLI 主路径；防构造期快照漏报）。"""
+    _isolate_declared_env(tmp_path, monkeypatch)
+    home, _ = _seed_home(tmp_path, servers=["audit-mcp"])
+
+    async with Computer(name="t", auto_connect=False, skill_home=home) as comp:
+        await comp.aadd_or_aupdate_server(_user_stdio_server("dyn-user"))
+        inv = comp.list_mcp_servers_with_metadata()
+
+        dyn = next(e for e in inv if e.name == "dyn-user")
+        assert dyn.managed_by == McpUserOwnership()
+        assert dyn.disabled, "禁用旗应透传（取运行期活跃配置）"
+        # 动态挂载不影响 bundled 观测面。
+        assert any(e.name == "audit-mcp" for e in inv)
+
+
+@pytest.mark.asyncio
+async def test_inventory_marks_remounted_bundled_server_as_plugin(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """boot 后经 ``reconcile_governance(hooks)`` 重挂的 bundled server：源一（运行期活跃集）命中仍标 plugin 且仅一条。"""
+    _isolate_declared_env(tmp_path, monkeypatch)
+    home, _ = _seed_home(tmp_path, servers=["audit-mcp"])
+
+    async with Computer(name="t", auto_connect=False, skill_home=home) as comp:
+
+        async def register(cfg, record) -> None:
+            await comp.aadd_or_aupdate_server(cfg, plugin=record.plugin, marketplace=record.marketplace)
+
+        report = await comp.reconcile_governance(
+            existing_server_names=lambda: {c.name for c in comp.mcp_servers},
+            register_server=register,
+            declared={},
+        )
+        assert report.remounted_servers == ["audit-mcp"]
+
+        entries = [e for e in comp.list_mcp_servers_with_metadata() if e.name == "audit-mcp"]
+        assert len(entries) == 1, "重挂后运行期条目与 ledger 条目按 name 去重为一条"
+        assert entries[0].managed_by == McpPluginOwnership(marketplace="acme", plugin="audit", plugin_id="audit@acme")
+
+
+@pytest.mark.asyncio
+async def test_inventory_passes_through_bundled_disabled_flag(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """bundled server 定义自带 ``disabled=true`` → 源二（未物化补入）disabled 旗透传。"""
+    _isolate_declared_env(tmp_path, monkeypatch)
+    home, _ = _seed_home(tmp_path, disabled_servers=["audit-mcp"])
+
+    comp = Computer(name="t", skill_home=home)
+    entry = next(e for e in comp.list_mcp_servers_with_metadata() if e.name == "audit-mcp")
+    assert entry.disabled, "bundled 配置的 disabled 旗应透传"
+    assert isinstance(entry.managed_by, McpPluginOwnership)

--- a/tests/unit_tests/computer/test_computer_inventory.py
+++ b/tests/unit_tests/computer/test_computer_inventory.py
@@ -104,7 +104,8 @@ async def test_inventory_boot_reports_user_and_plugin_ownership(tmp_path: Path, 
     _isolate_declared_env(tmp_path, monkeypatch)
     home, _ = _seed_home(tmp_path, servers=["audit-mcp"])
 
-    async with Computer(name="t", mcp_servers={_user_stdio_server("user-fs")}, skill_home=home) as comp:
+    # auto_connect=False：与 rust 测试同构（Computer::new(.., false, false)），boot 不主动拉起 disabled server。
+    async with Computer(name="t", mcp_servers={_user_stdio_server("user-fs")}, auto_connect=False, skill_home=home) as comp:
         inv = comp.list_mcp_servers_with_metadata()
 
         # 用户 server：managedBy=user，可从 MCP tab 全权管理（入口 mcp）。
@@ -175,7 +176,7 @@ async def test_inventory_merge_dedupes_by_name_runtime_entry_wins(tmp_path: Path
     home, _ = _seed_home(tmp_path, servers=["audit-mcp"])
 
     # 运行期物化一条同名 server（disabled=True；bundled 侧 disabled=False）。
-    async with Computer(name="t", mcp_servers={_user_stdio_server("audit-mcp")}, skill_home=home) as comp:
+    async with Computer(name="t", mcp_servers={_user_stdio_server("audit-mcp")}, auto_connect=False, skill_home=home) as comp:
         inv = [e for e in comp.list_mcp_servers_with_metadata() if e.name == "audit-mcp"]
         assert len(inv) == 1, "同名去重：运行期条目优先，不重复补入"
         assert inv[0].disabled, "disabled 应取运行期配置（运行期条目优先）"

--- a/tests/unit_tests/computer/test_computer_inventory.py
+++ b/tests/unit_tests/computer/test_computer_inventory.py
@@ -1,0 +1,182 @@
+# -*- coding: utf-8 -*-
+# filename: test_computer_inventory.py
+# @Time    : 2026/07/06
+# @Author  : JQQ
+# @Email   : jqq1716@gmail.com
+# @Software: PyCharm
+"""
+Computer 级 MCP server 归属 + 活跃 inventory 查询测试（#121，协议 v0.2.3 §4.8；对齐 rust-sdk #97）。
+
+测试意图 / Test intentions（hermetic：预置双账本 + catalog 树，零 git 零网络；fixture 与
+``test_computer_governance_recovery.py`` 同构）:
+- AC1 装+启用 plugin、同一 skill_home 重建 Computer、boot(skills-only) 后：inventory 同时返回
+  user server（managedBy=user 全权）与 plugin bundled server（managedBy=plugin 只读 + 正确
+  marketplace/plugin/pluginId），后者虽未物化仍出现（§4.8「进程未拉起也可观测」）；
+- AC2 disable / 卸载（账本移除）后：bundled server 不再出现在 inventory；
+- AC3 本地-only pid（无 ``@``）不采集（与 ``collect_enabled_bundled_servers`` 门控一致）；
+- 合并语义：同名时运行期条目优先（disabled 取运行期配置）且按 name 命中 bundled 集标 plugin；
+  结果按 name 排序稳定输出。
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Sequence
+from pathlib import Path
+
+import pytest
+from mcp import StdioServerParameters
+
+from a2c_smcp.computer.computer import Computer
+from a2c_smcp.computer.inventory import McpPluginOwnership, McpUserOwnership
+from a2c_smcp.computer.mcp_clients.model import StdioServerConfig
+from a2c_smcp.computer.settings.store import save_installed_plugins, save_known_marketplaces
+from a2c_smcp.computer.skills.home import marketplace_skill_dir
+
+_SRC = {"type": "git", "url": "https://example.com/acme.git"}
+
+
+# ── fixture 辅助（与 test_computer_governance_recovery.py 同构）/ helpers ─────
+def _write_json(path: Path, obj: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(obj), encoding="utf-8")
+
+
+def _seed_home(tmp_path: Path, *, servers: Sequence[str] = (), pid: str = "audit@acme") -> tuple[Path, Path]:
+    """预置 skill_home：catalog 树（acme/audit）+ known_marketplaces + installed 账本。返回 (home, plugin_root)。"""
+    home = tmp_path / "skill-home"
+    home.mkdir()
+    catalog = marketplace_skill_dir(home, "acme")
+    _write_json(
+        catalog / ".tfrobot-plugin" / "marketplace.json",
+        {
+            "name": "acme",
+            "owner": {"name": "X"},
+            "metadata": {"pluginRoot": "./plugins"},
+            "plugins": [{"name": "audit", "source": "audit", "version": "1.2.0"}],
+        },
+    )
+    plugin_root = catalog / "plugins" / "audit"
+    plugin_root.mkdir(parents=True, exist_ok=True)
+    for sname in servers:
+        server_def = {"name": sname, "type": "stdio", "server_parameters": {"command": "node"}}
+        _write_json(plugin_root / "mcp-servers" / f"{sname}.json", server_def)
+    save_known_marketplaces(
+        {"version": 1, "marketplaces": {"acme": {"source": _SRC, "installLocation": str(catalog.resolve()), "commitSha": "abc123"}}},
+        home=home,
+    )
+    save_installed_plugins(
+        {
+            "version": 1,
+            "plugins": {
+                pid: [
+                    {
+                        "scope": "user",
+                        "installPath": str(plugin_root),
+                        "version": "1.2.0",
+                        "commitSha": "abc123",
+                        "installedAt": "2026-07-06T00:00:00Z",
+                        "bundledMcpServers": list(servers),
+                    },
+                ],
+            },
+        },
+        home=home,
+    )
+    return home, plugin_root
+
+
+def _isolate_declared_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """隔离 declared 视图来源：XDG → tmp、cwd → tmp（防读真实 user/project settings）。"""
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "cfg"))
+    monkeypatch.chdir(tmp_path)
+
+
+def _user_stdio_server(name: str) -> StdioServerConfig:
+    """构造一条禁用的用户 stdio server（配置态即可，disabled 免 boot 拉起进程）/ a disabled user server。"""
+    return StdioServerConfig(name=name, disabled=True, server_parameters=StdioServerParameters(command="node"))
+
+
+# ── AC1：boot 后 user + plugin 归属并存，未物化 bundled 仍可观测 ───────────────
+@pytest.mark.asyncio
+async def test_inventory_boot_reports_user_and_plugin_ownership(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """boot(skills-only) 后：user server 全权；plugin bundled server 未物化仍出现且只读（§4.8 可观测）。"""
+    _isolate_declared_env(tmp_path, monkeypatch)
+    home, _ = _seed_home(tmp_path, servers=["audit-mcp"])
+
+    async with Computer(name="t", mcp_servers={_user_stdio_server("user-fs")}, skill_home=home) as comp:
+        inv = comp.list_mcp_servers_with_metadata()
+
+        # 用户 server：managedBy=user，可从 MCP tab 全权管理（入口 mcp）。
+        user = next(e for e in inv if e.name == "user-fs")
+        assert user.managed_by == McpUserOwnership()
+        assert user.disabled, "禁用旗应透传"
+        assert user.lifecycle.can_edit_from_mcp_tab
+        assert user.lifecycle.can_start_from_mcp_tab
+        assert user.lifecycle.manage_from == "mcp"
+
+        # plugin bundled server：boot(hooks=None) 未物化，仍经 ledger 派生出现，带完整归属 + 只读生命周期。
+        plugin = next(e for e in inv if e.name == "audit-mcp")
+        assert plugin.managed_by == McpPluginOwnership(marketplace="acme", plugin="audit", plugin_id="audit@acme")
+        assert not plugin.disabled
+        assert not plugin.lifecycle.can_edit_from_mcp_tab
+        assert not plugin.lifecycle.can_start_from_mcp_tab
+        assert plugin.lifecycle.manage_from == "marketplace"
+
+        # 结果按 name 排序（稳定可测输出）。
+        assert [e.name for e in inv] == sorted(e.name for e in inv)
+
+
+# ── AC2：disable / 卸载后 bundled server 不再出现 ──────────────────────────────
+@pytest.mark.asyncio
+async def test_inventory_excludes_disabled_plugin_server(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """user scope ``enabledPlugins=false`` → bundled server 不出现在 inventory（enabled 门控）。"""
+    _isolate_declared_env(tmp_path, monkeypatch)
+    home, _ = _seed_home(tmp_path, servers=["audit-mcp"])
+    _write_json(tmp_path / "cfg" / "a2c" / "settings.json", {"enabledPlugins": {"audit@acme": False}})
+
+    async with Computer(name="t", skill_home=home) as comp:
+        assert not any(e.name == "audit-mcp" for e in comp.list_mcp_servers_with_metadata())
+
+
+@pytest.mark.asyncio
+async def test_inventory_excludes_uninstalled_plugin_server(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """卸载（账本移除该 plugin 记录）后以同一 home 重建 Computer → bundled server 不再出现。"""
+    _isolate_declared_env(tmp_path, monkeypatch)
+    home, _ = _seed_home(tmp_path, servers=["audit-mcp"])
+
+    # 卸载前：inventory 含 plugin bundled server（未 boot 亦可查询——纯函数投影）。
+    comp_a = Computer(name="a", skill_home=home)
+    assert any(e.name == "audit-mcp" for e in comp_a.list_mcp_servers_with_metadata())
+
+    # 卸载效果 = installed_plugins.json 移除记录（uninstall 的账本落点）。
+    save_installed_plugins({"version": 1, "plugins": {}}, home=home)
+
+    comp_b = Computer(name="b", skill_home=home)
+    assert not any(e.name == "audit-mcp" for e in comp_b.list_mcp_servers_with_metadata())
+
+
+# ── AC3：本地-only pid（无 ``@``）不采集 ──────────────────────────────────────
+@pytest.mark.asyncio
+async def test_inventory_skips_local_only_pid(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """pid 无 ``@marketplace`` 段（本地-only 形态）→ 其 bundled server 不采集（与 recovery 门控一致）。"""
+    _isolate_declared_env(tmp_path, monkeypatch)
+    home, _ = _seed_home(tmp_path, servers=["audit-mcp"], pid="local-audit")
+
+    comp = Computer(name="t", skill_home=home)
+    assert not any(e.name == "audit-mcp" for e in comp.list_mcp_servers_with_metadata())
+
+
+# ── 合并语义：同名去重、运行期条目优先 ─────────────────────────────────────────
+@pytest.mark.asyncio
+async def test_inventory_merge_dedupes_by_name_runtime_entry_wins(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """用户配置与 bundled 同名 → 仅一条；disabled 取运行期配置（运行期优先），归属按 name 命中标 plugin（文档化退化）。"""
+    _isolate_declared_env(tmp_path, monkeypatch)
+    home, _ = _seed_home(tmp_path, servers=["audit-mcp"])
+
+    # 运行期物化一条同名 server（disabled=True；bundled 侧 disabled=False）。
+    async with Computer(name="t", mcp_servers={_user_stdio_server("audit-mcp")}, skill_home=home) as comp:
+        inv = [e for e in comp.list_mcp_servers_with_metadata() if e.name == "audit-mcp"]
+        assert len(inv) == 1, "同名去重：运行期条目优先，不重复补入"
+        assert inv[0].disabled, "disabled 应取运行期配置（运行期条目优先）"
+        assert isinstance(inv[0].managed_by, McpPluginOwnership), "name 命中 bundled 集 → 标 plugin（文档化退化）"

--- a/tests/unit_tests/computer/test_inventory.py
+++ b/tests/unit_tests/computer/test_inventory.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+# filename: test_inventory.py
+# @Time    : 2026/07/06
+# @Author  : JQQ
+# @Email   : jqq1716@gmail.com
+# @Software: PyCharm
+"""
+MCP server 归属 + 活跃 inventory 元数据类型测试（#121，对齐 rust-sdk #97 ``inventory.rs``）/ Inventory type tests。
+
+测试意图 / Test intentions（与 rust ``inventory.rs`` 单测逐一同构）:
+- user 归属：序列化 camelCase（``{"type":"user"}``）+ 全权生命周期（可编辑/可启停，入口 ``mcp``）；
+- plugin 归属：序列化 camelCase（``managedBy``/``pluginId`` 对齐协议 §4.8 / rust #96 示例）+ 只读生命周期；
+- roundtrip：``McpServerWithMetadata`` 序列化↔反序列化闭环。
+"""
+
+from __future__ import annotations
+
+import json
+
+from a2c_smcp.computer.inventory import (
+    McpLifecycle,
+    McpPluginOwnership,
+    McpServerWithMetadata,
+    McpUserOwnership,
+)
+
+
+def test_user_ownership_serializes_camelcase_and_grants_full_lifecycle() -> None:
+    """user 归属：lifecycle 全权（true/true/"mcp"），JSON 键名 camelCase 且判别值 type=user。"""
+    entry = McpServerWithMetadata.assemble("everything", disabled=False, managed_by=McpUserOwnership())
+    assert entry.lifecycle.can_edit_from_mcp_tab
+    assert entry.lifecycle.can_start_from_mcp_tab
+    assert entry.lifecycle.manage_from == McpLifecycle.MANAGE_FROM_MCP
+
+    v = json.loads(entry.model_dump_json())
+    assert v["name"] == "everything"
+    assert v["disabled"] is False
+    assert v["managedBy"]["type"] == "user"
+    assert v["lifecycle"]["canEditFromMcpTab"] is True
+    assert v["lifecycle"]["canStartFromMcpTab"] is True
+    assert v["lifecycle"]["manageFrom"] == "mcp"
+
+
+def test_plugin_ownership_serializes_camelcase_and_is_read_only() -> None:
+    """plugin 归属：lifecycle 只读（false/false/"marketplace"），JSON 逐字对齐 #96 示例键名。"""
+    entry = McpServerWithMetadata.assemble(
+        "audit-mcp",
+        disabled=False,
+        managed_by=McpPluginOwnership(marketplace="acme", plugin="audit", plugin_id="audit@acme"),
+    )
+    assert not entry.lifecycle.can_edit_from_mcp_tab
+    assert not entry.lifecycle.can_start_from_mcp_tab
+    assert entry.lifecycle.manage_from == McpLifecycle.MANAGE_FROM_MARKETPLACE
+
+    # 对齐 #96 JSON 示例键名 / mirror the #96 example.
+    v = json.loads(entry.model_dump_json())
+    assert v["managedBy"]["type"] == "plugin"
+    assert v["managedBy"]["marketplace"] == "acme"
+    assert v["managedBy"]["plugin"] == "audit"
+    assert v["managedBy"]["pluginId"] == "audit@acme"
+    assert v["lifecycle"]["manageFrom"] == "marketplace"
+
+
+def test_metadata_roundtrips_through_serialization() -> None:
+    """camelCase JSON 序列化 → 反序列化 roundtrip 闭环（判别联合正确还原 plugin 分支）。"""
+    entry = McpServerWithMetadata.assemble(
+        "audit-mcp",
+        disabled=True,
+        managed_by=McpPluginOwnership(marketplace="acme", plugin="audit", plugin_id="audit@acme"),
+    )
+    back = McpServerWithMetadata.model_validate_json(entry.model_dump_json())
+    assert back == entry
+    assert isinstance(back.managed_by, McpPluginOwnership)


### PR DESCRIPTION
## 概述

补齐 Rust SDK 已实现、Python 侧缺失的对外查询 API：`Computer.list_mcp_servers_with_metadata()`——面向 client（如 tfrobot-client）Skill / MCP tab，一次拿到「当前 Computer 有哪些 MCP server + 每条归谁（user vs plugin）+ 能否从普通 MCP tab 编辑/启停」，无需读 SDK ledger、无需解析 plugin manifest、无需持内存 ownership map。

- 协议依据：a2c-smcp-protocol **v0.2.3** `runtime-contract.md` §4.8（归属 = boot 纯函数；enabled bundled server 进程未拉起也须可查询）——已发布协议，无 wire 变更（字段仅 SDK-facing，不进 `client:*`）。
- Rust 对齐：rust-sdk #97（develop `inventory.rs` / `computer.rs`），类型与合并语义严格同构。

Closes #121

## 变更

- **新增 `a2c_smcp/computer/inventory.py`**：`McpOwnership` 判别联合（`{"type":"user"}` | `{"type":"plugin","marketplace","plugin","pluginId"}`）、`McpLifecycle`（归属单向派生：user → 全权/`"mcp"`；plugin → 只读/`"marketplace"`）、`McpServerWithMetadata`。`serialize_by_alias` 令 `model_dump*` 默认 camelCase，逐字对齐 rust serde `rename_all="camelCase"` + `tag="type"`。
- **`Computer.list_mcp_servers_with_metadata()`**：合并①运行期活跃配置集（manager 已建取新增的 `MCPServerManager.server_configs()` 快照，含动态挂载/hooks 重挂项；pre-boot 回退构造集）与②ledger 派生的 enabled-未物化 bundled 集（§4.8 可观测）；按 name 去重（运行期优先）+ 排序。归属 join key = name 的同名退化边界随 rust #97 同文档化（可靠冲突拦截属安装期职责）。
- **`MCPServerManager.server_configs()`**：公共不可变配置快照访问器（避免跨模块触碰私有 `_servers_config`）。

## 隔离审查（Step 7 硬门控）

code-reviewer 子代理两轮审查，🔴 清零：

- 🔴 初版源一照 issue 文本读 `self.mcp_servers`——Python 侧该属性为**构造期冻结快照**（`aadd_or_aupdate_server` 只写 manager，不回写），CLI 动态挂载 server 会被漏报 → 已改读 manager 活跃集并补直接复现测试。
- 🟡 `declared` 覆盖参数刻意不加（rust #97 同样硬编码同一解析视图，加参破坏同构；限制已文档化）；`__all__` 已补（不 re-export，随 recovery.py 先例）。

## 测试

- `tests/unit_tests/computer/test_inventory.py`（类型级 3 例：camelCase 序列化 / lifecycle 派生 / roundtrip，镜像 rust `inventory.rs` 单测）。
- `tests/unit_tests/computer/test_computer_inventory.py`（Computer 级 8 例，hermetic 零 git 零网络）：AC1 user+plugin 归属并存且未物化 bundled 可观测；AC2 disable / 卸载排除；本地-only pid 跳过；同名合并运行期优先；动态挂载必现；hooks 重挂源一命中标 plugin；bundled `disabled` 透传。
- 门禁：ruff + mypy 全绿；全量 **1756 passed**, 2 skipped, 4 xfailed。

🤖 Generated with [Claude Code](https://claude.com/claude-code)