### PR TITLE
feat(#123): plugin install/enable 分离——install 不激活、三态、enabledPlugins 缺省翻转（对齐协议 v0.3.0）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,46 @@ and this project adheres to [PEP 440](https://peps.python.org/pep-0440/) version
 > [#8](https://github.com/A2C-SMCP/python-sdk/issues/8).
 
 ### Breaking Changes
+- **Plugin install/enable separation — install no longer activates** (#123, aligned
+  with a2c-smcp-protocol **v0.3.0** `runtime-contract.md` §2.3/§2.4/§4.8; adjudication
+  record in #120 / protocol#11; rust mirror rust-sdk#103).
+  - **`enabledPlugins` default flipped**: an absent entry now means **not enabled**
+    (only an explicit `true` activates; `false` explicitly disables and overrides a
+    lower scope). Under v0.2.x, absent meant enabled.
+  - New declarative intent **`installedPlugins`** (settings.json array of
+    `<plugin>@<marketplace>`): the global install set. `install_plugin` now writes it
+    config-first to the **user scope**, materializes (clone / manifest validation /
+    foreign MCP name-conflict precheck / ledger), and **does not activate** — no SKILL
+    staging, no bundled-server mount, no `enabledPlugins` write → `installed_disabled`.
+    Materialization failure atomically rolls the intent entry back.
+  - `install_plugin` signature: **removed** `register_server=` / `remove_server=` /
+    `inject_inputs=` kwargs (install mounts nothing); `existing_server_names=` kept for
+    the conflict precheck. New `materialize_plugin()` exposes activation-free
+    materialization (reused by boot re-materialization).
+  - **`enable_plugin` is now atomic**: skills and bundled servers light up together;
+    on mount failure it rolls back to `installed_disabled` (unregisters newly staged
+    skills, removes newly mounted servers via the new `remove_server=` kwarg, restores
+    the previous `enabledPlugins` value — absent entries are deleted, not set `false`).
+  - `uninstall_plugin` now also removes the `installedPlugins` entry and clears
+    `enabledPlugins` entries (user always; project/local derived from recorded
+    `projectPath`) once no ledger records remain.
+  - **Boot recovery is intent-driven** (`recovery.py`): the install set comes from the
+    merged `installedPlugins` (the ledger is a rebuildable derived cache — deleting
+    `installed_plugins.json` is lossless: boot re-materializes missing entries, reported
+    via the new `GovernanceRecoveryReport.rematerialized`); the active set is
+    installed ∧ enabled; `installed_disabled` restores lazily (no projection).
+    Orphan detection (`list_orphan_plugins`) now keys off `installedPlugins`
+    (`declared_plugin_ids` **removed** in favor of `declared_installed_plugin_ids`).
+  - **One-time migration** (`migrate_legacy_installs`, run by `Computer.boot_up`):
+    existing ledger installs are written into `installedPlugins`, and plugins without
+    any `enabledPlugins` entry get `enabledPlugins=true` in the user scope so
+    pre-upgrade active plugins stay active (explicit `false` stays disabled). The
+    presence of the `installedPlugins` key in user settings marks migration done
+    (written even when empty), so manual intent removals are never resurrected.
+  - CLI: `plugin install` prints `installed_disabled` state and mounts nothing;
+    `plugin list` shows **all** installed plugins with a two-state enabled column
+    (`--available` kept as a compat no-op); `plugin list`/`info` enabled now means
+    explicit `true`; `plugin enable` wires `remove_server` for rollback.
 - **Connection-plane auth moved from HTTP header to the Socket.IO `auth` dict**
   (#112 / Jira AS-38; Epic TFRM-153). A2C-SMCP is auth-agnostic — **no protocol
   change**; `token` is an SDK/deployment convention aligned with rust-sdk /

--- a/a2c_smcp/computer/cli/commands/plugin.py
+++ b/a2c_smcp/computer/cli/commands/plugin.py
@@ -13,13 +13,17 @@ Plugin command handlers + boot-time MCP approval box。
 与 marketplace.py 同范式：handler 取**显式资源**（``registry`` / ``home`` / ``env``）+ flags，返回退出码
 （0 成功 / 1 用户错 / 2 网络错），包裹 :mod:`...settings.installer` 四动词 + :mod:`...settings.reconciler`
 gc。MCP 注入回调（``existing_server_names`` / ``register_server`` / ``remove_server`` / ``inject_inputs``）由
-REPL dispatcher 从活跃 ``Computer`` 装配后注入；Typer 非交互无 live Computer → 传 ``None``（ledger-only，
-MCP 挂载延到下次 REPL boot 经批准框落地）。
+REPL dispatcher 从活跃 ``Computer`` 装配后注入；Typer 非交互无 live Computer → 传 ``None``。
+
+**v0.3.0 语义（#123）**：``plugin install`` 只安装**不激活**（不挂 server、不投影 skills → ``installed_disabled``；
+仅传 ``existing_server_names`` 做冲突预检）；``plugin enable`` 才原子点亮 skills + bundled server（挂载失败
+回滚 ``installed_disabled``，故 enable 也注入 ``remove_server``）。``plugin list`` 默认列出**全部已安装**
+（enabled 列呈现两态；install 后必须可见）。
 
 **plugin 实时挂载 D2 上下文渲染（#69 Group A，§9.3 D2）**：plugin 的 ``mcp-servers/inputs.json`` 入池时 id
-前缀化为 ``<plugin>@<marketplace>/<id>``；挂载 bundled server 时，``_plugin_register_cb`` 携 plugin/marketplace
-上下文调 :meth:`Computer.aadd_or_aupdate_server`，使 server config 的裸 ``${input:id}`` 经 resolver D2 前缀回退
-解析。``_plugin_inject_inputs_cb`` 负责在 register 前把 inputs 注入 Computer 池。
+前缀化为 ``<plugin>@<marketplace>/<id>``；enable 挂载 bundled server 时，``_plugin_register_cb`` 携
+plugin/marketplace 上下文调 :meth:`Computer.aadd_or_aupdate_server`，使 server config 的裸 ``${input:id}`` 经
+resolver D2 前缀回退解析。``_plugin_inject_inputs_cb`` 负责在 register 前把 inputs 注入 Computer 池。
 
 **MCP 批准框（#69 Group B，§9.2）**：:func:`run_mcp_approval` 在 REPL 启动期跑——解析 ``.tfrobot/mcp.json``
 定义层、套门控、对 ``PENDING`` server 弹 y/a/n（写 local scope）；非交互无 TTY → skip+WARN（``--approve-all-mcp``
@@ -173,11 +177,12 @@ async def plugin_install(
     project_path: str | None = None,
     version: str | None = None,
     existing_server_names: ExistingServerNames | None = None,
-    register_server: RegisterServer | None = None,
-    inject_inputs: InjectInputs | None = None,
     json_output: bool = False,
 ) -> int:
-    """安装单个 plugin（外来 MCP 同名硬抛、原子失败，§10.6）/ Install a plugin (foreign name conflict hard-throws)。"""
+    """安装单个 plugin（**不激活**：写 installedPlugins + 物化 → ``installed_disabled``，v0.3.0 §2.4）/ Install。
+
+    外来 MCP 同名硬抛、原子失败（§10.6 预检保留）；skills/bundled server 由 ``plugin enable`` 原子点亮。
+    """
     if _split_plugin_id(plugin_id) is None:
         return _err(f"invalid plugin id {plugin_id!r} (expected '<plugin>@<marketplace>')", json_output=json_output)
     try:
@@ -185,7 +190,7 @@ async def plugin_install(
             record = await install_plugin(
                 plugin_id, registry, home,
                 scope=scope, project_path=project_path, version=version, env=env,
-                existing_server_names=existing_server_names, register_server=register_server, inject_inputs=inject_inputs,
+                existing_server_names=existing_server_names,
             )
     except MCPServerNameConflictError as e:
         # §10.6 硬抛、退出码 1 + JSON error（无 rename/force 逃生口）。
@@ -195,10 +200,12 @@ async def plugin_install(
 
     servers = record.get("bundledMcpServers") or []
     if json_output:
-        console.print_json(data={"installed": plugin_id, "scope": record.get("scope"), "bundledMcpServers": servers})
+        console.print_json(
+            data={"installed": plugin_id, "scope": record.get("scope"), "state": "installed_disabled", "bundledMcpServers": servers},
+        )
         return EXIT_OK
-    detail = f" ({len(servers)} MCP server(s) mounted)" if servers else ""
-    return _ok(f"installed {plugin_id!r}{detail}")
+    detail = f" ({len(servers)} MCP server(s) bundled, not mounted)" if servers else ""
+    return _ok(f"installed {plugin_id!r}{detail} (disabled; run 'plugin enable {plugin_id}' to activate)")
 
 
 async def plugin_uninstall(
@@ -229,13 +236,15 @@ async def plugin_enable(
     *,
     existing_server_names: ExistingServerNames | None = None,
     register_server: RegisterServer | None = None,
+    remove_server: RemoveServer | None = None,
     inject_inputs: InjectInputs | None = None,
     json_output: bool = False,
 ) -> int:
-    """启用单个 plugin（廉价复原：重挂 server + 复活 skills）/ Enable a plugin (cheap restore)。
+    """启用单个 plugin（**原子激活**：skills 与 bundled server 一并点亮，失败回滚 installed_disabled）/ Enable。
 
     **scope 契约**（installer §4.3）：从 ledger 逐 scope 读安装 scope 传入，绝不默认 ``user``，否则写错层、与 live
-    态背离。多 scope 记录 → 逐 scope enable。挂载前先经 ``inject_inputs`` 把 plugin-scoped inputs 注入池（#69 Group A）。
+    态背离。多 scope 记录 → 逐 scope enable。挂载前先经 ``inject_inputs`` 把 plugin-scoped inputs 注入池（#69 Group A）；
+    ``remove_server`` 供挂载失败时回滚摘除本次新增 server（v0.3.0 §2.4 enable 原子性）。
     """
     records = _installed_records(home, env, plugin_id)
     if not records:
@@ -248,7 +257,7 @@ async def plugin_enable(
             await enable_plugin(
                 plugin_id, registry, home,
                 scope=str(rec.get("scope", "user")), project_path=rec.get("projectPath"), env=env,
-                existing_server_names=existing_server_names, register_server=register_server,
+                existing_server_names=existing_server_names, register_server=register_server, remove_server=remove_server,
             )
     except MCPServerNameConflictError as e:
         return _err(str(e), json_output=json_output, error_code="mcp_server_name_conflict")
@@ -288,7 +297,7 @@ async def plugin_disable(
 
 
 def _enabled_plugins_view(home: Path, env: Mapping[str, str] | None) -> dict[str, Any]:
-    """合并视图的 ``enabledPlugins`` 映射（``id → bool``，缺省视为启用）/ Merged enabledPlugins map。"""
+    """合并视图的 ``enabledPlugins`` 映射（``id → bool``；v0.3.0 仅显式 ``true`` 为启用）/ Merged enabledPlugins map。"""
     ep = resolved_settings(env).get("enabledPlugins")
     return dict(ep) if isinstance(ep, Mapping) else {}
 
@@ -300,7 +309,10 @@ def plugin_list(
     available: bool = False,
     json_output: bool = False,
 ) -> int:
-    """列出 installed plugin（默认 enabled；``--available`` 含 disabled）/ List installed plugins。"""
+    """列出全部 installed plugin（enabled 列呈现两态；install-only 的 ``installed_disabled`` 必须可见）/ List。
+
+    v0.3.0（#123）：默认即列全部已安装——``--available`` 保留为兼容 no-op（旧语义"含 disabled"已成默认）。
+    """
     from a2c_smcp.computer.settings.store import load_installed_plugins
 
     installed = load_installed_plugins(home=home, env=env).get("plugins", {})
@@ -308,9 +320,7 @@ def plugin_list(
 
     rows: list[dict[str, Any]] = []
     for pid, records in installed.items():
-        enabled = enabled_map.get(pid) is not False  # 缺省 / true = 启用；显式 false = 禁用
-        if not enabled and not available:
-            continue
+        enabled = enabled_map.get(pid) is True  # 仅显式 true = 启用（缺省翻转，v0.3.0 §2.4）
         scopes = sorted({str(r.get("scope")) for r in records})
         bundled = sorted({s for r in records for s in (r.get("bundledMcpServers") or [])})
         rows.append({"id": pid, "enabled": enabled, "scopes": scopes, "bundledMcpServers": bundled})
@@ -347,7 +357,7 @@ def plugin_info(
     records = _installed_records(home, env, plugin_id)
     if not records:
         return _err(f"plugin {plugin_id!r} not installed", json_output=json_output)
-    enabled = _enabled_plugins_view(home, env).get(plugin_id) is not False
+    enabled = _enabled_plugins_view(home, env).get(plugin_id) is True  # 仅显式 true（缺省翻转，v0.3.0）
     info: dict[str, Any] = {"id": plugin_id, "enabled": enabled, "records": records}
     if json_output:
         console.print_json(data=info)
@@ -376,7 +386,7 @@ async def plugin_gc(
     confirm: Callable[[list[str]], Awaitable[bool]] | None = None,
     json_output: bool = False,
 ) -> int:
-    """清理孤儿 plugin（所有 scope 都不再声明 enabledPlugins[id]）/ GC orphan plugins。"""
+    """清理孤儿 plugin（账本有记录、``installedPlugins`` 安装意图不再包含，v0.3.0 §2.3）/ GC orphan plugins。"""
     declared = resolved_settings(env)
     orphans = list_orphan_plugins(home, declared, env=env)
     if not orphans:
@@ -503,23 +513,19 @@ async def repl_dispatch(comp: Any, parts: list[str], *, session: Any) -> None:
             console.print("[yellow]usage: plugin install <plugin>@<marketplace> [--version V] [--scope user|project|local][/yellow]")
             return
         plugin_id = pos[0]
-        split = _split_plugin_id(plugin_id)
-        if split is None:
+        if _split_plugin_id(plugin_id) is None:
             console.print("[yellow]invalid plugin id (expected '<plugin>@<marketplace>')[/yellow]")
             return
-        plugin, marketplace = split
         scope = flag_value(args, "--scope") or "user"
-        code = await plugin_install(
+        # v0.3.0（#123）：install 不激活——不注入 register/inject 回调、不 mark_skills_dirty（skills 无变化）；
+        # 仅传 existing_server_names 供冲突预检。激活走 `plugin enable`。
+        await plugin_install(
             registry, home, env, plugin_id,
             scope=scope, project_path=project_path if scope in ("project", "local") else None,
             version=flag_value(args, "--version"),
             existing_server_names=cbs.existing_server_names,
-            register_server=_plugin_register_cb(comp, plugin, marketplace),
-            inject_inputs=_plugin_inject_inputs_cb(comp, plugin, marketplace),
             json_output=json_output,
         )
-        if code == EXIT_OK:
-            comp.mark_skills_dirty()
     elif sub == "uninstall":
         if not pos:
             console.print("[yellow]usage: plugin uninstall <plugin>@<marketplace> [--keep-servers][/yellow]")
@@ -543,6 +549,7 @@ async def repl_dispatch(comp: Any, parts: list[str], *, session: Any) -> None:
             registry, home, env, pos[0],
             existing_server_names=cbs.existing_server_names,
             register_server=_plugin_register_cb(comp, plugin, marketplace),
+            remove_server=cbs.remove_server,  # enable 失败回滚摘除本次新增 server（v0.3.0 原子性）
             inject_inputs=_plugin_inject_inputs_cb(comp, plugin, marketplace),
             json_output=json_output,
         )

--- a/a2c_smcp/computer/cli/commands/settings.py
+++ b/a2c_smcp/computer/cli/commands/settings.py
@@ -240,7 +240,7 @@ async def repl_dispatch(comp: Any, parts: list[str], *, session: Any) -> None:
             value_tokens.append(tok)
         value = " ".join(value_tokens)
         code = settings_set(home, env, key, value, scope=scope or "user", json_output=json_output)
-        _emit_keys = {"enabledPlugins", "enabledMcpjsonServers", "disabledMcpjsonServers", "enableAllProjectMcpServers"}
+        _emit_keys = {"installedPlugins", "enabledPlugins", "enabledMcpjsonServers", "disabledMcpjsonServers", "enableAllProjectMcpServers"}
         if code == EXIT_OK and key in _emit_keys:
             comp.mark_skills_dirty()
     elif sub == "edit":

--- a/a2c_smcp/computer/cli/completer.py
+++ b/a2c_smcp/computer/cli/completer.py
@@ -37,7 +37,7 @@ _DYNAMIC_PLUGIN = {("plugin", s) for s in ("uninstall", "enable", "disable", "in
 _DYNAMIC_SETTINGS = {("settings", "get"), ("settings", "set")}
 # 已知 settings.json 顶层字段（与 schema.py FIELD_* 对齐；completer 静态名集，无需运行时反射）。
 _SETTINGS_KEYS = (
-    "extraKnownMarketplaces", "enabledPlugins", "strictKnownMarketplaces", "trustedMarketplaces",
+    "extraKnownMarketplaces", "installedPlugins", "enabledPlugins", "strictKnownMarketplaces", "trustedMarketplaces",
     "blockedMarketplaces", "enableAllProjectMcpServers", "enabledMcpjsonServers", "disabledMcpjsonServers",
     "allowedMcpServers", "deniedMcpServers", "permissions",
 )

--- a/a2c_smcp/computer/computer.py
+++ b/a2c_smcp/computer/computer.py
@@ -65,6 +65,7 @@ from a2c_smcp.computer.inputs.resolver import InputNotFoundError, InputResolver
 from a2c_smcp.computer.inventory import McpOwnership, McpPluginOwnership, McpServerWithMetadata, McpUserOwnership
 from a2c_smcp.computer.mcp_clients.manager import MCPServerManager
 from a2c_smcp.computer.mcp_clients.model import MCPServerConfig, MCPServerInput
+from a2c_smcp.computer.settings.installer import migrate_legacy_installs
 from a2c_smcp.computer.settings.recovery import (
     BundledServerRecord,
     GovernanceRecoveryReport,
@@ -343,11 +344,18 @@ class Computer(BaseComputer[PromptSession]):
         except Exception as e:  # pragma: no cover — 防御性兜底
             logger.error(f"SKILL Home 解析失败（不阻断 Computer 启动）/ SKILL Home resolve failed (non-blocking): {e}", exc_info=True)
 
-        # #117 治理启动恢复（协议 v0.2.3 §4.8.1，rust reconcile_governance 同位）：从双账本恢复
-        # enabled plugin 的 bundled SKILL。**skills-only**——bundled MCP server 不在 boot 拉进程
-        # （#93 client owns MCP config），client 经 reconcile_governance(hooks) 显式重挂（设计 Y）。
-        # Governance boot recovery (skills-only); bundled MCP servers stay client-driven via hooks.
+        # #117/#123 治理启动恢复（协议 v0.3.0 §4.8.1，rust reconcile_governance 同位）：先跑 v0.2.x → v0.3.0
+        # 一次性迁移（账本存量 → installedPlugins + enabledPlugins=true，保住升级前活跃态；标记键幂等），
+        # 再从安装意图恢复活跃（installed ∧ enabled）plugin 的 bundled SKILL。**skills-only**——bundled MCP
+        # server 不在 boot 拉进程（#93 client owns MCP config），client 经 reconcile_governance(hooks)
+        # 显式重挂（设计 Y）。One-time legacy migration, then intent-driven skills-only recovery.
         if self._skill_home is not None:
+            try:
+                migrated = migrate_legacy_installs(self._skill_home)
+                if migrated:
+                    logger.info("v0.3.0 governance migration: %d legacy install(s) migrated to installedPlugins", len(migrated))
+            except Exception as e:  # pragma: no cover — 失败隔离：迁移失败不阻断启动（下次 boot 重试）
+                logger.warning(f"v0.3.0 治理迁移失败（不阻断启动）/ governance migration failed (non-blocking): {e}")
             try:
                 recovery_report = await self.reconcile_governance()
                 if recovery_report.restored_skills or recovery_report.failed_marketplaces:
@@ -1348,10 +1356,11 @@ class Computer(BaseComputer[PromptSession]):
         declared: Mapping[str, Any] | None = None,
     ) -> GovernanceRecoveryReport:
         """
-        治理启动恢复公共入口（#117，协议 v0.2.3 §4.8；两 SDK 同构契约"设计 Y"）/ Governance recovery entry。
+        治理启动恢复公共入口（#117/#123，协议 v0.3.0 §4.8；两 SDK 同构契约"设计 Y"）/ Governance recovery entry。
 
-        阶段一（恒执行）：从双账本恢复 enabled plugin 的 bundled SKILL 进当前 Registry（ledger 驱动、
-        additive-only、幂等、失败降级不抛——见 :mod:`~a2c_smcp.computer.settings.recovery`）。
+        阶段一（恒执行）：从安装意图恢复**活跃**（installed ∧ ``enabledPlugins[id] is True``，缺省翻转）plugin
+        的 bundled SKILL 进当前 Registry，并重物化账本缺失的 installed pid（intent 驱动、additive-only、幂等、
+        失败降级不抛——见 :mod:`~a2c_smcp.computer.settings.recovery`；``installed_disabled`` 恢复为惰性）。
         阶段二（仅当给 ``register_server``）：client 显式重挂 bundled MCP server——逐 plugin 根先
         ``inject_inputs(record)``（携归属上下文做 plugin inputs 前缀化注入，bundled server 的
         ``${input:}`` D2 渲染前置；每 plugin 根仅一次），再逐 server 经 ``register_server(config, record)``
@@ -1367,7 +1376,8 @@ class Computer(BaseComputer[PromptSession]):
             （如 CLI 取 ``comp.mcp_servers`` 名集），仅在明确无冲突面的受控场景省略。
         :param register_server: 重挂回调 ``(config, record) -> Awaitable``；``None`` = skills-only。
         :param inject_inputs: plugin inputs 注入回调（入参含归属的 record）；每 plugin 根仅调一次。
-        :param declared: ``enabledPlugins`` 合并声明视图覆盖（``None`` = 现算 user/project/local/policy）。
+        :param declared: 合并声明视图覆盖（``installedPlugins`` + ``enabledPlugins`` 两键权威；
+            ``None`` = 现算 user/project/local/policy）。
         :return: :class:`GovernanceRecoveryReport`（``remounted_servers`` 仅阶段二填充）。
         """
         home = self.skill_home
@@ -1410,8 +1420,9 @@ class Computer(BaseComputer[PromptSession]):
         面向 client（如 ``tfrobot-client``）Skill / MCP tab：一次拿到「当前 Computer 有哪些 MCP server + 每条
         归谁（user vs plugin，含 marketplace / plugin / pluginId）+ 能否从普通 MCP tab 编辑 / 启停」，**无需**读
         SDK ledger、**无需**解析 plugin manifest、**无需**持内存 ownership map。协议依据 a2c-smcp-protocol
-        v0.2.3 §4.8（归属 = boot 纯函数、每次可复现；enabled bundled server 进程未拉起也须可查询）。元数据类型
-        见 :mod:`~a2c_smcp.computer.inventory`，**SDK-facing、不进** Agent-facing ``client:*`` wire。
+        v0.3.0 §4.8（归属 = boot 纯函数、每次可复现；enabled bundled server 进程未拉起也须可查询；
+        「已启用」= installed ∧ ``enabledPlugins[id] is True``，``installed_disabled`` 不进本投影，§2.4）。
+        元数据类型见 :mod:`~a2c_smcp.computer.inventory`，**SDK-facing、不进** Agent-facing ``client:*`` wire。
 
         合并两个来源（去重按 server 名，运行期条目优先）：
 

--- a/a2c_smcp/computer/settings/installer.py
+++ b/a2c_smcp/computer/settings/installer.py
@@ -5,11 +5,20 @@
 # @Email   : jqq1716@gmail.com
 # @Software: PyCharm
 """
-Plugin 显式生命周期：install / uninstall / enable / disable（v0.2.1 #63）
-Plugin explicit lifecycle: install / uninstall / enable / disable (v0.2.1 #63).
+Plugin 显式生命周期：install / uninstall / enable / disable（#63；#123 起对齐协议 v0.3.0 §2.4 install ⊥ enable）
+Plugin explicit lifecycle: install / uninstall / enable / disable (aligned to protocol v0.3.0 §2.4 since #123).
 
 SDK 设计 / Design: python-sdk docs/design-0.2.1-cli-marketplace-ux.md §3.3 / §4.3 / §6.2 / §7.2 / §10.6；
-                   父工单 #53 决策 #6（disable=整 plugin 下线）/ #18（MCP 外来同名硬抛、无逃生口）/ #19（uninstall 级联）。
+                   协议 v0.3.0 runtime-contract §2.3（config-first）/ §2.4（三态生命周期）；#123 裁决记录见 #120。
+
+**v0.3.0 语义（破坏性，#123）**：install ≠ activate。两个正交声明式意图——
+``installedPlugins``（**全局**安装事实，固定落 **user scope** settings.json；读取走 merged 并集）×
+``enabledPlugins``（per-scope 启用意图，**仅显式 ``true`` 激活**，absent/false 均不活跃）。
+``install`` 只 config-first 写 ``installedPlugins`` + 物化（:func:`materialize_plugin`：clone/账本/manifest
+校验/冲突预检），**不激活**（不 stage SKILL、不写 ``enabledPlugins``）→ ``installed_disabled``；
+``enable`` 才把 skills 与 bundled server **原子**并入投影（挂载失败回滚 ``installed_disabled``）；
+``uninstall`` 删意图 + 清 ``enabledPlugins`` 条目 + teardown。物化账本 ``installed_plugins.json``
+是可从 ``installedPlugins`` 重建的**纯派生缓存**（boot 重物化见 recovery，§4.9 删除无损）。
 
 本模块是 :mod:`~a2c_smcp.computer.settings.reconciler` 的**兄弟**——reconciler 做 additive-only 对账 + 孤儿
 gc/prune，本模块做**显式单 plugin** 增删启停，写 ``installed_plugins.json``（正是 :func:`gc_plugins` 读取的账本，
@@ -24,18 +33,21 @@ gc/prune，本模块做**显式单 plugin** 增删启停，写 ``installed_plugi
 **MCP 注入**：与 :func:`gc_plugins` 的 ``mcp_teardown`` 同款——bundled MCP server 的存在性查询 / 注册 / 摘除经
 注入回调（:data:`ExistingServerNames` / :data:`RegisterServer` / :data:`RemoveServer`），由 #69 CLI 层用
 ``Computer.aadd_or_aupdate_server`` / ``Computer.aremove_server`` / ``mcp_manager.get_server_status`` 包装；
-回调 ``None`` = ledger-only（单测 / 无 server 场景）。**install/enable 注册经 Computer 路径渲染 ``${input:}``**
-（§9.3，inputs 池消歧归 #65）。
+回调 ``None`` = ledger-only（单测 / 无 server 场景）。**enable 注册经 Computer 路径渲染 ``${input:}``**
+（§9.3，inputs 池消歧归 #65）；v0.3.0 起 install 不再收挂载回调（不激活）。
 
 边界（文档化，非缺陷）/ Documented boundaries：
-- 本模块操作 **live session**；跨重启恢复（``installed × enabled`` 交集）由治理启动恢复承担（#117）：
-  bundled SKILL 经 ``Computer.boot_up`` 内 :mod:`~a2c_smcp.computer.settings.recovery`（ledger 驱动）
+- 本模块操作 **live session**；跨重启恢复（活跃集 = installed ∧ enabled）由治理启动恢复承担（#117/#123）：
+  bundled SKILL 经 ``Computer.boot_up`` 内 :mod:`~a2c_smcp.computer.settings.recovery`（**intent 驱动**）
   自动重建；bundled MCP server 重挂由 client 显式经 ``Computer.reconcile_governance(hooks)`` 触发
   （#93 client owns MCP config；CLI 启动序列即参考接线）。
 - disable 的 skill orphan 为**内存态**（Registry 不落盘），同会话廉价复原；跨重启由治理恢复按
-  ``enabledPlugins`` 门控重建（显式 false 不复活）。uninstall 仅注销**活跃** SKILL（与
+  ``enabledPlugins`` 门控重建（仅显式 true 激活）。uninstall 仅注销**活跃** SKILL（与
   :func:`_unregister_marketplace_skills` 同限）；先 disable（orphan）再 uninstall 会残留内存孤儿条目，
   进程重启即清。
+- :func:`enable_plugin` 不校验 ``installedPlugins`` 意图成员资格（以账本记录为"可启用"依据）：手编移除意图
+  而账本未 gc 的窗口里 live enable 仍可点亮，但重启后 boot 门控（installed ∧ enabled）不会恢复，交由
+  reconcile 收敛。
 """
 
 from __future__ import annotations
@@ -49,8 +61,10 @@ from typing import Any
 from a2c_smcp.computer.mcp_clients.model import MCPServerConfig
 from a2c_smcp.computer.settings.schema import SettingsScope, is_valid_enabled_plugin_key
 from a2c_smcp.computer.settings.scope import (
+    DELETE,
     apply_write,
     load_settings_file,
+    resolve_settings,
     user_settings_path,
     workdir_local_settings_path,
     workdir_project_settings_path,
@@ -161,19 +175,49 @@ def _settings_path_for_scope(scope: str, project_path: str | None, env: Mapping[
     raise PluginInstallError(f"cannot write enabledPlugins to scope {scope!r} (writable: user|project|local)")
 
 
-def _write_enabled_plugin(plugin_id: str, value: bool, scope: str, project_path: str | None, env: Mapping[str, str] | None) -> None:
+def _write_enabled_plugin(plugin_id: str, value: bool | None, scope: str, project_path: str | None, env: Mapping[str, str] | None) -> None:
     """
     写 ``enabledPlugins[<plugin_id>] = value`` 到指定 scope 的 settings.json（持锁原子 RMW）/ Write the enabled flag。
 
+    ``value=None`` = 删除该条目（enable 失败回滚恢复 absent / uninstall 清条目，v0.3.0 §2.4）；条目本不存在 → no-op。
+
     复用 store 原语自组织：:func:`file_lock`（旁车 ``.lock``，建父目录）+ :func:`load_settings_file`（容错）+
-    :func:`apply_write`（递归进 ``enabledPlugins`` 仅改该 key、不毁兄弟）+ :func:`atomic_write_json`（``header=None``——
-    settings.json 是人编意图层，无写保护头 / version 字段，区别于物化文件）。
+    :func:`apply_write`（递归进 ``enabledPlugins`` 仅改该 key、不毁兄弟；:data:`DELETE` 删 key）+
+    :func:`atomic_write_json`（``header=None``——settings.json 是人编意图层，无写保护头 / version 字段，区别于物化文件）。
     """
     path, scope_enum = _settings_path_for_scope(scope, project_path, env)
     with file_lock(path):
         existing, _errors = load_settings_file(path, scope_enum)
-        updated = apply_write(existing, {"enabledPlugins": {plugin_id: value}})
+        if value is None:
+            enabled = existing.get("enabledPlugins")
+            if not isinstance(enabled, Mapping) or plugin_id not in enabled:
+                return  # 无条目可删（apply_write 对缺失父键会原样写入哨兵，须在此短路）
+            updated = apply_write(existing, {"enabledPlugins": {plugin_id: DELETE}})
+        else:
+            updated = apply_write(existing, {"enabledPlugins": {plugin_id: value}})
         atomic_write_json(path, updated)
+
+
+def _write_installed_plugin(plugin_id: str, present: bool, env: Mapping[str, str] | None) -> bool:
+    """
+    user scope ``installedPlugins`` 数组的持锁 RMW（增/删一个条目）；返回**写前**是否已含该条目 / RMW the install intent。
+
+    安装是全局一次的事实（协议 v0.3.0 §2.1/§2.4「plugin_installation」）→ 意图固定落 **user** settings.json
+    （#123 决策：不随 ``--scope`` 泄漏进可提交的 project 文件）；读取侧由 :func:`resolve_settings` merged
+    并集承担（project/local 声明亦被认可，支持声明式复现）。数组写回整体替换（§5.4 写语义），保序去重。
+    """
+    path = user_settings_path(env)
+    with file_lock(path):
+        existing, _errors = load_settings_file(path, SettingsScope.USER)
+        current = existing.get("installedPlugins")
+        entries: list[str] = list(current) if isinstance(current, list) else []
+        was_present = plugin_id in entries
+        if present and not was_present:
+            entries.append(plugin_id)
+        elif not present and was_present:
+            entries = [e for e in entries if e != plugin_id]
+        atomic_write_json(path, apply_write(existing, {"installedPlugins": entries}))
+        return was_present
 
 
 def _plugin_skill_names(registry: SkillRegistry, marketplace: str, plugin: str) -> list[str]:
@@ -255,9 +299,8 @@ def _require_existing_names_guard(
 # ---------------------------------------------------------------------------
 # install / uninstall / enable / disable
 # ---------------------------------------------------------------------------
-async def install_plugin(
+async def materialize_plugin(
     plugin_id: str,
-    registry: SkillRegistry,
     home: Path,
     *,
     scope: str = "user",
@@ -267,37 +310,30 @@ async def install_plugin(
     timeout: float = DEFAULT_GIT_TIMEOUT,
     env: Mapping[str, str] | None = None,
     existing_server_names: ExistingServerNames | None = None,
-    register_server: RegisterServer | None = None,
-    remove_server: RemoveServer | None = None,
-    inject_inputs: InjectInputs | None = None,
 ) -> InstalledPluginRecord:
     """
-    显式安装单个 plugin（**原子失败：冲突即抛、不留半装**）/ Install one plugin atomically。
+    物化单个 plugin（clone/定位 + manifest 校验 + 冲突预检 + 写账本；**零激活**）/ Materialize one plugin。
+
+    协议 v0.3.0 §2.3「Fetch 资产：意图 → 物化账本 → 克隆缓存 → 活跃集」中**物化账本**一环的执行体：
+    供 :func:`install_plugin`（显式安装）与治理启动恢复（账本删除后由 ``installedPlugins`` 意图重建，
+    §4.9「删除无损」）复用。不 stage SKILL、不挂 server、不写任何 settings 意图。
 
     顺序（§10.6「预检-先于-变更」）/ Order:
     1. 校验 ``plugin_id`` → ``(plugin, mp)``；从 ``known_marketplaces.json`` 取 mp source（未添加→抛）。
     2. 要求 catalog clone 已存在（``marketplace add`` 前置；缺失→抛）；读 marketplace.json 定位 entry。
     3. :func:`locate_plugin_root` 定位 plugin 根（必要时 clone 外部 plugin；失败→抛，零变更）。
-    4. :func:`load_bundled_servers` 全量解析 ``mcp-servers/<n>.json``（任一畸形→抛，注册前）。
-    5. **★冲突闸门**：外来同名→:class:`MCPServerNameConflictError`（零变更）；自有同名→幂等放行。
-    6-7. 过闸后变更：注册 bundled servers → :func:`stage_marketplace_skills` 注册 skills（复用既有 clone）。
-       任一失败 → **精确补偿回滚**（仅注销本次新增的 skill、仅移除本次新增的 server——重装失败不误删此前已有）
-       → 上抛，**不写账本**。
-    8. **★最后**写 ``installed_plugins.json``（仅全成功）：scope / installPath / version / commitSha /
+    4. strict 冲突检测（§4.4，#80）+ :func:`load_bundled_servers` 全量解析（任一畸形→抛，写账本前）。
+    5. **★冲突预检**：外来同名→:class:`MCPServerNameConflictError`（零变更）；自有同名→幂等放行；
+       ``existing_server_names=None``（boot 重物化等无 live manager 场景）→ 跳过预检。
+    6. 写 ``installed_plugins.json``（仅全成功）：scope / installPath / version / commitSha /
        installedAt / lastUpdated / bundledMcpServers。
 
     :param scope: 物化记录 scope（``managed|user|project|local``，默认 ``user``）。
-    :param version: 记录版本覆盖（``--version``）；缺省按 entry > plugin.json > commitSha 解析。v0.2.1 git-ref
-        锁版本由 entry source 的 ref 治理（version 仅作记录）。
-    :param existing_server_names / register_server / remove_server: MCP 注入回调（``None`` = ledger-only）。
-        **契约**：给了 ``register_server`` 就必须给 ``existing_server_names``（否则冲突闸门被静默旁路，违 §10.6）。
-    :param inject_inputs: 可选 plugin-scoped inputs 注入 hook（入参 ``plugin_root``）；在冲突闸门后、register 前调一次
-        （#69 Group A，§9.3 D2）。``None`` = 不注入。注入失败走补偿回滚上抛；注入的 inputs 不回滚（无害）。
+    :param version: 记录版本覆盖（``--version``）；缺省按 entry > plugin.json > commitSha 解析。
     :return: 写入的 :class:`InstalledPluginRecord`。
     """
     plugin, marketplace = _split_plugin_id(plugin_id)
-    _require_existing_names_guard(existing_server_names, register_server)
-    source, commit_sha = _resolve_marketplace_source(marketplace, home, env)
+    _source, commit_sha = _resolve_marketplace_source(marketplace, home, env)
 
     catalog_dir = marketplace_skill_dir(home, marketplace)
     if not catalog_dir.is_dir():
@@ -308,7 +344,7 @@ async def install_plugin(
     if entry is None:
         raise PluginInstallError(f"plugin {plugin!r} not found in marketplace {marketplace!r} manifest")
 
-    # 1-4：定位 + 解析（注册前，畸形即抛 → 原子前置）
+    # 3-4：定位 + 解析（写账本前，畸形即抛 → 原子前置）
     plugin_root, version_fallback = await locate_plugin_root(
         marketplace,
         plugin,
@@ -321,64 +357,20 @@ async def install_plugin(
         timeout=timeout,
         env=env,
     )
-    # plugin.json 读一次复用（冲突检测 + version 解析共用，与 staging._stage_one_plugin 姿态对齐，避免重复读盘）。
+    # plugin.json 读一次复用（strict 检测 + version 解析共用，与 staging._stage_one_plugin 姿态对齐，避免重复读盘）。
     plugin_manifest = read_plugin_metadata(plugin_root)
-    # strict mode 冲突检测（§4.4，#80）：strict=false + plugin.json 声明组件 → 拒绝加载（**硬错误**）。
-    # 早检——在挂载 server / 注册 skill 前拦截，不依赖 staging 降级，保证原子失败（未挂 server、未注册 skill）。
     try:
         check_strict_conflict(entry, plugin_manifest)
     except PluginManifestError as e:
         raise PluginInstallError(str(e)) from e
     servers = load_bundled_servers(plugin_root)
 
-    # 5：★冲突闸门（零变更）。owned = 自有同名白名单（其上次记录的 bundledMcpServers）。
+    # 5：★冲突预检（零变更）。owned = 自有同名白名单（其上次记录的 bundledMcpServers）。
     owned = _bundled_servers_of(home, plugin_id, env)
     existing = existing_server_names() if existing_server_names is not None else set()
     _conflict_check(servers, existing, owned)
 
-    # —— 过闸：开始变更，失败补偿回滚 ——
-    # 回滚前快照本 plugin 已活跃的 skill：使补偿只撤销**本次新增**——重装（plugin 已装、skill 已活跃、owned
-    # server 已挂）中途失败时，不误删此前就存在的 skill / 摘除原本工作的 server（精确回滚，避免 live 态破坏）。
-    skills_before = set(_plugin_skill_names(registry, marketplace, plugin))
-    registered: list[str] = []
-    try:
-        # 注入 plugin-scoped inputs 入池（#69 Group A）：须在 register（→render bundled server 的 ``${input:}``）之前，
-        # 使裸 id 经 D2 前缀回退命中带前缀池条目。失败即走下方补偿回滚上抛；inputs 注入本身**不回滚**
-        # （悬空前缀 def 无害——仅在被引用时消费，而该 cfg 已回滚不挂载）。
-        if inject_inputs is not None:
-            await inject_inputs(plugin_root)
-        if register_server is not None:
-            for cfg in servers:
-                await register_server(cfg)
-                registered.append(cfg.name)
-        # skills 注册：复用 #61（catalog 已 clone、plugin 已定位 → refresh=False 不重 clone）
-        await stage_marketplace_skills(
-            marketplace,
-            source,
-            registry,
-            home,
-            plugin_filter={plugin},
-            refresh=refresh,
-            timeout=timeout,
-            env=env,
-        )
-    except Exception:
-        # 精确回滚（逆序）：仅注销本次新增的 skill（不在 skills_before）、仅移除本次新增的 server（不在 owned，
-        # 即非自有/非重装前已挂）；再上抛（账本未写）。
-        for name in _plugin_skill_names(registry, marketplace, plugin):
-            if name not in skills_before:
-                registry.unregister(name)
-        if remove_server is not None:
-            for sname in registered:
-                if sname in owned:
-                    continue  # 自有 server（重装前已挂）：保留，不误摘
-                try:
-                    await remove_server(sname)
-                except Exception as e:  # 回滚 best-effort，不掩盖原异常
-                    logger.warning("install rollback: remove_server(%r) failed: %s", sname, e)
-        raise
-
-    # 8：★最后写账本（仅全成功）
+    # 6：写账本（仅全成功）
     bundled_names = [cfg.name for cfg in servers]
     resolved_version = version if version else resolve_plugin_version(entry, plugin_manifest, version_fallback)
     now = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
@@ -402,7 +394,76 @@ async def install_plugin(
         plugins[_pid] = kept
 
     update_installed_plugins(_put, home=home, env=env)
-    logger.info("installed plugin %r (servers=%s, skills staged)", plugin_id, bundled_names or "none")
+    return record
+
+
+async def install_plugin(
+    plugin_id: str,
+    registry: SkillRegistry,  # noqa: ARG001 - 签名与 uninstall/enable/disable 对称；v0.3.0 install 不再触碰 Registry
+    home: Path,
+    *,
+    scope: str = "user",
+    project_path: str | None = None,
+    version: str | None = None,
+    refresh: bool = False,
+    timeout: float = DEFAULT_GIT_TIMEOUT,
+    env: Mapping[str, str] | None = None,
+    existing_server_names: ExistingServerNames | None = None,
+) -> InstalledPluginRecord:
+    """
+    显式安装单个 plugin = config-first 写意图 + 物化；**不激活**（v0.3.0 §2.4 install 行）/ Install ≠ activate。
+
+    顺序 / Order:
+    1. cheap 预检（零变更）：``plugin_id`` 形态、marketplace 已添加、catalog 已 clone、manifest entry 存在。
+    2. **config-first**（§2.3）：把 ``plugin_id`` 写入 **user scope** ``installedPlugins``（全局安装意图）。
+    3. :func:`materialize_plugin` 物化（clone/strict/bundled 解析/冲突预检/写账本）。
+    4. 物化失败 → **原子回滚**：撤销第 2 步新写的意图条目（重装场景原已在 → 保留）→ 上抛（#123 决策 #3：
+       「失败 = 零变更」；协议对 install 失败未置可否，本 SDK 取更强不变量，rust-sdk#103 镜像）。
+
+    结果态 ``installed_disabled``：**不** stage SKILL、**不**写 ``enabledPlugins``、**不**挂 bundled server——
+    显式 :func:`enable_plugin` 才原子点亮（skills 与 server 一并）。
+
+    :param registry: 与其余三动词对称保留；install 自 v0.3.0 起不触碰 Registry。
+    :param scope: 物化记录 scope（``managed|user|project|local``，默认 ``user``）——只影响账本记录归档，
+        **不**影响意图落点（安装是全局一次的事实，意图恒写 user scope）。
+    :param existing_server_names: 可选冲突预检输入（``None`` = 跳过预检；enable 时仍有权威预检兜底）。
+    :return: 写入的 :class:`InstalledPluginRecord`。
+    """
+    plugin, marketplace = _split_plugin_id(plugin_id)
+
+    # 1：cheap 预检（不写任何状态；深校验交给 materialize）
+    _resolve_marketplace_source(marketplace, home, env)
+    catalog_dir = marketplace_skill_dir(home, marketplace)
+    if not catalog_dir.is_dir():
+        raise PluginInstallError(f"marketplace {marketplace!r} catalog not cloned at {catalog_dir} (run 'marketplace add/refresh' first)")
+    if find_plugin_entry(read_marketplace_manifest(catalog_dir), plugin) is None:
+        raise PluginInstallError(f"plugin {plugin!r} not found in marketplace {marketplace!r} manifest")
+
+    # 2：config-first 写全局安装意图（快照写前状态供原子回滚：重装时原已在 → 失败不误删）
+    was_present = _write_installed_plugin(plugin_id, True, env)
+
+    # 3-4：物化；失败回滚意图（best-effort，不掩盖原异常）
+    try:
+        record = await materialize_plugin(
+            plugin_id,
+            home,
+            scope=scope,
+            project_path=project_path,
+            version=version,
+            refresh=refresh,
+            timeout=timeout,
+            env=env,
+            existing_server_names=existing_server_names,
+        )
+    except Exception:
+        if not was_present:
+            try:
+                _write_installed_plugin(plugin_id, False, env)
+            except Exception as e:  # noqa: BLE001 - 回滚 best-effort
+                logger.warning("install rollback: failed to revert installedPlugins entry %r: %s", plugin_id, e)
+        raise
+
+    logger.info("installed plugin %r (servers=%s; installed_disabled, run 'plugin enable' to activate)", plugin_id, record.get("bundledMcpServers") or "none")
     return record
 
 
@@ -418,6 +479,11 @@ async def uninstall_plugin(
 ) -> bool:
     """
     卸载单个 plugin（删 installPath 树 + 注销 skills + 级联 stop+remove bundled server + 删账本记录）/ Uninstall。
+
+    **v0.3.0 §2.4 uninstall 行**：当该 pid 的账本记录**全部**移除（回 ``available``）时，同步删除 user scope
+    ``installedPlugins`` 意图条目 + 清 ``enabledPlugins`` 条目（user 必清；给了 ``project_path`` 时 project/local
+    一并 best-effort——managed/policy 只读层不触碰）。指定 ``scope`` 仅删该 scope 记录且其余 scope 仍在 →
+    意图与 enabled 条目保留（安装事实未消失）。
 
     :func:`gc_plugins` 的显式单 plugin 对应物。``--keep-servers`` 跳过 server 摘除（保留 config）。
     ``scope=None`` 删该 id 全部记录；指定 scope 仅删该 scope 记录（其余 scope 保留）。未安装 → ``False``（no-op）。
@@ -469,6 +535,20 @@ async def uninstall_plugin(
             plugins.pop(_pid, None)
 
     update_installed_plugins(_drop, home=home, env=env)
+
+    # v0.3.0：账本记录清空（回 available）→ 删全局安装意图 + 清 enabledPlugins 条目（意图是唯一权威，§2.3）。
+    # project/local 落点从被删记录的 projectPath 派生（无需调用方另传）；managed/policy 只读层不触碰。
+    remaining = load_installed_plugins(home=home, env=env).get("plugins", {}).get(plugin_id)
+    if not remaining:
+        _write_installed_plugin(plugin_id, False, env)
+        _write_enabled_plugin(plugin_id, None, "user", None, env)
+        project_paths = {p for r in targeted if isinstance(p := r.get("projectPath"), str) and p}
+        for pp in sorted(project_paths):
+            for s in ("project", "local"):
+                try:
+                    _write_enabled_plugin(plugin_id, None, s, pp, env)
+                except PluginInstallError as e:  # best-effort：清条目失败不阻断卸载
+                    logger.warning("uninstall: failed to clear enabledPlugins[%s] in %s scope at %s: %s", plugin_id, s, pp, e)
     logger.info(
         "uninstalled plugin %r (scope=%s, servers=%s)",
         plugin_id,
@@ -522,13 +602,17 @@ async def enable_plugin(
     env: Mapping[str, str] | None = None,
     existing_server_names: ExistingServerNames | None = None,
     register_server: RegisterServer | None = None,
+    remove_server: RemoveServer | None = None,
 ) -> None:
     """
-    启用单个 plugin（廉价复原，**无需重 clone/重装**）/ Enable = cheap restore (no re-clone)。
+    启用单个 plugin（**原子激活**：skills 与 bundled server 一并入投影，失败回滚 ``installed_disabled``）/ Enable。
 
-    顺序：① 从物化记录的 ``installPath`` 重解析 bundled servers → **★冲突预检（先于 settings 写 → enable 原子）**；
-    ② 写 ``enabledPlugins[id]=true``；③ 复活 skills——re-stage（:func:`stage_marketplace_skills` 的
-    :meth:`register_or_update` 把孤儿同名翻 ``orphaned=False``，``refresh=False`` 复用既有 clone）；④ 重挂 servers。
+    v0.3.0 §2.4「enable 原子性」：顺序 ① 从物化记录的 ``installPath`` 重解析 bundled servers →
+    **★冲突预检（先于 settings 写）**；② 快照该 scope ``enabledPlugins`` 原值 + 本 plugin 已活跃 skills →
+    写 ``enabledPlugins[id]=true``；③ 复活 skills——re-stage（:func:`stage_marketplace_skills` 的
+    :meth:`register_or_update` 把孤儿同名翻 ``orphaned=False``，``refresh=False`` 复用既有 clone）；
+    ④ 重挂 servers。③/④ 任一失败 → **回滚**：注销本次新增 skill、摘除本次新增 server（经 ``remove_server``）、
+    ``enabledPlugins`` 恢复原值（原 absent → 删条目）→ 上抛，净效果回 ``installed_disabled``。
     未安装 → :class:`PluginInstallError`（须先 install）。
 
     ⚠️ **scope 契约**：同 :func:`disable_plugin`——``scope`` 须与安装 scope 一致（调用方 / #69 从上下文传），否则
@@ -551,24 +635,95 @@ async def enable_plugin(
     existing = existing_server_names() if existing_server_names is not None else set()
     _conflict_check(servers, existing, owned)
 
-    # ② 写 enabledPlugins[id]=true（冲突预检通过后）
+    # ② 快照回滚基线（该 scope 文件的原值：True/False/None=absent；本 plugin 已活跃 skill 集）→ 写 true
+    settings_path, scope_enum = _settings_path_for_scope(scope, project_path, env)
+    prior_settings, _errors = load_settings_file(settings_path, scope_enum)
+    prior_enabled = prior_settings.get("enabledPlugins")
+    prev_value: bool | None = prior_enabled.get(plugin_id) if isinstance(prior_enabled, Mapping) else None
+    skills_before = set(_plugin_skill_names(registry, marketplace, plugin))
     _write_enabled_plugin(plugin_id, True, scope, project_path, env)
 
-    # ③ 复活 skills（re-stage：register_or_update 翻活孤儿；复用既有 clone）
-    source, _commit_sha = _resolve_marketplace_source(marketplace, home, env)
-    await stage_marketplace_skills(
-        marketplace,
-        source,
-        registry,
-        home,
-        plugin_filter={plugin},
-        refresh=False,
-        timeout=timeout,
-        env=env,
-    )
-
-    # ④ 重挂 servers
-    if register_server is not None:
-        for cfg in servers:
-            await register_server(cfg)
+    registered: list[str] = []
+    try:
+        # ③ 复活 skills（re-stage：register_or_update 翻活孤儿；复用既有 clone）
+        source, _commit_sha = _resolve_marketplace_source(marketplace, home, env)
+        await stage_marketplace_skills(
+            marketplace,
+            source,
+            registry,
+            home,
+            plugin_filter={plugin},
+            refresh=False,
+            timeout=timeout,
+            env=env,
+        )
+        # ④ 重挂 servers
+        if register_server is not None:
+            for cfg in servers:
+                await register_server(cfg)
+                registered.append(cfg.name)
+    except Exception:
+        # 回滚（逆序，best-effort 不掩盖原异常）：撤销本次新增 skill / server，enabledPlugins 恢复原值。
+        for name in _plugin_skill_names(registry, marketplace, plugin):
+            if name not in skills_before:
+                registry.unregister(name)
+        if remove_server is not None:
+            for sname in registered:
+                if sname in owned and sname in existing:
+                    continue  # 自有且 enable 前已挂：保留，不误摘
+                try:
+                    await remove_server(sname)
+                except Exception as e:  # noqa: BLE001 - 回滚 best-effort
+                    logger.warning("enable rollback: remove_server(%r) failed: %s", sname, e)
+        try:
+            _write_enabled_plugin(plugin_id, prev_value, scope, project_path, env)
+        except Exception as e:  # noqa: BLE001 - 回滚 best-effort
+            logger.warning("enable rollback: failed to restore enabledPlugins[%s]=%r: %s", plugin_id, prev_value, e)
+        raise
     logger.info("enabled plugin %r (scope=%s, skills recovered, servers remounted)", plugin_id, scope)
+
+
+# ---------------------------------------------------------------------------
+# v0.2.x → v0.3.0 一次性状态迁移 / One-time state migration
+# ---------------------------------------------------------------------------
+def migrate_legacy_installs(home: Path, *, env: Mapping[str, str] | None = None) -> list[str]:
+    """
+    v0.2.x「装即活跃」存量 → v0.3.0 双意图的一次性迁移（迁移指南「保住既有用户现状」）/ One-time legacy migration。
+
+    **标记 = user settings.json 是否含 ``installedPlugins`` 键**（#123 决策 #2）：键在（哪怕空数组）→ 已迁移，
+    严格 no-op——防「v0.3.0 后手动删意图、账本未 gc」被迁回复活（意图是唯一权威，§2.3）。键缺失（pre-v0.3.0
+    世界）→ 把账本全部合法 pid 写入 ``installedPlugins``，并对 merged ``enabledPlugins`` **无条目**的 pid 在
+    user scope 补 ``enabledPlugins=true``（v0.2.x 下 absent=active，翻转后会熄灯，须保住；显式 false 本就
+    禁用 → 不写，保持 ``installed_disabled``）。首跑**必写**标记键（空账本也写 ``[]``）。
+
+    合并视图经 :func:`resolve_settings`（user/project/local；无 flag/policy——boot 语境，与
+    ``Computer._resolve_declared_settings`` 已知限制一致）。由 ``Computer.boot_up`` 在治理恢复前调用（失败
+    隔离）；幂等、只跑一次。
+
+    :param home: SKILL Home 绝对根（账本读取）。
+    :param env: 环境映射（settings 路径解析），默认 ``os.environ``。
+    :return: 本次迁入 ``installedPlugins`` 的 pid 列表（已迁移 no-op → 空）。
+    """
+    path = user_settings_path(env)
+    with file_lock(path):
+        existing, _errors = load_settings_file(path, SettingsScope.USER)
+        if "installedPlugins" in existing:
+            return []  # 已迁移（标记键在）→ 严格 no-op
+
+        ledger_pids = [pid for pid in load_installed_plugins(home=home, env=env).get("plugins", {}) if is_valid_enabled_plugin_key(pid)]
+        merged_enabled = resolve_settings(env=env).settings.get("enabledPlugins")
+        merged_view: Mapping[str, Any] = merged_enabled if isinstance(merged_enabled, Mapping) else {}
+
+        updates: dict[str, Any] = {"installedPlugins": ledger_pids}
+        enabled_updates = {pid: True for pid in ledger_pids if pid not in merged_view}
+        if enabled_updates:
+            updates["enabledPlugins"] = enabled_updates
+        atomic_write_json(path, apply_write(existing, updates))
+        if ledger_pids:
+            logger.info(
+                "migrated %d legacy plugin install(s) to installedPlugins (v0.3.0): %s (enabled=true backfilled for %d)",
+                len(ledger_pids),
+                ledger_pids,
+                len(enabled_updates),
+            )
+        return ledger_pids

--- a/a2c_smcp/computer/settings/installer.py
+++ b/a2c_smcp/computer/settings/installer.py
@@ -463,7 +463,11 @@ async def install_plugin(
                 logger.warning("install rollback: failed to revert installedPlugins entry %r: %s", plugin_id, e)
         raise
 
-    logger.info("installed plugin %r (servers=%s; installed_disabled, run 'plugin enable' to activate)", plugin_id, record.get("bundledMcpServers") or "none")
+    logger.info(
+        "installed plugin %r (servers=%s; installed_disabled, run 'plugin enable' to activate)",
+        plugin_id,
+        record.get("bundledMcpServers") or "none",
+    )
     return record
 
 

--- a/a2c_smcp/computer/settings/installer.py
+++ b/a2c_smcp/computer/settings/installer.py
@@ -431,13 +431,18 @@ async def install_plugin(
     """
     plugin, marketplace = _split_plugin_id(plugin_id)
 
-    # 1：cheap 预检（不写任何状态；深校验交给 materialize）
+    # 1：cheap 预检（不写任何状态；深校验交给 materialize）——保持 fail-fast 零副作用
     _resolve_marketplace_source(marketplace, home, env)
     catalog_dir = marketplace_skill_dir(home, marketplace)
     if not catalog_dir.is_dir():
         raise PluginInstallError(f"marketplace {marketplace!r} catalog not cloned at {catalog_dir} (run 'marketplace add/refresh' first)")
     if find_plugin_entry(read_marketplace_manifest(catalog_dir), plugin) is None:
         raise PluginInstallError(f"plugin {plugin!r} not found in marketplace {marketplace!r} manifest")
+
+    # 1.5：预检过后、写意图键之前，先跑一次性迁移（幂等、标记键短路）。install 会写 installedPlugins 键——
+    #      若迁移尚未发生（如升级后未经 boot 的 headless CLI install），先写键会把迁移标记误置为"已迁移"，
+    #      永久丢弃 v0.2.x 存量活跃态（隔离审查 🔴#2 + N1：置于预检后保 fail-fast 无副作用）。
+    migrate_legacy_installs(home, env=env)
 
     # 2：config-first 写全局安装意图（快照写前状态供原子回滚：重装时原已在 → 失败不误删）
     was_present = _write_installed_plugin(plugin_id, True, env)
@@ -510,6 +515,10 @@ async def uninstall_plugin(
     if not targeted:
         logger.info("uninstall: plugin %r has no record in scope %r (no-op)", plugin_id, scope)
         return False
+
+    # no-op 早返回之后、任何变更之前，先跑一次性迁移（幂等）：uninstall 也写 installedPlugins 键
+    # （同 install 的标记误置风险，防迁移被抢跑关闭；置于此处保「未安装 = 真 no-op 零写盘」，审查 N1）。
+    migrate_legacy_installs(home, env=env)
 
     bundled: list[str] = []
     for rec in targeted:

--- a/a2c_smcp/computer/settings/reconciler.py
+++ b/a2c_smcp/computer/settings/reconciler.py
@@ -28,10 +28,10 @@ SDK 设计 / Design: python-sdk docs/design-0.2.1-cli-marketplace-ux.md §7.1（
   （生产由 #63 写入、本工单测试直接 seed）。
 - bundled MCP server 的起停经 :func:`gc_plugins` 的 ``mcp_teardown`` 回调注入；真正接线（MCP manager）
   由 computer.py 集成承担，不在 #62。
-- **与治理启动恢复的分工（#117）**：本模块是**声明式**对账（declared 驱动，恢复不了"装即活跃"、未写
-  ``enabledPlugins`` 的命令式安装）；boot 恢复走 :mod:`~a2c_smcp.computer.settings.recovery`
-  （**ledger 驱动**：``installed_plugins.json`` 为"已安装"事实源 + ``enabledPlugins`` 仅作禁用门控），
-  两者 additive-only 语义一致、职责不同。
+- **与治理启动恢复的分工（#117/#123）**：本模块是**marketplace 声明式**对账（``extraKnownMarketplaces``
+  驱动的 catalog 物化 + 启用 plugin 的 SKILL 注册）；boot 恢复走 :mod:`~a2c_smcp.computer.settings.recovery`
+  （**intent 驱动**：``installedPlugins`` 为安装事实源、活跃集 = installed ∧ ``enabledPlugins[id] is True``
+  （v0.3.0 缺省翻转）、账本缺失时重物化），两者 additive-only 语义一致、职责不同。
 
 并发 / Concurrency：:func:`reconcile` **串行** stage 各 marketplace（不 ``asyncio.gather``），遵守
 :func:`stage_marketplace_skills` 文档化的同步 ``file_lock`` 阻塞约束（store.py 同步设计的固有约束）。
@@ -116,32 +116,34 @@ def declared_marketplace_names(declared: Mapping[str, object]) -> set[str]:
     return set(_declared_marketplaces(declared))
 
 
-def declared_plugin_ids(declared: Mapping[str, object]) -> set[str]:
+def declared_installed_plugin_ids(declared: Mapping[str, object]) -> set[str]:
     """
-    所有**声明过**的 plugin id（``<plugin>@<mp>``，含 ``false`` 禁用项）/ All declared plugin ids。
+    merged ``installedPlugins``（全局安装意图，协议 v0.3.0 §2.4）中的合法 pid 集合 / Declared install intent。
 
-    用于 :func:`list_orphan_plugins` 的孤儿判定——``false`` = 声明禁用（**非**孤儿），仅 key 完全缺失才算孤儿。
+    用于 :func:`list_orphan_plugins` 的孤儿判定与「活跃集 = installed ∧ enabled」门控（#123）：
+    ``installed_disabled``（已安装未启用）是合法静止态、**非**孤儿；仅账本 pid ∉ 安装意图才算孤儿。
     """
-    raw = declared.get("enabledPlugins")
-    if not isinstance(raw, Mapping):
+    raw = declared.get("installedPlugins")
+    if not isinstance(raw, list):
         return set()
-    return {k for k in raw if is_valid_enabled_plugin_key(k)}
+    return {item for item in raw if isinstance(item, str) and is_valid_enabled_plugin_key(item)}
 
 
 def _enabled_plugin_names_for(marketplace: str, declared: Mapping[str, object]) -> set[str]:
     """
-    某 marketplace 下**启用**（``true``）的 plugin 名集合 / Enabled (``true``) plugin names for a marketplace。
+    某 marketplace 下**活跃**（installed ∧ ``enabledPlugins[id] is True``，v0.3.0 §4.8.1）的 plugin 名集合。
 
     ``enabledPlugins`` key 形如 ``<plugin>@<mp>``；返回去掉 ``@<mp>`` 后缀的 ``<plugin>`` 集合，作
-    :func:`stage_marketplace_skills` 的 ``plugin_filter``（缺启用项 → 空集 → 仅 clone catalog、不注册 SKILL）。
+    :func:`stage_marketplace_skills` 的 ``plugin_filter``（缺启用项/未安装 → 空集 → 仅 clone catalog、不注册 SKILL）。
     """
     raw = declared.get("enabledPlugins")
     if not isinstance(raw, Mapping):
         return set()
+    installed = declared_installed_plugin_ids(declared)
     suffix = f"@{marketplace}"
     names: set[str] = set()
     for key, enabled in raw.items():
-        if enabled is True and is_valid_enabled_plugin_key(key) and key.endswith(suffix):
+        if enabled is True and key in installed and key.endswith(suffix):
             names.add(key[: -len(suffix)])
     return names
 
@@ -210,8 +212,9 @@ async def reconcile(
     - **autoUpdate**（``decl.autoUpdate==True`` 或显式 ``refresh=True``）→ ``git pull``。
     - **orphan**（materialized∖declared）→ **完全不动**（不进循环；靠 :func:`prune_marketplaces` 显式清）。
 
-    每个 declared marketplace 物化其 ``enabledPlugins`` 中**启用**的 plugin 的 SKILL（``plugin_filter``）；
-    禁用 / 未声明 plugin 不注册。失败降级：stage 吞错返回空 → 本函数据 clone 树是否存在判 ``failed``。
+    每个 declared marketplace 物化其**活跃**（installed ∧ ``enabledPlugins[id] is True``，v0.3.0）plugin 的
+    SKILL（``plugin_filter``）；未安装 / 禁用 / 未声明 plugin 不注册。失败降级：stage 吞错返回空 →
+    本函数据 clone 树是否存在判 ``failed``。
 
     :param registry: 目标 :class:`SkillRegistry`。
     :param home: SKILL Home 绝对根（调用方保证存在）。
@@ -347,14 +350,16 @@ def list_orphan_plugins(
     env: Mapping[str, str] | None = None,
 ) -> list[str]:
     """
-    列出"所有 scope 都不再声明"的孤儿 plugin（installed 有、enabledPlugins 无此 key）/ List orphan plugins。
+    列出孤儿 plugin：账本有记录、``installedPlugins`` 安装意图不再包含（v0.3.0 §2.3 账本=派生缓存）/ Orphans。
 
-    ``false`` = 声明禁用（key 仍在）→ **非**孤儿；仅 key 完全缺失才算孤儿（见 :func:`declared_plugin_ids`）。
+    ``installed_disabled``（意图在、未启用）是合法静止态 → **非**孤儿；``enabledPlugins``（含 ``false``）
+    不参与孤儿判定（enablement 与 installation 正交，§2.4）。
 
-    :param declared: 单一声明视图（取 ``enabledPlugins`` 全部 key——含 ``false``——作"仍声明"集）。
-    :return: ``installed_plugins.json`` 中 plugin id ∉ 声明集 的列表（保持物化顺序）。
+    :param declared: 单一声明视图（取 ``installedPlugins`` 合法条目作"仍安装"集，见
+        :func:`declared_installed_plugin_ids`）。
+    :return: ``installed_plugins.json`` 中 plugin id ∉ 安装意图 的列表（保持物化顺序）。
     """
-    declared_ids = declared_plugin_ids(declared)
+    declared_ids = declared_installed_plugin_ids(declared)
     installed = load_installed_plugins(home=home, env=env)
     return [pid for pid in installed.get("plugins", {}) if pid not in declared_ids]
 

--- a/a2c_smcp/computer/settings/recovery.py
+++ b/a2c_smcp/computer/settings/recovery.py
@@ -142,6 +142,10 @@ async def recover_marketplace_skills(
     降级判定与 rust 同构：stage 内部吞错，事后 clone 树仍缺 → 该 marketplace 入 ``failed_marketplaces``；
     known_marketplaces 缺记录 → 同样降级。**绝不抛、不阻断其余**。
 
+    已知限制（文档化，rust 同构）：重物化无法从无 scope 的 ``installedPlugins`` 还原原安装 scope /
+    ``projectPath``——重建记录**归一为 user scope**（多 scope 记录塌缩单条）；此后 enable/disable 从账本
+    读 scope 会落 user 层。scope 精确复原需 committed 记录承载，属可选 pin-lock 扩展（§4.9.2）范畴。
+
     :param registry: 目标 :class:`SkillRegistry`（恢复注册进当前活跃集）。
     :param home: SKILL Home 绝对根。
     :param declared: 合并声明视图（取 ``installedPlugins`` + ``enabledPlugins`` 两键作权威门控）。
@@ -183,33 +187,46 @@ async def recover_marketplace_skills(
             )
             report.failed_marketplaces.append(marketplace)
             continue
-        names = await stage_marketplace_skills(
-            marketplace,
-            source,
-            registry,
-            home,
-            plugin_filter=active_plugins,
-            refresh=False,  # 离线优先：clone 在则零 git / offline-first
-            timeout=timeout,
-            env=env,
-        )
-        # 降级代理判定（rust 同构）：stage 失败降级不抛；事后 clone 树仍缺 = 源不可达且无本地物化。
+
+        # ① 保证 catalog 物化（空 filter = 仅 clone、零 SKILL 注册）——重物化与 skills stage 的共同前置。
+        #    降级代理判定（rust 同构）：stage 失败降级不抛；事后 clone 树仍缺 = 源不可达且无本地物化。
         if not marketplace_skill_dir(home, marketplace).is_dir():
-            logger.warning("governance recovery: marketplace %r clone missing and rebuild failed, degraded", marketplace)
-            report.failed_marketplaces.append(marketplace)
-            continue
-        # 重物化：意图有、账本缺（或 installPath 全失效）→ 由 (marketplace, plugin) 纯函数重建账本
-        # （§4.9 删除无损）。物化 ≠ 激活——installed_disabled 也重建（保 enable 廉价、账本可查询）；
-        # 冲突预检传 None（boot 无 live manager；重挂阶段自有 existing 名跳过护栏）。
+            await stage_marketplace_skills(
+                marketplace, source, registry, home, plugin_filter=set(), refresh=False, timeout=timeout, env=env,
+            )
+            if not marketplace_skill_dir(home, marketplace).is_dir():
+                logger.warning("governance recovery: marketplace %r clone missing and rebuild failed, degraded", marketplace)
+                report.failed_marketplaces.append(marketplace)
+                continue
+
+        # ② 先重物化、后 stage（§2.4 半态防御）：意图有、账本缺（或 installPath 全失效）→ 由
+        #    (marketplace, plugin) 纯函数重建账本（§4.9 删除无损）。物化 ≠ 激活——installed_disabled 也
+        #    重建（保 enable 廉价、账本可查询）；冲突预检传 None（boot 无 live manager；重挂阶段自有
+        #    existing 名跳过护栏）。**物化失败的活跃 plugin 整体保持 installed_disabled**（摘出 stage
+        #    filter，skills 不进投影——否则 skill 已亮、bundled server 不可查询即 rust-sdk#102 半态）。
         for plugin in needs_materialize:
             pid = f"{plugin}@{marketplace}"
             try:
                 await materialize_plugin(pid, home, refresh=False, timeout=timeout, env=env)
                 report.rematerialized.append(pid)
             except Exception as e:  # noqa: BLE001 - 失败降级铁律：WARN 跳过，不阻断 boot
-                logger.warning("governance recovery: re-materialize %r failed, degraded: %s", pid, e)
-        report.restored_skills.extend(names)
-        report.restored_plugins.extend(sorted(f"{plugin}@{marketplace}" for plugin in active_plugins))
+                logger.warning("governance recovery: re-materialize %r failed; kept installed_disabled (skills not staged): %s", pid, e)
+                active_plugins.discard(plugin)
+
+        # ③ stage skills（仅活跃且物化完好的 plugin）
+        if active_plugins:
+            names = await stage_marketplace_skills(
+                marketplace,
+                source,
+                registry,
+                home,
+                plugin_filter=active_plugins,
+                refresh=False,  # 离线优先：clone 在则零 git / offline-first
+                timeout=timeout,
+                env=env,
+            )
+            report.restored_skills.extend(names)
+            report.restored_plugins.extend(sorted(f"{plugin}@{marketplace}" for plugin in active_plugins))
 
     return report
 

--- a/a2c_smcp/computer/settings/recovery.py
+++ b/a2c_smcp/computer/settings/recovery.py
@@ -5,29 +5,32 @@
 # @Email   : jqq1716@gmail.com
 # @Software: PyCharm
 """
-治理启动恢复（#117，协议 v0.2.3 runtime-contract §4.8）/ Governance boot recovery。
+治理启动恢复（#117；#123 起对齐协议 v0.3.0 §4.8）/ Governance boot recovery。
 
-**ledger 驱动、additive-only、离线优先、enabled 门控**（与 rust-sdk ``settings/recovery.rs`` 同构）：
-从双账本（``installed_plugins.json`` + ``known_marketplaces.json``）重建 enabled plugin 的活跃集——
+**intent 驱动、additive-only、离线优先、installed ∧ enabled 门控**（与 rust-sdk ``settings/recovery.rs``
+同构）：安装集取自 merged ``installedPlugins``（全局安装意图，§4.8.1），活跃集 = 已安装 ∧
+``enabledPlugins[pid] is True``（**缺省翻转**：absent/false 均惰性，仅显式 true 激活）——
+``installed_disabled`` 恢复为惰性、不进投影。账本 ``installed_plugins.json`` 是可弃派生缓存：意图有、
+账本缺（或 installPath 全失效）→ boot 经 :func:`~a2c_smcp.computer.settings.installer.materialize_plugin`
+**重物化**（§4.9「删除无损」；物化 ≠ 激活，installed_disabled 也重建账本，保 enable 廉价）。
 bundled SKILL 经 :func:`~a2c_smcp.computer.skills.staging.stage_marketplace_skills`（``refresh=False``
 就地复用 clone 树）恢复进 Registry；bundled MCP server 经 :func:`collect_enabled_bundled_servers`
 纯函数**可查询**（含 plugin/marketplace 归属，§4.8.3），进程物化归 client（#93 client owns MCP config，
 §4.8 blockquote）——boot 默认不拉进程，重挂由 client 显式经
 :meth:`~a2c_smcp.computer.computer.Computer.reconcile_governance` 传 hooks 触发（设计 Y 同构契约）。
 
-为何不走声明式 :func:`~a2c_smcp.computer.settings.reconciler.reconcile`：命令式 ``install_plugin``
-**不写** ``enabledPlugins``（装即活跃），声明式对账恢复不了它；恢复以账本为"已安装"事实源、以
-``enabledPlugins`` 合并视图为启用门控（boot-active = installed ∧ ``enabledPlugins[pid] != False``，
-仅显式 false 禁用）。失败降级铁律：单 plugin / 单 marketplace / 单文件失败 → WARN + 记入报告，
-**不抛、不阻断 boot**（§3 degraded / §5.2）。
+失败降级铁律：单 plugin / 单 marketplace / 单文件失败 → WARN + 记入报告，**不抛、不阻断 boot**
+（§3 degraded / §5.2）。v0.2.x 存量（账本有、意图无）由 ``Computer.boot_up`` 先行
+:func:`~a2c_smcp.computer.settings.installer.migrate_legacy_installs` 一次性迁移，本模块不感知旧语义。
 
 已知限制（与 rust 同构文档化）：boot 内 declared 视图不含 ``--settings`` flag scope（Computer 无 flag
 知识；CLI 接线时可显式传 flag-aware ``declared``）——跨重启可靠 disable 请写 user scope。
 
-Ledger-driven, additive-only, offline-first governance recovery mirroring rust-sdk. Recovery reads the
-two ledgers as installed-facts, gates by the merged ``enabledPlugins`` view (only explicit ``false``
-disables), restores bundled SKILLs in place, and exposes enabled bundled MCP servers as a pure queryable
-function with ownership; process materialization stays with the client (#93).
+Intent-driven, additive-only, offline-first governance recovery mirroring rust-sdk (protocol v0.3.0):
+the install set comes from the merged ``installedPlugins`` intent, the active set is installed AND
+``enabledPlugins[pid] is True`` (default flipped), missing ledger entries are re-materialized from
+intent, restored SKILLs land in the Registry, and enabled bundled MCP servers stay queryable with
+ownership; process materialization stays with the client (#93).
 """
 
 from __future__ import annotations
@@ -38,6 +41,8 @@ from pathlib import Path
 from typing import Any
 
 from a2c_smcp.computer.mcp_clients.model import MCPServerConfig
+from a2c_smcp.computer.settings.installer import materialize_plugin
+from a2c_smcp.computer.settings.reconciler import declared_installed_plugin_ids
 from a2c_smcp.computer.settings.store import load_installed_plugins, load_known_marketplaces
 from a2c_smcp.computer.skills.home import marketplace_skill_dir
 from a2c_smcp.computer.skills.manifest import PluginManifestError, load_bundled_servers
@@ -52,12 +57,14 @@ logger = get_logger(__name__)
 class GovernanceRecoveryReport:
     """治理恢复报告（与 rust ``GovernanceRecoveryReport`` 同名同义，作观测 + 测试信号）/ Recovery report。
 
-    - ``restored_plugins``：clone 可达且已尝试 stage 的 plugin id（``<plugin>@<marketplace>``）；
+    - ``restored_plugins``：clone 可达且已尝试 stage 的活跃 plugin id（``<plugin>@<marketplace>``）；
       **非**"保证注册了 SKILL"（manifest 损坏时 stage 内部降级，权威清单看 ``restored_skills``）。
     - ``restored_skills``：本轮成功注册/刷新的 SKILL name 权威清单。
     - ``remounted_servers``：阶段二经 hooks 成功重挂的 server name（由编排方填充；本模块函数留空）。
     - ``failed_marketplaces``：源不可达 / clone 缺失且重建失败 / known 记录缺失（降级、不阻断）。
-    - ``skipped_disabled``：``enabledPlugins[pid] = false`` 刻意跳过的 plugin id。
+    - ``skipped_disabled``：``installed_disabled``（安装意图在、``enabledPlugins`` absent/false）惰性跳过的 pid
+      （v0.3.0 缺省翻转，§2.4）。
+    - ``rematerialized``：意图有、账本缺 → 本轮重物化成功重建账本的 pid（§4.9 删除无损）。
     """
 
     restored_plugins: list[str] = field(default_factory=list)
@@ -65,6 +72,7 @@ class GovernanceRecoveryReport:
     remounted_servers: list[str] = field(default_factory=list)
     failed_marketplaces: list[str] = field(default_factory=list)
     skipped_disabled: list[str] = field(default_factory=list)
+    rematerialized: list[str] = field(default_factory=list)
 
 
 @dataclass(frozen=True, slots=True)
@@ -89,11 +97,11 @@ RegisterBundledServer = Callable[[MCPServerConfig, BundledServerRecord], Awaitab
 
 
 def _plugin_boot_active(declared: Mapping[str, Any], pid: str) -> bool:
-    """boot-active 门控：仅显式 ``enabledPlugins[pid] = false`` 视为禁用（缺省/true 皆启用，与 rust 逐字一致）。"""
+    """boot-active 门控：仅显式 ``enabledPlugins[pid] is True`` 激活（v0.3.0 缺省翻转——absent/false 均惰性，与 rust 逐字一致）。"""
     enabled = declared.get("enabledPlugins")
     if isinstance(enabled, Mapping):
-        return enabled.get(pid) is not False
-    return True
+        return enabled.get(pid) is True
+    return False
 
 
 def _split_pid(pid: str) -> tuple[str, str] | None:
@@ -102,6 +110,17 @@ def _split_pid(pid: str) -> tuple[str, str] | None:
     if not sep or not plugin or not marketplace:
         return None
     return plugin, marketplace
+
+
+def _ledger_materialized(records: Any) -> bool:
+    """某 pid 的账本记录是否仍有效物化（至少一条记录的 ``installPath`` 目录存在）/ Whether the ledger entry is live。"""
+    if not isinstance(records, list):
+        return False
+    for rec in records:
+        install_path = rec.get("installPath") if isinstance(rec, Mapping) else None
+        if isinstance(install_path, str) and install_path and Path(install_path).is_dir():
+            return True
+    return False
 
 
 async def recover_marketplace_skills(
@@ -113,38 +132,47 @@ async def recover_marketplace_skills(
     timeout: float = DEFAULT_GIT_TIMEOUT,
 ) -> GovernanceRecoveryReport:
     """
-    阶段一：从双账本恢复 enabled installed plugin 的 bundled SKILL（幂等、additive-only）/ Phase 1: restore skills。
+    阶段一：从安装意图恢复活跃 plugin 的 bundled SKILL + 重物化缺失账本（幂等、additive-only）/ Phase 1。
 
-    按 marketplace 分组 → :func:`stage_marketplace_skills`（``refresh=False`` 离线优先：clone 在则就地复用重扫，
-    缺失才尝试 clone）。降级判定与 rust 同构：stage 内部吞错，事后 clone 树仍缺 → 该 marketplace 入
-    ``failed_marketplaces``；known_marketplaces 缺记录 → 同样降级。**绝不抛、不阻断其余**。
+    安装集 = merged ``installedPlugins``（§4.8.1；意图缺失/空 → noop——账本只是派生缓存，不参与决策，§2.3）。
+    按 marketplace 分组 → :func:`stage_marketplace_skills`（``plugin_filter`` = **活跃**子集：installed ∧
+    ``enabledPlugins[pid] is True``；``refresh=False`` 离线优先：clone 在则就地复用重扫，缺失才尝试 clone）→
+    对账本缺失/installPath 全失效的 installed pid（含 installed_disabled）经
+    :func:`~a2c_smcp.computer.settings.installer.materialize_plugin` 重物化（§4.9 删除无损；失败 WARN 跳过）。
+    降级判定与 rust 同构：stage 内部吞错，事后 clone 树仍缺 → 该 marketplace 入 ``failed_marketplaces``；
+    known_marketplaces 缺记录 → 同样降级。**绝不抛、不阻断其余**。
 
     :param registry: 目标 :class:`SkillRegistry`（恢复注册进当前活跃集）。
     :param home: SKILL Home 绝对根。
-    :param declared: ``enabledPlugins`` 合并声明视图（权威启用门控）。
+    :param declared: 合并声明视图（取 ``installedPlugins`` + ``enabledPlugins`` 两键作权威门控）。
     :param env: 环境映射（账本路径解析 + git 子进程），默认 ``os.environ``。
     :param timeout: 单次 git 操作超时（仅 clone 缺失重建时可能触发）。
     """
     report = GovernanceRecoveryReport()
-    installed = load_installed_plugins(home=home, env=env).get("plugins", {})
-    if not installed:
+    intent = sorted(declared_installed_plugin_ids(declared))
+    if not intent:
         return report
+    ledger = load_installed_plugins(home=home, env=env).get("plugins", {})
     known = load_known_marketplaces(home=home, env=env).get("marketplaces", {})
 
-    # enabled installed plugin 按 marketplace 分组 / group boot-active plugins by marketplace.
-    by_marketplace: dict[str, set[str]] = {}
-    for pid in installed:
+    # installed pid 按 marketplace 分组（plugin → 是否活跃）/ group intent pids by marketplace.
+    by_marketplace: dict[str, dict[str, bool]] = {}
+    for pid in intent:
         split = _split_pid(pid)
-        if split is None:
-            logger.debug("governance recovery: plugin id %r has no '@marketplace' segment, skipped (local-only form)", pid)
+        if split is None:  # declared 经 schema 校验必有 @；防御保留
             continue
-        if not _plugin_boot_active(declared, pid):
+        active = _plugin_boot_active(declared, pid)
+        if not active:
             report.skipped_disabled.append(pid)
-            continue
         plugin, marketplace = split
-        by_marketplace.setdefault(marketplace, set()).add(plugin)
+        by_marketplace.setdefault(marketplace, {})[plugin] = active
 
     for marketplace, plugins in sorted(by_marketplace.items()):
+        active_plugins = {p for p, is_active in plugins.items() if is_active}
+        needs_materialize = sorted(p for p in plugins if not _ledger_materialized(ledger.get(f"{p}@{marketplace}")))
+        if not active_plugins and not needs_materialize:
+            continue  # 全惰性且账本完好 → 零动作（installed_disabled 静止态）
+
         record = known.get(marketplace)
         source = record.get("source") if isinstance(record, Mapping) else None
         if not isinstance(source, Mapping):
@@ -160,7 +188,7 @@ async def recover_marketplace_skills(
             source,
             registry,
             home,
-            plugin_filter=set(plugins),
+            plugin_filter=active_plugins,
             refresh=False,  # 离线优先：clone 在则零 git / offline-first
             timeout=timeout,
             env=env,
@@ -170,8 +198,18 @@ async def recover_marketplace_skills(
             logger.warning("governance recovery: marketplace %r clone missing and rebuild failed, degraded", marketplace)
             report.failed_marketplaces.append(marketplace)
             continue
+        # 重物化：意图有、账本缺（或 installPath 全失效）→ 由 (marketplace, plugin) 纯函数重建账本
+        # （§4.9 删除无损）。物化 ≠ 激活——installed_disabled 也重建（保 enable 廉价、账本可查询）；
+        # 冲突预检传 None（boot 无 live manager；重挂阶段自有 existing 名跳过护栏）。
+        for plugin in needs_materialize:
+            pid = f"{plugin}@{marketplace}"
+            try:
+                await materialize_plugin(pid, home, refresh=False, timeout=timeout, env=env)
+                report.rematerialized.append(pid)
+            except Exception as e:  # noqa: BLE001 - 失败降级铁律：WARN 跳过，不阻断 boot
+                logger.warning("governance recovery: re-materialize %r failed, degraded: %s", pid, e)
         report.restored_skills.extend(names)
-        report.restored_plugins.extend(sorted(f"{plugin}@{marketplace}" for plugin in plugins))
+        report.restored_plugins.extend(sorted(f"{plugin}@{marketplace}" for plugin in active_plugins))
 
     return report
 
@@ -186,22 +224,25 @@ def collect_enabled_bundled_servers(
     阶段二输入（纯读、无锁、无副作用）：枚举 enabled installed plugin 的 bundled MCP server / Phase-2 pure collect。
 
     协议 §4.8 blockquote 的"SDK MUST 使 enabled bundled server 可查询"落点：client 据此物化进自己的
-    MCP 配置模型，或经 :meth:`Computer.reconcile_governance` 传 hooks 显式重挂。跨 plugin/scope 同名
+    MCP 配置模型，或经 :meth:`Computer.reconcile_governance` 传 hooks 显式重挂。门控 = **installed ∧
+    enabled**（v0.3.0 §4.8.1：pid ∈ merged ``installedPlugins`` 且 ``enabledPlugins[pid] is True``；
+    ``installed_disabled`` 不可见——不进活跃投影，§2.4）。跨 plugin/scope 同名
     server **首见保留去重**（账本插入序，与 rust 一致）；``installPath`` 缺失 / bundled JSON 损坏 →
     WARN 跳过该记录，不阻断其余、不抛。
 
     :param home: SKILL Home 绝对根。
-    :param declared: ``enabledPlugins`` 合并声明视图。
+    :param declared: 合并声明视图（``installedPlugins`` + ``enabledPlugins`` 两键）。
     :param env: 环境映射（账本路径解析），默认 ``os.environ``。
     """
     out: list[BundledServerRecord] = []
     seen: set[str] = set()
+    intent = declared_installed_plugin_ids(declared)
     installed = load_installed_plugins(home=home, env=env).get("plugins", {})
     for pid, records in installed.items():
         split = _split_pid(pid)
         if split is None:
             continue
-        if not _plugin_boot_active(declared, pid):
+        if pid not in intent or not _plugin_boot_active(declared, pid):
             continue
         plugin, marketplace = split
         for record in records:

--- a/a2c_smcp/computer/settings/schema.py
+++ b/a2c_smcp/computer/settings/schema.py
@@ -61,6 +61,7 @@ class SettingsScope(StrEnum):
 # ---------------------------------------------------------------------------
 FIELD_SCHEMA = "$schema"
 FIELD_EXTRA_KNOWN_MARKETPLACES = "extraKnownMarketplaces"
+FIELD_INSTALLED_PLUGINS = "installedPlugins"
 FIELD_ENABLED_PLUGINS = "enabledPlugins"
 FIELD_STRICT_KNOWN_MARKETPLACES = "strictKnownMarketplaces"
 FIELD_TRUSTED_MARKETPLACES = "trustedMarketplaces"
@@ -162,6 +163,7 @@ class ComputerSettings(TypedDict, total=False):
     """
 
     extraKnownMarketplaces: dict[str, MarketplaceEntry]
+    installedPlugins: list[str]
     enabledPlugins: dict[str, bool]
     strictKnownMarketplaces: bool
     trustedMarketplaces: list[str]
@@ -223,6 +225,23 @@ def _validate_string_array(key: str, value: Any, scope: SettingsScope) -> tuple[
             cleaned.append(item)
         else:
             errors.append(_err(scope, f"{key}[{idx}]", f"expected string, got {type(item).__name__}"))
+    return cleaned, errors
+
+
+def _validate_installed_plugins(key: str, value: Any, scope: SettingsScope) -> tuple[Any, list[SettingsValidationError]]:
+    """``installedPlugins``（全局安装意图，协议 v0.3.0 §2.4）：字符串数组，元素须 ``<plugin>@<marketplace>`` 形态。"""
+    if not isinstance(value, list):
+        return _DROP, [_err(scope, key, f"expected array, got {type(value).__name__}")]
+    cleaned: list[str] = []
+    errors: list[SettingsValidationError] = []
+    for idx, item in enumerate(value):
+        if not isinstance(item, str):
+            errors.append(_err(scope, f"{key}[{idx}]", f"expected string, got {type(item).__name__}"))
+            continue
+        if not is_valid_enabled_plugin_key(item):
+            errors.append(_err(scope, f"{key}[{idx}]", "entry must be '<plugin>@<marketplace>' (strict kebab)"))
+            continue
+        cleaned.append(item)
     return cleaned, errors
 
 
@@ -306,6 +325,7 @@ def _validate_permissions(key: str, value: Any, scope: SettingsScope) -> tuple[A
 # 字段 → 校验器映射（缺席 = 未知字段，passthrough）/ field → validator map (absent = unknown, passthrough).
 _FIELD_VALIDATORS = {
     FIELD_EXTRA_KNOWN_MARKETPLACES: _validate_extra_marketplaces,
+    FIELD_INSTALLED_PLUGINS: _validate_installed_plugins,
     FIELD_ENABLED_PLUGINS: _validate_enabled_plugins,
     FIELD_STRICT_KNOWN_MARKETPLACES: _validate_bool,
     FIELD_TRUSTED_MARKETPLACES: _validate_string_array,

--- a/tests/integration_tests/computer/settings/test_installer.py
+++ b/tests/integration_tests/computer/settings/test_installer.py
@@ -12,9 +12,10 @@ SDK 设计 / Design: python-sdk docs/design-0.2.1-cli-marketplace-ux.md §4.3 / 
 
 测试意图 / Test intentions（本地 ``git init --bare`` 裸仓作 file:// 源，无网络；plugin 同时含
 ``skills/<s>/SKILL.md`` + ``mcp-servers/<n>.json``；MCP 注入用录制式替身捕获校验后的 MCPServerConfig）:
-- install 端到端：真 clone catalog → 注册 plugin skills + 解析 bundled server + 写 installed_plugins.json。
-- uninstall 端到端：删 installPath 树 + 注销 skills + 级联 remove server + 删账本记录。
-- install→disable→enable：**不重 clone**（哨兵保留）+ skill 复活 + server 重挂。
+- install 端到端（v0.3.0 #123 不激活）：真 clone catalog → 解析 bundled server + 写 installedPlugins 意图 +
+  installed_plugins.json；**不**注册 skills、不挂 server → enable 才原子点亮。
+- uninstall 端到端：删 installPath 树 + 注销 skills + 级联 remove server + 删账本记录 + 清双意图。
+- install→enable→disable→enable：**不重 clone**（哨兵保留）+ skill 复活 + server 重挂。
 """
 
 import json
@@ -113,6 +114,7 @@ async def _add_marketplace(home: Path, bare: Path, env: dict[str, str]) -> None:
 # ── install 端到端 / end-to-end ──────────────────────────────────────────────
 @requires_git
 async def test_install_end_to_end(tmp_path: Path) -> None:
+    """v0.3.0：install 端到端 = 真 clone 物化 + 双账写入，零激活；enable 才点亮 skills + server。"""
     bare = _make_bare(tmp_path, "acme", _plugin_files())
     home = _home(tmp_path)
     env = _env(home)
@@ -123,15 +125,20 @@ async def test_install_end_to_end(tmp_path: Path) -> None:
     async def _register(cfg) -> None:
         captured.append(cfg.name)
 
-    record = await install_plugin(
-        "audit@acme-skills", reg, home, env=env, existing_server_names=lambda: set(), register_server=_register,
-    )
+    record = await install_plugin("audit@acme-skills", reg, home, env=env, existing_server_names=lambda: set())
 
     assert record["bundledMcpServers"] == ["figma"]
     assert record["version"] == "1.2.0"
-    assert reg.resolve("audit:lint") is not None  # 真 skill 注册
-    assert captured == ["figma"]  # bundled server 解析+注册
+    assert reg.resolve("audit:lint") is None  # install ≠ activate：skill 不注册
     assert "audit@acme-skills" in load_installed_plugins(home=home)["plugins"]
+    settings = json.loads((home / "cfg" / "a2c" / "settings.json").read_text(encoding="utf-8"))
+    assert settings["installedPlugins"] == ["audit@acme-skills"]  # config-first 意图
+    assert "enabledPlugins" not in settings
+
+    # enable：真 staging 注册 skill + 重挂 server（原子点亮）
+    await enable_plugin("audit@acme-skills", reg, home, env=env, existing_server_names=lambda: set(), register_server=_register)
+    assert reg.resolve("audit:lint") is not None
+    assert captured == ["figma"]
 
 
 @requires_git
@@ -149,7 +156,8 @@ async def test_uninstall_end_to_end(tmp_path: Path) -> None:
     async def _remove(name: str) -> None:
         removed.append(name)
 
-    await install_plugin("audit@acme-skills", reg, home, env=env, existing_server_names=lambda: set(), register_server=_register)
+    await install_plugin("audit@acme-skills", reg, home, env=env, existing_server_names=lambda: set())
+    await enable_plugin("audit@acme-skills", reg, home, env=env, existing_server_names=lambda: set(), register_server=_register)
     install_path = Path(load_installed_plugins(home=home)["plugins"]["audit@acme-skills"][0]["installPath"])
     assert install_path.exists() and reg.resolve("audit:lint") is not None
 
@@ -160,10 +168,13 @@ async def test_uninstall_end_to_end(tmp_path: Path) -> None:
     assert not install_path.exists()  # installPath 树清除
     assert reg.resolve("audit:lint") is None  # skills 注销
     assert "audit@acme-skills" not in load_installed_plugins(home=home)["plugins"]  # 账本记录删除
+    settings = json.loads((home / "cfg" / "a2c" / "settings.json").read_text(encoding="utf-8"))
+    assert settings["installedPlugins"] == []  # 意图删除（回 available）
+    assert "audit@acme-skills" not in settings.get("enabledPlugins", {})  # enabled 条目清除
 
 
 @requires_git
-async def test_install_disable_enable_no_reclone(tmp_path: Path) -> None:
+async def test_install_enable_disable_enable_no_reclone(tmp_path: Path) -> None:
     bare = _make_bare(tmp_path, "acme", _plugin_files())
     home = _home(tmp_path)
     env = _env(home)
@@ -178,8 +189,10 @@ async def test_install_disable_enable_no_reclone(tmp_path: Path) -> None:
     async def _remove(name: str) -> None:
         removed.append(name)
 
-    await install_plugin("audit@acme-skills", reg, home, env=env, existing_server_names=lambda: set(), register_server=_register)
+    await install_plugin("audit@acme-skills", reg, home, env=env, existing_server_names=lambda: set())
+    await enable_plugin("audit@acme-skills", reg, home, env=env, existing_server_names=lambda: set(), register_server=_register)
     assert reg.resolve("audit:lint") is not None
+    captured.clear()
     # 哨兵：植入 catalog clone 内 plugin 根，用于检测 enable 是否误重 clone（重 clone 会 wipe）。
     sentinel = marketplace_skill_dir(home, "acme-skills") / "plugins" / "audit" / "SENTINEL"
     sentinel.write_text("x", encoding="utf-8")
@@ -187,7 +200,6 @@ async def test_install_disable_enable_no_reclone(tmp_path: Path) -> None:
     # disable：摘 server + orphan skill
     await disable_plugin("audit@acme-skills", reg, home, env=env, remove_server=_remove)
     assert reg.is_orphan("audit:lint") and removed == ["figma"]
-    captured.clear()
 
     # enable：复活 skill + 重挂 server，且不重 clone
     await enable_plugin("audit@acme-skills", reg, home, env=env, existing_server_names=lambda: set(), register_server=_register)
@@ -231,11 +243,12 @@ async def test_install_strict_false_conflict_hard_fails_atomically(tmp_path: Pat
 
     # 早检拦截 → PluginInstallError（硬错误，conflicting manifests）
     with pytest.raises(PluginInstallError, match="conflicting manifests"):
-        await install_plugin(
-            "audit@acme-skills", reg, home, env=env, existing_server_names=lambda: set(), register_server=_register,
-        )
+        await install_plugin("audit@acme-skills", reg, home, env=env, existing_server_names=lambda: set())
 
-    # 原子失败：未挂 server、未注册 skill、未写 installed 记录
+    # 原子失败：未挂 server、未注册 skill、未写 installed 记录、意图回滚
     assert captured == []
     assert reg.resolve("audit:lint") is None
     assert "audit@acme-skills" not in load_installed_plugins(home=home)["plugins"]
+    settings_file = home / "cfg" / "a2c" / "settings.json"
+    if settings_file.exists():
+        assert "audit@acme-skills" not in json.loads(settings_file.read_text(encoding="utf-8")).get("installedPlugins", [])

--- a/tests/integration_tests/computer/settings/test_reconciler.py
+++ b/tests/integration_tests/computer/settings/test_reconciler.py
@@ -118,6 +118,7 @@ async def test_reconcile_clones_and_registers_only_enabled_plugin(tmp_path: Path
     reg = SkillRegistry()
     declared = {
         "extraKnownMarketplaces": {"acme-skills": {"source": _src(_url(bare))}},
+        "installedPlugins": ["audit@acme-skills", "fmt@acme-skills"],  # 两个都安装（v0.3.0 双意图）
         "enabledPlugins": {"audit@acme-skills": True},  # 仅启用 audit；fmt 不启用
     }
 
@@ -139,7 +140,7 @@ async def test_reconcile_source_changed_switches_repo(tmp_path: Path) -> None:
     bare2 = _make_bare(tmp_path, "repo2", _one_plugin_files("p", "new-skill"))
     home = _home(tmp_path)
     reg = SkillRegistry()
-    enabled = {"enabledPlugins": {"p@acme-skills": True}}
+    enabled = {"installedPlugins": ["p@acme-skills"], "enabledPlugins": {"p@acme-skills": True}}
 
     await reconcile(reg, home, {"extraKnownMarketplaces": {"acme-skills": {"source": _src(_url(bare1))}}, **enabled}, env=_env(home))
     assert reg.resolve("p:old-skill") is not None
@@ -163,7 +164,11 @@ async def test_prune_removes_clone_tree_and_record(tmp_path: Path) -> None:
     await reconcile(
         reg,
         home,
-        {"extraKnownMarketplaces": {"acme-skills": {"source": _src(_url(bare))}}, "enabledPlugins": {"p@acme-skills": True}},
+        {
+            "extraKnownMarketplaces": {"acme-skills": {"source": _src(_url(bare))}},
+            "installedPlugins": ["p@acme-skills"],
+            "enabledPlugins": {"p@acme-skills": True},
+        },
         env=_env(home),
     )
     clone = marketplace_skill_dir(home, "acme-skills")

--- a/tests/unit_tests/computer/cli/test_plugin.py
+++ b/tests/unit_tests/computer/cli/test_plugin.py
@@ -10,9 +10,10 @@
 设计依据 / Design: python-sdk docs/design-0.2.1-cli-marketplace-ux.md §4.3 / §10.6（S16）。
 
 测试意图 / Test intentions（相对源 plugin → locate_plugin_root 无 git；monkeypatch stage；XDG 重定向隔离）:
-- install：happy（写账本 + 注册 bundled server）/ 外来同名硬抛退出码 1 + JSON error code / 非法 id 退出码 1；
+- install（v0.3.0 #123 不激活）：happy（写 installedPlugins 意图 + 账本；**不**挂 server、不 stage skills）/
+  外来同名硬抛退出码 1 + JSON error code / 非法 id 退出码 1；
 - enable/disable：**scope 从 ledger 读**（seed project scope → 写 project settings，不写 user）；
-- uninstall / list / info / gc 退出码与输出形态；
+- uninstall / list（默认列全部已安装，enabled 两态）/ info / gc（孤儿 = 账本 ∉ installedPlugins）退出码与输出形态；
 - ``_plugin_inject_inputs_cb``：读 ``mcp-servers/inputs.json`` → 前缀化 → 注入 fake comp 池（#69 Group A）。
 """
 
@@ -114,7 +115,10 @@ class _FakeMCP:
 
 # ── install ───────────────────────────────────────────────────────────────────
 @pytest.mark.asyncio
-async def test_install_happy_writes_ledger_and_registers_servers(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_install_happy_writes_intent_and_ledger_without_activation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str],
+) -> None:
+    """v0.3.0：install 只写 installedPlugins 意图 + 账本 → installed_disabled（无挂载、无 skills）。"""
     home, env, reg = _home(tmp_path), _env(tmp_path), SkillRegistry()
     _setup_catalog(home, "acme", "audit", servers=["figma-mcp"])
     monkeypatch.setattr(_STAGE, _fake_stage())
@@ -122,11 +126,15 @@ async def test_install_happy_writes_ledger_and_registers_servers(tmp_path: Path,
 
     code = await plugin_cmd.plugin_install(
         reg, home, env, "audit@acme",
-        existing_server_names=mcp.existing_names, register_server=mcp.register, json_output=True,
+        existing_server_names=mcp.existing_names, json_output=True,
     )
     assert code == 0
+    assert json.loads(capsys.readouterr().out)["state"] == "installed_disabled"
     assert "audit@acme" in load_installed_plugins(home=home, env=env)["plugins"]
-    assert [c.name for c in mcp.registered] == ["figma-mcp"]
+    user = json.loads(user_settings_path(env).read_text(encoding="utf-8"))
+    assert user["installedPlugins"] == ["audit@acme"]
+    assert "enabledPlugins" not in user  # 不激活、不写启用意图
+    assert len(reg) == 0  # skills 不投影
 
 
 @pytest.mark.asyncio
@@ -136,16 +144,19 @@ async def test_install_foreign_name_conflict_exit1_json_error(
     home, env, reg = _home(tmp_path), _env(tmp_path), SkillRegistry()
     _setup_catalog(home, "acme", "audit", servers=["figma-mcp"])
     monkeypatch.setattr(_STAGE, _fake_stage())
-    # 外来同名（已存在且非自有）→ 硬抛、退出码 1、不写账本（§10.6）
+    # 外来同名（已存在且非自有）→ 硬抛、退出码 1、不写账本/意图（§10.6 + v0.3.0 原子回滚）
     mcp = _FakeMCP(existing={"figma-mcp"})
 
     code = await plugin_cmd.plugin_install(
         reg, home, env, "audit@acme",
-        existing_server_names=mcp.existing_names, register_server=mcp.register, json_output=True,
+        existing_server_names=mcp.existing_names, json_output=True,
     )
     assert code == 1
     assert json.loads(capsys.readouterr().out)["error"] == "mcp_server_name_conflict"
     assert "audit@acme" not in load_installed_plugins(home=home, env=env)["plugins"]
+    user_file = user_settings_path(env)
+    if user_file.exists():
+        assert "audit@acme" not in json.loads(user_file.read_text(encoding="utf-8")).get("installedPlugins", [])
 
 
 @pytest.mark.asyncio
@@ -214,37 +225,49 @@ def test_list_and_info(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> No
         {"version": 1, "plugins": {"audit@acme": [{"scope": "user", "installPath": "/x", "bundledMcpServers": ["figma-mcp"]}]}},
         home=home,
     )
+    # v0.3.0 缺省翻转：无 enabledPlugins 条目 = installed_disabled——默认列表仍可见，但 enabled=False
     assert plugin_cmd.plugin_list(home, env, json_output=True) == 0
     rows = json.loads(capsys.readouterr().out)
-    assert rows[0]["id"] == "audit@acme" and rows[0]["enabled"] is True
+    assert rows[0]["id"] == "audit@acme" and rows[0]["enabled"] is False
     assert plugin_cmd.plugin_info(home, env, "audit@acme", json_output=True) == 0
     assert plugin_cmd.plugin_info(home, env, "ghost@acme", json_output=True) == 1
 
 
-def test_list_hides_disabled_unless_available(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+def test_list_shows_all_installed_with_enabled_flag(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """v0.3.0：默认 list 列全部已安装（install-only 必须可见）；enabled 列仅显式 true 为 ✓。"""
     home, env = _home(tmp_path), _env(tmp_path)
-    save_installed_plugins({"version": 1, "plugins": {"audit@acme": [{"scope": "user", "installPath": "/x"}]}}, home=home)
-    # 显式 disable
+    save_installed_plugins(
+        {
+            "version": 1,
+            "plugins": {
+                "audit@acme": [{"scope": "user", "installPath": "/x"}],
+                "fmt@acme": [{"scope": "user", "installPath": "/y"}],
+            },
+        },
+        home=home,
+    )
     from a2c_smcp.computer.settings.scope import apply_write
     from a2c_smcp.computer.settings.scope import user_settings_path as _usp
     from a2c_smcp.computer.settings.store import atomic_write_json
 
-    atomic_write_json(_usp(env), apply_write({}, {"enabledPlugins": {"audit@acme": False}}))
+    atomic_write_json(_usp(env), apply_write({}, {"enabledPlugins": {"audit@acme": False, "fmt@acme": True}}))
     plugin_cmd.plugin_list(home, env, json_output=True)
-    assert json.loads(capsys.readouterr().out) == []  # 默认隐藏 disabled
+    rows = {r["id"]: r["enabled"] for r in json.loads(capsys.readouterr().out)}
+    assert rows == {"audit@acme": False, "fmt@acme": True}  # disabled 不再被默认隐藏
     plugin_cmd.plugin_list(home, env, available=True, json_output=True)
-    assert json.loads(capsys.readouterr().out)[0]["enabled"] is False  # --available 含 disabled
+    rows_avail = {r["id"]: r["enabled"] for r in json.loads(capsys.readouterr().out)}
+    assert rows_avail == rows  # --available 兼容 no-op（旧"含 disabled"已成默认）
 
 
 @pytest.mark.asyncio
 async def test_gc_no_orphans(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     home, env, reg = _home(tmp_path), _env(tmp_path), SkillRegistry()
-    # enabledPlugins 声明 audit@acme（在 user settings）→ 非孤儿；installed 仅 audit@acme → 无孤儿
+    # v0.3.0：孤儿判据 = 账本 ∉ installedPlugins → user settings 声明安装意图 audit@acme → 非孤儿
     from a2c_smcp.computer.settings.scope import apply_write
     from a2c_smcp.computer.settings.scope import user_settings_path as _usp
     from a2c_smcp.computer.settings.store import atomic_write_json
 
-    atomic_write_json(_usp(env), apply_write({}, {"enabledPlugins": {"audit@acme": True}}))
+    atomic_write_json(_usp(env), apply_write({}, {"installedPlugins": ["audit@acme"]}))
     save_installed_plugins({"version": 1, "plugins": {"audit@acme": [{"scope": "user", "installPath": "/x"}]}}, home=home)
     assert await plugin_cmd.plugin_gc(reg, home, env, json_output=True) == 0
     assert json.loads(capsys.readouterr().out)["removed"] == []
@@ -301,16 +324,18 @@ class _ReplComp:
 
 
 @pytest.mark.asyncio
-async def test_repl_install_marks_dirty_and_fires_register(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_repl_install_is_lazy_no_mount_no_dirty(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """v0.3.0：REPL install 不激活——不挂载 bundled server、skills 无变化不 mark dirty；账本 + 意图照写。"""
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "cfg"))
     home, reg = _home(tmp_path), SkillRegistry()
     _setup_catalog(home, "acme", "audit", servers=["figma-mcp"])
     monkeypatch.setattr(_STAGE, _fake_stage())
     comp = _ReplComp(home, reg)
     await plugin_cmd.repl_dispatch(comp, ["plugin", "install", "audit@acme"], session=None)
-    assert comp.dirty == 1  # 成功 → 触发去抖 emit
+    assert comp.dirty == 0  # skills 无变化 → 不触发去抖 emit
     assert "audit@acme" in load_installed_plugins(home=home)["plugins"]
-    assert any(getattr(s, "name", None) == "figma-mcp" for s in comp._servers)  # register cb fired（实时挂载）
+    assert comp._servers == []  # 不实时挂载（enable 才点亮）
+    assert len(reg) == 0
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/computer/settings/test_install_enable_separation.py
+++ b/tests/unit_tests/computer/settings/test_install_enable_separation.py
@@ -487,6 +487,88 @@ async def test_migrate_writes_marker_even_with_empty_ledger_and_idempotent(tmp_p
     assert migrate_legacy_installs(home, env=env) == []  # 幂等
 
 
+# ── 隔离审查回归（fix-review：2🔴 + 覆盖空洞）─────────────────────────────────
+@pytest.mark.asyncio
+async def test_recover_rematerialize_failure_keeps_installed_disabled(tmp_path: Path) -> None:
+    """🔴#1：enabled + 账本缺 + 物化失败（bundled JSON 畸形）→ skills **不**进投影（无 rust-sdk#102 半态）、不抛。"""
+    home = _home(tmp_path)
+    plugin_root = _setup_catalog(home, "acme", "audit", skills=["lint"])
+    (plugin_root / "mcp-servers").mkdir(parents=True, exist_ok=True)
+    (plugin_root / "mcp-servers" / "bad.json").write_text("{not json", encoding="utf-8")
+    reg = SkillRegistry()
+    declared = {"installedPlugins": [_PID], "enabledPlugins": {_PID: True}}
+
+    report = await recover_marketplace_skills(reg, home, declared, env=_env(tmp_path))
+
+    assert report.rematerialized == []
+    assert report.restored_skills == [] and report.restored_plugins == []  # 整体保持 installed_disabled
+    assert reg.resolve("audit:lint") is None  # skill 不亮（半态防御）
+    assert _PID not in load_installed_plugins(home=home)["plugins"]  # 账本未重建
+
+
+@pytest.mark.asyncio
+async def test_headless_install_before_first_boot_preserves_legacy_actives(tmp_path: Path, monkeypatch) -> None:
+    """🔴#2：升级后未经 boot 的 headless install 不得抢写迁移标记——install 前置迁移保住 v0.2.x 存量活跃态。"""
+    monkeypatch.chdir(tmp_path)
+    home = _home(tmp_path)
+    env = _env(tmp_path)
+    root = _setup_catalog(home, "acme", "audit", skills=["lint"])
+    _seed_installed(home, {"legacy@acme": [_record(root)]})  # v0.2.x 存量（settings 全无）
+    monkeypatch.setattr(_STAGE, _fake_stage([]))
+
+    await install_plugin(_PID, SkillRegistry(), home, env=env)
+
+    settings = _read_user_settings(env)
+    assert settings["installedPlugins"] == ["legacy@acme", _PID]  # 迁移先行，存量未丢
+    assert settings["enabledPlugins"] == {"legacy@acme": True}  # 存量保活跃；新装不写 enabled
+
+
+@pytest.mark.asyncio
+async def test_uninstall_scoped_keeps_intent_for_remaining_scopes(tmp_path: Path, monkeypatch) -> None:
+    """🟡#5：指定 scope 卸载且其余 scope 记录仍在 → installedPlugins 与 enabledPlugins 条目保留（§2.4）。"""
+    home = _home(tmp_path)
+    env = _env(tmp_path)
+    root = _setup_catalog(home, "acme", "audit")
+    workdir = tmp_path / "proj"
+    workdir.mkdir()
+    _seed_installed(
+        home,
+        {_PID: [_record(root), {**_record(root), "scope": "project", "projectPath": str(workdir)}]},
+    )
+    _write_json(user_settings_path(env), {"installedPlugins": [_PID], "enabledPlugins": {_PID: True}})
+    monkeypatch.setattr(_STAGE, _fake_stage([]))
+
+    ok = await uninstall_plugin(_PID, SkillRegistry(), home, env=env, scope="project", keep_servers=True)
+
+    assert ok is True
+    remaining = load_installed_plugins(home=home)["plugins"][_PID]
+    assert [r["scope"] for r in remaining] == ["user"]  # 仅删 project 记录
+    settings = _read_user_settings(env)
+    assert settings["installedPlugins"] == [_PID]  # 安装事实未消失 → 意图保留
+    assert settings["enabledPlugins"][_PID] is True  # enabled 条目保留
+
+
+@pytest.mark.asyncio
+async def test_enable_mount_failure_restores_previous_true(tmp_path: Path, monkeypatch) -> None:
+    """🟡#6：enable 失败且原值为显式 true（重复 enable / 另一 scope 已启用）→ 恢复 true，不误删。"""
+    home = _home(tmp_path)
+    env = _env(tmp_path)
+    root = _setup_catalog(home, "acme", "audit", servers=["alpha", "beta"], skills=["lint"])
+    _seed_installed(home, {_PID: [_record(root, servers=["alpha", "beta"])]})
+    _write_json(user_settings_path(env), {"installedPlugins": [_PID], "enabledPlugins": {_PID: True}})
+    monkeypatch.setattr(_STAGE, _fake_stage([]))
+    mcp = _FakeMCP()
+    mcp.fail_on = "beta"
+
+    with pytest.raises(RuntimeError, match="beta"):
+        await enable_plugin(
+            _PID, SkillRegistry(), home, env=env,
+            existing_server_names=mcp.existing_names, register_server=mcp.register, remove_server=mcp.remove,
+        )
+
+    assert _read_user_settings(env)["enabledPlugins"][_PID] is True
+
+
 # ── schema：installedPlugins 字段校验 ─────────────────────────────────────────
 def test_schema_validates_installed_plugins_entries() -> None:
     """installedPlugins：数组元素须 ``<plugin>@<marketplace>`` 形态；非法条目过滤 + 记错（容错风格）。"""

--- a/tests/unit_tests/computer/settings/test_install_enable_separation.py
+++ b/tests/unit_tests/computer/settings/test_install_enable_separation.py
@@ -1,0 +1,505 @@
+# -*- coding: utf-8 -*-
+# filename: test_install_enable_separation.py
+# @Time    : 2026/07/07
+# @Author  : JQQ
+# @Email   : jqq1716@gmail.com
+# @Software: PyCharm
+"""
+plugin install/enable 分离（#123，协议 v0.3.0 runtime-contract §2.3/§2.4/§4.8）/ install ⊥ enable separation。
+
+TDD 目标行为用例（settings 层；对应 conformance-tests §5「install ≠ activate」「enable 原子激活」等新增条目）:
+- install：config-first 写 **user scope** ``installedPlugins``（全局安装意图）+ 物化账本；**不激活**（不 stage
+  SKILL、不写 ``enabledPlugins``）→ ``installed_disabled``；物化失败**原子回滚**意图条目；冲突预检保留。
+- enable：挂载失败 MUST 回滚 ``installed_disabled``（``enabledPlugins`` 恢复原值 + 撤销本次 stage/register）。
+- uninstall：删 ``installedPlugins`` 条目 + 清 ``enabledPlugins`` 条目。
+- recovery：缺省翻转——活跃集 = 已安装（intent）∧ ``enabledPlugins`` 合并后 ``true``；absent/false 均惰性；
+  账本降级为派生缓存：intent 有、账本无 → boot 重物化（账本删除无损，§4.9）。
+- migrate_legacy_installs：一次性迁移（标记 = user settings ``installedPlugins`` 键存在；显式 false 不迁 true）。
+- schema：``installedPlugins`` 字段形态校验（非法条目过滤 + 记错）。
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import Sequence
+from pathlib import Path
+
+import pytest
+
+from a2c_smcp.computer.settings.installer import (
+    MCPServerNameConflictError,
+    enable_plugin,
+    install_plugin,
+    uninstall_plugin,
+)
+from a2c_smcp.computer.settings.recovery import (
+    collect_enabled_bundled_servers,
+    recover_marketplace_skills,
+)
+from a2c_smcp.computer.settings.schema import SettingsScope, validate_settings
+from a2c_smcp.computer.settings.scope import user_settings_path
+from a2c_smcp.computer.settings.store import load_installed_plugins, save_installed_plugins, save_known_marketplaces
+from a2c_smcp.computer.skills.home import SOURCE_MARKETPLACE, marketplace_skill_dir
+from a2c_smcp.computer.skills.registry import SkillRegistry
+
+_SRC = {"type": "git", "url": "https://example.com/acme.git"}
+_STAGE = "a2c_smcp.computer.settings.installer.stage_marketplace_skills"
+_PID = "audit@acme"
+
+
+# ── 辅助（与 test_installer.py / test_recovery.py 同构）/ helpers ─────────────
+def _home(tmp_path: Path) -> Path:
+    h = tmp_path / "skill-home"
+    h.mkdir()
+    return h
+
+
+def _env(tmp_path: Path) -> dict[str, str]:
+    """重定向 XDG_CONFIG_HOME → tmp，隔离 user settings.json 读写。"""
+    return {**os.environ, "XDG_CONFIG_HOME": str(tmp_path / "cfg")}
+
+
+def _write_json(path: Path, obj: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(obj), encoding="utf-8")
+
+
+def _read_user_settings(env: dict[str, str]) -> dict:
+    p = user_settings_path(env)
+    if not p.exists():
+        return {}
+    return json.loads(p.read_text(encoding="utf-8"))
+
+
+def _stdio(name: str, command: str = "node") -> dict:
+    return {"name": name, "type": "stdio", "server_parameters": {"command": command}}
+
+
+def _skill_md(name: str) -> str:
+    return f"---\nname: {name}\ndescription: a skill\nlicense: MIT\n---\n# {name}\nbody\n"
+
+
+def _setup_catalog(
+    home: Path,
+    mp: str,
+    plugin: str,
+    *,
+    servers: Sequence[str] = (),
+    skills: Sequence[str] = (),
+) -> Path:
+    """造 catalog 树 + marketplace.json + plugin 的 mcp-servers/、skills/，并 seed known_marketplaces。"""
+    catalog = marketplace_skill_dir(home, mp)
+    manifest = {
+        "name": mp,
+        "owner": {"name": "X"},
+        "metadata": {"pluginRoot": "./plugins"},
+        "plugins": [{"name": plugin, "source": plugin, "version": "1.2.0"}],
+    }
+    _write_json(catalog / ".tfrobot-plugin" / "marketplace.json", manifest)
+    plugin_root = catalog / "plugins" / plugin
+    plugin_root.mkdir(parents=True, exist_ok=True)
+    for sname in servers:
+        _write_json(plugin_root / "mcp-servers" / f"{sname}.json", _stdio(sname))
+    for sk in skills:
+        p = plugin_root / "skills" / sk / "SKILL.md"
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(_skill_md(sk), encoding="utf-8")
+    save_known_marketplaces(
+        {"version": 1, "marketplaces": {mp: {"source": _SRC, "installLocation": str(catalog.resolve()), "commitSha": "abc123"}}},
+        home=home,
+    )
+    return plugin_root
+
+
+def _record(plugin_root: Path, *, scope: str = "user", servers: Sequence[str] = ()) -> dict:
+    rec: dict = {
+        "scope": scope,
+        "installPath": str(plugin_root),
+        "version": "1.2.0",
+        "commitSha": "abc123",
+        "installedAt": "2026-07-06T00:00:00Z",
+    }
+    if servers:
+        rec["bundledMcpServers"] = list(servers)
+    return rec
+
+
+def _seed_installed(home: Path, plugins: dict[str, list[dict]]) -> None:
+    save_installed_plugins({"version": 1, "plugins": plugins}, home=home)
+
+
+def _fake_stage(calls: list[dict], *, fail: bool = False, register_skill: bool = True):
+    """替身 stage：记录入参；可选注册 ``<plugin>:lint``（供回滚断言）；可选抛错。"""
+
+    async def _stage(name, source, registry, home, *, plugin_filter=None, auto_update=False, refresh=False, timeout=0.0, env=None):
+        calls.append({"name": name, "plugin_filter": set(plugin_filter or ()), "refresh": refresh})
+        if register_skill:
+            for plugin in plugin_filter or set():
+                registry.register_or_update(
+                    {
+                        "name": f"{plugin}:lint",
+                        "source": f"{SOURCE_MARKETPLACE}:{name}",
+                        "path": str(marketplace_skill_dir(home, name).resolve()),
+                    },
+                )
+        if fail:
+            raise RuntimeError("stage boom")
+        return [f"{p}:lint" for p in plugin_filter or set()]
+
+    return _stage
+
+
+class _FakeMCP:
+    """记录 MCP 注入回调调用 / Records injected MCP callback invocations。"""
+
+    def __init__(self, existing: set[str] | None = None) -> None:
+        self.existing: set[str] = set(existing or ())
+        self.registered: list[str] = []
+        self.removed: list[str] = []
+        self.fail_on: str | None = None
+
+    def existing_names(self) -> set[str]:
+        return set(self.existing)
+
+    async def register(self, cfg) -> None:
+        if self.fail_on is not None and cfg.name == self.fail_on:
+            raise RuntimeError(f"register {cfg.name} boom")
+        self.registered.append(cfg.name)
+        self.existing.add(cfg.name)
+
+    async def remove(self, name: str) -> None:
+        self.removed.append(name)
+        self.existing.discard(name)
+
+
+# ── install：不激活 + config-first 意图（§2.4 操作表 install 行）─────────────
+@pytest.mark.asyncio
+async def test_install_only_writes_intent_and_ledger_without_activation(tmp_path: Path, monkeypatch) -> None:
+    """install-only：写 user ``installedPlugins`` + 账本；不 stage SKILL、不写 enabledPlugins → installed_disabled。"""
+    home = _home(tmp_path)
+    env = _env(tmp_path)
+    _setup_catalog(home, "acme", "audit", servers=["figma"], skills=["lint"])
+    calls: list[dict] = []
+    monkeypatch.setattr(_STAGE, _fake_stage(calls))
+    reg = SkillRegistry()
+
+    record = await install_plugin(_PID, reg, home, env=env)
+
+    # 物化照旧：账本 + bundled server 解析记录
+    assert record["bundledMcpServers"] == ["figma"]
+    assert _PID in load_installed_plugins(home=home)["plugins"]
+    # config-first：安装意图落 user scope settings.json
+    settings = _read_user_settings(env)
+    assert settings.get("installedPlugins") == [_PID]
+    # 不激活：SKILL 不 stage、enabledPlugins 不写（installed_disabled 惰性）
+    assert calls == []
+    assert len(reg) == 0
+    assert "enabledPlugins" not in settings
+
+
+@pytest.mark.asyncio
+async def test_install_project_scope_intent_still_lands_in_user_settings(tmp_path: Path, monkeypatch) -> None:
+    """安装是全局一次的事实：``--scope project`` 只影响账本记录，intent 仍写 user scope（决策 #1）。"""
+    home = _home(tmp_path)
+    env = _env(tmp_path)
+    workdir = tmp_path / "proj"
+    workdir.mkdir()
+    _setup_catalog(home, "acme", "audit", servers=[])
+    monkeypatch.setattr(_STAGE, _fake_stage([]))
+
+    record = await install_plugin(_PID, SkillRegistry(), home, scope="project", project_path=str(workdir), env=env)
+
+    assert record["scope"] == "project"
+    assert _read_user_settings(env).get("installedPlugins") == [_PID]
+    assert not (workdir / ".tfrobot" / "settings.json").exists()  # 意图不泄漏进项目文件
+
+
+@pytest.mark.asyncio
+async def test_install_materialize_failure_rolls_back_intent(tmp_path: Path, monkeypatch) -> None:
+    """物化失败（bundled JSON 畸形）→ 撤销刚写的 installedPlugins 条目 + 不写账本（决策 #3 原子回滚）。"""
+    home = _home(tmp_path)
+    env = _env(tmp_path)
+    plugin_root = _setup_catalog(home, "acme", "audit")
+    (plugin_root / "mcp-servers").mkdir(parents=True, exist_ok=True)
+    (plugin_root / "mcp-servers" / "bad.json").write_text("{not json", encoding="utf-8")
+    monkeypatch.setattr(_STAGE, _fake_stage([]))
+
+    with pytest.raises(Exception):  # noqa: B017 - PluginManifestError 或其包装均可
+        await install_plugin(_PID, SkillRegistry(), home, env=env)
+
+    assert _PID not in _read_user_settings(env).get("installedPlugins", [])
+    assert _PID not in load_installed_plugins(home=home)["plugins"]
+
+
+@pytest.mark.asyncio
+async def test_install_foreign_conflict_precheck_survives_separation(tmp_path: Path, monkeypatch) -> None:
+    """外来同名冲突预检保留（§2.4 install 行「预检 foreign MCP name 冲突」）：硬抛 + 意图/账本零变更。"""
+    home = _home(tmp_path)
+    env = _env(tmp_path)
+    _setup_catalog(home, "acme", "audit", servers=["figma"])
+    monkeypatch.setattr(_STAGE, _fake_stage([]))
+    mcp = _FakeMCP(existing={"figma"})
+
+    with pytest.raises(MCPServerNameConflictError, match="figma"):
+        await install_plugin(_PID, SkillRegistry(), home, env=env, existing_server_names=mcp.existing_names)
+
+    assert _PID not in _read_user_settings(env).get("installedPlugins", [])
+    assert _PID not in load_installed_plugins(home=home)["plugins"]
+
+
+# ── enable：原子激活失败回滚（§2.4「enable 原子性」blockquote）────────────────
+@pytest.mark.asyncio
+async def test_enable_mount_failure_rolls_back_to_installed_disabled(tmp_path: Path, monkeypatch) -> None:
+    """enable 挂载失败 → 回滚 installed_disabled：enabledPlugins 恢复 absent、本次 stage/register 全撤销。"""
+    home = _home(tmp_path)
+    env = _env(tmp_path)
+    root = _setup_catalog(home, "acme", "audit", servers=["alpha", "beta"], skills=["lint"])
+    _seed_installed(home, {_PID: [_record(root, servers=["alpha", "beta"])]})
+    _write_json(user_settings_path(env), {"installedPlugins": [_PID]})
+    calls: list[dict] = []
+    monkeypatch.setattr(_STAGE, _fake_stage(calls))
+    mcp = _FakeMCP()
+    mcp.fail_on = "beta"
+    reg = SkillRegistry()
+
+    with pytest.raises(RuntimeError, match="beta"):
+        await enable_plugin(
+            _PID, reg, home, env=env,
+            existing_server_names=mcp.existing_names, register_server=mcp.register, remove_server=mcp.remove,
+        )
+
+    settings = _read_user_settings(env)
+    assert _PID not in settings.get("enabledPlugins", {})  # 原 absent → 回滚删键
+    assert mcp.removed == ["alpha"]  # 已挂 alpha 撤销
+    assert reg.resolve("audit:lint") is None  # 本次 stage 的 skill 撤销
+    assert settings.get("installedPlugins") == [_PID]  # installation 保留
+
+
+@pytest.mark.asyncio
+async def test_enable_mount_failure_restores_previous_false(tmp_path: Path, monkeypatch) -> None:
+    """enable 失败且原值为显式 false → 恢复 false（不残留 true、不误删原禁用意图）。"""
+    home = _home(tmp_path)
+    env = _env(tmp_path)
+    root = _setup_catalog(home, "acme", "audit", servers=["figma"], skills=["lint"])
+    _seed_installed(home, {_PID: [_record(root, servers=["figma"])]})
+    _write_json(user_settings_path(env), {"installedPlugins": [_PID], "enabledPlugins": {_PID: False}})
+    monkeypatch.setattr(_STAGE, _fake_stage([]))
+    mcp = _FakeMCP()
+    mcp.fail_on = "figma"
+
+    with pytest.raises(RuntimeError, match="figma"):
+        await enable_plugin(
+            _PID, SkillRegistry(), home, env=env,
+            existing_server_names=mcp.existing_names, register_server=mcp.register, remove_server=mcp.remove,
+        )
+
+    assert _read_user_settings(env)["enabledPlugins"][_PID] is False
+
+
+# ── uninstall：删意图 + 清 enabled 条目（§2.4 uninstall 行）───────────────────
+@pytest.mark.asyncio
+async def test_uninstall_clears_intent_and_enabled_entries(tmp_path: Path, monkeypatch) -> None:
+    """uninstall → installedPlugins 删 pid + enabledPlugins 清条目 + 账本删除（回 available）。"""
+    home = _home(tmp_path)
+    env = _env(tmp_path)
+    root = _setup_catalog(home, "acme", "audit", servers=["figma"], skills=["lint"])
+    _seed_installed(home, {_PID: [_record(root, servers=["figma"])]})
+    _write_json(user_settings_path(env), {"installedPlugins": [_PID], "enabledPlugins": {_PID: True}})
+    monkeypatch.setattr(_STAGE, _fake_stage([]))
+    mcp = _FakeMCP()
+
+    ok = await uninstall_plugin(_PID, SkillRegistry(), home, env=env, remove_server=mcp.remove)
+
+    assert ok is True
+    settings = _read_user_settings(env)
+    assert settings.get("installedPlugins") == []
+    assert _PID not in settings.get("enabledPlugins", {})
+    assert _PID not in load_installed_plugins(home=home)["plugins"]
+
+
+# ── recovery：缺省翻转 + 活跃集 = installed ∧ enabled（§4.8.1）────────────────
+@pytest.mark.asyncio
+async def test_recover_installed_without_enabled_is_lazy(tmp_path: Path) -> None:
+    """installed_disabled（intent 有、enabledPlugins absent）→ 惰性：不 stage、入 skipped_disabled（缺省翻转）。"""
+    home = _home(tmp_path)
+    root = _setup_catalog(home, "acme", "audit", skills=["lint"])
+    _seed_installed(home, {_PID: [_record(root)]})
+    reg = SkillRegistry()
+
+    report = await recover_marketplace_skills(reg, home, {"installedPlugins": [_PID]}, env=_env(tmp_path))
+
+    assert report.restored_plugins == [] and report.restored_skills == []
+    assert report.skipped_disabled == [_PID]
+    assert reg.resolve("audit:lint") is None
+
+
+@pytest.mark.asyncio
+async def test_recover_requires_intent_not_ledger(tmp_path: Path) -> None:
+    """账本有、intent 无（孤儿派生缓存）→ 即使 enabledPlugins=true 也不激活（活跃集 = installed ∧ enabled）。"""
+    home = _home(tmp_path)
+    root = _setup_catalog(home, "acme", "audit", skills=["lint"])
+    _seed_installed(home, {_PID: [_record(root)]})
+    reg = SkillRegistry()
+    declared = {"installedPlugins": [], "enabledPlugins": {_PID: True}}
+
+    report = await recover_marketplace_skills(reg, home, declared, env=_env(tmp_path))
+
+    assert report.restored_plugins == [] and report.restored_skills == []
+    assert reg.resolve("audit:lint") is None
+    assert collect_enabled_bundled_servers(home, declared, env=_env(tmp_path)) == []
+
+
+@pytest.mark.asyncio
+async def test_recover_installed_and_enabled_restores(tmp_path: Path) -> None:
+    """installed_enabled（intent 含 ∧ enabledPlugins=true）→ SKILL 恢复（正向契约不变）。"""
+    home = _home(tmp_path)
+    root = _setup_catalog(home, "acme", "audit", skills=["lint"])
+    _seed_installed(home, {_PID: [_record(root)]})
+    reg = SkillRegistry()
+    declared = {"installedPlugins": [_PID], "enabledPlugins": {_PID: True}}
+
+    report = await recover_marketplace_skills(reg, home, declared, env=_env(tmp_path))
+
+    assert _PID in report.restored_plugins
+    assert "audit:lint" in report.restored_skills
+    assert reg.resolve("audit:lint") is not None
+
+
+@pytest.mark.asyncio
+async def test_recover_rematerializes_missing_ledger_from_intent(tmp_path: Path) -> None:
+    """账本删除 → boot 从 installedPlugins 重物化重建（§4.9「删除无损」；conformance §5 账本删除条目）。"""
+    home = _home(tmp_path)
+    _setup_catalog(home, "acme", "audit", servers=["figma"], skills=["lint"])  # 账本刻意不 seed
+    reg = SkillRegistry()
+    declared = {"installedPlugins": [_PID], "enabledPlugins": {_PID: True}}
+
+    report = await recover_marketplace_skills(reg, home, declared, env=_env(tmp_path))
+
+    assert report.rematerialized == [_PID]
+    rebuilt = load_installed_plugins(home=home)["plugins"][_PID][0]
+    assert rebuilt["installPath"].replace("\\", "/").endswith("marketplace/acme/plugins/audit")
+    assert rebuilt["bundledMcpServers"] == ["figma"]
+    assert "audit:lint" in report.restored_skills  # enabled → 重物化后照常激活
+    assert collect_enabled_bundled_servers(home, declared, env=_env(tmp_path))[0].config.name == "figma"
+
+
+@pytest.mark.asyncio
+async def test_recover_rematerializes_disabled_installs_without_activation(tmp_path: Path) -> None:
+    """installed_disabled 的重物化也执行（installed = materialized 不变量；enable 无需重 clone），但不激活。"""
+    home = _home(tmp_path)
+    _setup_catalog(home, "acme", "audit", servers=["figma"], skills=["lint"])
+    reg = SkillRegistry()
+    declared = {"installedPlugins": [_PID]}
+
+    report = await recover_marketplace_skills(reg, home, declared, env=_env(tmp_path))
+
+    assert report.rematerialized == [_PID]
+    assert _PID in load_installed_plugins(home=home)["plugins"]  # 账本重建
+    assert report.restored_skills == [] and reg.resolve("audit:lint") is None  # 仍惰性
+    assert report.skipped_disabled == [_PID]
+
+
+def test_collect_gates_on_installed_and_enabled(tmp_path: Path) -> None:
+    """collect：intent 有但未启用 → 空；installed ∧ true → 可查询（§4.8 blockquote 的 enabled 门槛翻转）。"""
+    home = _home(tmp_path)
+    root = _setup_catalog(home, "acme", "audit", servers=["figma"])
+    _seed_installed(home, {_PID: [_record(root, servers=["figma"])]})
+
+    assert collect_enabled_bundled_servers(home, {"installedPlugins": [_PID]}, env=_env(tmp_path)) == []
+    records = collect_enabled_bundled_servers(
+        home, {"installedPlugins": [_PID], "enabledPlugins": {_PID: True}}, env=_env(tmp_path),
+    )
+    assert [r.config.name for r in records] == ["figma"]
+
+
+# ── migrate_legacy_installs：一次性迁移（迁移指南「保住既有用户现状」）─────────
+# 红灯阶段函数尚不存在 → 函数内 import 使失败定位在单测粒度（绿灯后可上移模块顶）。
+@pytest.mark.asyncio
+async def test_migrate_writes_intent_and_enabled_true(tmp_path: Path, monkeypatch) -> None:
+    """v0.2.x 存量（账本有、settings 全无）→ 迁 installedPlugins + user enabledPlugins=true（保住活跃态）。"""
+    from a2c_smcp.computer.settings.installer import migrate_legacy_installs
+
+    monkeypatch.chdir(tmp_path)  # 隔离 project/local 层（#116 cwd 锚定）
+    home = _home(tmp_path)
+    env = _env(tmp_path)
+    root = _setup_catalog(home, "acme", "audit", skills=["lint"])
+    _seed_installed(home, {_PID: [_record(root)]})
+
+    migrated = migrate_legacy_installs(home, env=env)
+
+    assert migrated == [_PID]
+    settings = _read_user_settings(env)
+    assert settings["installedPlugins"] == [_PID]
+    assert settings["enabledPlugins"][_PID] is True
+
+
+@pytest.mark.asyncio
+async def test_migrate_preserves_explicit_false(tmp_path: Path, monkeypatch) -> None:
+    """升级前显式 false（v0.2.x 已禁用）→ 迁 installedPlugins 但不写 true（保持 installed_disabled）。"""
+    from a2c_smcp.computer.settings.installer import migrate_legacy_installs
+
+    monkeypatch.chdir(tmp_path)
+    home = _home(tmp_path)
+    env = _env(tmp_path)
+    root = _setup_catalog(home, "acme", "audit")
+    _seed_installed(home, {_PID: [_record(root)]})
+    _write_json(user_settings_path(env), {"enabledPlugins": {_PID: False}})
+
+    migrate_legacy_installs(home, env=env)
+
+    settings = _read_user_settings(env)
+    assert settings["installedPlugins"] == [_PID]
+    assert settings["enabledPlugins"][_PID] is False
+
+
+@pytest.mark.asyncio
+async def test_migrate_noop_when_marker_present(tmp_path: Path, monkeypatch) -> None:
+    """user settings 已含 installedPlugins 键（哪怕空数组）= 已迁移 → 严格 no-op（决策 #2 防复活）。"""
+    from a2c_smcp.computer.settings.installer import migrate_legacy_installs
+
+    monkeypatch.chdir(tmp_path)
+    home = _home(tmp_path)
+    env = _env(tmp_path)
+    root = _setup_catalog(home, "acme", "audit")
+    _seed_installed(home, {_PID: [_record(root)]})  # 账本残留（如 intent 手动删除后未 gc）
+    _write_json(user_settings_path(env), {"installedPlugins": []})
+
+    migrated = migrate_legacy_installs(home, env=env)
+
+    assert migrated == []
+    settings = _read_user_settings(env)
+    assert settings["installedPlugins"] == []  # 不复活
+    assert "enabledPlugins" not in settings
+
+
+@pytest.mark.asyncio
+async def test_migrate_writes_marker_even_with_empty_ledger_and_idempotent(tmp_path: Path, monkeypatch) -> None:
+    """空账本首跑也写标记键（[]），二次调用 no-op（只跑一次机制自洽）。"""
+    from a2c_smcp.computer.settings.installer import migrate_legacy_installs
+
+    monkeypatch.chdir(tmp_path)
+    home = _home(tmp_path)
+    env = _env(tmp_path)
+
+    assert migrate_legacy_installs(home, env=env) == []
+    assert _read_user_settings(env)["installedPlugins"] == []
+    assert migrate_legacy_installs(home, env=env) == []  # 幂等
+
+
+# ── schema：installedPlugins 字段校验 ─────────────────────────────────────────
+def test_schema_validates_installed_plugins_entries() -> None:
+    """installedPlugins：数组元素须 ``<plugin>@<marketplace>`` 形态；非法条目过滤 + 记错（容错风格）。"""
+    cleaned, errors = validate_settings(
+        {"installedPlugins": ["audit@acme", "Bad Name", 42]},
+        SettingsScope.USER,
+    )
+    assert cleaned["installedPlugins"] == ["audit@acme"]
+    assert len(errors) == 2
+
+
+def test_schema_installed_plugins_whole_field_type_error_drops() -> None:
+    """整字段类型错（非数组）→ 判废回退（与其它已知字段同纪律）。"""
+    cleaned, errors = validate_settings({"installedPlugins": {"audit@acme": True}}, SettingsScope.USER)
+    assert "installedPlugins" not in cleaned
+    assert len(errors) == 1

--- a/tests/unit_tests/computer/settings/test_installer.py
+++ b/tests/unit_tests/computer/settings/test_installer.py
@@ -12,8 +12,9 @@ SDK 设计 / Design: python-sdk docs/design-0.2.1-cli-marketplace-ux.md §3.3/§
 
 测试意图 / Test intentions（不依赖 git——用相对路径 plugin（locate_plugin_root 无 git）+ monkeypatch
 ``stage_marketplace_skills`` + 注入回调记录 MCP 调用；settings 写经 ``XDG_CONFIG_HOME`` 重定向隔离）:
-- install：外来同名硬抛+原子（零变更）/ 自有同名幂等 / happy 写账本+注册 / 过闸后失败补偿回滚
-  （register 失败 / stage 失败两路）/ ledger-only（无注入）/ 未添加 mp / catalog 未 clone / 非法 id。
+- install（v0.3.0 #123 不激活）：happy 写 installedPlugins 意图 + 账本（不 stage、不挂 server）/ 外来同名硬抛+
+  原子（零变更）/ 自有同名幂等 / 重装失败不丢既有意图与账本 / 未添加 mp / catalog 未 clone / 非法 id。
+  install-only 目标行为与回滚细节另见 test_install_enable_separation.py。
 - uninstall：级联 stop+remove + 注销 + 删记录 + 删 installPath 树 / --keep-servers / 未安装 no-op。
 - disable：写 enabledPlugins=false + 摘 server + orphan skill（可复原）/ scope 路由 / 非法 scope。
 - enable：写 true + 复活 skill + 重挂 server / 未安装抛 / 外来同名冲突且 settings 未写（原子）。
@@ -136,33 +137,34 @@ class _FakeMCP:
 
 
 # ── install ──────────────────────────────────────────────────────────────────
-async def test_install_happy_writes_ledger_and_registers(tmp_path: Path, monkeypatch) -> None:
+async def test_install_happy_writes_intent_and_ledger(tmp_path: Path, monkeypatch) -> None:
+    """happy：记录字段完整（scope/version/commitSha/installPath/bundled）+ 意图落 user；不激活（v0.3.0）。"""
     home = _home(tmp_path)
+    env = _env(tmp_path)
     _setup_catalog(home, "acme", "audit", servers=["figma"])
     calls: list[dict] = []
     monkeypatch.setattr(_STAGE, _fake_stage(calls))
     mcp = _FakeMCP()
     reg = SkillRegistry()
 
-    record = await install_plugin(
-        "audit@acme", reg, home, env=_env(tmp_path),
-        existing_server_names=mcp.existing_names, register_server=mcp.register, remove_server=mcp.remove,
-    )
+    record = await install_plugin("audit@acme", reg, home, env=env, existing_server_names=mcp.existing_names)
 
     assert record["scope"] == "user"
     assert record["version"] == "1.2.0"  # entry.version 胜
     assert record["commitSha"] == "abc123"
     assert record["bundledMcpServers"] == ["figma"]
     assert record["installPath"].replace("\\", "/").endswith("marketplace/acme/plugins/audit")
-    assert mcp.registered == ["figma"]
-    assert calls[0]["plugin_filter"] == {"audit"} and calls[0]["refresh"] is False
-    assert reg.resolve("audit:lint") is not None
+    assert calls == []  # 不 stage（install ≠ activate）
+    assert reg.resolve("audit:lint") is None
     ipf = load_installed_plugins(home=home)["plugins"]
     assert ipf["audit@acme"][0]["bundledMcpServers"] == ["figma"]
+    user = json.loads(user_settings_path(env).read_text(encoding="utf-8"))
+    assert user["installedPlugins"] == ["audit@acme"]
 
 
 async def test_install_foreign_conflict_is_atomic(tmp_path: Path, monkeypatch) -> None:
     home = _home(tmp_path)
+    env = _env(tmp_path)
     _setup_catalog(home, "acme", "audit", servers=["figma"])
     calls: list[dict] = []
     monkeypatch.setattr(_STAGE, _fake_stage(calls))
@@ -170,15 +172,13 @@ async def test_install_foreign_conflict_is_atomic(tmp_path: Path, monkeypatch) -
     reg = SkillRegistry()
 
     with pytest.raises(MCPServerNameConflictError, match="figma"):
-        await install_plugin(
-            "audit@acme", reg, home, env=_env(tmp_path),
-            existing_server_names=mcp.existing_names, register_server=mcp.register, remove_server=mcp.remove,
-        )
+        await install_plugin("audit@acme", reg, home, env=env, existing_server_names=mcp.existing_names)
 
-    assert mcp.registered == []  # 零注册
-    assert calls == []  # stage 未调用（冲突闸门在变更前）
+    assert calls == []  # stage 未调用
     assert reg.resolve("audit:lint") is None
     assert "audit@acme" not in load_installed_plugins(home=home)["plugins"]  # 不写账本
+    user = json.loads(user_settings_path(env).read_text(encoding="utf-8"))
+    assert user.get("installedPlugins", []) == []  # 意图原子回滚（零变更）
 
 
 async def test_install_own_same_name_is_idempotent(tmp_path: Path, monkeypatch) -> None:
@@ -189,51 +189,9 @@ async def test_install_own_same_name_is_idempotent(tmp_path: Path, monkeypatch) 
     mcp = _FakeMCP(existing={"figma"})  # figma 存在但归本 plugin 自有 → 不冲突
     reg = SkillRegistry()
 
-    record = await install_plugin(
-        "audit@acme", reg, home, env=_env(tmp_path),
-        existing_server_names=mcp.existing_names, register_server=mcp.register, remove_server=mcp.remove,
-    )
+    record = await install_plugin("audit@acme", reg, home, env=_env(tmp_path), existing_server_names=mcp.existing_names)
 
-    assert mcp.registered == ["figma"]  # 幂等再注册（overwrite 自有）
-    assert record["bundledMcpServers"] == ["figma"]
-
-
-async def test_install_rolls_back_on_server_register_failure(tmp_path: Path, monkeypatch) -> None:
-    home = _home(tmp_path)
-    _setup_catalog(home, "acme", "audit", servers=["alpha", "beta"])
-    calls: list[dict] = []
-    monkeypatch.setattr(_STAGE, _fake_stage(calls))
-    mcp = _FakeMCP()
-    mcp.fail_on = "beta"  # 第二个 server 注册失败
-    reg = SkillRegistry()
-
-    with pytest.raises(RuntimeError, match="beta"):
-        await install_plugin(
-            "audit@acme", reg, home, env=_env(tmp_path),
-            existing_server_names=mcp.existing_names, register_server=mcp.register, remove_server=mcp.remove,
-        )
-
-    assert mcp.removed == ["alpha"]  # 已注册的 alpha 被回滚移除
-    assert calls == []  # stage 在 server 循环之后 → 未到达
-    assert "audit@acme" not in load_installed_plugins(home=home)["plugins"]  # 账本未写
-
-
-async def test_install_rolls_back_on_stage_failure(tmp_path: Path, monkeypatch) -> None:
-    home = _home(tmp_path)
-    _setup_catalog(home, "acme", "audit", servers=["figma"])
-    monkeypatch.setattr(_STAGE, _fake_stage([], fail=True))  # stage 先注册 skill 再抛
-    mcp = _FakeMCP()
-    reg = SkillRegistry()
-
-    with pytest.raises(RuntimeError, match="stage boom"):
-        await install_plugin(
-            "audit@acme", reg, home, env=_env(tmp_path),
-            existing_server_names=mcp.existing_names, register_server=mcp.register, remove_server=mcp.remove,
-        )
-
-    assert mcp.registered == ["figma"] and mcp.removed == ["figma"]  # 注册后回滚移除
-    assert reg.resolve("audit:lint") is None  # 已注册 skill 回滚注销
-    assert "audit@acme" not in load_installed_plugins(home=home)["plugins"]
+    assert record["bundledMcpServers"] == ["figma"]  # 幂等重物化（自有同名放行）
 
 
 async def test_install_ledger_only_without_injection(tmp_path: Path, monkeypatch) -> None:
@@ -242,7 +200,7 @@ async def test_install_ledger_only_without_injection(tmp_path: Path, monkeypatch
     monkeypatch.setattr(_STAGE, _fake_stage([]))
     reg = SkillRegistry()
 
-    record = await install_plugin("audit@acme", reg, home, env=_env(tmp_path))  # 无注入
+    record = await install_plugin("audit@acme", reg, home, env=_env(tmp_path))  # 无注入 → 跳过冲突预检
 
     assert record["bundledMcpServers"] == ["figma"]  # 解析+记录（即使未注册 server）
     assert "audit@acme" in load_installed_plugins(home=home)["plugins"]
@@ -265,52 +223,42 @@ async def test_install_catalog_not_cloned_raises(tmp_path: Path) -> None:
         await install_plugin("audit@acme", SkillRegistry(), home)
 
 
-async def test_install_register_without_existing_names_raises(tmp_path: Path, monkeypatch) -> None:
-    """护栏：给了 register_server 但缺 existing_server_names → 抛（防冲突闸门被静默旁路）。"""
-    home = _home(tmp_path)
-    _setup_catalog(home, "acme", "audit", servers=["figma"])
-    monkeypatch.setattr(_STAGE, _fake_stage([]))
-    mcp = _FakeMCP()
-
-    with pytest.raises(PluginInstallError, match="existing_server_names is required"):
-        await install_plugin("audit@acme", SkillRegistry(), home, env=_env(tmp_path), register_server=mcp.register)
-
-
 async def test_install_reinstall_failure_preserves_existing(tmp_path: Path, monkeypatch) -> None:
-    """精确回滚：重装中途失败时，不误删此前已有的 skill / 不误摘自有 server（仅撤销本次新增）。"""
+    """重装失败原子性：物化中途失败时，既有安装意图 / 账本记录 / 活跃 skill 全不丢（仅撤销本次新增）。"""
     home = _home(tmp_path)
+    env = _env(tmp_path)
     mcp = _FakeMCP()
     reg = SkillRegistry()
-    await _install(home, tmp_path, monkeypatch, mcp, reg, servers=["figma"])  # 首装 figma + audit:lint
+    await _install(home, tmp_path, monkeypatch, mcp, reg, servers=["figma"])  # 首装+enable：figma + audit:lint 活跃
     assert reg.resolve("audit:lint") is not None and mcp.registered == ["figma"]
 
-    # 重装：plugin 新增一个会注册失败的 server（zeta）；owned={figma}、既有 skill audit:lint 活跃
+    # 重装：plugin 新增一个畸形 bundled JSON（zeta）→ 物化失败；意图/账本/live 态须保持首装状态
     plugin_root = marketplace_skill_dir(home, "acme") / "plugins" / "audit"
-    _write_json(plugin_root / "mcp-servers" / "zeta.json", _stdio("zeta"))
+    (plugin_root / "mcp-servers" / "zeta.json").write_text("{not json", encoding="utf-8")
     mcp.registered.clear()
     mcp.removed.clear()
-    mcp.fail_on = "zeta"
 
-    with pytest.raises(RuntimeError, match="zeta"):
-        await install_plugin(
-            "audit@acme", reg, home, env=_env(tmp_path),
-            existing_server_names=mcp.existing_names, register_server=mcp.register, remove_server=mcp.remove,
-        )
+    with pytest.raises(Exception, match="zeta"):
+        await install_plugin("audit@acme", reg, home, env=env, existing_server_names=mcp.existing_names)
 
     assert reg.resolve("audit:lint") is not None  # 既有 skill 未被误注销
-    assert mcp.removed == []  # 自有 figma 未被误摘（zeta 注册失败本就没进）
+    assert mcp.removed == []  # 自有 figma 未被误摘
     assert "figma" in mcp.existing  # figma 仍挂在 manager
     rec = load_installed_plugins(home=home)["plugins"]["audit@acme"][0]
     assert rec["bundledMcpServers"] == ["figma"]  # 账本仍为首装记录（本次失败未改写）
+    user = json.loads(user_settings_path(env).read_text(encoding="utf-8"))
+    assert user["installedPlugins"] == ["audit@acme"]  # 重装失败不误删既有意图（was_present → 不回滚）
 
 
 # ── uninstall ─────────────────────────────────────────────────────────────────
 async def _install(home: Path, tmp_path: Path, monkeypatch, mcp: _FakeMCP, reg: SkillRegistry, *, servers: list[str]) -> Path:
-    """安装一个 plugin（happy）作为 uninstall/disable/enable 的前置；返回 installPath。"""
+    """安装 + 启用一个 plugin 作为 uninstall/disable/enable 的活跃前置（v0.3.0 install 不激活，须显式 enable）。"""
     install_path = _setup_catalog(home, "acme", "audit", servers=servers)
     monkeypatch.setattr(_STAGE, _fake_stage([]))
-    await install_plugin(
-        "audit@acme", reg, home, env=_env(tmp_path),
+    env = _env(tmp_path)
+    await install_plugin("audit@acme", reg, home, env=env, existing_server_names=mcp.existing_names)
+    await enable_plugin(
+        "audit@acme", reg, home, env=env,
         existing_server_names=mcp.existing_names, register_server=mcp.register, remove_server=mcp.remove,
     )
     return install_path
@@ -318,29 +266,34 @@ async def _install(home: Path, tmp_path: Path, monkeypatch, mcp: _FakeMCP, reg: 
 
 async def test_uninstall_default_cascades(tmp_path: Path, monkeypatch) -> None:
     home = _home(tmp_path)
+    env = _env(tmp_path)
     mcp = _FakeMCP()
     reg = SkillRegistry()
     install_path = await _install(home, tmp_path, monkeypatch, mcp, reg, servers=["figma"])
     assert install_path.exists()
     mcp.removed.clear()
 
-    ok = await uninstall_plugin("audit@acme", reg, home, remove_server=mcp.remove)
+    ok = await uninstall_plugin("audit@acme", reg, home, env=env, remove_server=mcp.remove)
 
     assert ok is True
     assert mcp.removed == ["figma"]  # 级联 stop+remove
     assert reg.resolve("audit:lint") is None  # skills 注销
     assert "audit@acme" not in load_installed_plugins(home=home)["plugins"]  # 记录删除
     assert not install_path.exists()  # installPath 树清除
+    user = json.loads(user_settings_path(env).read_text(encoding="utf-8"))
+    assert user["installedPlugins"] == []  # v0.3.0：安装意图删除（回 available）
+    assert "audit@acme" not in user.get("enabledPlugins", {})  # enabledPlugins 条目清除
 
 
 async def test_uninstall_keep_servers_skips_teardown(tmp_path: Path, monkeypatch) -> None:
     home = _home(tmp_path)
+    env = _env(tmp_path)
     mcp = _FakeMCP()
     reg = SkillRegistry()
     await _install(home, tmp_path, monkeypatch, mcp, reg, servers=["figma"])
     mcp.removed.clear()
 
-    ok = await uninstall_plugin("audit@acme", reg, home, keep_servers=True, remove_server=mcp.remove)
+    ok = await uninstall_plugin("audit@acme", reg, home, env=env, keep_servers=True, remove_server=mcp.remove)
 
     assert ok is True
     assert mcp.removed == []  # 保留 server

--- a/tests/unit_tests/computer/settings/test_installer.py
+++ b/tests/unit_tests/computer/settings/test_installer.py
@@ -302,7 +302,9 @@ async def test_uninstall_keep_servers_skips_teardown(tmp_path: Path, monkeypatch
 
 
 async def test_uninstall_not_installed_is_noop(tmp_path: Path) -> None:
-    assert await uninstall_plugin("ghost@acme", SkillRegistry(), _home(tmp_path)) is False
+    env = _env(tmp_path)
+    assert await uninstall_plugin("ghost@acme", SkillRegistry(), _home(tmp_path), env=env) is False
+    assert not user_settings_path(env).exists()  # 真 no-op：零写盘（迁移不被 no-op 路径触发，审查 N1）
 
 
 # ── disable ───────────────────────────────────────────────────────────────────

--- a/tests/unit_tests/computer/settings/test_reconciler.py
+++ b/tests/unit_tests/computer/settings/test_reconciler.py
@@ -13,10 +13,11 @@ SDK 设计 / Design: python-sdk docs/design-0.2.1-cli-marketplace-ux.md §7.1/§
 测试意图 / Test intentions（不依赖 git——monkeypatch ``stage_marketplace_skills``，只验 reconciler 编排决策）:
 - 四分支：missing→clone(refresh=False) / sourceChanged→wipe+reclone / autoUpdate→pull(refresh=True) /
   orphan(materialized∖declared)→**完全不动**（stage 不被调用、物化记录不变）；附 up_to_date / failed。
-- plugin_filter 由 ``enabledPlugins`` 推导（仅 ``true`` 且属本 marketplace 的 plugin）。
-- 声明视图提取过滤非法 marketplace 名 / 非对象条目 / 非法 plugin key。
+- plugin_filter = installed ∧ ``enabledPlugins[id] is True``（v0.3.0 §4.8.1，#123）且属本 marketplace。
+- 声明视图提取过滤非法 marketplace 名 / 非对象条目 / 非法 pid 条目。
 - 孤儿清理：list/prune marketplace（clone 树 + 外部 plugin 树 + 物化条目 + Registry SKILL）；
-  list/gc plugin（installPath + 物化条目 + Registry SKILL + bundled MCP 回调）；installPath 越界守卫。
+  list/gc plugin（孤儿 = 账本 pid ∉ ``installedPlugins``；installPath + 物化条目 + Registry SKILL +
+  bundled MCP 回调）；installPath 越界守卫。
 """
 
 from collections.abc import Awaitable, Callable, Mapping
@@ -25,8 +26,8 @@ from typing import Any
 
 from a2c_smcp.computer.settings.reconciler import (
     ReconcileReport,
+    declared_installed_plugin_ids,
     declared_marketplace_names,
-    declared_plugin_ids,
     gc_plugins,
     list_orphan_marketplaces,
     list_orphan_plugins,
@@ -117,7 +118,11 @@ async def test_reconcile_missing_clones(tmp_path: Path, monkeypatch) -> None:
     home = _home(tmp_path)
     calls: list[dict[str, Any]] = []
     monkeypatch.setattr(_RECONCILER, _fake_stage(calls, skills=["audit:lint"]))
-    declared = {"extraKnownMarketplaces": {"acme": {"source": _SRC_A}}, "enabledPlugins": {"audit@acme": True}}
+    declared = {
+        "extraKnownMarketplaces": {"acme": {"source": _SRC_A}},
+        "installedPlugins": ["audit@acme"],
+        "enabledPlugins": {"audit@acme": True},
+    }
 
     report = await reconcile(SkillRegistry(), home, declared)
 
@@ -224,16 +229,19 @@ async def test_reconcile_failed_when_clone_absent_after_stage(tmp_path: Path, mo
     assert report.installed == [] and report.updated == []
 
 
-async def test_reconcile_plugin_filter_only_true_and_same_marketplace(tmp_path: Path, monkeypatch) -> None:
+async def test_reconcile_plugin_filter_installed_true_and_same_marketplace(tmp_path: Path, monkeypatch) -> None:
+    """plugin_filter = installed ∧ true ∧ 本 marketplace（v0.3.0：enabled 但未安装的 ghost 不入）。"""
     home = _home(tmp_path)
     calls: list[dict[str, Any]] = []
     monkeypatch.setattr(_RECONCILER, _fake_stage(calls))
     declared = {
         "extraKnownMarketplaces": {"acme": {"source": _SRC_A}},
+        "installedPlugins": ["audit@acme", "fmt@acme", "x@other"],
         "enabledPlugins": {
-            "audit@acme": True,  # 启用、本 mp → 入
-            "fmt@acme": False,  # 禁用 → 不入
-            "x@other": True,  # 启用但别的 mp → 不入
+            "audit@acme": True,  # installed ∧ 启用、本 mp → 入
+            "fmt@acme": False,  # installed 但禁用 → 不入
+            "x@other": True,  # installed ∧ 启用但别的 mp → 不入
+            "ghost@acme": True,  # 启用但**未安装** → 不入（活跃集 = installed ∧ enabled）
             "bad-key-no-at": True,  # 非法 key → 忽略
         },
     }
@@ -255,15 +263,16 @@ def test_declared_marketplace_names_filters_invalid() -> None:
     assert declared_marketplace_names(declared) == {"good-mp"}
 
 
-def test_declared_plugin_ids_filters_invalid() -> None:
-    declared = {"enabledPlugins": {"audit@acme": True, "disabled@acme": False, "no-at-sign": True}}
-    # 含 false（声明禁用，仍是"已声明"）；滤掉非法 key
-    assert declared_plugin_ids(declared) == {"audit@acme", "disabled@acme"}
+def test_declared_installed_plugin_ids_filters_invalid() -> None:
+    declared = {"installedPlugins": ["audit@acme", "disabled@acme", "no-at-sign", 42]}
+    # 安装意图集与 enablement 正交（禁用项仍"已安装"）；滤掉非法形态 / 非字符串条目
+    assert declared_installed_plugin_ids(declared) == {"audit@acme", "disabled@acme"}
 
 
 def test_declared_helpers_handle_missing_keys() -> None:
     assert declared_marketplace_names({}) == set()
-    assert declared_plugin_ids({}) == set()
+    assert declared_installed_plugin_ids({}) == set()
+    assert declared_installed_plugin_ids({"installedPlugins": "not-a-list"}) == set()
 
 
 # ── marketplace prune ───────────────────────────────────────────────────────
@@ -322,7 +331,8 @@ async def test_list_and_gc_plugins(tmp_path: Path) -> None:
     reg = SkillRegistry()
     _reg_skill(reg, "audit:lint", "acme", audit_path)
     _reg_skill(reg, "keep:do", "acme", keep_path)
-    declared = {"enabledPlugins": {"keep@acme": True}}  # audit 不再声明 → 孤儿
+    # v0.3.0：孤儿 = 账本 pid ∉ installedPlugins（enablement 正交、不参与判定）→ audit 不在安装意图 → 孤儿
+    declared = {"installedPlugins": ["keep@acme"], "enabledPlugins": {"keep@acme": True}}
 
     assert list_orphan_plugins(home, declared) == ["audit@acme"]
 

--- a/tests/unit_tests/computer/settings/test_recovery.py
+++ b/tests/unit_tests/computer/settings/test_recovery.py
@@ -5,13 +5,15 @@
 # @Email   : jqq1716@gmail.com
 # @Software: PyCharm
 """
-治理启动恢复单元测试（#117，协议 v0.2.3 §4.8）/ Governance boot-recovery unit tests。
+治理启动恢复单元测试（#117；#123 起对齐协议 v0.3.0 §4.8）/ Governance boot-recovery unit tests。
 
 镜像 rust-sdk recovery.rs 的 hermetic 套件（无 git、无网络：预置 catalog clone 树 + ``refresh=False``
-就地复用）。测试意图 / Test intentions:
-- ``recover_marketplace_skills``：enabled installed plugin 的 bundled SKILL 恢复 + 幂等；
-  ``enabledPlugins=false`` 跳过不复活（disable 负向）；账本无记录不恢复（uninstall 负向）；
+就地复用）。测试意图 / Test intentions（v0.3.0：安装集 = declared ``installedPlugins``；活跃 =
+installed ∧ ``enabledPlugins[pid] is True``，缺省翻转）:
+- ``recover_marketplace_skills``：installed ∧ enabled plugin 的 bundled SKILL 恢复 + 幂等；
+  absent/``false`` 惰性不复活（缺省翻转 + disable 负向）；意图无条目不恢复（uninstall 负向，账本仅派生缓存）；
   known_marketplaces 缺记录 / clone 缺失且源不可达 → ``failed_marketplaces`` 降级不抛；空 home noop。
+  重物化（账本删除重建）见 test_install_enable_separation.py。
 - ``collect_enabled_bundled_servers``：含归属（plugin/marketplace）纯函数输出（§4.8.3）；
   跨 plugin 同名 server 首见去重；installPath 缺失 / JSON 损坏 → WARN 跳过不阻断。
 """
@@ -116,21 +118,22 @@ def _record(plugin_root: Path, *, scope: str = "user", servers: Sequence[str] = 
 # ── recover_marketplace_skills ────────────────────────────────────────────────
 @pytest.mark.asyncio
 async def test_recover_restages_enabled_installed_plugin_and_idempotent(tmp_path: Path) -> None:
-    """enabled（缺省即启用）installed plugin → bundled SKILL 恢复进 Registry；二次调用幂等。"""
+    """installed ∧ enabled=true plugin → bundled SKILL 恢复进 Registry；二次调用幂等。"""
     home = _home(tmp_path)
     root = _setup_catalog(home, "acme", "audit", skills=["lint"])
     _seed_installed(home, {"audit@acme": [_record(root)]})
     reg = SkillRegistry()
+    declared = {"installedPlugins": ["audit@acme"], "enabledPlugins": {"audit@acme": True}}
 
-    report = await recover_marketplace_skills(reg, home, {"enabledPlugins": {}}, env=_env(tmp_path))
+    report = await recover_marketplace_skills(reg, home, declared, env=_env(tmp_path))
 
     assert "audit@acme" in report.restored_plugins
     assert "audit:lint" in report.restored_skills
     assert reg.resolve("audit:lint") is not None
     assert report.failed_marketplaces == [] and report.skipped_disabled == []
 
-    # 幂等：显式 true 亦启用；registry 不重复注册
-    report2 = await recover_marketplace_skills(reg, home, {"enabledPlugins": {"audit@acme": True}}, env=_env(tmp_path))
+    # 幂等：registry 不重复注册
+    report2 = await recover_marketplace_skills(reg, home, declared, env=_env(tmp_path))
     assert "audit:lint" in report2.restored_skills
     assert len(reg) == 1
 
@@ -142,7 +145,7 @@ async def test_recover_skips_disabled_plugin_and_collect_skips(tmp_path: Path) -
     root = _setup_catalog(home, "acme", "audit", servers=["figma"], skills=["lint"])
     _seed_installed(home, {"audit@acme": [_record(root, servers=["figma"])]})
     reg = SkillRegistry()
-    declared = {"enabledPlugins": {"audit@acme": False}}
+    declared = {"installedPlugins": ["audit@acme"], "enabledPlugins": {"audit@acme": False}}
 
     report = await recover_marketplace_skills(reg, home, declared, env=_env(tmp_path))
 
@@ -153,13 +156,14 @@ async def test_recover_skips_disabled_plugin_and_collect_skips(tmp_path: Path) -
 
 
 @pytest.mark.asyncio
-async def test_recover_without_ledger_record_is_noop(tmp_path: Path) -> None:
-    """账本无记录（uninstall 后）→ 即使 catalog 树仍在也不恢复（uninstall 负向；ledger 驱动）。"""
+async def test_recover_without_intent_is_noop(tmp_path: Path) -> None:
+    """安装意图无条目（uninstall 后）→ 即使 catalog 树 / 账本仍在也不恢复（意图是唯一权威，账本仅派生缓存）。"""
     home = _home(tmp_path)
-    _setup_catalog(home, "acme", "audit", skills=["lint"])  # 树在、账本空
+    root = _setup_catalog(home, "acme", "audit", skills=["lint"])  # 树在
+    _seed_installed(home, {"audit@acme": [_record(root)]})  # 账本残留（未 gc）
     reg = SkillRegistry()
 
-    report = await recover_marketplace_skills(reg, home, {}, env=_env(tmp_path))
+    report = await recover_marketplace_skills(reg, home, {"enabledPlugins": {"audit@acme": True}}, env=_env(tmp_path))
 
     assert report.restored_plugins == [] and report.restored_skills == []
     assert len(reg) == 0
@@ -172,8 +176,9 @@ async def test_recover_degrades_when_marketplace_record_absent(tmp_path: Path) -
     root = _setup_catalog(home, "acme", "audit", skills=["lint"], seed_known=False)
     _seed_installed(home, {"audit@acme": [_record(root)]})
     reg = SkillRegistry()
+    declared = {"installedPlugins": ["audit@acme"], "enabledPlugins": {"audit@acme": True}}
 
-    report = await recover_marketplace_skills(reg, home, {}, env=_env(tmp_path))
+    report = await recover_marketplace_skills(reg, home, declared, env=_env(tmp_path))
 
     assert report.failed_marketplaces == ["acme"]
     assert report.restored_skills == []
@@ -189,8 +194,9 @@ async def test_recover_degrades_when_clone_missing_and_unreachable(tmp_path: Pat
     )
     _seed_installed(home, {"audit@acme": [_record(tmp_path / "gone")]})
     reg = SkillRegistry()
+    declared = {"installedPlugins": ["audit@acme"], "enabledPlugins": {"audit@acme": True}}
 
-    report = await recover_marketplace_skills(reg, home, {}, env=_env(tmp_path))
+    report = await recover_marketplace_skills(reg, home, declared, env=_env(tmp_path))
 
     assert report.failed_marketplaces == ["acme"]
     assert report.restored_skills == []
@@ -219,11 +225,12 @@ async def test_recover_revives_orphaned_skill(tmp_path: Path) -> None:
     root = _setup_catalog(home, "acme", "audit", skills=["lint"])
     _seed_installed(home, {"audit@acme": [_record(root)]})
     reg = SkillRegistry()
-    await recover_marketplace_skills(reg, home, {}, env=_env(tmp_path))
+    declared = {"installedPlugins": ["audit@acme"], "enabledPlugins": {"audit@acme": True}}
+    await recover_marketplace_skills(reg, home, declared, env=_env(tmp_path))
     assert reg.mark_orphan("audit:lint") is True
     assert reg.resolve("audit:lint") is None  # 孤儿不可解析
 
-    report = await recover_marketplace_skills(reg, home, {}, env=_env(tmp_path))
+    report = await recover_marketplace_skills(reg, home, declared, env=_env(tmp_path))
 
     assert "audit:lint" in report.restored_skills
     assert reg.resolve("audit:lint") is not None  # 复活
@@ -245,13 +252,18 @@ async def test_recover_empty_home_is_noop(tmp_path: Path) -> None:
 
 
 # ── collect_enabled_bundled_servers ──────────────────────────────────────────
+def _declared_enabled(*pids: str) -> dict:
+    """installed ∧ enabled=true 的 declared 视图速造（v0.3.0 门控两键）。"""
+    return {"installedPlugins": list(pids), "enabledPlugins": {pid: True for pid in pids}}
+
+
 def test_collect_returns_enabled_bundled_servers_with_ownership(tmp_path: Path) -> None:
-    """enabled plugin 的 bundled server 可查询，且归属（plugin/marketplace/installPath）为纯函数输出（§4.8.3）。"""
+    """installed ∧ enabled plugin 的 bundled server 可查询，且归属（plugin/marketplace/installPath）为纯函数输出（§4.8.3）。"""
     home = _home(tmp_path)
     root = _setup_catalog(home, "acme", "audit", servers=["figma", "blender"])
     _seed_installed(home, {"audit@acme": [_record(root, servers=["figma", "blender"])]})
 
-    records = collect_enabled_bundled_servers(home, {}, env=_env(tmp_path))
+    records = collect_enabled_bundled_servers(home, _declared_enabled("audit@acme"), env=_env(tmp_path))
 
     assert {r.config.name for r in records} == {"figma", "blender"}
     for r in records:
@@ -270,7 +282,7 @@ def test_collect_dedupes_same_server_name_across_plugins(tmp_path: Path) -> None
         {"audit@acme": [_record(root_a, servers=["shared"])], "fmt@beta": [_record(root_b, servers=["shared"])]},
     )
 
-    records = collect_enabled_bundled_servers(home, {}, env=_env(tmp_path))
+    records = collect_enabled_bundled_servers(home, _declared_enabled("audit@acme", "fmt@beta"), env=_env(tmp_path))
 
     assert len(records) == 1
     assert records[0].config.name == "shared"
@@ -295,7 +307,7 @@ def test_collect_enumerates_multi_scope_records_with_dedup(tmp_path: Path) -> No
         },
     )
 
-    records = collect_enabled_bundled_servers(home, {}, env=_env(tmp_path))
+    records = collect_enabled_bundled_servers(home, _declared_enabled("audit@acme"), env=_env(tmp_path))
 
     assert {r.config.name for r in records} == {"figma", "extra"}
     figma = next(r for r in records if r.config.name == "figma")
@@ -321,6 +333,8 @@ def test_collect_skips_missing_install_path_and_corrupt_json(tmp_path: Path) -> 
         },
     )
 
-    records = collect_enabled_bundled_servers(home, {}, env=_env(tmp_path))
+    records = collect_enabled_bundled_servers(
+        home, _declared_enabled("audit@acme", "fmt@beta", "ghost@acme"), env=_env(tmp_path),
+    )
 
     assert {r.config.name for r in records} == {"figma"}

--- a/tests/unit_tests/computer/test_computer_governance_recovery.py
+++ b/tests/unit_tests/computer/test_computer_governance_recovery.py
@@ -27,6 +27,8 @@ from a2c_smcp.computer.settings.store import save_installed_plugins, save_known_
 from a2c_smcp.computer.skills.home import marketplace_skill_dir
 
 _SRC = {"type": "git", "url": "https://example.com/acme.git"}
+# v0.3.0（#123）：活跃 = installed ∧ enabledPlugins=true（缺省翻转）→ hooks 用例显式给足两键意图。
+_DECLARED_ENABLED = {"installedPlugins": ["audit@acme"], "enabledPlugins": {"audit@acme": True}}
 
 
 # ── fixture 辅助（与 test_recovery.py 同构）/ helpers ─────────────────────────
@@ -138,7 +140,7 @@ async def test_reconcile_governance_remounts_via_hooks_and_idempotent(tmp_path: 
             existing_server_names=lambda: set(),
             register_server=register,
             inject_inputs=inject,
-            declared={},
+            declared=_DECLARED_ENABLED,
         )
         assert report.remounted_servers == ["figma"]
         assert calls == [("figma", "audit", "acme")]
@@ -148,7 +150,7 @@ async def test_reconcile_governance_remounts_via_hooks_and_idempotent(tmp_path: 
             existing_server_names=lambda: set(),
             register_server=register,
             inject_inputs=inject,
-            declared={},
+            declared=_DECLARED_ENABLED,
         )
         assert report2.remounted_servers == ["figma"]  # 幂等：结果一致
 
@@ -173,7 +175,7 @@ async def test_reconcile_governance_injects_once_per_plugin_root(tmp_path: Path,
             existing_server_names=lambda: set(),
             register_server=register,
             inject_inputs=inject,
-            declared={},
+            declared=_DECLARED_ENABLED,
         )
         assert sorted(mounted) == ["blender", "figma"]
         assert sorted(report.remounted_servers) == ["blender", "figma"]
@@ -193,7 +195,7 @@ async def test_reconcile_governance_register_failure_non_blocking(tmp_path: Path
         report = await comp.reconcile_governance(
             existing_server_names=lambda: set(),
             register_server=register,
-            declared={},
+            declared=_DECLARED_ENABLED,
         )
         assert report.remounted_servers == []
         assert "audit:lint" in report.restored_skills
@@ -214,7 +216,7 @@ async def test_reconcile_governance_conflict_skips_existing_name(tmp_path: Path,
         report = await comp.reconcile_governance(
             existing_server_names=lambda: {"figma"},
             register_server=register,
-            declared={},
+            declared=_DECLARED_ENABLED,
         )
         assert calls == []
         assert report.remounted_servers == []

--- a/tests/unit_tests/computer/test_computer_install_enable_v030.py
+++ b/tests/unit_tests/computer/test_computer_install_enable_v030.py
@@ -1,0 +1,176 @@
+# -*- coding: utf-8 -*-
+# filename: test_computer_install_enable_v030.py
+# @Time    : 2026/07/07
+# @Author  : JQQ
+# @Email   : jqq1716@gmail.com
+# @Software: PyCharm
+"""
+Computer 级 install/enable 分离行为（#123，协议 v0.3.0 §2.4/§4.8）/ Computer-level v0.3.0 lifecycle tests。
+
+测试意图 / Test intentions（hermetic：预置 catalog 树 + 账本 + user settings，零 git 零网络）:
+- boot 一次性迁移：v0.2.x 存量（账本有、settings 无 installedPlugins 键）→ 迁 intent + enabledPlugins=true，
+  升级前活跃态保住（skills 恢复）；升级前显式 false → 迁 intent、保持禁用。
+- installed_disabled 重启惰性：标记键在、未启用 → boot 不投影（conformance §5「重启恢复（installed_disabled）」）。
+- installed_enabled 重启恢复：intent ∧ true → 能力重现（conformance §5「重启恢复（enabled）」）。
+- 标记键防复活：intent 空数组 + 账本残留 → 不迁回、不激活。
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Sequence
+from pathlib import Path
+
+import pytest
+
+from a2c_smcp.computer.computer import Computer
+from a2c_smcp.computer.settings.store import save_installed_plugins, save_known_marketplaces
+from a2c_smcp.computer.skills.home import marketplace_skill_dir
+
+_SRC = {"type": "git", "url": "https://example.com/acme.git"}
+_PID = "audit@acme"
+
+
+# ── fixture 辅助（与 test_computer_governance_recovery.py 同构）──────────────
+def _write_json(path: Path, obj: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(obj), encoding="utf-8")
+
+
+def _skill_md(name: str) -> str:
+    return f"---\nname: {name}\ndescription: a skill\nlicense: MIT\n---\n# {name}\nbody\n"
+
+
+def _seed_home(tmp_path: Path, *, servers: Sequence[str] = (), skills: Sequence[str] = ()) -> tuple[Path, Path]:
+    """预置 skill_home：catalog 树（acme/audit）+ known_marketplaces + installed 账本。返回 (home, plugin_root)。"""
+    home = tmp_path / "skill-home"
+    home.mkdir()
+    catalog = marketplace_skill_dir(home, "acme")
+    _write_json(
+        catalog / ".tfrobot-plugin" / "marketplace.json",
+        {
+            "name": "acme",
+            "owner": {"name": "X"},
+            "metadata": {"pluginRoot": "./plugins"},
+            "plugins": [{"name": "audit", "source": "audit", "version": "1.2.0"}],
+        },
+    )
+    plugin_root = catalog / "plugins" / "audit"
+    plugin_root.mkdir(parents=True, exist_ok=True)
+    for sname in servers:
+        _write_json(plugin_root / "mcp-servers" / f"{sname}.json", {"name": sname, "type": "stdio", "server_parameters": {"command": "node"}})
+    for sk in skills:
+        p = plugin_root / "skills" / sk / "SKILL.md"
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(_skill_md(sk), encoding="utf-8")
+    save_known_marketplaces(
+        {"version": 1, "marketplaces": {"acme": {"source": _SRC, "installLocation": str(catalog.resolve()), "commitSha": "abc123"}}},
+        home=home,
+    )
+    save_installed_plugins(
+        {
+            "version": 1,
+            "plugins": {
+                _PID: [
+                    {
+                        "scope": "user",
+                        "installPath": str(plugin_root),
+                        "version": "1.2.0",
+                        "commitSha": "abc123",
+                        "installedAt": "2026-07-06T00:00:00Z",
+                        "bundledMcpServers": list(servers),
+                    },
+                ],
+            },
+        },
+        home=home,
+    )
+    return home, plugin_root
+
+
+def _isolate_declared_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """隔离 declared 视图来源：XDG → tmp、cwd → tmp（防读真实 user/project settings）。"""
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "cfg"))
+    monkeypatch.chdir(tmp_path)
+
+
+def _user_settings_file(tmp_path: Path) -> Path:
+    return tmp_path / "cfg" / "a2c" / "settings.json"
+
+
+def _read_user_settings(tmp_path: Path) -> dict:
+    p = _user_settings_file(tmp_path)
+    return json.loads(p.read_text(encoding="utf-8")) if p.exists() else {}
+
+
+# ── boot 一次性迁移（迁移指南「保住既有用户现状」）────────────────────────────
+@pytest.mark.asyncio
+async def test_boot_migrates_legacy_ledger_installs_and_stays_active(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """v0.2.x 存量升级首个 boot：迁 installedPlugins + enabledPlugins=true，升级前活跃的 skills 保住。"""
+    _isolate_declared_env(tmp_path, monkeypatch)
+    home, _ = _seed_home(tmp_path, skills=["lint"])
+
+    async with Computer(name="t", skill_home=home) as comp:
+        names = {ref["name"] for ref in comp.get_skills()}
+        assert "audit:lint" in names
+
+    settings = _read_user_settings(tmp_path)
+    assert settings.get("installedPlugins") == [_PID]
+    assert settings.get("enabledPlugins", {}).get(_PID) is True
+
+
+@pytest.mark.asyncio
+async def test_boot_migration_preserves_explicit_false(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """升级前显式禁用（false）：迁 intent 但不翻 true，boot 后保持惰性。"""
+    _isolate_declared_env(tmp_path, monkeypatch)
+    home, _ = _seed_home(tmp_path, skills=["lint"])
+    _write_json(_user_settings_file(tmp_path), {"enabledPlugins": {_PID: False}})
+
+    async with Computer(name="t", skill_home=home) as comp:
+        names = {ref["name"] for ref in comp.get_skills()}
+        assert "audit:lint" not in names
+
+    settings = _read_user_settings(tmp_path)
+    assert settings.get("installedPlugins") == [_PID]
+    assert settings.get("enabledPlugins", {}).get(_PID) is False
+
+
+# ── 三态重启恢复（conformance §5）────────────────────────────────────────────
+@pytest.mark.asyncio
+async def test_boot_installed_disabled_stays_lazy(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """installed_disabled（intent 有、未启用）重启 → 仍惰性：skills 不进投影（缺省翻转生效）。"""
+    _isolate_declared_env(tmp_path, monkeypatch)
+    home, _ = _seed_home(tmp_path, skills=["lint"])
+    _write_json(_user_settings_file(tmp_path), {"installedPlugins": [_PID]})
+
+    async with Computer(name="t", skill_home=home) as comp:
+        names = {ref["name"] for ref in comp.get_skills()}
+        assert "audit:lint" not in names
+
+
+@pytest.mark.asyncio
+async def test_boot_installed_enabled_restores(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """installed_enabled（intent ∧ true）重启 → 能力重现（正向契约不变）。"""
+    _isolate_declared_env(tmp_path, monkeypatch)
+    home, _ = _seed_home(tmp_path, skills=["lint"])
+    _write_json(_user_settings_file(tmp_path), {"installedPlugins": [_PID], "enabledPlugins": {_PID: True}})
+
+    async with Computer(name="t", skill_home=home) as comp:
+        names = {ref["name"] for ref in comp.get_skills()}
+        assert "audit:lint" in names
+
+
+@pytest.mark.asyncio
+async def test_boot_marker_prevents_resurrection(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """intent 空数组（已迁移标记）+ 账本残留 → 不迁回、不激活（意图是唯一权威，账本只是派生缓存）。"""
+    _isolate_declared_env(tmp_path, monkeypatch)
+    home, _ = _seed_home(tmp_path, skills=["lint"])
+    _write_json(_user_settings_file(tmp_path), {"installedPlugins": []})
+
+    async with Computer(name="t", skill_home=home) as comp:
+        names = {ref["name"] for ref in comp.get_skills()}
+        assert "audit:lint" not in names
+
+    settings = _read_user_settings(tmp_path)
+    assert settings.get("installedPlugins") == []
+    assert "enabledPlugins" not in settings

--- a/tests/unit_tests/computer/test_computer_install_enable_v030.py
+++ b/tests/unit_tests/computer/test_computer_install_enable_v030.py
@@ -58,7 +58,8 @@ def _seed_home(tmp_path: Path, *, servers: Sequence[str] = (), skills: Sequence[
     plugin_root = catalog / "plugins" / "audit"
     plugin_root.mkdir(parents=True, exist_ok=True)
     for sname in servers:
-        _write_json(plugin_root / "mcp-servers" / f"{sname}.json", {"name": sname, "type": "stdio", "server_parameters": {"command": "node"}})
+        server_def = {"name": sname, "type": "stdio", "server_parameters": {"command": "node"}}
+        _write_json(plugin_root / "mcp-servers" / f"{sname}.json", server_def)
     for sk in skills:
         p = plugin_root / "skills" / sk / "SKILL.md"
         p.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/unit_tests/computer/test_computer_inventory.py
+++ b/tests/unit_tests/computer/test_computer_inventory.py
@@ -5,7 +5,7 @@
 # @Email   : jqq1716@gmail.com
 # @Software: PyCharm
 """
-Computer 级 MCP server 归属 + 活跃 inventory 查询测试（#121，协议 v0.2.3 §4.8；对齐 rust-sdk #97）。
+Computer 级 MCP server 归属 + 活跃 inventory 查询测试（#121，协议 §4.8；#123 起 enabled 门控 = installed ∧ true；对齐 rust-sdk #97）。
 
 测试意图 / Test intentions（hermetic：预置双账本 + catalog 树，零 git 零网络；fixture 与
 ``test_computer_governance_recovery.py`` 同构）:
@@ -152,12 +152,15 @@ async def test_inventory_excludes_uninstalled_plugin_server(tmp_path: Path, monk
     """卸载（账本移除该 plugin 记录）后以同一 home 重建 Computer → bundled server 不再出现。"""
     _isolate_declared_env(tmp_path, monkeypatch)
     home, _ = _seed_home(tmp_path, servers=["audit-mcp"])
+    # 未 boot（无迁移）→ 显式 seed v0.3.0 双意图（installed ∧ enabled）。
+    _write_json(tmp_path / "cfg" / "a2c" / "settings.json", {"installedPlugins": ["audit@acme"], "enabledPlugins": {"audit@acme": True}})
 
     # 卸载前：inventory 含 plugin bundled server（未 boot 亦可查询——纯函数投影）。
     comp_a = Computer(name="a", skill_home=home)
     assert any(e.name == "audit-mcp" for e in comp_a.list_mcp_servers_with_metadata())
 
-    # 卸载效果 = installed_plugins.json 移除记录（uninstall 的账本落点）。
+    # 卸载的账本落点 = installed_plugins.json 移除记录（v0.3.0 意图条目亦会删；此处仅移账本即须熄灯——
+    # 无记录 = 无 config 可投影）。
     save_installed_plugins({"version": 1, "plugins": {}}, home=home)
 
     comp_b = Computer(name="b", skill_home=home)
@@ -221,7 +224,7 @@ async def test_inventory_marks_remounted_bundled_server_as_plugin(tmp_path: Path
         report = await comp.reconcile_governance(
             existing_server_names=lambda: {c.name for c in comp.mcp_servers},
             register_server=register,
-            declared={},
+            declared={"installedPlugins": ["audit@acme"], "enabledPlugins": {"audit@acme": True}},
         )
         assert report.remounted_servers == ["audit-mcp"]
 
@@ -235,6 +238,8 @@ async def test_inventory_passes_through_bundled_disabled_flag(tmp_path: Path, mo
     """bundled server 定义自带 ``disabled=true`` → 源二（未物化补入）disabled 旗透传。"""
     _isolate_declared_env(tmp_path, monkeypatch)
     home, _ = _seed_home(tmp_path, disabled_servers=["audit-mcp"])
+    # 未 boot（无迁移）→ 显式 seed v0.3.0 双意图。
+    _write_json(tmp_path / "cfg" / "a2c" / "settings.json", {"installedPlugins": ["audit@acme"], "enabledPlugins": {"audit@acme": True}})
 
     comp = Computer(name="t", skill_home=home)
     entry = next(e for e in comp.list_mcp_servers_with_metadata() if e.name == "audit-mcp")


### PR DESCRIPTION
## 概要

实现 python-sdk#123：plugin **install ⊥ enable 分离**，对齐 a2c-smcp-protocol **v0.3.0**（`0.3.0-dev`）`runtime-contract.md` §2.1/§2.3/§2.4/§4.8/§4.9（协议裁决 protocol#11 / 讨论 #120；rust 镜像 rust-sdk#103）。**破坏性行为变更**。

## 目标模型

| 状态 | `installedPlugins` | `enabledPlugins`（合并后） | 投影 |
|---|---|---|---|
| available | 不含 | — | 无 |
| installed_disabled | 含 | absent 或 `false` | 无（惰性） |
| installed_enabled | 含 | `true` | skills + bundled server 一并 |

## 变更点

- **schema**：新增 `installedPlugins`（全局安装意图，`<plugin>@<marketplace>` 数组）+ 形态校验；merged 读取天然并集。
- **installer**：
  - `install_plugin` = cheap 预检 → 一次性迁移前置 → config-first 写 **user scope** `installedPlugins` → `materialize_plugin`（新拆分：clone/manifest/冲突预检/账本，零激活）；物化失败**原子回滚**意图。签名移除 `register_server`/`remove_server`/`inject_inputs`。
  - `enable_plugin` **原子激活**：skills+server 一并点亮；失败回滚 installed_disabled（撤销新增 skill/server、`enabledPlugins` 恢复原值——absent 走 DELETE 删键）。
  - `uninstall_plugin`：账本清空时删意图 + 清 `enabledPlugins` 条目（user + 记录派生的 project/local）。
  - `migrate_legacy_installs` 一次性迁移：账本存量 → `installedPlugins` + 无条目者 user `enabledPlugins=true`（保住 v0.2.x 活跃态；显式 false 不迁）；标记 = user settings 的 `installedPlugins` 键存在（防复活）。
- **recovery**：`_plugin_boot_active` **缺省翻转**（仅 `true` 激活）；安装集取自 declared `installedPlugins`；账本降级纯派生缓存——**删除无损**，boot 重物化（先物化后 stage，物化失败的活跃 plugin 整体保持 installed_disabled，无 rust-sdk#102 半态）；`GovernanceRecoveryReport.rematerialized` 新字段。
- **reconciler**：孤儿判据改 `installedPlugins`（`declared_plugin_ids` → `declared_installed_plugin_ids`）；`plugin_filter` = installed ∧ enabled。
- **computer**：`boot_up` 前置迁移（失败隔离）。
- **CLI**：`plugin install` 不挂载（提示 installed_disabled）；`plugin list` 默认列全部已安装（enabled 两态；`--available` 兼容 no-op）；`plugin enable` 接 `remove_server` 回滚。

## 已拍板决策（AskUserQuestion）

1. `installedPlugins` 固定写 user scope、读 merged 并集；2. 迁移标记 = 键存在（空也写 `[]`）；3. install 物化失败原子回滚意图。

## 验收对照（conformance-tests §5 / 迁移指南）

- [x] install-only ⇒ 在已安装列表、skills 不进投影、活跃 MCP 不含 bundled server
- [x] installed_disabled 重启 ⇒ 仍惰性；enable ⇒ skills+server 一并出现
- [x] enable 挂载失败 ⇒ 回滚 installed_disabled（absent/false/true 三种原值均恢复）
- [x] installed_enabled 重启 ⇒ 能力与归属重现；disable/uninstall 重启 ⇒ 不恢复
- [x] 账本删除 ⇒ 从 installedPlugins 重物化重建，恢复不受影响
- [x] 一次性迁移保住 v0.2.x 活跃态、显式 false 不复活、headless 首装不抢写标记

## 质量门

- TDD：红灯先行（20 红实证）→ 绿；新增 30+ 用例；存量矩阵 ~35 例迁移新语义。
- 全量 **1781 passed** + `poe lint`（ruff+mypy）绿。
- 隔离审查：code-reviewer 初审 2🔴+5🟡 → 修复后复核 **2🔴 CONFIRMED-FIXED**（回归用例经 revert 实证）+ N1 已顺手处理，结论可合入。

## 挂账（follow-up，不阻塞）

- 重物化 scope 归一 user 的精确复原（§4.9.2 pin-lock 扩展范畴，已文档化，rust 同构）。
- 「意图 ∖ 账本」长期悬挂条目的 prune 补强；`--available` 弃用提示。
- 存量残留观察：installPath 在而 bundled JSON 事后损坏的窄半态（先于本 PR 存在）。

Closes #123（develop 合并不自动触发，届时手动关闭）

Refs: a2c-smcp-protocol#11, python-sdk#120, rust-sdk#102/#103

🤖 Generated with [Claude Code](https://claude.com/claude-code)