### PR TITLE
feat(#125): v0.3.0 plugin 生命周期收尾——scope 推回、悬挂 prune、--available 弃用、账本判据升级

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,38 @@ and this project adheres to [PEP 440](https://peps.python.org/pep-0440/) version
     divergence deferred to a separate protocol-first effort.
 
 ### Added
+- **Plugin lifecycle follow-ups** (#125, closing out the #123 isolated-review items;
+  rust mirror evaluation via rust-sdk#103):
+  - **Re-materialization scope inference** — boot recovery now infers the original
+    install scope of rebuilt ledger records from per-layer `enabledPlugins` entries
+    (and project/local `installedPlugins` declarations) instead of always normalizing
+    to the user scope; multi-layer clues rebuild multiple records, dead stale-scope
+    records are swept, and clue-less rebuilds are normalized to user scope with a
+    WARN plus the new `GovernanceRecoveryReport.scope_normalized` field. This keeps
+    `plugin disable`/`uninstall` writing to the correct settings layer across boots.
+    `uninstall_plugin` additionally clears cwd-visible project/local `enabledPlugins`
+    entries (guarded so it never creates a `.tfrobot/` dir in a bare cwd). Known
+    blind spot (documented): layers of *other* project paths are not visible from
+    the current cwd — precise restoration remains pin-lock territory (§4.9.2).
+  - **Dangling-intent diagnosis & prune** — new `list_dangling_plugin_intents`
+    (reconciler) detects `installedPlugins` entries with no live materialization that
+    are statically unreachable (four reasons: `marketplace-not-added`,
+    `catalog-missing`, `manifest-unreadable`, `entry-missing`; reachable-but-not-yet
+    materialized intents are reported as recoverable and self-heal at next boot).
+    `plugin gc` now reports them (JSON: `removed` unchanged + new `dangling`,
+    `prunedIntents`, `recoverable`) and can prune via the new
+    `installer.prune_plugin_intent` — REPL behind the confirm gate, non-interactive
+    Typer requires the explicit `--prune-dangling` flag (pruning deletes
+    authoritative intent, unlike orphan gc which only drops derived cache).
+    Committable project/local `installedPlugins` declarations are never rewritten
+    (WARN with the file path instead).
+  - **Ledger liveness now validates bundled JSON** — `ledger_entry_materialized`
+    (public in reconciler, migrated from `recovery._ledger_materialized`) treats a
+    record as materialized only if the `installPath` directory exists **and**
+    `load_bundled_servers` parses; a corrupt bundled server JSON now triggers
+    re-materialization (repair) or keeps the plugin wholly `installed_disabled`
+    (no more "skill lit, server WARN-skipped" half-state).
+
 - **Connection protocol-version handshake** (#17 / #18). Clients (Agent + Computer,
   async + sync) auto-append `a2c_version` to the Socket.IO connect URL query;
   `a2c_smcp.PROTOCOL_VERSION` (`"0.2.0"`) is the single source. Server-side
@@ -110,6 +142,11 @@ and this project adheres to [PEP 440](https://peps.python.org/pep-0440/) version
 - office/role isolation invariants in `on_client_*` now raise
   `a2c_smcp.exceptions.SMCPNamespaceError` instead of `assert` (stripped under
   `python -O`); async + sync namespaces aligned (#31).
+
+### Deprecated
+- `plugin list --available` is a no-op since v0.3.0 (listing all installed plugins is
+  the default) and now emits a deprecation notice (non-JSON mode; JSON mode logs a
+  warning to keep stdout parseable). Planned for removal in a future release (#125).
 
 ### Tests & Docs
 - `tests/e2e/test_v02_full_flow.py` (#20): real-process full chain over a real

--- a/a2c_smcp/computer/cli/commands/plugin.py
+++ b/a2c_smcp/computer/cli/commands/plugin.py
@@ -53,6 +53,7 @@ from a2c_smcp.computer.settings.installer import (
     disable_plugin,
     enable_plugin,
     install_plugin,
+    prune_plugin_intent,
     uninstall_plugin,
 )
 from a2c_smcp.computer.settings.mcp_config import (
@@ -64,7 +65,17 @@ from a2c_smcp.computer.settings.mcp_config import (
     gate_mcp_servers,
     resolve_mcp_config,
 )
-from a2c_smcp.computer.settings.reconciler import gc_plugins, list_orphan_plugins
+from a2c_smcp.computer.settings.reconciler import (
+    DANGLING_CATALOG_MISSING,
+    DANGLING_ENTRY_MISSING,
+    DANGLING_MANIFEST_UNREADABLE,
+    DANGLING_MARKETPLACE_NOT_ADDED,
+    declared_installed_plugin_ids,
+    gc_plugins,
+    ledger_entry_materialized,
+    list_dangling_plugin_intents,
+    list_orphan_plugins,
+)
 from a2c_smcp.computer.skills.manifest import MCP_INPUTS_FILENAME, MCP_SERVERS_SUBDIR
 from a2c_smcp.computer.skills.registry import SkillRegistry
 
@@ -377,6 +388,33 @@ def plugin_info(
     return EXIT_OK
 
 
+# 悬挂意图 reason → 分档修复提示（catalog-missing 可能只是断网后 clone 未建，裁量留给用户）/ per-reason hints.
+_DANGLING_HINTS: dict[str, str] = {
+    DANGLING_MARKETPLACE_NOT_ADDED: "marketplace unknown — no self-heal path",
+    DANGLING_CATALOG_MISSING: "boot/'marketplace refresh' may re-clone; prune only if the source is gone for good",
+    DANGLING_MANIFEST_UNREADABLE: "try 'marketplace refresh' first; prune only if it stays broken",
+    DANGLING_ENTRY_MISSING: "prune only if upstream removed the plugin",
+}
+
+
+def _recoverable_intents(
+    home: Path,
+    declared: Mapping[str, Any],
+    dangling: list[tuple[str, str]],
+    env: Mapping[str, str] | None,
+) -> list[str]:
+    """「静态可达但未物化」的意图 pid（下次 boot 由 recovery 重物化自愈——只提示、绝不 prune）/ Recoverable。"""
+    from a2c_smcp.computer.settings.store import load_installed_plugins
+
+    ledger = load_installed_plugins(home=home, env=env).get("plugins", {})
+    dangling_ids = {pid for pid, _ in dangling}
+    return sorted(
+        pid
+        for pid in declared_installed_plugin_ids(declared)
+        if pid not in dangling_ids and not ledger_entry_materialized(ledger.get(pid))
+    )
+
+
 async def plugin_gc(
     registry: SkillRegistry,
     home: Path,
@@ -384,24 +422,64 @@ async def plugin_gc(
     *,
     mcp_teardown: Callable[[list[str]], Awaitable[None]] | None = None,
     confirm: Callable[[list[str]], Awaitable[bool]] | None = None,
+    prune_dangling: bool = False,
     json_output: bool = False,
 ) -> int:
-    """清理孤儿 plugin（账本有记录、``installedPlugins`` 安装意图不再包含，v0.3.0 §2.3）/ GC orphan plugins。"""
+    """
+    清理孤儿 plugin（账本 ∖ 意图）+ 诊断/prune 悬挂意图（意图 ∖ 账本 ∧ 静态不可达，#125 任务 2）/ GC + prune。
+
+    权威性不对称安全阀：孤儿删除的是**派生缓存**（恒安全）→ 无 confirm 也自动执行（Typer 现状不变）；
+    悬挂 prune 删的是**权威意图**（§2.3）→ 须 confirm 门（REPL）或显式 ``--prune-dangling``
+    （Typer 非交互缺省只诊断）。「静态可达未物化」→ ``recoverable``：仅提示（下次 boot 自愈）、绝不删。
+    JSON 契约：``removed``（不变）+ ``dangling``（诊断 ``{id, reason}``）+ ``prunedIntents``（实际删）
+    + ``recoverable``。
+    """
     declared = resolved_settings(env)
     orphans = list_orphan_plugins(home, declared, env=env)
-    if not orphans:
+    dangling = list_dangling_plugin_intents(home, declared, env=env)
+    recoverable = _recoverable_intents(home, declared, dangling, env)
+    prunable = dangling if prune_dangling else []
+
+    if not orphans and not dangling and not recoverable:
         if json_output:
-            console.print_json(data={"removed": []})
+            console.print_json(data={"removed": [], "dangling": [], "prunedIntents": [], "recoverable": []})
         else:
             console.print("[dim]No orphan plugins.[/dim]")
         return EXIT_OK
-    if confirm is not None and not await confirm(orphans):
-        return _err("aborted by user", json_output=json_output)
-    removed = await gc_plugins(orphans, registry, home, env=env, mcp_teardown=mcp_teardown)
+
+    if confirm is not None and (orphans or prunable):
+        items = list(orphans) + [f"{pid} (dangling intent: {reason})" for pid, reason in prunable]
+        if not await confirm(items):
+            return _err("aborted by user", json_output=json_output)
+
+    removed = await gc_plugins(orphans, registry, home, env=env, mcp_teardown=mcp_teardown) if orphans else []
+    pruned: list[str] = []
+    for pid, _reason in prunable:
+        try:
+            prune_plugin_intent(pid, home, env=env)
+            pruned.append(pid)
+        except PluginInstallError as e:  # 单条失败降级，不阻断其余
+            if not json_output:
+                console.print(f"[yellow]⚠ prune {pid!r} failed: {e}[/yellow]")
+
     if json_output:
-        console.print_json(data={"removed": removed})
+        console.print_json(
+            data={
+                "removed": removed,
+                "dangling": [{"id": pid, "reason": reason} for pid, reason in dangling],
+                "prunedIntents": pruned,
+                "recoverable": recoverable,
+            },
+        )
         return EXIT_OK
-    return _ok(f"gc removed {len(removed)} orphan plugin(s): {', '.join(removed) or '—'}")
+    if removed or not (dangling or recoverable):
+        _ok(f"gc removed {len(removed)} orphan plugin(s): {', '.join(removed) or '—'}")
+    for pid, reason in dangling:
+        status = "pruned" if pid in pruned else "diagnosed only (confirm in REPL or pass --prune-dangling)"
+        console.print(f"[yellow]⚠ dangling intent {pid} [{reason}] — {status}; {_DANGLING_HINTS.get(reason, '')}[/yellow]")
+    for pid in recoverable:
+        console.print(f"[dim]recoverable: {pid} (not materialized; next boot will re-materialize)[/dim]")
+    return EXIT_OK
 
 
 # ── MCP 批准框（启动期，§9.2，#69 Group B）/ MCP approval box (boot-time) ─────────
@@ -571,13 +649,14 @@ async def repl_dispatch(comp: Any, parts: list[str], *, session: Any) -> None:
         plugin_info(home, env, pos[0], json_output=json_output)
     elif sub == "gc":
 
-        async def _confirm(orphans: list[str]) -> bool:
-            ans = (await session.prompt_async(f"GC {len(orphans)} orphan plugin(s): {', '.join(orphans)}? [y/N]: ")).strip().lower()
+        async def _confirm(items: list[str]) -> bool:
+            ans = (await session.prompt_async(f"GC {len(items)} item(s): {', '.join(items)}? [y/N]: ")).strip().lower()
             return ans in {"y", "yes"}
 
+        # REPL 有 confirm 门 → 悬挂意图 prune 一并纳入确认（#125 任务 2；Typer 非交互须显式 --prune-dangling）
         code = await plugin_gc(
             registry, home, env,
-            mcp_teardown=_batch_teardown(cbs.remove_server), confirm=_confirm, json_output=json_output,
+            mcp_teardown=_batch_teardown(cbs.remove_server), confirm=_confirm, prune_dangling=True, json_output=json_output,
         )
         if code == EXIT_OK:
             comp.mark_skills_dirty()

--- a/a2c_smcp/computer/cli/commands/plugin.py
+++ b/a2c_smcp/computer/cli/commands/plugin.py
@@ -465,13 +465,19 @@ async def plugin_gc(
 
     removed = await gc_plugins(orphans, registry, home, env=env, mcp_teardown=mcp_teardown) if orphans else []
     pruned: list[str] = []
+    residual: list[str] = []
     for pid, _reason in prunable:
         try:
-            prune_plugin_intent(pid, home, env=env)
-            pruned.append(pid)
-        except PluginInstallError as e:  # 单条失败降级，不阻断其余
+            # False = cwd 可见 project/local 层仍有 committable 声明残留（merged 意图仍含 pid）——
+            # 不计入 prunedIntents，否则自动化「prune 到干净」永不收敛（隔离审查 🟡#1）。
+            if prune_plugin_intent(pid, home, env=env):
+                pruned.append(pid)
+            else:
+                residual.append(pid)
+        except Exception as e:  # noqa: BLE001 - 单条失败降级不阻断其余（OSError/锁竞争等，隔离审查 🟡#2）
             if not json_output:
                 console.print(f"[yellow]⚠ prune {pid!r} failed: {e}[/yellow]")
+            logger.warning("plugin gc: prune %r failed: %s", pid, e)
 
     if json_output:
         console.print_json(
@@ -479,6 +485,7 @@ async def plugin_gc(
                 "removed": removed,
                 "dangling": [{"id": pid, "reason": reason} for pid, reason in dangling],
                 "prunedIntents": pruned,
+                "residualDeclarations": residual,
                 "recoverable": recoverable,
             },
         )
@@ -486,7 +493,12 @@ async def plugin_gc(
     if removed or not (dangling or recoverable):
         _ok(f"gc removed {len(removed)} orphan plugin(s): {', '.join(removed) or '—'}")
     for pid, reason in dangling:
-        status = "pruned" if pid in pruned else "diagnosed only (confirm in REPL or pass --prune-dangling)"
+        if pid in pruned:
+            status = "pruned"
+        elif pid in residual:
+            status = "intent declaration remains in project/local settings (remove manually)"
+        else:
+            status = "diagnosed only (confirm in REPL or pass --prune-dangling)"
         console.print(f"[yellow]⚠ dangling intent {pid} [{reason}] — {status}; {_DANGLING_HINTS.get(reason, '')}[/yellow]")
     for pid in recoverable:
         console.print(f"[dim]recoverable: {pid} (not materialized; next boot will re-materialize)[/dim]")

--- a/a2c_smcp/computer/cli/commands/plugin.py
+++ b/a2c_smcp/computer/cli/commands/plugin.py
@@ -78,6 +78,9 @@ from a2c_smcp.computer.settings.reconciler import (
 )
 from a2c_smcp.computer.skills.manifest import MCP_INPUTS_FILENAME, MCP_SERVERS_SUBDIR
 from a2c_smcp.computer.skills.registry import SkillRegistry
+from a2c_smcp.utils.logger import get_logger
+
+logger = get_logger(__name__)
 
 # 退出码语义（§4.6）/ Exit code semantics（与 marketplace.py 对齐）。
 EXIT_OK = 0
@@ -322,9 +325,17 @@ def plugin_list(
 ) -> int:
     """列出全部 installed plugin（enabled 列呈现两态；install-only 的 ``installed_disabled`` 必须可见）/ List。
 
-    v0.3.0（#123）：默认即列全部已安装——``--available`` 保留为兼容 no-op（旧语义"含 disabled"已成默认）。
+    v0.3.0（#123）：默认即列全部已安装——``--available`` 保留为兼容 no-op（旧语义"含 disabled"已成默认），
+    **已弃用、计划移除**（#125 任务 3）：非 JSON 模式打弃用提示；JSON 模式走 logger（stdout 保持纯 JSON）。
     """
     from a2c_smcp.computer.settings.store import load_installed_plugins
+
+    if available:  # 弃用提示（deprecation notice）——行为不变，仅提示
+        msg = "--available is deprecated (listing all installed plugins is the default since v0.3.0) and will be removed"
+        if json_output:
+            logger.warning("plugin list: %s", msg)
+        else:
+            console.print(f"[yellow]⚠ {msg} / --available 已弃用（v0.3.0 起默认列全部已安装），将在后续版本移除[/yellow]")
 
     installed = load_installed_plugins(home=home, env=env).get("plugins", {})
     enabled_map = _enabled_plugins_view(home, env)

--- a/a2c_smcp/computer/cli/help.py
+++ b/a2c_smcp/computer/cli/help.py
@@ -56,9 +56,9 @@ NAMESPACE_COMMANDS: dict[str, list[tuple[str, str]]] = {
         ("plugin install <plugin>@<mp> [--version V] [--scope S]", "安装 plugin（外来 MCP 同名硬抛）/ install (name conflict aborts)"),
         ("plugin uninstall <plugin>@<mp> [--keep-servers]", "卸载 plugin / uninstall"),
         ("plugin enable|disable <plugin>@<mp>", "启用 / 禁用（整 plugin 上/下线）/ enable / disable (whole plugin)"),
-        ("plugin list [--available] [--json]", "列出 installed plugin / list plugins"),
+        ("plugin list [--json]", "列出全部 installed plugin（--available 已弃用）/ list plugins (--available deprecated)"),
         ("plugin info <plugin>@<mp> [--json]", "plugin 详情 / plugin detail"),
-        ("plugin gc", "清理孤儿 plugin / gc orphan plugins"),
+        ("plugin gc [--prune-dangling]", "清理孤儿 plugin + 诊断/prune 悬挂意图 / gc orphans + dangling intents"),
     ],
     "skill": [
         ("skill list [--source mp|mcp|user] [--json]", "跨源列出可见 SKILL / list skills"),
@@ -121,9 +121,9 @@ FLAGS: dict[tuple[str, str], list[str]] = {
     ("plugin", "uninstall"): ["--keep-servers", "--json"],
     ("plugin", "enable"): ["--json"],
     ("plugin", "disable"): ["--json"],
-    ("plugin", "list"): ["--available", "--json"],
+    ("plugin", "list"): ["--available", "--json"],  # --available 已弃用（兼容 no-op），保留补全至移除
     ("plugin", "info"): ["--json"],
-    ("plugin", "gc"): ["--json"],
+    ("plugin", "gc"): ["--prune-dangling", "--json"],
     ("settings", "show"): ["--scope", "--json"],
     ("settings", "get"): ["--scope", "--json"],
     ("settings", "set"): ["--scope", "--json"],

--- a/a2c_smcp/computer/cli/main.py
+++ b/a2c_smcp/computer/cli/main.py
@@ -527,9 +527,18 @@ def _plugin_info(plugin_id: str = typer.Argument(...), json_output: bool = typer
 
 
 @plugin_app.command("gc")
-def _plugin_gc(json_output: bool = typer.Option(False, "--json")) -> None:
-    """清理孤儿 plugin（非交互无 confirm → 直接清）/ GC orphan plugins (no confirm non-interactively)."""
-    code = asyncio.run(plugin_cmd.plugin_gc(SkillRegistry(), ensure_skill_home(), os.environ, confirm=None, json_output=json_output))
+def _plugin_gc(
+    prune_dangling: bool = typer.Option(
+        False, "--prune-dangling", help="连带 prune 悬挂安装意图（意图 ∖ 账本 ∧ 不可达）/ also prune dangling intents",
+    ),
+    json_output: bool = typer.Option(False, "--json"),
+) -> None:
+    """清理孤儿 plugin + 诊断悬挂意图（非交互删权威意图须显式 --prune-dangling）/ GC orphans + diagnose dangling."""
+    code = asyncio.run(
+        plugin_cmd.plugin_gc(
+            SkillRegistry(), ensure_skill_home(), os.environ, confirm=None, prune_dangling=prune_dangling, json_output=json_output,
+        ),
+    )
     raise typer.Exit(code)
 
 

--- a/a2c_smcp/computer/cli/main.py
+++ b/a2c_smcp/computer/cli/main.py
@@ -513,7 +513,9 @@ def _plugin_disable(plugin_id: str = typer.Argument(...), json_output: bool = ty
 
 @plugin_app.command("list")
 def _plugin_list(
-    available: bool = typer.Option(False, "--available", help="含 disabled / include disabled"),
+    available: bool = typer.Option(
+        False, "--available", help="[deprecated] 已弃用：v0.3.0 起默认列全部已安装 / no-op, listing all is the default",
+    ),
     json_output: bool = typer.Option(False, "--json"),
 ) -> None:
     """列出 installed plugin / List installed plugins."""

--- a/a2c_smcp/computer/settings/installer.py
+++ b/a2c_smcp/computer/settings/installer.py
@@ -198,6 +198,30 @@ def _write_enabled_plugin(plugin_id: str, value: bool | None, scope: str, projec
         atomic_write_json(path, updated)
 
 
+def _clear_enabled_entries_visible_layers(plugin_id: str, project_paths: set[str], env: Mapping[str, str] | None) -> None:
+    """
+    清理 ``enabledPlugins[plugin_id]`` 的全部**可见层**条目：user 恒清；project/local 对「账本 projectPath ∪ cwd」
+    逐一清（#125 任务 1：账本重物化归一后丢 projectPath，仅遍历账本会漏掉 cwd 可见层的残留 ``true``——
+    卸载后残留会让重装立即激活，违反 install 不激活）/ Clear enabled entries across visible layers。
+
+    project/local 写调用前**先查 settings 文件存在**：:func:`~a2c_smcp.computer.settings.store.file_lock`
+    会 ``mkdir(parents=True)`` 建父目录 + 建 ``.lock``，而 :func:`_write_enabled_plugin` 的 no-op 短路在锁后——
+    无守卫会在无 ``.tfrobot/`` 的 cwd 制造垃圾目录。managed/policy 只读层不触碰；清失败 WARN 不阻断（best-effort）。
+    """
+    _write_enabled_plugin(plugin_id, None, "user", None, env)
+    targets = {str(Path(p)) for p in project_paths if p}
+    targets.add(str(Path.cwd()))
+    for pp in sorted(targets):
+        for s in ("project", "local"):
+            try:
+                path, _scope = _settings_path_for_scope(s, pp, env)
+                if not path.exists():  # 存在性守卫：不为清理凭空建 .tfrobot/ + .lock
+                    continue
+                _write_enabled_plugin(plugin_id, None, s, pp, env)
+            except PluginInstallError as e:  # best-effort：清条目失败不阻断
+                logger.warning("failed to clear enabledPlugins[%s] in %s scope at %s: %s", plugin_id, s, pp, e)
+
+
 def _write_installed_plugin(plugin_id: str, present: bool, env: Mapping[str, str] | None) -> bool:
     """
     user scope ``installedPlugins`` 数组的持锁 RMW（增/删一个条目）；返回**写前**是否已含该条目 / RMW the install intent。
@@ -550,18 +574,12 @@ async def uninstall_plugin(
     update_installed_plugins(_drop, home=home, env=env)
 
     # v0.3.0：账本记录清空（回 available）→ 删全局安装意图 + 清 enabledPlugins 条目（意图是唯一权威，§2.3）。
-    # project/local 落点从被删记录的 projectPath 派生（无需调用方另传）；managed/policy 只读层不触碰。
+    # project/local 落点 = 被删记录的 projectPath ∪ cwd（#125 任务 1：归一记录丢 projectPath 时 cwd 可见层兜底）。
     remaining = load_installed_plugins(home=home, env=env).get("plugins", {}).get(plugin_id)
     if not remaining:
         _write_installed_plugin(plugin_id, False, env)
-        _write_enabled_plugin(plugin_id, None, "user", None, env)
         project_paths = {p for r in targeted if isinstance(p := r.get("projectPath"), str) and p}
-        for pp in sorted(project_paths):
-            for s in ("project", "local"):
-                try:
-                    _write_enabled_plugin(plugin_id, None, s, pp, env)
-                except PluginInstallError as e:  # best-effort：清条目失败不阻断卸载
-                    logger.warning("uninstall: failed to clear enabledPlugins[%s] in %s scope at %s: %s", plugin_id, s, pp, e)
+        _clear_enabled_entries_visible_layers(plugin_id, project_paths, env)
     logger.info(
         "uninstalled plugin %r (scope=%s, servers=%s)",
         plugin_id,

--- a/a2c_smcp/computer/settings/installer.py
+++ b/a2c_smcp/computer/settings/installer.py
@@ -589,7 +589,7 @@ async def uninstall_plugin(
     return True
 
 
-def prune_plugin_intent(plugin_id: str, home: Path, *, env: Mapping[str, str] | None = None) -> None:
+def prune_plugin_intent(plugin_id: str, home: Path, *, env: Mapping[str, str] | None = None) -> bool:
     """
     prune 单个**悬挂安装意图**（``installedPlugins`` 声明 ∧ 无有效物化 ∧ 静态不可达，#125 任务 2）/ Prune intent。
 
@@ -603,6 +603,9 @@ def prune_plugin_intent(plugin_id: str, home: Path, *, env: Mapping[str, str] | 
     2. 删 user 层安装意图；3. 清可见层 ``enabledPlugins`` 条目（user + 账本 projectPath ∪ cwd）；
     4. 弹出该 pid 账本残骸记录（若有）；5. pid 仍见于 cwd 可见 project/local 层 ``installedPlugins``
        声明 → WARN 指明文件路径、**不改写**（committable 团队声明不由本地 gc 静默动，下轮 gc 会再次列出）。
+
+    :return: ``True`` = 意图已彻底移除；``False`` = cwd 可见 project/local 层仍有 committable 声明残留
+        （merged 意图仍含该 pid，下轮 gc 会再次列为悬挂——调用方不得将其计入「已 prune」，隔离审查 🟡#1）。
     """
     _split_plugin_id(plugin_id)  # 形态校验（非法 → PluginInstallError，零变更）
     migrate_legacy_installs(home, env=env)
@@ -621,19 +624,22 @@ def prune_plugin_intent(plugin_id: str, home: Path, *, env: Mapping[str, str] | 
         ("project", workdir_project_settings_path(cwd), SettingsScope.PROJECT),
         ("local", workdir_local_settings_path(cwd), SettingsScope.LOCAL),
     )
+    fully_pruned = True
     for scope_name, path, scope_enum in residual_layers:
         if not path.exists():
             continue
         data, _errors = load_settings_file(path, scope_enum)
         declared = data.get("installedPlugins")
         if isinstance(declared, list) and plugin_id in declared:
+            fully_pruned = False
             logger.warning(
                 "prune: %r still declared in %s scope settings %s; not rewriting committable declaration (remove manually)",
                 plugin_id,
                 scope_name,
                 path,
             )
-    logger.info("pruned dangling plugin intent %r", plugin_id)
+    logger.info("pruned dangling plugin intent %r (fully_pruned=%s)", plugin_id, fully_pruned)
+    return fully_pruned
 
 
 async def disable_plugin(

--- a/a2c_smcp/computer/settings/installer.py
+++ b/a2c_smcp/computer/settings/installer.py
@@ -589,6 +589,53 @@ async def uninstall_plugin(
     return True
 
 
+def prune_plugin_intent(plugin_id: str, home: Path, *, env: Mapping[str, str] | None = None) -> None:
+    """
+    prune 单个**悬挂安装意图**（``installedPlugins`` 声明 ∧ 无有效物化 ∧ 静态不可达，#125 任务 2）/ Prune intent。
+
+    :func:`~a2c_smcp.computer.settings.reconciler.list_dangling_plugin_intents` 的执行对应物——针对悬挂意图的
+    uninstall 等价物（无 MCP/SKILL 面：悬挂 pid 从未物化成功，无已挂 server、无已 stage skill）。删的是
+    **权威意图**（§2.3），调用方（CLI ``plugin gc``）须过 confirm 门 / 显式 ``--prune-dangling``
+    （§4.8.4 删除走显式路径）。settings 意图写权归 installer（与 install/uninstall 同边界）。
+
+    顺序 / Order:
+    1. 一次性迁移先行（写 ``installedPlugins`` 键前防迁移标记误置，同 install/uninstall 铁律）；
+    2. 删 user 层安装意图；3. 清可见层 ``enabledPlugins`` 条目（user + 账本 projectPath ∪ cwd）；
+    4. 弹出该 pid 账本残骸记录（若有）；5. pid 仍见于 cwd 可见 project/local 层 ``installedPlugins``
+       声明 → WARN 指明文件路径、**不改写**（committable 团队声明不由本地 gc 静默动，下轮 gc 会再次列出）。
+    """
+    _split_plugin_id(plugin_id)  # 形态校验（非法 → PluginInstallError，零变更）
+    migrate_legacy_installs(home, env=env)
+    records = load_installed_plugins(home=home, env=env).get("plugins", {}).get(plugin_id, [])
+    project_paths = {p for r in records if isinstance(p := r.get("projectPath"), str) and p}
+    _write_installed_plugin(plugin_id, False, env)
+    _clear_enabled_entries_visible_layers(plugin_id, project_paths, env)
+
+    def _drop(data: InstalledPluginsFile, _pid: str = plugin_id) -> None:
+        data["plugins"].pop(_pid, None)
+
+    update_installed_plugins(_drop, home=home, env=env)
+
+    cwd = Path.cwd()
+    residual_layers = (
+        ("project", workdir_project_settings_path(cwd), SettingsScope.PROJECT),
+        ("local", workdir_local_settings_path(cwd), SettingsScope.LOCAL),
+    )
+    for scope_name, path, scope_enum in residual_layers:
+        if not path.exists():
+            continue
+        data, _errors = load_settings_file(path, scope_enum)
+        declared = data.get("installedPlugins")
+        if isinstance(declared, list) and plugin_id in declared:
+            logger.warning(
+                "prune: %r still declared in %s scope settings %s; not rewriting committable declaration (remove manually)",
+                plugin_id,
+                scope_name,
+                path,
+            )
+    logger.info("pruned dangling plugin intent %r", plugin_id)
+
+
 async def disable_plugin(
     plugin_id: str,
     registry: SkillRegistry,

--- a/a2c_smcp/computer/settings/reconciler.py
+++ b/a2c_smcp/computer/settings/reconciler.py
@@ -54,6 +54,12 @@ from a2c_smcp.computer.settings.store import (
     update_known_marketplaces,
 )
 from a2c_smcp.computer.skills.home import SOURCE_MARKETPLACE, marketplace_skill_dir
+from a2c_smcp.computer.skills.manifest import (
+    PluginManifestError,
+    find_plugin_entry,
+    load_bundled_servers,
+    read_marketplace_manifest,
+)
 from a2c_smcp.computer.skills.registry import SkillRegistry
 from a2c_smcp.computer.skills.staging import (
     _EXTERNAL_PLUGINS_NS,
@@ -362,6 +368,88 @@ def list_orphan_plugins(
     declared_ids = declared_installed_plugin_ids(declared)
     installed = load_installed_plugins(home=home, env=env)
     return [pid for pid in installed.get("plugins", {}) if pid not in declared_ids]
+
+
+def ledger_entry_materialized(records: object) -> bool:
+    """
+    某 pid 的账本记录是否仍有效物化：至少一条记录「``installPath`` 目录存在 ∧ bundled JSON 可解析」/ Live check。
+
+    v0.3.0 §5.8（安装路径非权威，boot MUST 重新校验）+ #125 任务 4：仅查目录存在会漏掉「目录在、bundled JSON
+    事后损坏」——stage 后 skill 亮而 :func:`~a2c_smcp.computer.settings.recovery.collect_enabled_bundled_servers`
+    WARN-skip，即 rust-sdk#102 同型半态。判据升级为可解析：:class:`PluginManifestError` → 该记录失效 →
+    触发重物化（catalog 完好则修复指回；不可修复则整体保持 ``installed_disabled``，skill 不单独亮）。
+
+    原 ``recovery._ledger_materialized`` 迁入公开化（#125 任务 2）：boot 恢复的重物化触发与
+    :func:`list_dangling_plugin_intents` 的悬挂判据共用本单点。
+    """
+    if not isinstance(records, list):
+        return False
+    for rec in records:
+        install_path = rec.get("installPath") if isinstance(rec, Mapping) else None
+        if not (isinstance(install_path, str) and install_path and Path(install_path).is_dir()):
+            continue
+        try:
+            load_bundled_servers(Path(install_path))
+        except PluginManifestError as e:
+            logger.warning("ledger record %s has corrupt bundled server JSON, treated as unmaterialized: %s", install_path, e)
+            continue
+        return True
+    return False
+
+
+# 悬挂意图 reason 分档（#125 任务 2；wire 值入 CLI JSON 输出，rust 镜像同字面）/ dangling reason tiers.
+DANGLING_MARKETPLACE_NOT_ADDED = "marketplace-not-added"
+DANGLING_CATALOG_MISSING = "catalog-missing"
+DANGLING_MANIFEST_UNREADABLE = "manifest-unreadable"
+DANGLING_ENTRY_MISSING = "entry-missing"
+
+
+def list_dangling_plugin_intents(
+    home: Path,
+    declared: Mapping[str, object],
+    *,
+    env: Mapping[str, str] | None = None,
+) -> list[tuple[str, str]]:
+    """
+    列出悬挂安装意图：``installedPlugins`` 声明 ∧ 账本无有效物化 ∧ **静态不可达**（#125 任务 2）/ Dangling intents。
+
+    与 :func:`list_orphan_plugins` 互为反向：孤儿 = 账本 ∖ 意图（删派生缓存，恒安全）；悬挂 = 意图 ∖ 账本且
+    离线判定无法重物化（prune 删的是**权威意图**，须 confirm / 显式 flag——§4.8.4 删除走显式路径）。
+    「静态可达但未物化」**不**列入——下次 boot 由 recovery 重物化自愈，非 prune 对象。
+
+    纯本地零网络。reason 四档供 CLI 分档提示（``catalog-missing`` 可能只是临时断网后 clone 未建，裁量留给调用方）：
+
+    - :data:`DANGLING_MARKETPLACE_NOT_ADDED`：known_marketplaces 无记录（无自愈路径，最强 prune 信号）；
+    - :data:`DANGLING_CATALOG_MISSING`：known 在、catalog clone 缺失（boot/refresh 会重试 clone）;
+    - :data:`DANGLING_MANIFEST_UNREADABLE`：clone 在、marketplace.json 损坏/缺失（先 ``marketplace refresh``）;
+    - :data:`DANGLING_ENTRY_MISSING`：manifest 合法但无该 plugin entry（上游已移除才 prune）。
+
+    :return: ``[(pid, reason)]``，按 pid 排序稳定输出。
+    """
+    ledger = load_installed_plugins(home=home, env=env).get("plugins", {})
+    known = load_known_marketplaces(home=home, env=env).get("marketplaces", {})
+    out: list[tuple[str, str]] = []
+    for pid in sorted(declared_installed_plugin_ids(declared)):
+        if ledger_entry_materialized(ledger.get(pid)):
+            continue
+        plugin, _, marketplace = pid.partition("@")
+        record = known.get(marketplace)
+        if not isinstance(record, Mapping) or not isinstance(record.get("source"), Mapping):
+            out.append((pid, DANGLING_MARKETPLACE_NOT_ADDED))
+            continue
+        catalog_dir = marketplace_skill_dir(home, marketplace)
+        if not catalog_dir.is_dir():
+            out.append((pid, DANGLING_CATALOG_MISSING))
+            continue
+        try:
+            manifest = read_marketplace_manifest(catalog_dir)
+        except PluginManifestError:
+            out.append((pid, DANGLING_MANIFEST_UNREADABLE))
+            continue
+        if find_plugin_entry(manifest, plugin) is None:
+            out.append((pid, DANGLING_ENTRY_MISSING))
+        # else：静态可达（known ∧ clone ∧ entry）→ recoverable，boot 自愈，不列
+    return out
 
 
 async def gc_plugins(

--- a/a2c_smcp/computer/settings/reconciler.py
+++ b/a2c_smcp/computer/settings/reconciler.py
@@ -370,31 +370,51 @@ def list_orphan_plugins(
     return [pid for pid in installed.get("plugins", {}) if pid not in declared_ids]
 
 
-def ledger_entry_materialized(records: object) -> bool:
+def ledger_record_materialized(rec: object) -> bool:
     """
-    某 pid 的账本记录是否仍有效物化：至少一条记录「``installPath`` 目录存在 ∧ bundled JSON 可解析」/ Live check。
+    单条账本记录是否仍有效物化：「``installPath`` 目录存在 ∧ bundled JSON 可解析」/ Per-record live check。
 
     v0.3.0 §5.8（安装路径非权威，boot MUST 重新校验）+ #125 任务 4：仅查目录存在会漏掉「目录在、bundled JSON
     事后损坏」——stage 后 skill 亮而 :func:`~a2c_smcp.computer.settings.recovery.collect_enabled_bundled_servers`
     WARN-skip，即 rust-sdk#102 同型半态。判据升级为可解析：:class:`PluginManifestError` → 该记录失效 →
     触发重物化（catalog 完好则修复指回；不可修复则整体保持 ``installed_disabled``，skill 不单独亮）。
+    记录级单点：entry 级 any/all 变体与 recovery 死记录清扫共用（判据对称，隔离审查 🟡#4）。
+    """
+    install_path = rec.get("installPath") if isinstance(rec, Mapping) else None
+    if not (isinstance(install_path, str) and install_path and Path(install_path).is_dir()):
+        return False
+    try:
+        load_bundled_servers(Path(install_path))
+    except PluginManifestError as e:
+        logger.warning("ledger record %s has corrupt bundled server JSON, treated as unmaterialized: %s", install_path, e)
+        return False
+    return True
 
-    原 ``recovery._ledger_materialized`` 迁入公开化（#125 任务 2）：boot 恢复的重物化触发与
-    :func:`list_dangling_plugin_intents` 的悬挂判据共用本单点。
+
+def ledger_entry_materialized(records: object) -> bool:
+    """
+    某 pid 是否**存在**有效物化记录（∃ 语义）/ Whether any record is live。
+
+    原 ``recovery._ledger_materialized`` 迁入公开化（#125 任务 2）：作 :func:`list_dangling_plugin_intents`
+    的悬挂判据——只要还有一条活记录就不是「意图 ∖ 账本」悬挂（prune 对象须是零有效物化）。
+    boot 重物化触发请用 :func:`ledger_entry_fully_materialized`（∀ 语义——混合健康度也要修复）。
     """
     if not isinstance(records, list):
         return False
-    for rec in records:
-        install_path = rec.get("installPath") if isinstance(rec, Mapping) else None
-        if not (isinstance(install_path, str) and install_path and Path(install_path).is_dir()):
-            continue
-        try:
-            load_bundled_servers(Path(install_path))
-        except PluginManifestError as e:
-            logger.warning("ledger record %s has corrupt bundled server JSON, treated as unmaterialized: %s", install_path, e)
-            continue
-        return True
-    return False
+    return any(ledger_record_materialized(rec) for rec in records)
+
+
+def ledger_entry_fully_materialized(records: object) -> bool:
+    """
+    某 pid 的账本记录是否**全部**有效物化（∀ 语义，非空）/ Whether every record is live。
+
+    boot 重物化触发判据（#125 隔离审查 🟡#4）：∃ 语义会让「一条健康 + 一条损坏」的混合健康度 pid 永不进
+    ``needs_materialize``——损坏 scope 记录每次 boot 被 collect WARN-skip、又不被清扫，即窄化半态回归口。
+    ∀ 语义下混合健康度触发重物化：健康 scope 幂等重建、损坏残留由 sweep（同记录级判据）清扫。
+    """
+    if not isinstance(records, list) or not records:
+        return False
+    return all(ledger_record_materialized(rec) for rec in records)
 
 
 # 悬挂意图 reason 分档（#125 任务 2；wire 值入 CLI JSON 输出，rust 镜像同字面）/ dangling reason tiers.

--- a/a2c_smcp/computer/settings/recovery.py
+++ b/a2c_smcp/computer/settings/recovery.py
@@ -43,7 +43,19 @@ from typing import Any
 from a2c_smcp.computer.mcp_clients.model import MCPServerConfig
 from a2c_smcp.computer.settings.installer import materialize_plugin
 from a2c_smcp.computer.settings.reconciler import declared_installed_plugin_ids, ledger_entry_materialized
-from a2c_smcp.computer.settings.store import load_installed_plugins, load_known_marketplaces
+from a2c_smcp.computer.settings.schema import SettingsScope
+from a2c_smcp.computer.settings.scope import (
+    load_settings_file,
+    user_settings_path,
+    workdir_local_settings_path,
+    workdir_project_settings_path,
+)
+from a2c_smcp.computer.settings.store import (
+    InstalledPluginsFile,
+    load_installed_plugins,
+    load_known_marketplaces,
+    update_installed_plugins,
+)
 from a2c_smcp.computer.skills.home import marketplace_skill_dir
 from a2c_smcp.computer.skills.manifest import PluginManifestError, load_bundled_servers
 from a2c_smcp.computer.skills.registry import SkillRegistry
@@ -65,6 +77,8 @@ class GovernanceRecoveryReport:
     - ``skipped_disabled``：``installed_disabled``（安装意图在、``enabledPlugins`` absent/false）惰性跳过的 pid
       （v0.3.0 缺省翻转，§2.4）。
     - ``rematerialized``：意图有、账本缺 → 本轮重物化成功重建账本的 pid（§4.9 删除无损）。
+    - ``scope_normalized``：重物化时**无任何层线索**、记录归一 user scope 的 pid（#125 任务 1 显式标注；
+      有线索时经 :func:`_infer_record_scopes` 推回原 scope，不入此列）。
     """
 
     restored_plugins: list[str] = field(default_factory=list)
@@ -73,6 +87,7 @@ class GovernanceRecoveryReport:
     failed_marketplaces: list[str] = field(default_factory=list)
     skipped_disabled: list[str] = field(default_factory=list)
     rematerialized: list[str] = field(default_factory=list)
+    scope_normalized: list[str] = field(default_factory=list)
 
 
 @dataclass(frozen=True, slots=True)
@@ -112,6 +127,66 @@ def _split_pid(pid: str) -> tuple[str, str] | None:
     return plugin, marketplace
 
 
+def _intent_layer_snapshot(env: Mapping[str, str] | None, cwd: Path) -> dict[str, Mapping[str, Any]]:
+    """
+    user / project / local 三层 settings 的**原始分层**快照（merged 视图丢失层归属，scope 推回需逐层看）/ Raw layers。
+
+    project/local 锚定 ``cwd``（#116 单锚点模型）：异地项目的层不可见——该盲区由归一 fallback + WARN 兜底。
+    复用 :func:`~a2c_smcp.computer.settings.scope.load_settings_file`（缺失文件 → ``({}, [])``，纯读零副作用）。
+    """
+    user_data, _ = load_settings_file(user_settings_path(env), SettingsScope.USER)
+    project_data, _ = load_settings_file(workdir_project_settings_path(cwd), SettingsScope.PROJECT)
+    local_data, _ = load_settings_file(workdir_local_settings_path(cwd), SettingsScope.LOCAL)
+    return {"user": user_data, "project": project_data, "local": local_data}
+
+
+def _infer_record_scopes(pid: str, layers: Mapping[str, Mapping[str, Any]], cwd: Path) -> list[tuple[str, str | None]]:
+    """
+    由分层线索推回账本记录 scope——enable/disable「写入层 = 安装 scope」契约（installer）的逆运算（#125 任务 1）。
+
+    线索规则 / Clue rules:
+    - project/local 层：``enabledPlugins`` 含 pid 键（``true``/``false`` 均证明该层与 pid 有 scope 绑定）**或**
+      ``installedPlugins`` 声明含 pid（声明式复现场景）→ ``(scope, str(cwd))``；
+    - user 层：仅 ``enabledPlugins`` 含 pid 键算——user 层 ``installedPlugins`` 是 install 恒写的全局意图，无区分度；
+    - 多层命中 → 多条记录（user→project→local 稳定序，多 scope 不塌缩）；全无线索 → ``[]``
+      （调用方 fallback ``[("user", None)]`` + ``scope_normalized`` 归一标注）。
+    """
+    out: list[tuple[str, str | None]] = []
+    for scope_name in ("user", "project", "local"):
+        data = layers.get(scope_name) or {}
+        enabled = data.get("enabledPlugins")
+        clue = isinstance(enabled, Mapping) and pid in enabled
+        if scope_name != "user" and not clue:
+            installed = data.get("installedPlugins")
+            clue = isinstance(installed, list) and pid in installed
+        if clue:
+            out.append((scope_name, str(cwd) if scope_name != "user" else None))
+    return out
+
+
+def _sweep_dead_records(pid: str, home: Path, env: Mapping[str, str] | None) -> None:
+    """
+    重建成功后清扫该 pid 下 ``installPath`` 已死的残留记录（派生缓存卫生，非资产删除、不违 §4.8.4）。
+
+    动机：``needs_materialize`` 的触发前提是该 pid 全部记录失效；按线索重建后若残留死 scope 记录，
+    CLI enable/disable 会循环逐 scope 误写死层（如已不可推回的异地 project 层）。
+    """
+
+    def _mut(data: InstalledPluginsFile, _pid: str = pid) -> None:
+        records = data["plugins"].get(_pid)
+        if not isinstance(records, list):
+            return
+        alive = [
+            r
+            for r in records
+            if isinstance(r, Mapping) and isinstance(p := r.get("installPath"), str) and p and Path(p).is_dir()
+        ]
+        if alive:
+            data["plugins"][_pid] = alive
+
+    update_installed_plugins(_mut, home=home, env=env)
+
+
 async def recover_marketplace_skills(
     registry: SkillRegistry,
     home: Path,
@@ -131,9 +206,12 @@ async def recover_marketplace_skills(
     降级判定与 rust 同构：stage 内部吞错，事后 clone 树仍缺 → 该 marketplace 入 ``failed_marketplaces``；
     known_marketplaces 缺记录 → 同样降级。**绝不抛、不阻断其余**。
 
-    已知限制（文档化，rust 同构）：重物化无法从无 scope 的 ``installedPlugins`` 还原原安装 scope /
-    ``projectPath``——重建记录**归一为 user scope**（多 scope 记录塌缩单条）；此后 enable/disable 从账本
-    读 scope 会落 user 层。scope 精确复原需 committed 记录承载，属可选 pin-lock 扩展（§4.9.2）范畴。
+    scope 推回（#125 任务 1）：重物化前经 :func:`_infer_record_scopes` 扫描 user / cwd 锚定 project/local
+    三层的 ``enabledPlugins`` 条目（及 project/local 的 ``installedPlugins`` 声明）作 scope 线索——
+    enable/disable「写入层 = 安装 scope」契约的逆运算；多层线索重建多条记录，重建后清扫死残留记录。
+    已知盲区（文档化，rust 同构）：**cwd 不可见的异地 project/local 层线索无法推回**——无线索时归一
+    user scope + WARN + ``report.scope_normalized`` 显式标注；完美复原需 committed 记录承载，属可选
+    pin-lock 扩展（§4.9.2）范畴。
 
     :param registry: 目标 :class:`SkillRegistry`（恢复注册进当前活跃集）。
     :param home: SKILL Home 绝对根。
@@ -147,6 +225,8 @@ async def recover_marketplace_skills(
         return report
     ledger = load_installed_plugins(home=home, env=env).get("plugins", {})
     known = load_known_marketplaces(home=home, env=env).get("marketplaces", {})
+    cwd = Path.cwd()
+    layers = _intent_layer_snapshot(env, cwd)  # scope 推回线索快照（循环外一次，#125 任务 1）
 
     # installed pid 按 marketplace 分组（plugin → 是否活跃）/ group intent pids by marketplace.
     by_marketplace: dict[str, dict[str, bool]] = {}
@@ -193,14 +273,31 @@ async def recover_marketplace_skills(
         #    重建（保 enable 廉价、账本可查询）；冲突预检传 None（boot 无 live manager；重挂阶段自有
         #    existing 名跳过护栏）。**物化失败的活跃 plugin 整体保持 installed_disabled**（摘出 stage
         #    filter，skills 不进投影——否则 skill 已亮、bundled server 不可查询即 rust-sdk#102 半态）。
+        #    scope 经分层线索推回（#125 任务 1）；无线索 → 归一 user + WARN + scope_normalized 标注。
         for plugin in needs_materialize:
             pid = f"{plugin}@{marketplace}"
+            targets = _infer_record_scopes(pid, layers, cwd)
+            normalized = not targets
+            if normalized:
+                targets = [("user", None)]
             try:
-                await materialize_plugin(pid, home, refresh=False, timeout=timeout, env=env)
+                for scope_name, project_path in targets:
+                    await materialize_plugin(
+                        pid, home, scope=scope_name, project_path=project_path, refresh=False, timeout=timeout, env=env,
+                    )
                 report.rematerialized.append(pid)
             except Exception as e:  # noqa: BLE001 - 失败降级铁律：WARN 跳过，不阻断 boot
                 logger.warning("governance recovery: re-materialize %r failed; kept installed_disabled (skills not staged): %s", pid, e)
                 active_plugins.discard(plugin)
+                continue
+            if normalized:
+                report.scope_normalized.append(pid)
+                logger.warning(
+                    "governance recovery: no scope clue for %r; ledger record normalized to user scope "
+                    "(original install scope unrecoverable without committed pin-lock, §4.9.2)",
+                    pid,
+                )
+            _sweep_dead_records(pid, home, env)
 
         # ③ stage skills（仅活跃且物化完好的 plugin）
         if active_plugins:

--- a/a2c_smcp/computer/settings/recovery.py
+++ b/a2c_smcp/computer/settings/recovery.py
@@ -42,7 +42,11 @@ from typing import Any
 
 from a2c_smcp.computer.mcp_clients.model import MCPServerConfig
 from a2c_smcp.computer.settings.installer import materialize_plugin
-from a2c_smcp.computer.settings.reconciler import declared_installed_plugin_ids, ledger_entry_materialized
+from a2c_smcp.computer.settings.reconciler import (
+    declared_installed_plugin_ids,
+    ledger_entry_fully_materialized,
+    ledger_record_materialized,
+)
 from a2c_smcp.computer.settings.schema import SettingsScope
 from a2c_smcp.computer.settings.scope import (
     load_settings_file,
@@ -145,9 +149,13 @@ def _infer_record_scopes(pid: str, layers: Mapping[str, Mapping[str, Any]], cwd:
     由分层线索推回账本记录 scope——enable/disable「写入层 = 安装 scope」契约（installer）的逆运算（#125 任务 1）。
 
     线索规则 / Clue rules:
-    - project/local 层：``enabledPlugins`` 含 pid 键（``true``/``false`` 均证明该层与 pid 有 scope 绑定）**或**
-      ``installedPlugins`` 声明含 pid（声明式复现场景）→ ``(scope, str(cwd))``；
-    - user 层：仅 ``enabledPlugins`` 含 pid 键算——user 层 ``installedPlugins`` 是 install 恒写的全局意图，无区分度；
+    - project/local 层：``enabledPlugins[pid] is True`` **或** ``installedPlugins`` 声明含 pid（声明式复现）
+      → ``(scope, str(cwd))``。纯 ``false`` **不算**——它可能是团队对 user-scope 安装的独立禁用覆盖（§2.4
+      三态合并），当作 install-scope 线索会凭空捏造记录，此后 CLI enable 逐 scope 写会把团队 ``false``
+      覆写为 ``true``（隔离审查 🟡#3）。误差方向不对称：漏推回 → fallback user、disable 语义靠合并仍成立
+      （安全）；错捏造 → enable 反向覆写治理意图（不安全）。
+    - user 层：``enabledPlugins`` 含 pid 键即算（含 ``false``——与 fallback 同落点，无捏造风险）；
+      user 层 ``installedPlugins`` 是 install 恒写的全局意图，无区分度、不算。
     - 多层命中 → 多条记录（user→project→local 稳定序，多 scope 不塌缩）；全无线索 → ``[]``
       （调用方 fallback ``[("user", None)]`` + ``scope_normalized`` 归一标注）。
     """
@@ -155,10 +163,13 @@ def _infer_record_scopes(pid: str, layers: Mapping[str, Mapping[str, Any]], cwd:
     for scope_name in ("user", "project", "local"):
         data = layers.get(scope_name) or {}
         enabled = data.get("enabledPlugins")
-        clue = isinstance(enabled, Mapping) and pid in enabled
-        if scope_name != "user" and not clue:
-            installed = data.get("installedPlugins")
-            clue = isinstance(installed, list) and pid in installed
+        if scope_name == "user":
+            clue = isinstance(enabled, Mapping) and pid in enabled
+        else:
+            clue = isinstance(enabled, Mapping) and enabled.get(pid) is True
+            if not clue:
+                installed = data.get("installedPlugins")
+                clue = isinstance(installed, list) and pid in installed
         if clue:
             out.append((scope_name, str(cwd) if scope_name != "user" else None))
     return out
@@ -166,21 +177,19 @@ def _infer_record_scopes(pid: str, layers: Mapping[str, Mapping[str, Any]], cwd:
 
 def _sweep_dead_records(pid: str, home: Path, env: Mapping[str, str] | None) -> None:
     """
-    重建成功后清扫该 pid 下 ``installPath`` 已死的残留记录（派生缓存卫生，非资产删除、不违 §4.8.4）。
+    重建成功后清扫该 pid 下失效的残留记录（派生缓存卫生，非资产删除、不违 §4.8.4）。
 
-    动机：``needs_materialize`` 的触发前提是该 pid 全部记录失效；按线索重建后若残留死 scope 记录，
-    CLI enable/disable 会循环逐 scope 误写死层（如已不可推回的异地 project 层）。
+    动机：重物化按线索重建后若残留失效 scope 记录，CLI enable/disable 会循环逐 scope 误写死层
+    （如已不可推回的异地 project 层）。判据与重物化触发同源
+    （:func:`~a2c_smcp.computer.settings.reconciler.ledger_record_materialized`：目录在 ∧ bundled JSON
+    可解析——「目录在但 JSON 损坏」的记录同样清扫，隔离审查 🟡#4 判据对称）。
     """
 
     def _mut(data: InstalledPluginsFile, _pid: str = pid) -> None:
         records = data["plugins"].get(_pid)
         if not isinstance(records, list):
             return
-        alive = [
-            r
-            for r in records
-            if isinstance(r, Mapping) and isinstance(p := r.get("installPath"), str) and p and Path(p).is_dir()
-        ]
+        alive = [r for r in records if ledger_record_materialized(r)]
         if alive:
             data["plugins"][_pid] = alive
 
@@ -242,7 +251,9 @@ async def recover_marketplace_skills(
 
     for marketplace, plugins in sorted(by_marketplace.items()):
         active_plugins = {p for p, is_active in plugins.items() if is_active}
-        needs_materialize = sorted(p for p in plugins if not ledger_entry_materialized(ledger.get(f"{p}@{marketplace}")))
+        # ∀ 语义（fully）：混合健康度（一条健康 + 一条损坏/死路径）也触发重物化——健康 scope 幂等重建、
+        # 损坏残留由 sweep 清扫（隔离审查 🟡#4：∃ 语义会让损坏 scope 记录每次 boot 被 WARN-skip 却永不修复）。
+        needs_materialize = sorted(p for p in plugins if not ledger_entry_fully_materialized(ledger.get(f"{p}@{marketplace}")))
         if not active_plugins and not needs_materialize:
             continue  # 全惰性且账本完好 → 零动作（installed_disabled 静止态）
 

--- a/a2c_smcp/computer/settings/recovery.py
+++ b/a2c_smcp/computer/settings/recovery.py
@@ -42,7 +42,7 @@ from typing import Any
 
 from a2c_smcp.computer.mcp_clients.model import MCPServerConfig
 from a2c_smcp.computer.settings.installer import materialize_plugin
-from a2c_smcp.computer.settings.reconciler import declared_installed_plugin_ids
+from a2c_smcp.computer.settings.reconciler import declared_installed_plugin_ids, ledger_entry_materialized
 from a2c_smcp.computer.settings.store import load_installed_plugins, load_known_marketplaces
 from a2c_smcp.computer.skills.home import marketplace_skill_dir
 from a2c_smcp.computer.skills.manifest import PluginManifestError, load_bundled_servers
@@ -112,17 +112,6 @@ def _split_pid(pid: str) -> tuple[str, str] | None:
     return plugin, marketplace
 
 
-def _ledger_materialized(records: Any) -> bool:
-    """某 pid 的账本记录是否仍有效物化（至少一条记录的 ``installPath`` 目录存在）/ Whether the ledger entry is live。"""
-    if not isinstance(records, list):
-        return False
-    for rec in records:
-        install_path = rec.get("installPath") if isinstance(rec, Mapping) else None
-        if isinstance(install_path, str) and install_path and Path(install_path).is_dir():
-            return True
-    return False
-
-
 async def recover_marketplace_skills(
     registry: SkillRegistry,
     home: Path,
@@ -173,7 +162,7 @@ async def recover_marketplace_skills(
 
     for marketplace, plugins in sorted(by_marketplace.items()):
         active_plugins = {p for p, is_active in plugins.items() if is_active}
-        needs_materialize = sorted(p for p in plugins if not _ledger_materialized(ledger.get(f"{p}@{marketplace}")))
+        needs_materialize = sorted(p for p in plugins if not ledger_entry_materialized(ledger.get(f"{p}@{marketplace}")))
         if not active_plugins and not needs_materialize:
             continue  # 全惰性且账本完好 → 零动作（installed_disabled 静止态）
 

--- a/tests/unit_tests/computer/cli/test_plugin.py
+++ b/tests/unit_tests/computer/cli/test_plugin.py
@@ -583,3 +583,60 @@ def test_list_available_prints_deprecation_warning(tmp_path: Path, capsys: pytes
 
     plugin_cmd.plugin_list(home, env)
     assert "deprecated" not in capsys.readouterr().out
+
+
+@pytest.mark.asyncio
+async def test_gc_prune_residual_committable_declaration_not_counted(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str],
+) -> None:
+    """悬挂意图仅来自 committable project 层声明 → prune 不改写该文件、不计入 prunedIntents（隔离审查 🟡#1：
+    误报会让自动化「prune 到干净」永不收敛），归 residualDeclarations 显式暴露。"""
+    _isolate_env(tmp_path, monkeypatch)
+    home, env, reg = _home(tmp_path), dict(os.environ), SkillRegistry()
+    proj_path = workdir_project_settings_path(Path.cwd())
+    _write_json(proj_path, {"installedPlugins": ["ghost@nowhere"]})
+    before = proj_path.read_text(encoding="utf-8")
+
+    code = await plugin_cmd.plugin_gc(reg, home, env, json_output=True, prune_dangling=True)
+
+    assert code == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["dangling"] == [{"id": "ghost@nowhere", "reason": "marketplace-not-added"}]
+    assert out["prunedIntents"] == []  # 未真正移除，不得计入
+    assert out["residualDeclarations"] == ["ghost@nowhere"]
+    assert proj_path.read_text(encoding="utf-8") == before  # committable 声明未被改写
+
+
+@pytest.mark.asyncio
+async def test_gc_confirm_accept_removes_orphans_and_prunes_dangling(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """confirm 通过（返回 True）→ 孤儿删除 + 悬挂真 prune 双双生效（隔离审查 🟡#6 正路覆盖）。"""
+    _isolate_env(tmp_path, monkeypatch)
+    home, env, reg = _home(tmp_path), dict(os.environ), SkillRegistry()
+    orphan_path = _seed_orphan_and_dangling(home, env)
+
+    async def _confirm(items: list[str]) -> bool:
+        return True
+
+    code = await plugin_cmd.plugin_gc(reg, home, env, confirm=_confirm, prune_dangling=True)
+
+    assert code == 0
+    assert not orphan_path.exists()  # 孤儿已删
+    assert "orphan@acme" not in load_installed_plugins(home=home)["plugins"]
+    user = json.loads(user_settings_path(env).read_text(encoding="utf-8"))
+    assert "ghost@nowhere" not in user.get("installedPlugins", [])  # 悬挂已 prune
+    assert "ghost@nowhere" not in user.get("enabledPlugins", {})
+
+
+def test_list_available_json_stdout_stays_pure(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """--available + --json：弃用提示走 logger，stdout 保持纯 JSON 可解析（隔离审查 🟡#5 验收补缺）。"""
+    home, env = _home(tmp_path), _env(tmp_path)
+    save_installed_plugins({"version": 1, "plugins": {"audit@acme": [{"scope": "user", "installPath": "/x"}]}}, home=home)
+
+    plugin_cmd.plugin_list(home, env, available=True, json_output=True)
+
+    out = capsys.readouterr().out
+    rows = json.loads(out)  # stdout 可整体解析 = 纯 JSON
+    assert rows[0]["id"] == "audit@acme"
+    assert "deprecated" not in out

--- a/tests/unit_tests/computer/cli/test_plugin.py
+++ b/tests/unit_tests/computer/cli/test_plugin.py
@@ -461,3 +461,125 @@ async def test_run_governance_remount_existing_from_comp_servers(tmp_path: Path,
         await plugin_cmd.run_governance_remount(comp)
 
         assert recorded == []
+
+
+# ── #125 任务 1：危害链回归——重物化推回后 disable 跨 boot 有效 ─────────────────
+@pytest.mark.asyncio
+async def test_disable_effective_across_boot_after_rematerialization(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """project 装+enable → 账本丢失 → recover 推回 project 记录 → disable 写 project 层 false（merged 不再 enabled）。"""
+    from a2c_smcp.computer.settings.recovery import recover_marketplace_skills
+
+    _isolate_env(tmp_path, monkeypatch)
+    home, env, reg = _home(tmp_path), dict(os.environ), SkillRegistry()
+    _setup_catalog(home, "acme", "audit", servers=["figma-mcp"])
+    workdir = Path.cwd()
+    # 模拟 project scope 安装+启用后账本丢失：仅 settings 意图在
+    _write_json(user_settings_path(env), {"installedPlugins": ["audit@acme"]})
+    _write_json(workdir_project_settings_path(workdir), {"enabledPlugins": {"audit@acme": True}})
+    declared = {"installedPlugins": ["audit@acme"], "enabledPlugins": {"audit@acme": True}}
+
+    report = await recover_marketplace_skills(reg, home, declared, env=env)
+    assert report.rematerialized == ["audit@acme"]
+
+    mcp = _FakeMCP()
+    code = await plugin_cmd.plugin_disable(reg, home, env, "audit@acme", remove_server=mcp.remove)
+
+    assert code == 0
+    proj = json.loads(workdir_project_settings_path(workdir).read_text(encoding="utf-8"))
+    assert proj["enabledPlugins"]["audit@acme"] is False  # 写对层（project，而非归一后的 user）
+    assert plugin_cmd._enabled_plugins_view(home, env).get("audit@acme") is not True  # merged 视图不再 enabled
+
+
+# ── #125 任务 2：plugin gc 扩展（悬挂意图诊断/prune + 权威性不对称安全阀）────────
+def _seed_orphan_and_dangling(home: Path, env: dict[str, str]) -> Path:
+    """孤儿（账本 ∖ 意图，live installPath）+ 悬挂（意图 ∖ 账本，marketplace 未添加）。返回孤儿 installPath。"""
+    orphan_path = marketplace_skill_dir(home, "acme") / "plugins" / "orphan"
+    orphan_path.mkdir(parents=True, exist_ok=True)
+    save_installed_plugins(
+        {"version": 1, "plugins": {"orphan@acme": [{"scope": "user", "installPath": str(orphan_path)}]}},
+        home=home,
+    )
+    _write_json(user_settings_path(env), {"installedPlugins": ["ghost@nowhere"], "enabledPlugins": {"ghost@nowhere": True}})
+    return orphan_path
+
+
+@pytest.mark.asyncio
+async def test_gc_prunes_dangling_json_contract(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str],
+) -> None:
+    """JSON 契约：``removed`` 键不变；增 ``dangling``（诊断+reason）/``prunedIntents``（实际删）/``recoverable``。"""
+    _isolate_env(tmp_path, monkeypatch)
+    home, env, reg = _home(tmp_path), dict(os.environ), SkillRegistry()
+    orphan_path = _seed_orphan_and_dangling(home, env)
+
+    code = await plugin_cmd.plugin_gc(reg, home, env, json_output=True, prune_dangling=True)
+
+    assert code == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["removed"] == ["orphan@acme"]
+    assert out["dangling"] == [{"id": "ghost@nowhere", "reason": "marketplace-not-added"}]
+    assert out["prunedIntents"] == ["ghost@nowhere"]
+    assert out["recoverable"] == []
+    assert not orphan_path.exists()
+    user = json.loads(user_settings_path(env).read_text(encoding="utf-8"))
+    assert "ghost@nowhere" not in user.get("installedPlugins", [])  # 意图已 prune
+    assert "ghost@nowhere" not in user.get("enabledPlugins", {})
+
+
+@pytest.mark.asyncio
+async def test_gc_confirm_combined_and_abort_keeps_everything(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """confirm 收到孤儿+悬挂组合描述（悬挂条目带 reason 后缀）；拒绝 → 零变更、退出码 1。"""
+    _isolate_env(tmp_path, monkeypatch)
+    home, env, reg = _home(tmp_path), dict(os.environ), SkillRegistry()
+    orphan_path = _seed_orphan_and_dangling(home, env)
+    got: list[str] = []
+
+    async def _confirm(items: list[str]) -> bool:
+        got.extend(items)
+        return False
+
+    code = await plugin_cmd.plugin_gc(reg, home, env, confirm=_confirm, prune_dangling=True)
+
+    assert code == 1
+    assert any("orphan@acme" in s for s in got)
+    assert any("ghost@nowhere" in s and "dangling" in s for s in got)  # 悬挂条目带标注
+    assert orphan_path.exists()  # 零变更
+    assert "orphan@acme" in load_installed_plugins(home=home)["plugins"]
+    user = json.loads(user_settings_path(env).read_text(encoding="utf-8"))
+    assert user["installedPlugins"] == ["ghost@nowhere"]
+
+
+@pytest.mark.asyncio
+async def test_gc_prune_dangling_off_by_default_diagnose_only(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str],
+) -> None:
+    """权威性不对称：非交互（Typer 默认）悬挂意图**只诊断不删**——删权威意图需显式 ``--prune-dangling``。"""
+    _isolate_env(tmp_path, monkeypatch)
+    home, env, reg = _home(tmp_path), dict(os.environ), SkillRegistry()
+    _write_json(user_settings_path(env), {"installedPlugins": ["ghost@nowhere"]})
+
+    code = await plugin_cmd.plugin_gc(reg, home, env, json_output=True)  # prune_dangling 缺省 False
+
+    assert code == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["dangling"] == [{"id": "ghost@nowhere", "reason": "marketplace-not-added"}]
+    assert out["prunedIntents"] == []
+    user = json.loads(user_settings_path(env).read_text(encoding="utf-8"))
+    assert user["installedPlugins"] == ["ghost@nowhere"]  # 意图原样保留
+
+
+# ── #125 任务 3：plugin list --available 弃用提示 ──────────────────────────────
+def test_list_available_prints_deprecation_warning(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """--available 为兼容 no-op：非 JSON 模式打弃用提示；不带 flag 时不打。"""
+    home, env = _home(tmp_path), _env(tmp_path)
+    save_installed_plugins({"version": 1, "plugins": {"audit@acme": [{"scope": "user", "installPath": "/x"}]}}, home=home)
+
+    plugin_cmd.plugin_list(home, env, available=True)
+    assert "deprecated" in capsys.readouterr().out
+
+    plugin_cmd.plugin_list(home, env)
+    assert "deprecated" not in capsys.readouterr().out

--- a/tests/unit_tests/computer/settings/test_install_enable_separation.py
+++ b/tests/unit_tests/computer/settings/test_install_enable_separation.py
@@ -719,6 +719,54 @@ async def test_uninstall_does_not_create_tfrobot_dir_in_cwd(tmp_path: Path, monk
     assert not (workdir / ".tfrobot").exists()  # 不制造垃圾目录/锁文件
 
 
+@pytest.mark.asyncio
+async def test_recover_rematerialize_ignores_project_false_override(tmp_path: Path, monkeypatch) -> None:
+    """project 层纯 ``false`` 是禁用覆盖、非 install-scope 线索——不得捏造 project 记录（隔离审查 🟡#3：
+    否则 CLI enable 逐 scope 写会把团队 ``false`` 覆写为 ``true``，反向覆写治理意图）。"""
+    home = _home(tmp_path)
+    env = _env(tmp_path)
+    workdir = tmp_path / "proj"
+    workdir.mkdir()
+    monkeypatch.chdir(workdir)
+    _setup_catalog(home, "acme", "audit", servers=["figma"], skills=["lint"])
+    _write_json(user_settings_path(env), {"installedPlugins": [_PID], "enabledPlugins": {_PID: True}})
+    _write_json(workdir_project_settings_path(workdir), {"enabledPlugins": {_PID: False}})  # 团队禁用覆盖
+    declared = {"installedPlugins": [_PID], "enabledPlugins": {_PID: False}}  # merged：project false 获胜
+
+    report = await recover_marketplace_skills(SkillRegistry(), home, declared, env=env)
+
+    assert report.rematerialized == [_PID]
+    records = load_installed_plugins(home=home)["plugins"][_PID]
+    assert [(r["scope"], r.get("projectPath")) for r in records] == [("user", None)]  # 不捏造 project 记录
+    assert report.scope_normalized == []  # user 层有线索，非归一
+
+
+@pytest.mark.asyncio
+async def test_recover_repairs_mixed_health_records(tmp_path: Path, monkeypatch) -> None:
+    """混合健康度（健康 user 记录 + 损坏 project 记录）也触发重物化并清扫损坏残留（隔离审查 🟡#4：
+    ∃ 判据会让损坏 scope 记录每次 boot 被 WARN-skip 却永不修复——窄化半态回归口）。"""
+    home = _home(tmp_path)
+    env = _env(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    root = _setup_catalog(home, "acme", "audit", servers=["figma"], skills=["lint"])
+    stale = home / "stale-project-copy"
+    (stale / "mcp-servers").mkdir(parents=True)
+    (stale / "mcp-servers" / "bad.json").write_text("{not json", encoding="utf-8")
+    _seed_installed(
+        home,
+        {_PID: [_record(root, servers=["figma"]), {"scope": "project", "installPath": str(stale), "projectPath": "/elsewhere"}]},
+    )
+    _write_json(user_settings_path(env), {"installedPlugins": [_PID], "enabledPlugins": {_PID: True}})
+    declared = {"installedPlugins": [_PID], "enabledPlugins": {_PID: True}}
+
+    report = await recover_marketplace_skills(SkillRegistry(), home, declared, env=env)
+
+    assert report.rematerialized == [_PID]  # ∀ 判据：混合健康度触发重物化
+    records = load_installed_plugins(home=home)["plugins"][_PID]
+    assert [(r["scope"], r["installPath"]) for r in records] == [("user", str(root))]  # 损坏 project 残留被清扫
+    assert [r.config.name for r in collect_enabled_bundled_servers(home, declared, env=env)] == ["figma"]  # 无半态
+
+
 # ── #125 任务 2：悬挂意图 prune 执行入口（installer 是 settings 意图唯一写者）──
 def test_prune_plugin_intent_clears_intent_enabled_and_dead_ledger(tmp_path: Path, monkeypatch) -> None:
     """prune：删 user 意图 + 清 user/cwd 可见层 enabled 条目 + 弹出死账本记录（针对悬挂意图的 uninstall 等价物）。"""

--- a/tests/unit_tests/computer/settings/test_install_enable_separation.py
+++ b/tests/unit_tests/computer/settings/test_install_enable_separation.py
@@ -38,7 +38,7 @@ from a2c_smcp.computer.settings.recovery import (
     recover_marketplace_skills,
 )
 from a2c_smcp.computer.settings.schema import SettingsScope, validate_settings
-from a2c_smcp.computer.settings.scope import user_settings_path
+from a2c_smcp.computer.settings.scope import user_settings_path, workdir_local_settings_path, workdir_project_settings_path
 from a2c_smcp.computer.settings.store import load_installed_plugins, save_installed_plugins, save_known_marketplaces
 from a2c_smcp.computer.skills.home import SOURCE_MARKETPLACE, marketplace_skill_dir
 from a2c_smcp.computer.skills.registry import SkillRegistry
@@ -567,6 +567,259 @@ async def test_enable_mount_failure_restores_previous_true(tmp_path: Path, monke
         )
 
     assert _read_user_settings(env)["enabledPlugins"][_PID] is True
+
+
+# ── #125 任务 1：重物化 scope 混合线索推回（enable/disable scope 契约的逆运算）──
+@pytest.mark.asyncio
+async def test_recover_rematerialize_infers_project_scope_from_enabled_layer(tmp_path: Path, monkeypatch) -> None:
+    """project 层 ``enabledPlugins[pid]`` 条目 = scope 线索 → 重建记录 scope=project + projectPath=cwd（非归一 user）。"""
+    home = _home(tmp_path)
+    env = _env(tmp_path)
+    workdir = tmp_path / "proj"
+    workdir.mkdir()
+    monkeypatch.chdir(workdir)
+    _setup_catalog(home, "acme", "audit", servers=["figma"], skills=["lint"])
+    _write_json(workdir_project_settings_path(workdir), {"enabledPlugins": {_PID: True}})
+    declared = {"installedPlugins": [_PID], "enabledPlugins": {_PID: True}}
+
+    report = await recover_marketplace_skills(SkillRegistry(), home, declared, env=env)
+
+    assert report.rematerialized == [_PID]
+    records = load_installed_plugins(home=home)["plugins"][_PID]
+    assert [(r["scope"], r.get("projectPath")) for r in records] == [("project", str(Path.cwd()))]
+    assert report.scope_normalized == []  # 有线索 → 不归一
+
+
+@pytest.mark.asyncio
+async def test_recover_rematerialize_multi_layer_clues_rebuild_multi_records(tmp_path: Path, monkeypatch) -> None:
+    """多层线索（user false + local true）→ 重建多条记录（多 scope 不塌缩单条）。"""
+    home = _home(tmp_path)
+    env = _env(tmp_path)
+    workdir = tmp_path / "proj"
+    workdir.mkdir()
+    monkeypatch.chdir(workdir)
+    _setup_catalog(home, "acme", "audit", servers=["figma"], skills=["lint"])
+    _write_json(user_settings_path(env), {"installedPlugins": [_PID], "enabledPlugins": {_PID: False}})
+    _write_json(workdir_local_settings_path(workdir), {"enabledPlugins": {_PID: True}})
+    declared = {"installedPlugins": [_PID], "enabledPlugins": {_PID: True}}
+
+    report = await recover_marketplace_skills(SkillRegistry(), home, declared, env=env)
+
+    assert report.rematerialized == [_PID]
+    records = load_installed_plugins(home=home)["plugins"][_PID]
+    by_scope = {r["scope"]: r.get("projectPath") for r in records}
+    assert by_scope == {"user": None, "local": str(Path.cwd())}
+    assert report.scope_normalized == []
+
+
+@pytest.mark.asyncio
+async def test_recover_rematerialize_no_clue_falls_back_user_and_reports(tmp_path: Path, monkeypatch, caplog) -> None:
+    """无任何层线索 → 归一 user + WARN + ``report.scope_normalized`` 显式标注（issue #125 方向 b 兜底）。"""
+    import logging
+
+    home = _home(tmp_path)
+    env = _env(tmp_path)
+    workdir = tmp_path / "proj"
+    workdir.mkdir()
+    monkeypatch.chdir(workdir)
+    _setup_catalog(home, "acme", "audit", servers=["figma"], skills=["lint"])
+    declared = {"installedPlugins": [_PID]}
+
+    with caplog.at_level(logging.WARNING):
+        report = await recover_marketplace_skills(SkillRegistry(), home, declared, env=env)
+
+    assert report.rematerialized == [_PID]
+    assert report.scope_normalized == [_PID]
+    records = load_installed_plugins(home=home)["plugins"][_PID]
+    assert [(r["scope"], r.get("projectPath")) for r in records] == [("user", None)]
+    assert _PID in caplog.text and "normalized" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_recover_rematerialize_project_installed_declaration_is_clue(tmp_path: Path, monkeypatch) -> None:
+    """project 层 ``installedPlugins`` 声明（声明式复现场景）亦是 scope 线索（installed_disabled 无 enabled 条目时）。"""
+    home = _home(tmp_path)
+    env = _env(tmp_path)
+    workdir = tmp_path / "proj"
+    workdir.mkdir()
+    monkeypatch.chdir(workdir)
+    _setup_catalog(home, "acme", "audit", servers=["figma"], skills=["lint"])
+    _write_json(workdir_project_settings_path(workdir), {"installedPlugins": [_PID]})
+    declared = {"installedPlugins": [_PID]}
+
+    report = await recover_marketplace_skills(SkillRegistry(), home, declared, env=env)
+
+    assert report.rematerialized == [_PID]
+    records = load_installed_plugins(home=home)["plugins"][_PID]
+    assert [(r["scope"], r.get("projectPath")) for r in records] == [("project", str(Path.cwd()))]
+    assert report.scope_normalized == []
+
+
+@pytest.mark.asyncio
+async def test_recover_rematerialize_replaces_dead_records_of_stale_scopes(tmp_path: Path, monkeypatch) -> None:
+    """重建成功后清扫该 pid 下 installPath 已死的残留记录（防 CLI enable/disable 循环误写死 scope 层）。"""
+    home = _home(tmp_path)
+    env = _env(tmp_path)
+    workdir = tmp_path / "proj"
+    workdir.mkdir()
+    monkeypatch.chdir(workdir)
+    _setup_catalog(home, "acme", "audit", servers=["figma"], skills=["lint"])
+    _seed_installed(home, {_PID: [{"scope": "project", "installPath": str(tmp_path / "gone"), "projectPath": str(workdir)}]})
+    _write_json(user_settings_path(env), {"installedPlugins": [_PID], "enabledPlugins": {_PID: True}})
+    declared = {"installedPlugins": [_PID], "enabledPlugins": {_PID: True}}
+
+    report = await recover_marketplace_skills(SkillRegistry(), home, declared, env=env)
+
+    assert report.rematerialized == [_PID]
+    records = load_installed_plugins(home=home)["plugins"][_PID]
+    assert [(r["scope"], r.get("projectPath")) for r in records] == [("user", None)]  # 死 project 记录被清扫
+
+
+@pytest.mark.asyncio
+async def test_uninstall_clears_cwd_visible_enabled_entries_without_ledger_projectpath(tmp_path: Path, monkeypatch) -> None:
+    """uninstall 清理集并入 cwd：账本记录无 projectPath（归一后形态）时，cwd 可见 project 层条目也清净（防重装即激活）。"""
+    home = _home(tmp_path)
+    env = _env(tmp_path)
+    workdir = tmp_path / "proj"
+    workdir.mkdir()
+    monkeypatch.chdir(workdir)
+    root = _setup_catalog(home, "acme", "audit")
+    _seed_installed(home, {_PID: [_record(root)]})  # user record，无 projectPath
+    _write_json(user_settings_path(env), {"installedPlugins": [_PID], "enabledPlugins": {_PID: True}})
+    _write_json(workdir_project_settings_path(workdir), {"enabledPlugins": {_PID: True}})
+    monkeypatch.setattr(_STAGE, _fake_stage([]))
+
+    ok = await uninstall_plugin(_PID, SkillRegistry(), home, env=env)
+
+    assert ok is True
+    proj = json.loads(workdir_project_settings_path(workdir).read_text(encoding="utf-8"))
+    assert _PID not in proj.get("enabledPlugins", {})
+
+
+@pytest.mark.asyncio
+async def test_uninstall_does_not_create_tfrobot_dir_in_cwd(tmp_path: Path, monkeypatch) -> None:
+    """cwd 无 ``.tfrobot/`` 时 uninstall 不得凭空创建（file_lock 会 mkdir——写调用必须先存在性守卫）。"""
+    home = _home(tmp_path)
+    env = _env(tmp_path)
+    workdir = tmp_path / "bare"
+    workdir.mkdir()
+    monkeypatch.chdir(workdir)
+    root = _setup_catalog(home, "acme", "audit")
+    _seed_installed(home, {_PID: [_record(root)]})
+    _write_json(user_settings_path(env), {"installedPlugins": [_PID], "enabledPlugins": {_PID: True}})
+    monkeypatch.setattr(_STAGE, _fake_stage([]))
+
+    ok = await uninstall_plugin(_PID, SkillRegistry(), home, env=env)
+
+    assert ok is True
+    assert not (workdir / ".tfrobot").exists()  # 不制造垃圾目录/锁文件
+
+
+# ── #125 任务 2：悬挂意图 prune 执行入口（installer 是 settings 意图唯一写者）──
+def test_prune_plugin_intent_clears_intent_enabled_and_dead_ledger(tmp_path: Path, monkeypatch) -> None:
+    """prune：删 user 意图 + 清 user/cwd 可见层 enabled 条目 + 弹出死账本记录（针对悬挂意图的 uninstall 等价物）。"""
+    from a2c_smcp.computer.settings.installer import prune_plugin_intent
+
+    home = _home(tmp_path)
+    env = _env(tmp_path)
+    workdir = tmp_path / "proj"
+    workdir.mkdir()
+    monkeypatch.chdir(workdir)
+    _write_json(user_settings_path(env), {"installedPlugins": [_PID], "enabledPlugins": {_PID: True}})
+    _write_json(workdir_project_settings_path(workdir), {"enabledPlugins": {_PID: False}})
+    _seed_installed(home, {_PID: [{"scope": "user", "installPath": str(tmp_path / "gone")}]})
+
+    prune_plugin_intent(_PID, home, env=env)
+
+    settings = _read_user_settings(env)
+    assert _PID not in settings.get("installedPlugins", [])
+    assert _PID not in settings.get("enabledPlugins", {})
+    proj = json.loads(workdir_project_settings_path(workdir).read_text(encoding="utf-8"))
+    assert _PID not in proj.get("enabledPlugins", {})
+    assert _PID not in load_installed_plugins(home=home)["plugins"]
+
+
+def test_prune_plugin_intent_runs_legacy_migration_first(tmp_path: Path, monkeypatch) -> None:
+    """prune 写 installedPlugins 键前必须先跑一次性迁移（防标记误置永久丢弃 v0.2.x 存量活跃态，同 install/uninstall）。"""
+    from a2c_smcp.computer.settings.installer import prune_plugin_intent
+
+    monkeypatch.chdir(tmp_path)
+    home = _home(tmp_path)
+    env = _env(tmp_path)
+    root = _setup_catalog(home, "acme", "legacy")
+    _seed_installed(home, {"legacy@acme": [_record(root)], _PID: [{"scope": "user", "installPath": str(tmp_path / "gone")}]})
+    # user settings 无 installedPlugins 键 = 迁移尚未发生
+
+    prune_plugin_intent(_PID, home, env=env)
+
+    settings = _read_user_settings(env)
+    assert settings["installedPlugins"] == ["legacy@acme"]  # 迁移先行：存量迁入；目标 pid 已 prune
+    assert settings["enabledPlugins"].get("legacy@acme") is True  # 存量活跃态保住
+    assert _PID not in settings["enabledPlugins"]
+
+
+def test_prune_plugin_intent_warns_on_residual_project_declaration(tmp_path: Path, monkeypatch, caplog) -> None:
+    """pid 仍见于 project 层 ``installedPlugins`` 声明 → WARN 指明文件路径、不静默改写 committable 团队声明。"""
+    import logging
+
+    from a2c_smcp.computer.settings.installer import prune_plugin_intent
+
+    home = _home(tmp_path)
+    env = _env(tmp_path)
+    workdir = tmp_path / "proj"
+    workdir.mkdir()
+    monkeypatch.chdir(workdir)
+    proj_path = workdir_project_settings_path(workdir)
+    _write_json(proj_path, {"installedPlugins": [_PID]})
+    _write_json(user_settings_path(env), {"installedPlugins": [_PID]})
+
+    with caplog.at_level(logging.WARNING):
+        prune_plugin_intent(_PID, home, env=env)
+
+    proj = json.loads(proj_path.read_text(encoding="utf-8"))
+    assert proj.get("installedPlugins") == [_PID]  # committable 声明不动
+    assert str(proj_path) in caplog.text  # WARN 指路人工处理
+
+
+# ── #125 任务 4：账本失效判据补 bundled JSON 校验（半态防御闭环）──────────────
+@pytest.mark.asyncio
+async def test_recover_rematerializes_on_corrupt_bundled_json(tmp_path: Path) -> None:
+    """账本 installPath 目录在、bundled JSON 损坏 → 判失效走重物化（catalog 完好 → 修复指回 catalog root）。"""
+    home = _home(tmp_path)
+    _setup_catalog(home, "acme", "audit", servers=["figma"], skills=["lint"])
+    stale = home / "stale-copy"
+    (stale / "mcp-servers").mkdir(parents=True)
+    (stale / "mcp-servers" / "bad.json").write_text("{not json", encoding="utf-8")
+    _seed_installed(home, {_PID: [{"scope": "user", "installPath": str(stale)}]})
+    reg = SkillRegistry()
+    declared = {"installedPlugins": [_PID], "enabledPlugins": {_PID: True}}
+
+    report = await recover_marketplace_skills(reg, home, declared, env=_env(tmp_path))
+
+    assert report.rematerialized == [_PID]
+    rebuilt = load_installed_plugins(home=home)["plugins"][_PID]
+    assert all(r["installPath"] != str(stale) for r in rebuilt)  # 修复：不再指向损坏副本
+    assert "audit:lint" in report.restored_skills
+    assert collect_enabled_bundled_servers(home, declared, env=_env(tmp_path))[0].config.name == "figma"  # server 可查询（无半态）
+
+
+@pytest.mark.asyncio
+async def test_recover_corrupt_bundled_json_unrepairable_stays_disabled(tmp_path: Path) -> None:
+    """catalog 自身损坏（重物化也失败）→ 整体保持 installed_disabled：skill 不亮、server 不可查询（半态消除）。"""
+    home = _home(tmp_path)
+    plugin_root = _setup_catalog(home, "acme", "audit", skills=["lint"])
+    (plugin_root / "mcp-servers").mkdir(parents=True, exist_ok=True)
+    (plugin_root / "mcp-servers" / "bad.json").write_text("{not json", encoding="utf-8")
+    _seed_installed(home, {_PID: [_record(plugin_root)]})  # 目录在、JSON 损坏——旧判据误判「已物化」
+    reg = SkillRegistry()
+    declared = {"installedPlugins": [_PID], "enabledPlugins": {_PID: True}}
+
+    report = await recover_marketplace_skills(reg, home, declared, env=_env(tmp_path))
+
+    assert report.rematerialized == []
+    assert report.restored_skills == [] and report.restored_plugins == []
+    assert reg.resolve("audit:lint") is None  # skill 不单独点亮（rust-sdk#102 半态防御）
+    assert collect_enabled_bundled_servers(home, declared, env=_env(tmp_path)) == []
 
 
 # ── schema：installedPlugins 字段校验 ─────────────────────────────────────────

--- a/tests/unit_tests/computer/settings/test_install_enable_separation.py
+++ b/tests/unit_tests/computer/settings/test_install_enable_separation.py
@@ -615,7 +615,7 @@ async def test_recover_rematerialize_multi_layer_clues_rebuild_multi_records(tmp
 @pytest.mark.asyncio
 async def test_recover_rematerialize_no_clue_falls_back_user_and_reports(tmp_path: Path, monkeypatch, caplog) -> None:
     """无任何层线索 → 归一 user + WARN + ``report.scope_normalized`` 显式标注（issue #125 方向 b 兜底）。"""
-    import logging
+    from a2c_smcp.computer.settings import recovery as recovery_mod
 
     home = _home(tmp_path)
     env = _env(tmp_path)
@@ -625,8 +625,12 @@ async def test_recover_rematerialize_no_clue_falls_back_user_and_reports(tmp_pat
     _setup_catalog(home, "acme", "audit", servers=["figma"], skills=["lint"])
     declared = {"installedPlugins": [_PID]}
 
-    with caplog.at_level(logging.WARNING):
+    # 项目 logger "a2c_smcp" 关闭 propagate → caplog.handler 直挂源模块 logger（同 test_window_uri 惯例）
+    recovery_mod.logger.addHandler(caplog.handler)
+    try:
         report = await recover_marketplace_skills(SkillRegistry(), home, declared, env=env)
+    finally:
+        recovery_mod.logger.removeHandler(caplog.handler)
 
     assert report.rematerialized == [_PID]
     assert report.scope_normalized == [_PID]
@@ -760,8 +764,7 @@ def test_prune_plugin_intent_runs_legacy_migration_first(tmp_path: Path, monkeyp
 
 def test_prune_plugin_intent_warns_on_residual_project_declaration(tmp_path: Path, monkeypatch, caplog) -> None:
     """pid 仍见于 project 层 ``installedPlugins`` 声明 → WARN 指明文件路径、不静默改写 committable 团队声明。"""
-    import logging
-
+    from a2c_smcp.computer.settings import installer as installer_mod
     from a2c_smcp.computer.settings.installer import prune_plugin_intent
 
     home = _home(tmp_path)
@@ -773,8 +776,12 @@ def test_prune_plugin_intent_warns_on_residual_project_declaration(tmp_path: Pat
     _write_json(proj_path, {"installedPlugins": [_PID]})
     _write_json(user_settings_path(env), {"installedPlugins": [_PID]})
 
-    with caplog.at_level(logging.WARNING):
+    # 项目 logger 关闭 propagate → caplog.handler 直挂源模块 logger（同 test_window_uri 惯例）
+    installer_mod.logger.addHandler(caplog.handler)
+    try:
         prune_plugin_intent(_PID, home, env=env)
+    finally:
+        installer_mod.logger.removeHandler(caplog.handler)
 
     proj = json.loads(proj_path.read_text(encoding="utf-8"))
     assert proj.get("installedPlugins") == [_PID]  # committable 声明不动

--- a/tests/unit_tests/computer/settings/test_reconciler.py
+++ b/tests/unit_tests/computer/settings/test_reconciler.py
@@ -424,3 +424,108 @@ async def test_gc_plugin_id_without_at_sign(tmp_path: Path) -> None:
     assert removed == ["noatsign"]
     assert not p.exists()
     assert "noatsign" not in load_installed_plugins(home=home)["plugins"]
+
+
+# ── #125 任务 2/4：悬挂意图检测 + 账本失效判据（红灯阶段函数内 import 定位失败粒度）──
+def _write_manifest(home: Path, mp: str, plugins: list[str]) -> Path:
+    """造 catalog clone + marketplace.json（entry 集合可控，供 dangling 判据分档）。"""
+    import json
+
+    catalog = marketplace_skill_dir(home, mp)
+    p = catalog / ".tfrobot-plugin" / "marketplace.json"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    manifest = {
+        "name": mp,
+        "owner": {"name": "X"},
+        "metadata": {"pluginRoot": "./plugins"},
+        "plugins": [{"name": pl, "source": pl, "version": "1.0.0"} for pl in plugins],
+    }
+    p.write_text(json.dumps(manifest), encoding="utf-8")
+    return catalog
+
+
+def test_list_dangling_marketplace_not_added(tmp_path: Path) -> None:
+    """意图有、账本无、marketplace 不在 known_marketplaces → 最强 prune 信号（无自愈路径）。"""
+    from a2c_smcp.computer.settings.reconciler import DANGLING_MARKETPLACE_NOT_ADDED, list_dangling_plugin_intents
+
+    home = _home(tmp_path)
+    declared = {"installedPlugins": ["audit@acme"]}
+
+    assert list_dangling_plugin_intents(home, declared) == [("audit@acme", DANGLING_MARKETPLACE_NOT_ADDED)]
+
+
+def test_list_dangling_catalog_missing(tmp_path: Path) -> None:
+    """known 记录在、catalog clone 缺失 → 列入但 reason 分档（boot/refresh 可能自愈，裁量留给 confirm）。"""
+    from a2c_smcp.computer.settings.reconciler import DANGLING_CATALOG_MISSING, list_dangling_plugin_intents
+
+    home = _home(tmp_path)
+    _seed_known(home, {"acme": _SRC_A})  # 不建 clone 树
+    declared = {"installedPlugins": ["audit@acme"]}
+
+    assert list_dangling_plugin_intents(home, declared) == [("audit@acme", DANGLING_CATALOG_MISSING)]
+
+
+def test_list_dangling_manifest_unreadable_and_entry_missing(tmp_path: Path) -> None:
+    """clone 在但 manifest 损坏 → manifest-unreadable；manifest 合法但无 entry → entry-missing。"""
+    from a2c_smcp.computer.settings.reconciler import (
+        DANGLING_ENTRY_MISSING,
+        DANGLING_MANIFEST_UNREADABLE,
+        list_dangling_plugin_intents,
+    )
+
+    home = _home(tmp_path)
+    _seed_known(home, {"acme": _SRC_A, "beta": _SRC_B})
+    # acme：clone 在、manifest 畸形
+    bad = marketplace_skill_dir(home, "acme") / ".tfrobot-plugin" / "marketplace.json"
+    bad.parent.mkdir(parents=True, exist_ok=True)
+    bad.write_text("{not json", encoding="utf-8")
+    # beta：manifest 合法但不含 audit
+    _write_manifest(home, "beta", ["other"])
+    declared = {"installedPlugins": ["audit@acme", "audit@beta"]}
+
+    assert list_dangling_plugin_intents(home, declared) == [
+        ("audit@acme", DANGLING_MANIFEST_UNREADABLE),
+        ("audit@beta", DANGLING_ENTRY_MISSING),
+    ]
+
+
+def test_list_dangling_excludes_materialized_and_recoverable(tmp_path: Path) -> None:
+    """活账本 pid 与「静态可达但未物化」pid 均不列（后者下次 boot 自愈，不是 prune 对象）。"""
+    from a2c_smcp.computer.settings.reconciler import list_dangling_plugin_intents
+
+    home = _home(tmp_path)
+    _seed_known(home, {"acme": _SRC_A})
+    _write_manifest(home, "acme", ["audit", "keep"])
+    keep_path = marketplace_skill_dir(home, "acme") / "plugins" / "keep"
+    keep_path.mkdir(parents=True)
+    _seed_installed(home, {"keep@acme": [{"scope": "user", "installPath": str(keep_path)}]})
+    declared = {"installedPlugins": ["keep@acme", "audit@acme"]}  # audit：无账本但三查全过 → recoverable
+
+    assert list_dangling_plugin_intents(home, declared) == []
+
+
+def test_list_dangling_covers_all_dead_installpath_records(tmp_path: Path) -> None:
+    """有账本记录但 installPath 全死 ∧ 静态不可达 → 仍列入（账本残骸不挡诊断）。"""
+    from a2c_smcp.computer.settings.reconciler import DANGLING_MARKETPLACE_NOT_ADDED, list_dangling_plugin_intents
+
+    home = _home(tmp_path)
+    _seed_installed(home, {"audit@acme": [{"scope": "user", "installPath": str(tmp_path / "gone")}]})
+    declared = {"installedPlugins": ["audit@acme"]}
+
+    assert list_dangling_plugin_intents(home, declared) == [("audit@acme", DANGLING_MARKETPLACE_NOT_ADDED)]
+
+
+def test_ledger_entry_materialized_rejects_corrupt_bundled_json(tmp_path: Path) -> None:
+    """#125 任务 4：判据 = 目录在 ∧ bundled JSON 可解析；「目录在、JSON 损坏」→ False（旧判据误判 True 的半态触发面）。"""
+    from a2c_smcp.computer.settings.reconciler import ledger_entry_materialized
+
+    corrupt_root = tmp_path / "corrupt"
+    (corrupt_root / "mcp-servers").mkdir(parents=True)
+    (corrupt_root / "mcp-servers" / "bad.json").write_text("{not json", encoding="utf-8")
+    ok_root = tmp_path / "ok"
+    ok_root.mkdir()
+
+    assert ledger_entry_materialized([{"scope": "user", "installPath": str(corrupt_root)}]) is False
+    assert ledger_entry_materialized([{"scope": "user", "installPath": str(ok_root)}]) is True  # 无 bundled server 合法
+    assert ledger_entry_materialized([{"scope": "user", "installPath": str(tmp_path / "gone")}]) is False  # 目录缺失
+    assert ledger_entry_materialized(None) is False  # 非 list 防御


### PR DESCRIPTION
Closes #125

## 概述

#123（PR #124）隔离审查挂账的 4 项收尾，TDD 红绿灯推进（红灯 commit 7bf0d33：22 用例失败原因与危害链逐一吻合）。

## 四项任务

### 1. 重物化 scope 复原（混合线索推回）
- **危害链**：账本重建归一 user scope → CLI enable/disable 从账本读 scope 写错层 → 跨 boot disable 失效；uninstall 清 enabledPlugins 漏 cwd 层 → 残留 `true` → 重装立即激活。
- **修法**：`_infer_record_scopes` = enable/disable「写入层=安装 scope」契约的逆运算——project/local 层 `enabledPlugins[pid] is True` 或 `installedPlugins` 声明为线索（纯 `false` 是禁用覆盖、不算，防捏造记录让 enable 反向覆写团队 `false`）；多层线索重建多条记录；无线索归一 user + WARN + 新 `GovernanceRecoveryReport.scope_normalized` 字段；重建后 `_sweep_dead_records` 清扫失效残留。uninstall 清理集并入 cwd（`.tfrobot` 垃圾目录守卫：`file_lock` 会 mkdir，写前先 exists）。
- **已知盲区**（文档化）：cwd 不可见的异地 project/local 层不可推回（#116 单锚点固有）；完美复原属协议 §4.9.2 pin-lock 可选扩展，本次不做。

### 2. 「意图 ∖ 账本」悬挂条目 prune（扩展 plugin gc）
- `list_dangling_plugin_intents`（reconciler）：意图 ∧ 无有效物化 ∧ 静态不可达，四档 reason（`marketplace-not-added` / `catalog-missing` / `manifest-unreadable` / `entry-missing`），零网络；「可达未物化」归 recoverable 只提示（下次 boot 自愈，§4.8.4 boot 不删）。
- `prune_plugin_intent`（installer，意图唯一写者）：迁移标记先行 → 删 user 意图 → 清可见层 enabled 条目 → 弹账本残骸；committable project/local 声明**不改写**（WARN 指路），未真移除不计入 `prunedIntents`（归 `residualDeclarations`）。
- **权威性不对称安全阀**：孤儿删除（派生缓存）保持自动；悬挂 prune（删权威意图）REPL 走 confirm 门、Typer 须显式 `--prune-dangling`（缺省只诊断）。JSON 契约 `removed` 键不变，增 `dangling` / `prunedIntents` / `residualDeclarations` / `recoverable`。
- 事实澄清：悬挂意图此前**不出现**在 `plugin list`（list 读账本）——比 issue 括注更糟：意图层权威说已安装、list 不可见、enable 报 not installed。

### 3. `plugin list --available` 弃用
- 兼容 no-op 保留 + 弃用提示（非 JSON 模式 console `⚠`；JSON 模式走 logger，stdout 保持纯 JSON）；Typer/help 文案标 `[deprecated]`；CHANGELOG Deprecated 记移除计划。

### 4. 账本失效判据补 bundled JSON 校验
- `ledger_record_materialized`（记录级）= 目录在 ∧ `load_bundled_servers` 可解析；`ledger_entry_materialized`（∃，dangling 判据）与 `ledger_entry_fully_materialized`（∀，boot 重物化触发——混合健康度也修复）分立；sweep 与之判据同源。闭环：损坏 → 重物化修复（指回 catalog）或整体保持 installed_disabled（skill 不单独亮，rust-sdk#102 同型半态消除）；catalog 自身损坏的修复路径 = `marketplace refresh`。

## 隔离审查（Step 7.5 硬门控）

独立 code-reviewer 子代理复审：0 🔴 / 6 🟡 / 3 🔵。6 🟡 全部落实（a1bea88）：prunedIntents 误报、prune 降级捕获过窄、false 线索捏造记录、判活判据不对称 + 2 项测试补缺。3 🔵 记录为已知取舍（recoverable 重复读盘微优化、uninstall 改动 project 层的可见提示、prune 批处理不分档确认）。

## 验证

- TDD：红灯 22 用例 → 全绿；新增 28 用例覆盖四项验收 + 审查对抗场景
- 全量：**1809 passed**（unit+integration）+ **e2e 62 passed** ×2 轮
- 门禁：ruff All checks passed + mypy Success（102 files）

## 关联

- 协议：a2c-smcp-protocol v0.3.0 `runtime-contract.md` §2.3/§2.4/§4.8/§4.9/§5.8（合规复核通过，无协议变更）
- rust-sdk#103：镜像评估参照——新增函数均为纯函数/明确入口（`ledger_record_materialized` / `ledger_entry_fully_materialized` / `list_dangling_plugin_intents` / `prune_plugin_intent` / `_infer_record_scopes`），报告字段同名

🤖 Generated with [Claude Code](https://claude.com/claude-code)