### PR TITLE
feat(#129,#130,#131): BundleID 模型——MCP Server 身份/命名/路由统一为 bundle_id

### DIFF
--- a/a2c_smcp/agent/client.py
+++ b/a2c_smcp/agent/client.py
@@ -445,7 +445,7 @@ class AsyncSMCPAgentClient(AsyncClient, BaseAgentClient):
 
         Args:
             computer (str): 目标 Computer 名称 / Target Computer name
-            mcp_server (str): 目标 MCP Server 名称 / Target MCP Server name
+            mcp_server (str): 目标 MCP Server 的 bundle_id（= get_config servers 字典 key，协议 #18）/ Target server bundle_id
             cursor (str | None): MCP 标准翻页游标；首次传 None / MCP pagination cursor; None for first page
             timeout (int): 超时时间（秒）/ Timeout in seconds
 

--- a/a2c_smcp/agent/errors.py
+++ b/a2c_smcp/agent/errors.py
@@ -25,7 +25,7 @@ class SMCPProtocolError(Exception):
 
     当 Agent SDK 在 Socket.IO ack 中识别到 flat ErrorPayload（顶层含 ``code``）时抛出，
     覆盖范围 / Covers:
-      - ``client:get_resources``：``4014`` / ``4015``（顶层平铺 ``mcp_server_name`` / ``capability``）
+      - ``client:get_resources``：``4014`` / ``4015``（顶层平铺 ``mcp_server``(bundle_id) / ``capability``）
       - ``client:get_skill[s]``：``4014`` 复用（SKILL ``name`` 合法但未命中）/ ``4016`` Invalid Name /
         ``4017`` Skill Resource Not Accessible（v0.2.1 ``details.reason``）
       - ``client:get_blob``：``4018 Blob Not Accessible``（v0.2.1 ``details.reason``）
@@ -38,8 +38,8 @@ class SMCPProtocolError(Exception):
         self.payload: ErrorPayload = payload
         self.code: int = int(payload.get("code", -1))
         self.error_message: str = str(payload.get("message", ""))
-        # 4014 / 4015 顶层 code-specific 字段 / Top-level code-specific fields (4014 / 4015)
-        self.mcp_server_name: str | None = payload.get("mcp_server_name")
+        # 4014 / 4015 顶层 code-specific 字段（``mcp_server`` = bundle_id，协议 #18）/ Top-level fields (4014 / 4015)
+        self.mcp_server: str | None = payload.get("mcp_server")
         self.capability: str | None = payload.get("capability")
         # 4016 / 4017 / 4018 details 容器（v0.2.1 起 code-specific 字段下沉到 details）
         # details container for 4016 / 4017 / 4018 (since v0.2.1 code-specific fields live under details)

--- a/a2c_smcp/agent/sync_client.py
+++ b/a2c_smcp/agent/sync_client.py
@@ -427,7 +427,7 @@ class SMCPAgentClient(Client, BaseAgentSyncClient):
 
         Args:
             computer (str): 目标 Computer 名称 / Target Computer name
-            mcp_server (str): 目标 MCP Server 名称 / Target MCP Server name
+            mcp_server (str): 目标 MCP Server 的 bundle_id（= get_config servers 字典 key，协议 #18）/ Target server bundle_id
             cursor (str | None): MCP 标准翻页游标；首次传 None / MCP pagination cursor; None for first page
             timeout (int): 超时时间（秒）/ Timeout in seconds
 

--- a/a2c_smcp/computer/base.py
+++ b/a2c_smcp/computer/base.py
@@ -54,7 +54,7 @@ class BaseComputer(Generic[S], ABC):
 
     # -------- MCP Server lifecycle --------
     @abstractmethod
-    async def aremove_server(self, server_name: str, *, session: S | None = None) -> None:  # pragma: no cover
+    async def aremove_server(self, bundle_id: str, *, session: S | None = None) -> None:  # pragma: no cover
         """
         中文: 动态移除某个服务配置。
         English: Remove a server config dynamically.

--- a/a2c_smcp/computer/computer.py
+++ b/a2c_smcp/computer/computer.py
@@ -88,6 +88,7 @@ from a2c_smcp.computer.skills import (
 from a2c_smcp.computer.types import ToolCallRecord
 from a2c_smcp.smcp import A2CSkillRef, Desktop, SMCPTool
 from a2c_smcp.types import AttributeValue
+from a2c_smcp.utils.bundle_id import resolve_bundle_id
 from a2c_smcp.utils.env import env_truthy
 from a2c_smcp.utils.logger import get_logger, truncate
 from a2c_smcp.utils.window_uri import is_window_uri
@@ -755,16 +756,25 @@ class Computer(BaseComputer[PromptSession]):
         try:
             if isinstance(server, dict):
                 raw = server
+                # BundleID 取 raw（protocol#17）：注入前配置即身份来源。构 raw model 求 bundle_id
+                # （占位 ${input:*} 按字面参与摘要）。注：raw 若在**非字符串**字段（如 timeout）含占位会在此
+                # 提前校验失败——属边角（§9.4 占位面向字符串字段），正常配置不触及。
+                raw_model: MCPServerConfig = TypeAdapter(MCPServerConfig).validate_python(raw)
                 rendered = await self._config_render.arender(raw, _resolve_input_by_id, variables=variables)
                 rendered = self._apply_env_file(rendered)
                 # 使用 TypeAdapter 将 union 类型解析为具体模型
                 validated: MCPServerConfig = TypeAdapter(MCPServerConfig).validate_python(rendered)
             else:
                 raw = server.model_dump(mode="json")
+                raw_model = server  # 模型入参即未渲染 raw（self._mcp_servers / 调用方原样）
                 rendered = await self._config_render.arender(raw, _resolve_input_by_id, variables=variables)
                 rendered = self._apply_env_file(rendered)
                 validated = type(server).model_validate(rendered)
-            return validated
+            # 物化 bundle_id：在 RAW 配置上 derive-on-load（protocol#15/#17），注入渲染后 config——
+            # 使 config.bundle_id 解析后恒有值、作 no-double-open 去重键跨渲染阶段稳定。model_copy 不重跑
+            # validator（resolved 已合法）。生成不在 Pydantic（config frozen）。
+            resolved_bundle_id = resolve_bundle_id(raw_model)
+            return validated.model_copy(update={"bundle_id": resolved_bundle_id})
         except Exception as e:
             name = (server.get("name") if isinstance(server, dict) else getattr(server, "name", "unknown")) or "unknown"
             logger.error(f"动态渲染/校验MCP配置失败: {name} - {e}", exc_info=True)
@@ -800,19 +810,19 @@ class Computer(BaseComputer[PromptSession]):
         validated = await self._arender_and_validate_server(server, session=session, plugin=plugin, marketplace=marketplace)
         await self.mcp_manager.aadd_or_aupdate_server(validated)
 
-    async def aremove_server(self, server_name: str, *, session: PromptSession | None = None) -> None:
+    async def aremove_server(self, bundle_id: str, *, session: PromptSession | None = None) -> None:
         """
-        动态移除某个MCP Server配置。
-        Remove a MCP Server config dynamically.
+        动态移除某个MCP Server配置（按 bundle_id）。
+        Remove a MCP Server config dynamically (by bundle_id).
 
         Args:
-            server_name (str): 配置名称。
+            bundle_id (str): MCP Server 唯一身份 bundle_id（协议 #18）。
         """
         if not self.mcp_manager:
             # 未初始化则无操作
             logger.warning("MCP 管理器尚未初始化，忽略移除操作 / MCP manager not initialized, skip remove")
             return
-        await self.mcp_manager.aremove_server(server_name)
+        await self.mcp_manager.aremove_server(bundle_id)
 
     def update_inputs(self, inputs: set[MCPServerInput], *, session: PromptSession | None = None) -> None:
         """

--- a/a2c_smcp/computer/mcp_clients/manager.py
+++ b/a2c_smcp/computer/mcp_clients/manager.py
@@ -4,9 +4,7 @@
 # @Email   : jiaqia@qknode.com
 # @Software: PyCharm
 import asyncio
-import copy
 import json
-from collections import defaultdict
 from collections.abc import AsyncGenerator, Iterable
 from typing import Any
 
@@ -17,7 +15,8 @@ from vrl_python import VRLRuntime
 from a2c_smcp.computer.mcp_clients.base_client import MCPServerNotFoundError
 from a2c_smcp.computer.mcp_clients.model import A2C_TOOL_META, A2C_VRL_TRANSFORMED, MCPClientProtocol, MCPServerConfig, ToolMeta
 from a2c_smcp.computer.mcp_clients.utils import client_factory
-from a2c_smcp.types import SERVER_NAME, TOOL_NAME
+from a2c_smcp.types import BUNDLE_ID, EXPOSED_TOOL_NAME, TOOL_NAME
+from a2c_smcp.utils.bundle_id import resolve_bundle_id
 from a2c_smcp.utils.logger import get_logger, truncate
 
 logger = get_logger("computer")
@@ -50,16 +49,15 @@ class MCPServerManager:
         auto_reconnect: bool = True,
         message_handler: MessageHandlerFnT | None = None,
     ) -> None:
-        # 存储所有服务器配置
-        self._servers_config: dict[SERVER_NAME, MCPServerConfig] = {}
-        # 存储活动客户端 {server_name: client}
-        self._active_clients: dict[SERVER_NAME, MCPClientProtocol] = {}
-        # 工具到服务器的映射 {tool_name: server_name}
-        self._tool_mapping: dict[TOOL_NAME, SERVER_NAME] = {}
-        # 工具的alias到server+original_name的映射 {alias: (server_name, original_name)}
-        self._alias_mapping: dict[str, tuple[SERVER_NAME, TOOL_NAME]] = {}
-        # 禁用工具集合
-        self._disabled_tools: set[TOOL_NAME] = set()
+        # 存储所有服务器配置，以 bundle_id 为唯一身份键（协议 #15/#18：身份=bundle_id，name 降纯 display 不做键）
+        # Server configs keyed by bundle_id (unique identity; name is pure display, never a key — protocol #15/#18).
+        self._servers_config: dict[BUNDLE_ID, MCPServerConfig] = {}
+        # 活动客户端 {bundle_id: client}
+        self._active_clients: dict[BUNDLE_ID, MCPClientProtocol] = {}
+        # ExposedToolMapping：exposed_tool_name -> (bundle_id, 原始工具名)。list_tools 与 tool_call **共用同一份**表
+        # （协议 §ExposedToolMapping）。exposed = {bundle_id}__{alias ?? 原始名}，bundle_id 无 `__` 保证单射→查表不 split。
+        # 被 forbidden 的工具**不进本表**（不可见不可调用）；跨 bundle_id 天然唯一，无需跨 server 对账。
+        self._exposed_tools: dict[EXPOSED_TOOL_NAME, tuple[BUNDLE_ID, TOOL_NAME]] = {}
         # 自动重连标志
         self._auto_reconnect: bool = auto_reconnect
         # 自动连接标志
@@ -69,27 +67,27 @@ class MCPServerManager:
         # 内部锁防止并发修改
         self._lock = asyncio.Lock()
 
-    def get_server_config(self, server_name: SERVER_NAME) -> MCPServerConfig:
-        """通过名称获取服务配置"""
-        return self._servers_config[server_name]
+    def get_server_config(self, bundle_id: BUNDLE_ID) -> MCPServerConfig:
+        """通过 bundle_id 获取服务配置 / Get server config by bundle_id。"""
+        return self._servers_config[bundle_id]
 
     def server_configs(self) -> tuple[MCPServerConfig, ...]:
         """全部服务配置的不可变快照（运行期活跃配置集，含动态挂载/重挂项）/ snapshot of all active server configs。"""
         return tuple(self._servers_config.values())
 
-    def get_tool_meta(self, server_name: SERVER_NAME, tool_name: TOOL_NAME) -> ToolMeta | None:
+    def get_tool_meta(self, bundle_id: BUNDLE_ID, tool_name: TOOL_NAME) -> ToolMeta | None:
         """
-        中文: 获取指定服务器下某工具合并后的元数据（优先具体 tool_meta，缺失字段回落 default_tool_meta）。
-        English: Get merged ToolMeta for a tool under the given server (specific overrides; fallback to default).
+        中文: 获取指定服务器（bundle_id）下某工具合并后的元数据（优先具体 tool_meta，缺失字段回落 default_tool_meta）。
+        English: Get merged ToolMeta for a tool under the given server (bundle_id).
 
         Args:
-            server_name (SERVER_NAME): 服务器名称 / server name
-            tool_name (TOOL_NAME): 工具原始名称或别名解析后的名称 / tool name
+            bundle_id (BUNDLE_ID): 服务器唯一身份 / server bundle_id
+            tool_name (TOOL_NAME): 工具**原始名称**（非 exposed）/ original tool name
 
         Returns:
             ToolMeta | None: 合并后的工具元数据；若两侧均为空返回 None / merged ToolMeta or None if both absent.
         """
-        config = self.get_server_config(server_name)
+        config = self.get_server_config(bundle_id)
         return self._merged_tool_meta(config, tool_name)
 
     async def enable_auto_connect(self) -> None:
@@ -125,18 +123,21 @@ class MCPServerManager:
             await self._astop_all()
             # 2. 清空所有状态存储
             self._clear_all()
-            # 3. 添加新配置
+            # 3. 添加新配置（no-double-open，加载期 first-wins）：按配置顺序 per-bundle_id 保留**首个**，
+            #    其余作 Computer 本地诊断（WARN，非协议错误码）。同 bundle_id = 同软件，任一时刻只一个。
+            #    (protocol §no-double-open, boot=first-wins). Runtime add/update is update-in-place (see _add_or_update).
+            seen_bundle_ids: set[BUNDLE_ID] = set()
             for server in servers:
+                bundle_id = resolve_bundle_id(server)
+                if bundle_id in seen_bundle_ids:
+                    logger.warning(
+                        f"no-double-open: 重复 bundle_id '{bundle_id}'（name={server.name!r}）——保留配置顺序首个、"
+                        f"跳过此项（Computer 本地诊断，非协议错误码）；如需多实例请显式指定不同 bundle_id。",
+                    )
+                    continue
+                seen_bundle_ids.add(bundle_id)
                 await self._add_or_update_server_config(server)
-            try:
-                await self._arefresh_tool_mapping()
-            except ToolNameDuplicatedError as e:  # pragma: no cover
-                # 极端分支：仅在外部错误用法下触发，主流程不会走到这里
-                # 中文：此处为防御性分支，正常流程不会触发
-                # English: Defensive branch, not triggered in normal flow
-                await self._astop_all()  # pragma: no cover
-                self._clear_all()  # pragma: no cover
-                raise e  # pragma: no cover
+            await self._arefresh_tool_mapping()
 
     async def _add_or_update_server_config(self, config: MCPServerConfig) -> None:
         """
@@ -148,119 +149,100 @@ class MCPServerManager:
         Args:
             config (MCPServerConfig): MCP服务器配置
         """
-        if config.name in self._servers_config:
-            # 配置更新时检查是否激活
-            if config.name in self._active_clients:
+        bundle_id = resolve_bundle_id(config)
+        if bundle_id in self._servers_config:
+            # 运行期同 bundle_id = **原地更新**（intentional replace；name 可变、bundle_id 稳定），不算 no-double-open 冲突
+            # Runtime same bundle_id = update-in-place (protocol §no-double-open runtime branch).
+            if bundle_id in self._active_clients:
                 if self._auto_reconnect:
-                    self._servers_config[config.name] = config
-                    await self._arestart_server(config.name)
+                    self._servers_config[bundle_id] = config
+                    await self._arestart_server(bundle_id)
                 else:
-                    raise RuntimeError(f"Server {config.name} is active. Stop it before updating config")
+                    raise RuntimeError(
+                        f"Server bundle_id={bundle_id!r} (name={config.name!r}) is active. Stop it before updating config",
+                    )
             else:
                 # 配置存在但客户端未激活，更新配置并根据 auto_connect 决定是否启动
                 # Config exists but client is not active, update config and start if auto_connect is enabled
-                self._servers_config[config.name] = config
+                self._servers_config[bundle_id] = config
                 if self._auto_connect:
-                    await self._astart_client(config.name)
+                    await self._astart_client(bundle_id)
         else:
-            self._servers_config[config.name] = config
+            self._servers_config[bundle_id] = config
             if self._auto_connect:
-                await self._astart_client(config.name)
+                await self._astart_client(bundle_id)
 
     async def aadd_or_aupdate_server(self, config: MCPServerConfig) -> None:
-        """
-        添加或更新服务器配置
-
-        Args:
-            config (MCPServerConfig): MCP服务器配置
-        """
+        """添加或更新服务器配置。运行期同 ``bundle_id`` = **原地更新**（不算 no-double-open 冲突）。"""
         async with self._lock:
-            backup_config = copy.deepcopy(self._servers_config)
-            try:
-                await self._add_or_update_server_config(config)
-                await self._arefresh_tool_mapping()
-            except ToolNameDuplicatedError as e:
-                self._servers_config = backup_config
-                raise e
-
-    async def aremove_server(self, server_name: str) -> None:
-        """移除服务器配置"""
-        async with self._lock:
-            if server_name in self._active_clients:
-                await self._astop_client(server_name)
-            del self._servers_config[server_name]
+            await self._add_or_update_server_config(config)
             await self._arefresh_tool_mapping()
 
-    async def _arestart_server(self, server_name: str) -> None:
-        """
-        重启服务器客户端
+    async def aremove_server(self, bundle_id: BUNDLE_ID) -> None:
+        """按 bundle_id 移除服务器配置 / Remove a server config by bundle_id。"""
+        async with self._lock:
+            if bundle_id in self._active_clients:
+                await self._astop_client(bundle_id)
+            del self._servers_config[bundle_id]
+            await self._arefresh_tool_mapping()
 
-        Args:
-            server_name (str): 服务器名称
-        """
+    async def _arestart_server(self, bundle_id: BUNDLE_ID) -> None:
+        """重启服务器客户端（按 bundle_id）。"""
         # 明确使用当前管理器中的最新配置
-        config = self._servers_config.get(server_name)
+        config = self._servers_config.get(bundle_id)
         if not config:
-            # 极端分支：仅在外部错误用法下触发，主流程不会走到这里
-            # 中文：此处为防御性分支，正常流程不会触发
-            # English: Defensive branch, not triggered in normal flow
-            raise ValueError(f"Server {server_name} not found in config")  # pragma: no cover
+            # 防御性分支：正常流程不会触发 / Defensive branch, not triggered in normal flow
+            raise ValueError(f"Server bundle_id={bundle_id!r} not found in config")  # pragma: no cover
 
         # 确保使用最新配置重启
-        if server_name in self._active_clients:
-            await self._astop_client(server_name)
+        if bundle_id in self._active_clients:
+            await self._astop_client(bundle_id)
 
         # 只有启用的配置才能重启
         if not config.disabled:
-            await self._astart_client(server_name)
+            await self._astart_client(bundle_id)
 
     async def astart_all(self) -> None:
         """启动所有启用的服务器"""
         async with self._lock:
             logger.debug(f"Manager Start all async task: {asyncio.current_task()}")
-            for server_name in self._servers_config:
-                if not self._servers_config[server_name].disabled:
-                    await self._astart_client(server_name)
+            for bundle_id in self._servers_config:
+                if not self._servers_config[bundle_id].disabled:
+                    await self._astart_client(bundle_id)
 
-    async def astart_client(self, server_name: str) -> None:
-        """启动单个服务器客户端"""
+    async def astart_client(self, bundle_id: BUNDLE_ID) -> None:
+        """启动单个服务器客户端（按 bundle_id）。"""
         async with self._lock:
-            await self._astart_client(server_name)
+            await self._astart_client(bundle_id)
 
-    async def _astart_client(self, server_name: str) -> None:
-        """启动单个服务器客户端"""
-        config = self._servers_config.get(server_name)
+    async def _astart_client(self, bundle_id: BUNDLE_ID) -> None:
+        """启动单个服务器客户端（按 bundle_id）。"""
+        config = self._servers_config.get(bundle_id)
         if not config:
-            # 极端分支：仅在外部错误用法下触发，主流程不会走到这里
-            # 中文：此处为防御性分支，正常流程不会触发
-            # English: Defensive branch, not triggered in normal flow
-            raise ValueError(f"Unknown server: {server_name}")  # pragma: no cover
+            # 防御性分支：正常流程不会触发 / Defensive branch, not triggered in normal flow
+            raise ValueError(f"Unknown server bundle_id={bundle_id!r}")  # pragma: no cover
 
         if config.disabled:
-            raise RuntimeError(f"Cannot start disabled server: {server_name}")
+            raise RuntimeError(f"Cannot start disabled server bundle_id={bundle_id!r} (name={config.name!r})")
 
-        if server_name in self._active_clients:
+        if bundle_id in self._active_clients:
             return  # 已经启动
 
         # 根据配置类型创建客户端
         client = client_factory(config, message_handler=self._message_handler)
         await client.aconnect()
-        self._active_clients[server_name] = client
-        try:
-            await self._arefresh_tool_mapping()
-        except ToolNameDuplicatedError as e:
-            await client.adisconnect()
-            del self._active_clients[server_name]
-            raise e
+        self._active_clients[bundle_id] = client
+        # ExposedToolMapping 刷新不再抛跨 server 重名（bundle_id 前缀天然唯一），无需回滚
+        await self._arefresh_tool_mapping()
 
-    async def astop_client(self, server_name: str) -> None:
-        """停止单个服务器客户端"""
+    async def astop_client(self, bundle_id: BUNDLE_ID) -> None:
+        """停止单个服务器客户端（按 bundle_id）。"""
         async with self._lock:
-            await self._astop_client(server_name)
+            await self._astop_client(bundle_id)
 
-    async def _astop_client(self, server_name: str) -> None:
-        """停止单个服务器客户端"""
-        client = self._active_clients.pop(server_name, None)
+    async def _astop_client(self, bundle_id: BUNDLE_ID) -> None:
+        """停止单个服务器客户端（按 bundle_id）。"""
+        client = self._active_clients.pop(bundle_id, None)
         if client:
             await client.adisconnect()
             await self._arefresh_tool_mapping()
@@ -277,12 +259,10 @@ class MCPServerManager:
             await self._astop_all()
 
     def _clear_all(self) -> None:
-        """清空所有连接（别名）"""
+        """清空所有连接与映射 / Clear all state。"""
         self._servers_config.clear()
         self._active_clients.clear()
-        self._tool_mapping.clear()
-        self._alias_mapping.clear()
-        self._disabled_tools.clear()
+        self._exposed_tools.clear()
 
     async def aclose(self) -> None:
         """关闭所有连接（别名）"""
@@ -292,71 +272,48 @@ class MCPServerManager:
         self._clear_all()
 
     async def _arefresh_tool_mapping(self) -> None:
-        """刷新工具映射和禁用状态"""
-        # 清空现有映射
-        self._tool_mapping.clear()
-        self._disabled_tools.clear()
-        self._alias_mapping.clear()
+        """重建 ExposedToolMapping：``_exposed_tools[exposed_tool_name] = (bundle_id, 原始工具名)``。
 
-        # 临时存储工具源服务器
-        tool_sources: dict[TOOL_NAME, list[str]] = defaultdict(list)
+        Rebuild the shared ExposedToolMapping used by both ``available_tools`` and ``tool_call`` routing.
 
-        # 收集所有活动服务器的工具
-        for server_name, client in self._active_clients.items():
-            config = self._servers_config[server_name]
+        ``exposed_tool_name = {bundle_id}__{alias ?? 原始名}``（协议 §exposed_tool_name）。跨 bundle_id 因前缀
+        天然唯一——**无需**跨 server 重名对账（旧 ``ToolNameDuplicatedError`` 场景消失）。forbidden 工具**不进表**
+        （不可见不可调用）。同一 bundle_id 内两工具经 ``alias`` 撞出相同 exposed → 保留首个 + Computer 本地诊断
+        （WARN，非协议错误码）。
+        """
+        self._exposed_tools.clear()
+        for bundle_id, client in self._active_clients.items():
+            config = self._servers_config[bundle_id]
             try:
                 tools = await client.list_tools()
-                for t in tools:
-                    original_tool_name = t.name
-                    # 获取合并后的工具元数据（浅合并，具体配置优先，其次使用默认配置）
-                    # Get merged tool meta (shallow merge: specific overrides default)
-                    tool_meta = self._merged_tool_meta(config, original_tool_name)
-
-                    # 确定最终显示的工具名（优先使用别名）
-                    display_name: str = tool_meta.alias if tool_meta and tool_meta.alias else original_tool_name
-
-                    # 检查是否为禁用工具 (根据配置，但此时需要注意如果原始名称在禁用列表中，也应该禁用，因为此处的禁用列表是归属于某个
-                    # ServerConfig的，不存在重复名称的情况，用户有可能配置了alias，但是使用原始名称禁用。)
-                    # 禁用判定必须**先于** tool_sources 收集：被禁用的工具不暴露、不路由、也不应参与跨 server
-                    # 重名冲突检测（#106）——否则「禁用了仍触发 ToolNameDuplicatedError」，用户无法靠 forbid 一方规避重名。
-                    # The forbidden check must precede tool_sources collection: a disabled tool is neither exposed nor
-                    # routed, and must not participate in cross-server duplicate detection (#106).
-                    if display_name in (config.forbidden_tools or []) or original_tool_name in (config.forbidden_tools or []):
-                        self._disabled_tools.add(display_name)
-                        continue
-
-                    # 如果使用提别名，则更新别名映射
-                    if display_name != original_tool_name:
-                        self._alias_mapping[display_name] = (server_name, original_tool_name)
-
-                    # 将工具添加到映射
-                    tool_sources[display_name].append(server_name)
             except Exception as e:
-                logger.error(f"Error listing tools for {server_name}: {e}", exc_info=True)
-
-        # 构建最终映射（处理工具名冲突）
-        for tool, sources in tool_sources.items():
-            if len(sources) > 1:
-                logger.warning(f"Warning: Tool '{tool}' exists in multiple servers: {sources}")
-                suggestion = (
-                    "Please use the 'alias' feature in ToolMeta to resolve conflicts. "
-                    "Each tool should have a unique name or alias across all servers."
-                )
-                raise ToolNameDuplicatedError(f"Tool '{tool}' exists in multiple servers: {sources}\n{suggestion}")
-            self._tool_mapping[tool] = sources[0]
-
-        # 跨 server 误伤对账（#106）：_disabled_tools 按全局 display_name 索引，若某名被某 server forbid，
-        # 但同名工具由其它 server 正常提供（已进入 _tool_mapping），应以**存活方为准**，否则 avalidate_tool_call
-        # 会因 _disabled_tools 命中而误拒可用工具。单 server 独有工具被 forbid（无其它提供方）则仍保留禁用语义。
-        # Cross-server reconciliation: a name forbidden on one server but live on another must keep the live one.
-        self._disabled_tools.difference_update(self._tool_mapping.keys())
+                logger.error(f"Error listing tools for bundle_id={bundle_id!r} (name={config.name!r}): {e}", exc_info=True)
+                continue
+            for t in tools or []:
+                original_tool_name = t.name
+                # 合并后的工具元数据（具体 tool_meta 优先，回落 default_tool_meta）
+                tool_meta = self._merged_tool_meta(config, original_tool_name)
+                # alias 仅替换 exposed 的**工具名部分**（协议新语义，仍带 {bundle_id}__ 前缀）；无 alias 回退原始名
+                tool_part = tool_meta.alias if tool_meta and tool_meta.alias else original_tool_name
+                # forbidden：按**原始名**或 **alias 后工具名**匹配（用户可用任一禁用）；命中即不暴露、不路由
+                if original_tool_name in (config.forbidden_tools or []) or tool_part in (config.forbidden_tools or []):
+                    continue
+                exposed = f"{bundle_id}__{tool_part}"
+                if exposed in self._exposed_tools:
+                    # 同一 bundle_id 内 alias 撞名（跨 bundle_id 不可能撞）→ 保留首个 + 诊断，指导修正 alias
+                    logger.warning(
+                        f"exposed_tool_name 冲突（同 bundle_id={bundle_id!r} 内 alias 撞名）：'{exposed}'——保留首个、"
+                        f"跳过原始工具 '{original_tool_name}'；请修正 tool_meta.alias（Computer 本地诊断，非协议错误码）。",
+                    )
+                    continue
+                self._exposed_tools[exposed] = (bundle_id, original_tool_name)
 
     async def arefresh_tools(self) -> None:
-        """公开的工具映射刷新入口：锁内重建 ``_tool_mapping`` / ``_alias_mapping`` / ``_disabled_tools``（#127）。
+        """公开的工具映射刷新入口：锁内重建 ExposedToolMapping（``_exposed_tools``）（#127）。
 
-        Public tool-mapping refresh entry: rebuild mappings under the lock (#127).
+        Public tool-mapping refresh entry: rebuild the ExposedToolMapping under the lock (#127).
 
-        用途 / Use: MCP Server 运行期 ``tools/list_changed`` 后，boot 期构建的 ``_tool_mapping`` 已陈旧——
+        用途 / Use: MCP Server 运行期 ``tools/list_changed`` 后，boot 期构建的 ``_exposed_tools`` 已陈旧——
         **新增**工具不在映射中，``available_tools()`` 迭代映射键时永远漏掉它（``client:get_tools`` 看不到新工具）。
         本方法在 **安全上下文**（如 socketio ``on_get_tools`` 服务路径）被调用以刷新映射。
 
@@ -368,46 +325,42 @@ class MCPServerManager:
         async with self._lock:
             await self._arefresh_tool_mapping()
 
-    async def avalidate_tool_call(self, tool_name: TOOL_NAME, parameters: dict) -> tuple[SERVER_NAME, TOOL_NAME]:
-        """
-        判断工具调用的合法性，如果合法，返回对应的服务名称与原始工具名称
+    async def avalidate_tool_call(self, tool_name: EXPOSED_TOOL_NAME, parameters: dict) -> tuple[BUNDLE_ID, TOOL_NAME]:
+        """校验 ``exposed_tool_name`` 并经 ExposedToolMapping 解析到 ``(bundle_id, 原始工具名)``。
+
+        Validate an ``exposed_tool_name`` and route it via ExposedToolMapping to ``(bundle_id, original_tool_name)``.
 
         Args:
-            tool_name (str): 被调用的工具名称，可能是alias
-            parameters (dict): 工具调用的参数
+            tool_name (EXPOSED_TOOL_NAME): Agent 传入的 exposed_tool_name（``{bundle_id}__{alias??原始名}``）。
+            parameters (dict): 工具调用参数（当前版本不做 Schema 校验）。
 
         Returns:
-            tuple[SERVER_NAME, TOOL_NAME]: 经过校验后的合法服务名与工具名
+            tuple[BUNDLE_ID, TOOL_NAME]: 归属 bundle_id 与**原始**工具名。
+
+        Raises:
+            ValueError: exposed_tool_name 未命中 ExposedToolMapping（上层映射协议 ``4001``）。
         """
-        # 标记当前parameters尚未被使用
+        # 标记当前parameters尚未被使用 / parameters not schema-checked in this version
         logger.debug(f"{truncate(parameters)}未被检查。当前版本不支持Schema校验。")
-        # 检查工具是否可用
-        if tool_name in self._disabled_tools:
-            raise PermissionError(f"Tool '{tool_name}' is disabled by configuration")
-
-        server_name = self._tool_mapping.get(tool_name)
-        if not server_name:
-            raise ValueError(f"Tool '{tool_name}' not found in any active server")
-
-        # 如果tool_name是一个别名，则使用别名映射到原始名称
-        if tool_name in self._alias_mapping:
-            original_server_name, tool_name = self._alias_mapping[tool_name]
-            assert original_server_name == server_name, "Alias mapping should map to the same server"
-        return server_name, tool_name
+        # 整键查表（禁 split 反解身份；bundle_id 无 `__` 保证单射，原始名内含 `__` 无害）
+        route = self._exposed_tools.get(tool_name)
+        if route is None:
+            raise ValueError(f"Tool '{tool_name}' not found in ExposedToolMapping")
+        return route
 
     async def acall_tool(
         self,
-        server_name: SERVER_NAME,
+        bundle_id: BUNDLE_ID,
         tool_name: TOOL_NAME,
         parameters: dict,
         timeout: float | None = None,
     ) -> CallToolResult:
         """
-        触发MCP工具的调用。注意此方法tool_name必须是工具原始名称，如果是alias别名调用，需要使用 aexecute_tool
+        触发MCP工具的调用。注意此方法 tool_name 必须是工具**原始名称**，若以 exposed_tool_name 调用请用 aexecute_tool。
 
         Args:
-            server_name (str): 服务名称
-            tool_name (str): 工具名称
+            bundle_id (BUNDLE_ID): 目标 MCP Server 唯一身份 / target server bundle_id
+            tool_name (str): 工具**原始名称** / original tool name
             parameters (dict): 工具调用参数
             timeout (float | None): 超时时间
 
@@ -415,12 +368,12 @@ class MCPServerManager:
             CallToolResult: MCP 标准返回格式
         """
         # 获取MCP服务客户端连接
-        client = self._active_clients.get(server_name)
+        client = self._active_clients.get(bundle_id)
         if not client:
-            raise RuntimeError(f"Server '{server_name}' for tool '{tool_name}' is not active")
+            raise RuntimeError(f"Server bundle_id={bundle_id!r} for tool '{tool_name}' is not active")
 
         # 获取合并后的工具元数据
-        config = self._servers_config[server_name]
+        config = self._servers_config[bundle_id]
         tool_meta = self._merged_tool_meta(config, tool_name)
 
         # 执行工具调用
@@ -487,195 +440,187 @@ class MCPServerManager:
         except Exception as e:
             raise RuntimeError(f"Tool execution failed: {e}") from e
 
-    async def aexecute_tool(self, tool_name: TOOL_NAME, parameters: dict, timeout: float | None = None) -> CallToolResult:
-        """执行指定工具 与 acall_tool 的区别在于此方法支持使用alias别名进行调用。"""
-        server_name, tool_name = await self.avalidate_tool_call(tool_name, parameters)
-        return await self.acall_tool(server_name, tool_name, parameters, timeout)
+    async def aexecute_tool(self, tool_name: EXPOSED_TOOL_NAME, parameters: dict, timeout: float | None = None) -> CallToolResult:
+        """执行指定工具。入参 ``tool_name`` 为 **exposed_tool_name**，经 ExposedToolMapping 解析后调用原始工具。"""
+        bundle_id, original_tool_name = await self.avalidate_tool_call(tool_name, parameters)
+        return await self.acall_tool(bundle_id, original_tool_name, parameters, timeout)
 
-    async def list_resources(self, server_name: SERVER_NAME, cursor: str | None = None) -> tuple[list[Resource], str | None]:
+    async def list_resources(self, bundle_id: BUNDLE_ID, cursor: str | None = None) -> tuple[list[Resource], str | None]:
         """
-        中文: 单页透传指定 MCP Server 的 `resources/list`，供 v0.2 `client:get_resources` 使用。
+        中文: 单页透传指定 MCP Server（bundle_id）的 `resources/list`，供 v0.2 `client:get_resources` 使用。
         英文: Single-page transparent forward of a server's `resources/list`, for v0.2 `client:get_resources`.
 
         不做 scheme / 元数据过滤、不做跨 Server 聚合；翻页由调用方通过 cursor 控制。
         No scheme/metadata filtering, no cross-server aggregation; pagination is caller-driven via cursor.
 
         Args:
-            server_name (SERVER_NAME): 目标 MCP Server 名称 / Target MCP Server name.
+            bundle_id (BUNDLE_ID): 目标 MCP Server 的 bundle_id（wire `mcp_server`，协议 #18）/ Target server bundle_id.
             cursor (str | None): MCP 标准翻页游标；首次传 None / MCP pagination cursor; None for first page.
 
         Returns:
-            tuple[list[Resource], str | None]: (本页资源, 下一页游标——None 表示末页) /
-                (resources on this page, next cursor — None when last page).
+            tuple[list[Resource], str | None]: (本页资源, 下一页游标——None 表示末页)。
 
         Raises:
-            MCPServerNotFoundError: server_name 未注册（→ 上层映射 4014）/
-                server_name not registered (mapped to 4014 upstream).
-            MCPCapabilityNotSupportedError: 目标 Server 未声明 `resources` 能力（→ 上层映射 4015）/
-                target server did not declare `resources` capability (mapped to 4015 upstream).
+            MCPServerNotFoundError: bundle_id 未注册（→ 上层映射 4014，payload ``mcp_server``=bundle_id）。
+            MCPCapabilityNotSupportedError: 目标 Server 未声明 `resources` 能力（→ 上层映射 4015）。
         """
-        client = self._active_clients.get(server_name)
+        client = self._active_clients.get(bundle_id)
         if client is None:
-            raise MCPServerNotFoundError(f"MCP Server '{server_name}' is not registered")
+            raise MCPServerNotFoundError(f"MCP Server bundle_id={bundle_id!r} is not registered")
         return await client.list_resources_page(cursor)
 
-    def get_server_status(self) -> list[tuple[str, bool, str]]:
-        """获取服务器状态列表"""
+    def get_server_status(self) -> list[tuple[BUNDLE_ID, bool, str]]:
+        """获取服务器状态列表 [(bundle_id, 是否活跃, 状态), ...]（身份=bundle_id）。"""
         return [
             (
-                server_name,
-                server_name in self._active_clients,
-                "pending" if server_name not in self._active_clients else self._active_clients[server_name].state,
+                bundle_id,
+                bundle_id in self._active_clients,
+                "pending" if bundle_id not in self._active_clients else self._active_clients[bundle_id].state,
             )
-            for server_name in self._servers_config
+            for bundle_id in self._servers_config
         ]
 
     async def available_tools(self) -> AsyncGenerator[Tool, Any]:
-        """获取可用工具及其元数据"""
+        """获取暴露给 Agent 的工具及其元数据；``Tool.name`` = **exposed_tool_name**（``{bundle_id}__{alias??原始名}``）。
+
+        Yield tools exposed to the Agent; each ``Tool.name`` is the exposed_tool_name (协议 §exposed_tool_name / #106)。
+        Agent 即以 exposed_tool_name 寻址，``aexecute_tool`` 经 ExposedToolMapping 解析回原始名调用上游。
+        """
         async with self._lock:
-            servers_cached_tools = defaultdict(list)
-            for tool_name, server in self._tool_mapping.items():
-                if server not in servers_cached_tools and server in self._active_clients:
-                    client = self._active_clients[server]
-                    tools = await client.list_tools()
-                    servers_cached_tools[server] = tools
-
-                config = self._servers_config[server]
-                assert not config.disabled, "Server should not be disabled"
-
-                original_server, original_tool_name = self._alias_mapping.get(tool_name) or (server, tool_name)
-                assert original_server == server, "Alias mapping error"
+            servers_cached_tools: dict[BUNDLE_ID, list[Tool]] = {}
+            for exposed_name, (bundle_id, original_tool_name) in self._exposed_tools.items():
+                if bundle_id not in self._active_clients:
+                    continue
+                if bundle_id not in servers_cached_tools:
+                    servers_cached_tools[bundle_id] = await self._active_clients[bundle_id].list_tools()
+                tools = servers_cached_tools[bundle_id]
+                config = self._servers_config[bundle_id]
 
                 tool = next((t for t in tools if t.name == original_tool_name), None)
                 if tool:
                     a2c_meta = self._merged_tool_meta(config, original_tool_name)
-                    # 对外暴露 display_name（alias 优先，无 alias 时即原始名）作为 Tool.name（#106）：Agent 按此名寻址，
-                    # 含连字符 / 冲突的原始名才能借 alias 适配下游命名约束。tool_name 即 _tool_mapping 的 key（display_name）。
-                    # 产出名字改写后的**副本**，避免原地 mutate 缓存对象（servers_cached_tools 按原始名复用，原地改名会破坏后续查找）。
-                    # Expose display_name as Tool.name (#106); yield a renamed copy to avoid mutating the cached tool object.
-                    update: dict[str, Any] = {"name": tool_name}
+                    # 产出名字改写后的**副本**（改 name 为 exposed_name），避免原地 mutate 缓存对象。
+                    # Yield a renamed copy (name=exposed_name) to avoid mutating the cached tool object.
+                    update: dict[str, Any] = {"name": exposed_name}
                     if a2c_meta:
                         merged_meta = dict(tool.meta) if tool.meta else {}
                         merged_meta[A2C_TOOL_META] = a2c_meta
                         update["meta"] = merged_meta
                     yield tool.model_copy(update=update)
 
-    async def list_windows(self, window_uri: str | None = None) -> list[tuple[SERVER_NAME, Resource]]:
+    async def list_windows(self, window_uri: str | None = None) -> list[tuple[BUNDLE_ID, Resource]]:
         """
-        列出所有活动MCP服务器的窗口资源，并附带其归属的server名称。
-        List window resources from all active MCP servers with owning server name.
+        列出所有活动MCP服务器的窗口资源，并附带其归属 server 的 **bundle_id**（desktop 按 bundle_id 分组，协议 #18）。
+        List window resources from all active MCP servers with owning server **bundle_id**.
 
         Args:
             window_uri (str | None): 若提供，则仅返回URI完全匹配的窗口；否则返回所有窗口。
 
         Returns:
-            list[tuple[SERVER_NAME, Resource]]: [(server_name, resource), ...]
+            list[tuple[BUNDLE_ID, Resource]]: [(bundle_id, resource), ...]（``window://host`` 的 host 不受影响）。
         """
-        results: list[tuple[SERVER_NAME, Resource]] = []
+        results: list[tuple[BUNDLE_ID, Resource]] = []
         # 不加锁读取活跃客户端快照，避免长时间持锁阻塞 I/O
         active_snapshot = list(self._active_clients.items())
-        for server_name, client in active_snapshot:
+        for bundle_id, client in active_snapshot:
             try:
                 resources = await client.list_windows()
             except Exception as e:
-                logger.error(f"Error listing windows for {server_name}: {e}", exc_info=True)
+                logger.error(f"Error listing windows for bundle_id={bundle_id!r}: {e}", exc_info=True)
                 continue
 
             for res in resources:
                 if window_uri is not None and str(res.uri) != window_uri:
                     continue
-                results.append((server_name, res))
+                results.append((bundle_id, res))
         return results
 
-    async def list_skill_resources(self, server_name: SERVER_NAME | None = None) -> list[tuple[SERVER_NAME, Resource]]:
+    async def list_skill_resources(self, bundle_id: BUNDLE_ID | None = None) -> list[tuple[BUNDLE_ID, Resource]]:
         """
-        中文: 枚举活跃 MCP Server 的 ``skill://`` 资源（附 server 归属），**完整消费 cursor 翻页直至末尾**。
-        英文: Enumerate ``skill://`` resources from active MCP servers (with owning server), exhausting cursor pages.
+        中文: 枚举活跃 MCP Server 的 ``skill://`` 资源（附归属 **bundle_id**），**完整消费 cursor 翻页直至末尾**。
+        英文: Enumerate ``skill://`` resources from active MCP servers (with owning **bundle_id**), exhausting pages.
 
         与 :meth:`list_resources`（单页、Agent 控制翻页）不同：SKILL 物化由 Computer 主导，须拿到**全量**
         ``skill://`` 集合，故在此完整消费翻页（协议 skill.md §12）。未声明 ``resources`` 能力或枚举出错的
-        server **跳过**（记 ERROR、不中断其余），对齐「SKILL 通道不使用 4015——无 resources 能力的 server
-        在物化阶段即被排除」（error-handling.md / skill.md §1.5）。
-        Unlike :meth:`list_resources` (single-page, Agent-driven): Computer-driven SKILL materialization needs
-        the full ``skill://`` set, so pages are exhausted here. Servers lacking ``resources`` capability or
-        erroring are skipped (logged ERROR, others continue).
+        server **跳过**（记 ERROR、不中断其余），对齐「SKILL 通道不使用 4015」（error-handling.md / skill.md §1.5）。
+        Servers lacking ``resources`` capability or erroring are skipped (logged ERROR, others continue).
+
+        注意 / Note: 归属键为 **bundle_id**（路由用）。SKILL name 的 ``<server>`` 段仍取 server **name**（协议 #18：
+        SKILL ``<server>`` 段与 BundleID 正交、不变）——由 staging 经 ``get_server_config(bundle_id).name`` 派生。
 
         Args:
-            server_name (SERVER_NAME | None): 若提供仅枚举该 server（用于 ResourceListChanged 单 server 重枚举）；
-                否则枚举全部活跃 server / restrict to one server, else enumerate all active servers.
+            bundle_id (BUNDLE_ID | None): 若提供仅枚举该 server（ResourceListChanged 单 server 重枚举）；否则全部活跃 server。
 
         Returns:
-            list[tuple[SERVER_NAME, Resource]]: [(server_name, skill_resource), ...]
+            list[tuple[BUNDLE_ID, Resource]]: [(bundle_id, skill_resource), ...]
         """
-        results: list[tuple[SERVER_NAME, Resource]] = []
+        results: list[tuple[BUNDLE_ID, Resource]] = []
         active_snapshot = list(self._active_clients.items())
-        for sname, client in active_snapshot:
-            if server_name is not None and sname != server_name:
+        for bid, client in active_snapshot:
+            if bundle_id is not None and bid != bundle_id:
                 continue
             try:
                 cursor: str | None = None
                 pages = 0
                 while True:
                     page, cursor = await client.list_resources_page(cursor)
-                    results.extend((sname, res) for res in page if str(res.uri).startswith("skill://"))
+                    results.extend((bid, res) for res in page if str(res.uri).startswith("skill://"))
                     pages += 1
                     if not cursor:
                         break
                     if pages >= _MAX_SKILL_LIST_PAGES:
                         logger.error(
-                            f"list_skill_resources: server {sname} exceeded {_MAX_SKILL_LIST_PAGES} pages "
+                            f"list_skill_resources: bundle_id={bid!r} exceeded {_MAX_SKILL_LIST_PAGES} pages "
                             f"(non-terminating cursor?); aborting enumeration for this server",
                         )
                         break
             except Exception as e:
                 # 未声明 resources 能力 / 连接异常 / 翻页失败 → 跳过该 server，不阻断其余
-                logger.error(f"Error listing skill resources for {sname}: {e}", exc_info=True)
+                logger.error(f"Error listing skill resources for bundle_id={bid!r}: {e}", exc_info=True)
                 continue
         return results
 
-    async def read_resource(self, server_name: SERVER_NAME, uri: str) -> ReadResourceResult:
+    async def read_resource(self, bundle_id: BUNDLE_ID, uri: str) -> ReadResourceResult:
         """
-        中文: 读取指定 MCP Server 的单个资源内容（通用 ``resources/read`` 入口，供 SKILL ``resources`` 模式
-              逐子资源物化与子文件渐进式披露复用）。
-        英文: Read a single resource's contents from a server (generic ``resources/read`` entry; reused by
-              SKILL ``resources``-mode per-sub-resource materialization).
+        中文: 读取指定 MCP Server（bundle_id）的单个资源内容（通用 ``resources/read`` 入口，供 SKILL ``resources``
+              模式逐子资源物化与子文件渐进式披露、及 ``client:get_resources`` 复用）。
+        英文: Read a single resource's contents from a server by bundle_id (generic ``resources/read`` entry).
 
         复用既有 ``client.get_window_detail``——其实现为通用 ``read_resource``（命名沿用历史，非仅 window）。
-        Reuses ``client.get_window_detail`` whose impl is a generic ``read_resource`` (name is historical).
 
         Raises:
-            MCPServerNotFoundError: server_name 未注册 / server_name not registered.
+            MCPServerNotFoundError: bundle_id 未注册（→ 上层映射 4014）/ bundle_id not registered.
         """
-        client = self._active_clients.get(server_name)
+        client = self._active_clients.get(bundle_id)
         if client is None:
-            raise MCPServerNotFoundError(f"MCP Server '{server_name}' is not registered")
+            raise MCPServerNotFoundError(f"MCP Server bundle_id={bundle_id!r} is not registered")
         return await client.get_window_detail(uri)
 
-    async def get_windows_details(self, window_uri: str | None = None) -> list[tuple[SERVER_NAME, Resource, ReadResourceResult]]:
+    async def get_windows_details(self, window_uri: str | None = None) -> list[tuple[BUNDLE_ID, Resource, ReadResourceResult]]:
         """
-        中文: 读取所有活动 MCP 服务器的窗口资源详情。由于 MCP 协议中的 Resource 仅为标识，需要通过 read_resource 获取内容。
-        英文: Read detailed contents for window resources from all active MCP servers. Resource is an identifier; use read_resource.
+        中文: 读取所有活动 MCP 服务器的窗口资源详情（附归属 bundle_id）。Resource 仅为标识，需 read_resource 取内容。
+        英文: Read detailed contents for window resources from all active MCP servers (with owning bundle_id).
 
         Args:
             window_uri (str | None): 若提供，则仅读取该 URI 完全匹配的窗口；否则读取所有窗口。
 
         Returns:
-            list[tuple[SERVER_NAME, Resource, list[object]]]: 列表项为 (server_name, resource, contents)。
+            list[tuple[BUNDLE_ID, Resource, ReadResourceResult]]: 列表项为 (bundle_id, resource, contents)。
         """
-        details: list[tuple[SERVER_NAME, Resource, ReadResourceResult]] = []
+        details: list[tuple[BUNDLE_ID, Resource, ReadResourceResult]] = []
         active_snapshot = list(self._active_clients.items())
-        for server_name, client in active_snapshot:
+        for bundle_id, client in active_snapshot:
             try:
                 resources = await client.list_windows()
             except Exception as e:
-                logger.error(f"Error listing windows for {server_name}: {e}", exc_info=True)
+                logger.error(f"Error listing windows for bundle_id={bundle_id!r}: {e}", exc_info=True)
                 continue
 
             for res in resources:
                 if window_uri is not None and str(res.uri) != window_uri:
                     continue
                 content = await client.get_window_detail(res)
-                details.append((server_name, res, content))
+                details.append((bundle_id, res, content))
         return details
 
     @staticmethod

--- a/a2c_smcp/computer/mcp_clients/model.py
+++ b/a2c_smcp/computer/mcp_clients/model.py
@@ -12,6 +12,7 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator, model_valida
 from vrl_python import VRLRuntime
 
 from a2c_smcp.types import SERVER_NAME, TOOL_NAME
+from a2c_smcp.utils.bundle_id import validate_explicit_bundle_id
 
 if TYPE_CHECKING:
     from a2c_smcp.computer.mcp_clients.base_client import STATES
@@ -27,7 +28,11 @@ class ToolMeta(BaseModel):
     alias: str | None = Field(
         default=None,
         title="工具别名",
-        description="如果不同MCP Server中存在同名工具，允许通过此别名修改，从而解决名称冲突",
+        description=(
+            "工具别名（BundleID 模型，协议 0.3.0）。仅替换 exposed_tool_name 的**工具名部分**，"
+            "仍带 `{bundle_id}__` 前缀（非对整个 exposed_tool_name 的完全替换）。含连字符/冲突的原始名"
+            "可借此适配下游命名约束。"
+        ),
     )
     tags: list[str] | None = Field(default=None, title="工具标签", description="用于对工具进行分类")
     # 不同MCP工具返回值并不统一，虽然其满足MCP标准的返回格式，但具体的原始内容命名仍然无法避免出现不一致的情况。通过object_mapper可以方便
@@ -45,6 +50,14 @@ class BaseMCPServerConfig(BaseModel):
     """MCP服务器配置基类"""
 
     name: SERVER_NAME  # MCP Server的名称
+    # BundleID 模型（协议 0.3.0，a2c-smcp-protocol#15）：MCP Server 软件级唯一身份。
+    # 省略时由 name 经确定性算法在 Computer 注册边界（derive-on-load）生成，解析后恒有值；
+    # 此处仅承载**显式**值并校验（生成不在 Pydantic，因 config frozen=True）。见 utils/bundle_id.py。
+    bundle_id: str | None = Field(
+        default=None,
+        title="Bundle 唯一标识",
+        description="MCP Server 唯一身份（BundleID）。省略则由 name 确定性生成；显式值须为 [A-Za-z0-9_-] 且无连续 '__'。",
+    )
     disabled: bool = Field(default=False, title="是否禁用", description="是否禁用MCP Server")
     forbidden_tools: list[TOOL_NAME] = Field(
         default_factory=list,
@@ -105,6 +118,18 @@ class BaseMCPServerConfig(BaseModel):
             raise ValueError(error_msg)
 
         return v
+
+    @field_validator("bundle_id")
+    @classmethod
+    def validate_bundle_id(cls, v: str | None) -> str | None:
+        """仅校验**显式**提供的 bundle_id（非空、无连续 `__`、字符集 `[A-Za-z0-9_-]`）。
+
+        Validate an explicitly-provided bundle_id only. 省略（None）不校验——触发注册边界缺省生成
+        （:func:`a2c_smcp.utils.bundle_id.resolve_bundle_id`）。
+        """
+        if v is None:
+            return v
+        return validate_explicit_bundle_id(v)
 
     def __hash__(self) -> int:
         """对于MCP Server配置，以name作为唯一标识凭证，如果name相同则表示完全相同"""

--- a/a2c_smcp/computer/skills/staging.py
+++ b/a2c_smcp/computer/skills/staging.py
@@ -462,7 +462,10 @@ async def stage_mcp_skills(
     registered: list[str] = []
     seen_this_run: set[str] = set()  # 本 run 已处理的合成 name，用于真冲突检测（§1.5 保留先到者）
     for sname, resources in by_server.items():
-        normalized_server = normalize_mcp_server_segment(sname)
+        # sname = bundle_id（manager 身份键）。SKILL ``<server>`` 段与磁盘路径仍取 server **name**（协议 #18：
+        # SKILL ``<server>`` 段与 BundleID 正交、不变）；``read_resource`` 仍按 bundle_id 路由。
+        server_display_name = manager.get_server_config(sname).name
+        normalized_server = normalize_mcp_server_segment(server_display_name)
         for res in resources:
             meta = dict(getattr(res, "meta", None) or {})
             mode = meta.get("source")
@@ -489,7 +492,10 @@ async def stage_mcp_skills(
                 shutil.rmtree(staged, ignore_errors=True)
                 continue
 
-            name = _finalize_and_register(sname, normalized_server, meta, staged, root_uri, home, registry, seen_this_run)
+            # SKILL name 的 `<server>` 段取 server **name**（非 bundle_id）——协议 #18 SKILL `<server>` 段不变。
+            name = _finalize_and_register(
+                server_display_name, normalized_server, meta, staged, root_uri, home, registry, seen_this_run,
+            )
             if name is not None:
                 registered.append(name)
     return registered

--- a/a2c_smcp/computer/socketio/client.py
+++ b/a2c_smcp/computer/socketio/client.py
@@ -68,6 +68,7 @@ from a2c_smcp.smcp import (
 from a2c_smcp.smcp import (
     MCPServerConfig as SMCPServerConfigDict,
 )
+from a2c_smcp.utils.bundle_id import resolve_bundle_id
 from a2c_smcp.utils.handshake import (
     DEFAULT_HANDSHAKE_TRANSPORTS,
     HANDSHAKE_CONNECT_ERRORS,
@@ -538,10 +539,17 @@ class SMCPComputerClient(AsyncClient):
         # 从 Computer 中获取初始化时传入的配置集合（不可变元组）
         # From Computer, get the immutable tuple of initial MCP server configs
         for cfg in self.computer.mcp_servers:
+            # 身份键 = bundle_id（协议 #18）；从 raw config derive（与注册边界 seam 一致，raw #17）。
+            # no-double-open：同 bundle_id 保留首个（与 manager boot first-wins 一致）。
+            bundle_id = resolve_bundle_id(cfg)
+            if bundle_id in servers:
+                continue
             # 使用强校验转换为协议定义（中英文）/ Validate strictly to protocol definition (bilingual)
             # 若类型不匹配，抛出异常，属于硬性 Bug / If mismatched, raise to surface a hard bug.
             validated_server: dict = TypeAdapter(SMCPServerConfigDict).validate_python(cfg.model_dump(mode="json"), from_attributes=True)
-            servers[cfg.name] = validated_server
+            # 物化解析后 bundle_id（entry 携 bundle_id + name(display)，供 Agent tool→server 归属桥）
+            validated_server["bundle_id"] = bundle_id
+            servers[bundle_id] = validated_server
 
         inputs: list[MCPServerInput] = []
         for i in self.computer.inputs:
@@ -585,14 +593,14 @@ class SMCPComputerClient(AsyncClient):
             return ErrorPayload(
                 code=int(ErrorCode.MCP_SERVER_NOT_FOUND),
                 message="MCP Server not registered",
-                mcp_server_name=mcp_server,
+                mcp_server=mcp_server,
             )
         except MCPCapabilityNotSupportedError as e:
             logger.warning(f"client:get_resources MCP Server '{mcp_server}' 未声明 resources 能力 / capability missing: {e}")
             return ErrorPayload(
                 code=int(ErrorCode.MCP_CAPABILITY_NOT_SUPPORTED),
                 message="MCP Server does not support 'resources' capability",
-                mcp_server_name=mcp_server,
+                mcp_server=mcp_server,
                 capability="resources",
             )
         ret: GetResourcesRet = {
@@ -740,7 +748,7 @@ def _skill_not_found(name: str) -> ErrorPayload:
     """``4014`` 复用 flat ErrorPayload：name 合法但 Registry 未命中（未注册 / 卸载 / 孤儿）。
 
     SKILL 通道复用 ``MCP_SERVER_NOT_FOUND`` 语义（error-handling.md §SKILL）；``name`` 经 ``details`` 下沉
-    （非 mcp_server，故不平铺 ``mcp_server_name``）。
+    （SKILL 按 name 寻址、非 mcp_server(bundle_id)，故不平铺 ``mcp_server``）。
     """
     return ErrorPayload(code=int(ErrorCode.MCP_SERVER_NOT_FOUND), message="Skill not found", details={"name": name})
 

--- a/a2c_smcp/smcp.py
+++ b/a2c_smcp/smcp.py
@@ -150,8 +150,8 @@ class ToolMeta(TypedDict, total=False):
     # 不同MCP工具返回值并不统一，虽然其满足MCP标准的返回格式，但具体的原始内容命名仍然无法避免出现不一致的情况。通过object_mapper可以方便
     # 前端对其进行转换，以使用标准组件渲染解析。
     ret_object_mapper: NotRequired[dict | None]
-    # 工具别名，与 model.ToolMeta.alias 对齐，用于解决不同 Server 下工具重名冲突
-    # Tool alias, align with model.ToolMeta.alias, used to resolve name conflicts across servers
+    # 工具别名（BundleID 模型，协议 0.3.0）。仅替换 exposed_tool_name 的**工具名部分**，仍带 {bundle_id}__ 前缀。
+    # Tool alias (BundleID model): replaces only the tool-name part of exposed_tool_name, keeps the {bundle_id}__ prefix.
     alias: NotRequired[str | None]
     # 工具标签，用于对工具进行分类
     # Tool tags, used to categorize tools
@@ -162,6 +162,9 @@ class BaseMCPServerConfig(TypedDict):
     """MCP服务器配置基类"""
 
     name: SERVER_NAME  # MCP Server的名称
+    # MCP Server 唯一身份（BundleID 模型，协议 0.3.0）。省略/未解析为 None；注册边界 derive 后恒有值。
+    # MCP Server unique identity (BundleID model). None when omitted/unresolved; always set after derive.
+    bundle_id: NotRequired[str | None]
     disabled: bool
     forbidden_tools: list[str]  # 禁用的工具列表，因为一个mcp可能有非常多工具，有些工具用户需要禁用。
     tool_meta: dict[TOOL_NAME, ToolMeta]
@@ -492,7 +495,7 @@ class GetResourcesReq(AgentCallData, total=True):
     """
 
     computer: str
-    mcp_server: str  # 必填：MCP Server 名称 / Required: MCP Server name
+    mcp_server: str  # 必填：目标 MCP Server 的 bundle_id（= get_config servers 字典 key，协议 #18）/ Required: target server bundle_id
     cursor: NotRequired[str]
 
 
@@ -518,8 +521,8 @@ class ErrorPayload(TypedDict, total=False):
 
     分流字段顶层平铺 / Code-specific dispatch fields are top-level:
       - 4008: server_version / client_version / min_supported / max_supported
-      - 4014: mcp_server_name
-      - 4015: mcp_server_name / capability
+      - 4014: mcp_server（bundle_id）
+      - 4015: mcp_server（bundle_id）/ capability
 
     v0.2.1 起，4016 / 4017 / 4018 的 code-specific 字段下沉到 ``details`` 子对象（无顶层平铺新字段）：
     From v0.2.1, code-specific fields for 4016 / 4017 / 4018 live under ``details`` (no new top-level fields):
@@ -540,8 +543,8 @@ class ErrorPayload(TypedDict, total=False):
     client_version: str
     min_supported: str
     max_supported: str
-    # 4014 / MCP Server not found；4015 / MCP Capability not supported
-    mcp_server_name: str
+    # 4014 / MCP Server not found；4015 / MCP Capability not supported。值 = 目标 server 的 **bundle_id**（协议 #18）
+    mcp_server: str
     # 4015 / 缺失的 capability 名（如 "resources"）/ Missing capability name (e.g. "resources")
     capability: str
     # 诊断容器 / Diagnostic container

--- a/a2c_smcp/types.py
+++ b/a2c_smcp/types.py
@@ -27,3 +27,7 @@ AttributesAsKey = tuple[
 ]
 TOOL_NAME: TypeAlias = str
 SERVER_NAME: TypeAlias = str
+# BundleID 模型（协议 0.3.0，a2c-smcp-protocol#15）：MCP Server 唯一身份 + 聚合暴露名。
+# BUNDLE_ID：MCP Server 软件级唯一标识；EXPOSED_TOOL_NAME：暴露给 LLM 的 `{bundle_id}__{alias??原始名}`。
+BUNDLE_ID: TypeAlias = str
+EXPOSED_TOOL_NAME: TypeAlias = str

--- a/a2c_smcp/utils/bundle_id.py
+++ b/a2c_smcp/utils/bundle_id.py
@@ -1,0 +1,186 @@
+# -*- coding: utf-8 -*-
+# filename: bundle_id.py
+# @Time    : 2026/07/11
+# @Author  : JQQ
+# @Email   : jqq1716@gmail.com
+# @Software: PyCharm
+"""
+BundleID 生成 / 校验 / connection-identity TLV 摘要（单一权威）/ Deterministic BundleID derivation (single source of truth).
+
+协议依据 / Protocol: a2c-smcp-protocol docs/specification/data-structures.md §「MCP Tool 命名与路由（BundleID 模型）」
+                     （refs A2C-SMCP/a2c-smcp-protocol#15；规范 commit 95b8553，0.3.0-dev）。
+
+存在意义 / Why this module：
+    `bundle_id` 缺省生成 **MUST** 逐字节确定、各 SDK（Python / Rust）产出同一结果——是跨 SDK 硬门槛。
+    本模块以实现内置、与宿主无关的算法（Unicode 码点迭代 + 显式 ASCII 类 + SHA-256 摘要）为
+    Computer 注册边界（`_arender_and_validate_server`）提供**唯一**权威，杜绝跨 SDK / 跨决策点漂移。
+    SHA-256 与 rust 对齐，禁语言内建 hash()（进程级随机化）、禁 base32/64（大小写/padding 变体）。
+
+✅ P0 一致性夹具 / Conformance vectors (LOCKED)：
+    TLV 字节帧已由协议仓一致性向量「定死」并**逐字节对拍全绿**（`a2c-smcp-protocol` develop `57c2f9f`，
+    16 条，`tests/unit_tests/utils/test_bundle_id_conformance.py`）。rust-sdk#117 回执确认 3 处契约：
+      [1] ✅ 类型判别符（"stdio"/"streamable"/"sse"）与普通字符串字段同构，走 u32 长度前缀（非裸拼接）。
+      [3] ✅ 顶层帧为判别符起的扁平拼接，无外层长度 / 计数包裹。
+      [2] ⚠️ **raw（协议 #17 已定，`57c2f9f`）**：connection-identity 取 **raw / 未注入**配置——
+          `${input:*}` / `${env:*}` / secret 占位**按字面**参与摘要，**MUST NOT** 先渲染。本模块对传入
+          config 的字段值**原样摘要**（不感知渲染）；「取 raw」由调用方（Computer 注册边界
+          `_arender_and_validate_server`）在 `ConfigRender.arender` **之前** derive-on-raw 保证。
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+import struct
+from collections.abc import Mapping, Sequence
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from a2c_smcp.computer.mcp_clients.model import MCPServerConfig
+
+# 显式 ASCII 字符类 [A-Za-z0-9_-]（规范 Step 1.1：MUST 用显式类，MUST NOT 用 \w——各语言 Unicode \w 集合不一致）。
+# Explicit ASCII class; any non-ASCII code point falls outside and is replaced.
+_ALLOWED_CHARS: frozenset[str] = frozenset(
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-",
+)
+# 折叠连续下划线（含原文 `__`）为单个；**不**折 `-`（规范 Step 1.2）。
+_CONSECUTIVE_UNDERSCORE = re.compile(r"_+")
+# 合法显式 bundle_id 的字符集断言（[A-Za-z0-9_-]+，`.` 等一律非法）。
+_VALID_BUNDLE_ID = re.compile(r"^[A-Za-z0-9_-]+$")
+
+# fallback 前缀（规范 Step 3）：`bundle_` + 16 个小写 hex（= SHA-256 摘要前 8 字节）。
+_FALLBACK_PREFIX = "bundle_"
+
+
+def normalize_name(name: str) -> str:
+    """规范化 `name` 为候选 bundle_id（规范 Step 1）；结果可能为空（→ 触发 fallback）。
+
+    Normalize a server ``name`` into a candidate bundle_id (spec Step 1); may return "" (→ fallback).
+
+    步骤（按 **Unicode 码点**迭代，`for c in name`，MUST NOT 按 UTF-8 字节 / grapheme）：
+      1. 非 `[A-Za-z0-9_-]` 码点（任何非 ASCII 一律命中）→ `_`；
+      2. 折叠连续 `_`（含原文 `__`）为单个，**不**折 `-`；
+      3. 裁首尾 `[_-]`；
+      4. **不**做大小写折叠（`MyServer` ≠ `myserver`）。
+    """
+    # Step 1.1 — 逐码点替换（Python `for c in str` 即按码点迭代）
+    replaced = "".join(c if c in _ALLOWED_CHARS else "_" for c in name)
+    # Step 1.2 — 折叠连续 `_`（含 `__`），不折 `-`
+    folded = _CONSECUTIVE_UNDERSCORE.sub("_", replaced)
+    # Step 1.3 — 裁首尾 `[_-]`；Step 1.4 — 不做大小写折叠（无操作）
+    return folded.strip("_-")
+
+
+def is_valid_bundle_id(bundle_id: str) -> bool:
+    """显式 bundle_id 是否合法：非空、无连续 `__`、字符集 `[A-Za-z0-9_-]`（含 `.` 判非法）。"""
+    return bool(bundle_id) and "__" not in bundle_id and _VALID_BUNDLE_ID.match(bundle_id) is not None
+
+
+def validate_explicit_bundle_id(bundle_id: str) -> str:
+    """校验**显式**传入的 bundle_id，合法则原样返回，否则抛 ``ValueError``。
+
+    Validate an explicitly-provided bundle_id; return it unchanged or raise ``ValueError``.
+
+    仅校验显式值——**省略** bundle_id 不算错误（走缺省生成，见 :func:`generate_bundle_id`）。
+    """
+    if not bundle_id:
+        raise ValueError("bundle_id MUST NOT be empty (omit the field entirely to trigger default generation)")
+    if "__" in bundle_id:
+        raise ValueError(
+            f"bundle_id MUST NOT contain consecutive underscores '__' (reserved separator between "
+            f"bundle_id and tool name): {bundle_id!r}",
+        )
+    if _VALID_BUNDLE_ID.match(bundle_id) is None:
+        raise ValueError(f"bundle_id charset MUST be [A-Za-z0-9_-] (e.g. '.' is invalid): {bundle_id!r}")
+    return bundle_id
+
+
+# ————————————————————————————————————————————————————————————————————————————
+# connection-identity TLV 字节帧（规范 §connection-identity）/ TLV byte frame
+#
+# 为避免 JSON 跨语言序列化漂移，用长度前缀（TLV）字节帧、MUST NOT 用 JSON。所有多字节整数为 **u32 大端**。
+# All multi-byte integers are u32 big-endian; strings are UTF-8. See ASSUMPTION[1..3] in the module docstring.
+# ————————————————————————————————————————————————————————————————————————————
+
+
+def _str_field(value: str) -> bytes:
+    """字符串字段 = u32 大端字节长度 ‖ UTF-8 字节。"""
+    raw = value.encode("utf-8")
+    return struct.pack(">I", len(raw)) + raw
+
+
+def _list_field(items: Sequence[str]) -> bytes:
+    """列表 = u32 大端元素数 ‖ 元素*（**保序**——参数顺序有语义）。空列表 → 计数 0。"""
+    out = struct.pack(">I", len(items))
+    for item in items:
+        out += _str_field(item)
+    return out
+
+
+def _map_field(mapping: Mapping[str, str] | None) -> bytes:
+    """映射 = u32 大端条目数 ‖ (key ‖ value)*，**按 key 码点序升序**。空 / None → 计数 0。
+
+    Python ``sorted`` 按码点排序；规范注明「UTF-8 字节序 = 码点序」，二者对全部合法 Unicode 等价。
+    """
+    items = sorted((mapping or {}).items(), key=lambda kv: kv[0])
+    out = struct.pack(">I", len(items))
+    for key, value in items:
+        out += _str_field(key) + _str_field(value)
+    return out
+
+
+def connection_identity_tlv(config: MCPServerConfig) -> bytes:
+    """构造该 Server 的 connection-identity TLV 字节串（fallback 摘要输入，规范 §connection-identity）。
+
+    仅纳入**连接建立字段**；**排除** disabled/tool_meta/forbidden_tools/vrl/env_file/cwd/encoding/timeout 系列。
+      - stdio           → 判别符 ‖ command ‖ args(列表,保序) ‖ env(映射,按 key 排序)
+      - streamable/sse  → 判别符 ‖ url ‖ headers(映射,按 key 排序)
+
+    判别符取协议 §9.1 小写 type（Http 变体在本 SDK 即记 ``streamable``，与规范一致）。
+    字节帧（rust-sdk#117 回执确认 + 协议向量 57c2f9f 锁定）：判别符走 :func:`_str_field`（u32 长度前缀）；
+    无外层包裹、判别符起扁平拼接。**raw（#17）**：本函数对 ``config`` 字段值原样摘要——调用方须传**未渲染**
+    config（占位字面），故 ``${input:*}`` 参与摘要、bundle_id 跨渲染阶段稳定（见模块 docstring）。
+    """
+    # 逐分支访问 config.server_parameters（直接比对 config.type 以触发判别联合窄化；先提取 params 会丢失窄化）。
+    if config.type == "stdio":
+        stdio_params = config.server_parameters
+        # ASSUMPTION[1] discriminator as length-prefixed string field
+        return (
+            _str_field("stdio")
+            + _str_field(stdio_params.command)
+            + _list_field(list(stdio_params.args or []))
+            + _map_field(stdio_params.env)
+        )
+    if config.type in ("streamable", "sse"):
+        http_params = config.server_parameters
+        # config.type 已窄化为 "streamable" | "sse"，即协议 §9.1 判别符（Http 变体在本 SDK 即 "streamable"）。
+        return _str_field(config.type) + _str_field(str(http_params.url)) + _map_field(http_params.headers)
+    # 未知 type：正常流程不可达（MCPServerConfig 为封闭联合）；防御性硬失败暴露 SDK bug。
+    raise ValueError(f"Unknown MCP server type for bundle_id fallback digest: {config.type!r}")  # pragma: no cover
+
+
+def generate_bundle_id(config: MCPServerConfig) -> str:
+    """从 `name`（+ 连接身份）**确定性缺省生成** bundle_id（规范 Step 1→3），忽略任何显式 bundle_id。
+
+    Deterministically derive a bundle_id from ``name`` (+ connection identity); ignores any explicit value.
+    这是一致性测试向量对拍的入口：``(name, connection config) → 期望 bundle_id``。
+    """
+    normalized = normalize_name(config.name)
+    if normalized:  # Step 2 — 非空即取
+        return normalized
+    # Step 3 — fallback：bundle_ + lowercase_hex(SHA-256(TLV)[:8])（前 8 字节 = 16 hex）
+    digest8 = hashlib.sha256(connection_identity_tlv(config)).digest()[:8]
+    return _FALLBACK_PREFIX + digest8.hex()  # .hex() 已为小写
+
+
+def resolve_bundle_id(config: MCPServerConfig) -> str:
+    """解析该 Server 的最终 bundle_id：显式值优先（经校验），否则缺省生成。
+
+    Resolve the final bundle_id: explicit (validated) wins, else deterministic default generation.
+    在 Computer 注册边界（derive-on-load）调用；**MUST NOT** 回写配置源（如 mcp.json）。
+    """
+    explicit = getattr(config, "bundle_id", None)
+    if explicit is not None:
+        # 显式值：Pydantic field_validator 已校验；此处防御性再校验，保证注册边界单一权威。
+        return validate_explicit_bundle_id(explicit)
+    return generate_bundle_id(config)

--- a/tests/e2e/computer/mcp_clients/test_manager.py
+++ b/tests/e2e/computer/mcp_clients/test_manager.py
@@ -87,7 +87,7 @@ if .tool_name == "browser_navigate" || .tool_name == "browser_navigate_back" {
         # English: Call browser_navigate tool to open Baidu homepage
         baidu_url = "https://www.baidu.com"
         result = await manager.acall_tool(
-            server_name="playwright",
+            bundle_id="playwright",
             tool_name="browser_navigate",
             parameters={"url": baidu_url},
             timeout=30.0,  # 中文: 浏览器操作可能需要较长时间 / English: Browser operations may take longer

--- a/tests/e2e/computer/test_cli_desktop_e2e.py
+++ b/tests/e2e/computer/test_cli_desktop_e2e.py
@@ -120,7 +120,7 @@ def test_desktop_order_respects_recent_tool_calls(cli_proc: pexpect.spawn, tmp_p
         "agent": "r-e2e",
         "req_id": "req-e2e",
         "computer": "client",
-        "tool_name": "mark_b",  # 由 B server 提供
+        "tool_name": "e2e-desktop-B__mark_b",  # 由 B server 提供（exposed_tool_name = {bundle_id}__mark_b）
         "params": {},
         "timeout": 5,
     }
@@ -154,7 +154,7 @@ def test_desktop_order_respects_recent_tool_calls(cli_proc: pexpect.spawn, tmp_p
         "agent": "r-e2e",
         "req_id": "req-e2e-2",
         "computer": "client",
-        "tool_name": "mark_a",  # 由 A server 提供
+        "tool_name": "e2e-desktop-A__mark_a",  # 由 A server 提供
         "params": {},
         "timeout": 5,
     }
@@ -179,7 +179,7 @@ def test_desktop_order_respects_recent_tool_calls(cli_proc: pexpect.spawn, tmp_p
         "agent": "r-e2e",
         "req_id": "req-e2e-3",
         "computer": "client",
-        "tool_name": "mark_b",
+        "tool_name": "e2e-desktop-B__mark_b",
         "params": {},
         "timeout": 5,
     }

--- a/tests/e2e/computer/test_cli_history.py
+++ b/tests/e2e/computer/test_cli_history.py
@@ -66,7 +66,7 @@ def test_history_after_tc(cli_proc: pexpect.spawn, tmp_path: Path) -> None:
     # 3) tools 确认一下 hello 可用
     child.sendline("tools")
     tools_out = expect_prompt_stable(child, quiet=0.6, max_wait=12.0)
-    assert "hello" in strip_ansi(tools_out)
+    assert "e2e-hist__hello" in strip_ansi(tools_out)
 
     # 4) 通过 tc 触发一次调用（固定 req_id 以便断言）
     req_id = "req-e2e-history-1"
@@ -74,7 +74,7 @@ def test_history_after_tc(cli_proc: pexpect.spawn, tmp_path: Path) -> None:
         "agent": "bot-e2e",
         "req_id": req_id,
         "computer": "ignored",
-        "tool_name": "hello",
+        "tool_name": "e2e-hist__hello",
         "params": {"name": "Hist"},
         "timeout": 10,
     }

--- a/tests/e2e/computer/test_cli_tc.py
+++ b/tests/e2e/computer/test_cli_tc.py
@@ -75,7 +75,7 @@ def test_tc_call_hello(cli_proc: pexpect.spawn, tmp_path: Path) -> None:
     # 3) 确认工具已可见（tools 列表应包含 hello）
     child.sendline("tools")
     tools_out = expect_prompt_stable(child, quiet=0.6, max_wait=12.0)
-    assert "hello" in strip_ansi(tools_out)
+    assert "e2e-tc__hello" in strip_ansi(tools_out)
 
     # 4) 构造 tc 负载，工具名使用原始 MCP 工具名（不加前缀）。
     #    中文: Manager 会在所有已启动 server 中解析该工具名；我们前一步已确认 tools 中包含 hello。
@@ -84,7 +84,7 @@ def test_tc_call_hello(cli_proc: pexpect.spawn, tmp_path: Path) -> None:
         "agent": "bot-e2e",
         "req_id": "req-e2e-hello",
         "computer": "ignored",
-        "tool_name": "hello",
+        "tool_name": "e2e-tc__hello",
         "params": {"name": "E2E"},
         "timeout": 10,
     }
@@ -138,7 +138,7 @@ def test_tc_default_and_tool_both_false_then_error(cli_proc: pexpect.spawn, tmp_
         "agent": "r-e2e",
         "req_id": "req-e2e",
         "computer": "client",
-        "tool_name": "mark_b",
+        "tool_name": "e2e-tc-b-both-false__mark_b",
         "params": {},
         "timeout": 5,
     }
@@ -190,7 +190,7 @@ def test_tc_tool_true_overrides_default(cli_proc: pexpect.spawn, tmp_path: Path)
         "agent": "r-e2e",
         "req_id": "req-e2e",
         "computer": "client",
-        "tool_name": "mark_b",
+        "tool_name": "e2e-tc-b-tool-true__mark_b",
         "params": {},
         "timeout": 5,
     }
@@ -240,7 +240,7 @@ def test_tc_tool_unset_uses_default(cli_proc: pexpect.spawn, tmp_path: Path) -> 
         "agent": "r-e2e",
         "req_id": "req-e2e",
         "computer": "client",
-        "tool_name": "mark_b",
+        "tool_name": "e2e-tc-b-default-true__mark_b",
         "params": {},
         "timeout": 5,
     }

--- a/tests/e2e/computer/test_cli_tc_vrl.py
+++ b/tests/e2e/computer/test_cli_tc_vrl.py
@@ -82,7 +82,7 @@ def test_tc_with_vrl_transformation_basic(cli_proc: pexpect.spawn, tmp_path: Pat
     # Verify tool is visible
     child.sendline("tools")
     tools_out = expect_prompt_stable(child, quiet=0.6, max_wait=12.0)
-    assert "hello" in strip_ansi(tools_out)
+    assert "e2e-tc-vrl-basic__hello" in strip_ansi(tools_out)
 
     # 5) 构造 tc 负载并调用
     # Construct tc payload and call
@@ -90,7 +90,7 @@ def test_tc_with_vrl_transformation_basic(cli_proc: pexpect.spawn, tmp_path: Pat
         "agent": "bot-e2e-vrl",
         "req_id": "req-e2e-vrl-hello",
         "computer": "ignored",
-        "tool_name": "hello",
+        "tool_name": "e2e-tc-vrl-basic__hello",
         "params": {"name": "VRL-Test"},
         "timeout": 10,
     }
@@ -165,7 +165,7 @@ def test_tc_with_vrl_field_mapping(cli_proc: pexpect.spawn, tmp_path: Path) -> N
     # Verify tool is visible
     child.sendline("tools")
     tools_out = expect_prompt_stable(child, quiet=0.6, max_wait=12.0)
-    assert "mark_a" in strip_ansi(tools_out)
+    assert "e2e-tc-vrl-mapping__mark_a" in strip_ansi(tools_out)
 
     # 5) 构造 tc 负载并调用
     # Construct tc payload and call
@@ -173,7 +173,7 @@ def test_tc_with_vrl_field_mapping(cli_proc: pexpect.spawn, tmp_path: Path) -> N
         "agent": "bot-e2e-vrl-map",
         "req_id": "req-e2e-vrl-map",
         "computer": "ignored",
-        "tool_name": "mark_a",
+        "tool_name": "e2e-tc-vrl-mapping__mark_a",
         "params": {},
         "timeout": 10,
     }
@@ -294,7 +294,7 @@ def test_tc_vrl_transformation_preserves_original_content(cli_proc: pexpect.spaw
         "agent": "bot-e2e-vrl-preserve",
         "req_id": "req-e2e-vrl-preserve",
         "computer": "ignored",
-        "tool_name": "hello",
+        "tool_name": "e2e-tc-vrl-preserve__hello",
         "params": {"name": "Preserve-Test"},
         "timeout": 10,
     }

--- a/tests/e2e/test_async_integration_e2e.py
+++ b/tests/e2e/test_async_integration_e2e.py
@@ -218,7 +218,7 @@ async def test_async_integration_computer_agent_server_basic_flow(
 
         # 验证工具列表包含 mark_a 工具 / Verify tool list contains mark_a tool
         tool_names = [t["name"] for t in tools]
-        assert "mark_a" in tool_names, f"Expected 'mark_a' in tools, got {tool_names}"
+        assert "e2e-async-integration-server__mark_a" in tool_names, f"Expected exposed 'mark_a' in tools, got {tool_names}"
 
         print(f"[E2E] Test assertions completed in {time.time() - start_time:.2f}s")
 
@@ -321,7 +321,7 @@ async def test_async_integration_agent_call_computer_tool(
         # 2. Agent 调用 mark_a 工具 / Agent calls mark_a tool
         result = await agent_client.emit_tool_call(
             computer=computer_sid,
-            tool_name="mark_a",
+            tool_name="e2e-async-integration-server-2__mark_a",
             params={},
             timeout=15,  # 增加超时时间 / Increase timeout
         )
@@ -432,7 +432,9 @@ async def test_async_integration_agent_cancel_inflight_tool_call(
         # 显式铸 req（控 req_id），调用 slow_echo（delay=5s）；用底层 call 以便与 cancel 解耦地并发等待。
         # Explicitly mint req (control req_id) calling slow_echo (delay=5s); use low-level call to await independently.
         slow_delay = 5.0
-        req = agent_client.create_tool_call_request(computer=computer_sid, tool_name="slow_echo", params={"delay": slow_delay}, timeout=15)
+        req = agent_client.create_tool_call_request(
+            computer=computer_sid, tool_name="e2e-async-integration-server-cancel__slow_echo", params={"delay": slow_delay}, timeout=15,
+        )
         t0 = time.time()
         call_task = asyncio.ensure_future(agent_client.call(TOOL_CALL_EVENT, req, namespace=SMCP_NAMESPACE, timeout=15))
 
@@ -657,7 +659,7 @@ async def test_async_integration_multiple_tool_calls(
         for _ in range(3):
             result = await agent_client.emit_tool_call(
                 computer=computer_sid,
-                tool_name="mark_a",
+                tool_name="e2e-async-integration-server-4__mark_a",
                 params={},
                 timeout=15,  # 增加超时时间 / Increase timeout
             )
@@ -675,7 +677,7 @@ async def test_async_integration_multiple_tool_calls(
         concurrent_tasks = [
             agent_client.emit_tool_call(
                 computer=computer_sid,
-                tool_name="mark_a",
+                tool_name="e2e-async-integration-server-4__mark_a",
                 params={},
                 timeout=15,  # 增加超时时间 / Increase timeout
             )
@@ -788,7 +790,7 @@ async def test_async_integration_desktop_sync_after_tool_call(
         # 3. 调用工具 / Call tool
         result = await agent_client.emit_tool_call(
             computer=computer_sid,
-            tool_name="mark_a",
+            tool_name="e2e-async-integration-server-5__mark_a",
             params={},
             timeout=15,  # 增加超时时间 / Increase timeout
         )

--- a/tests/e2e/test_async_integration_vrl_e2e.py
+++ b/tests/e2e/test_async_integration_vrl_e2e.py
@@ -218,7 +218,7 @@ async def test_async_integration_agent_receives_vrl_transformed_result(
         # Agent calls tool
         result = await agent_client.emit_tool_call(
             computer=computer_name,
-            tool_name="mark_a",
+            tool_name="e2e-vrl-integration-server-1__mark_a",
             params={},
             timeout=15,
         )
@@ -390,7 +390,7 @@ async def test_async_integration_vrl_field_mapping_and_extraction(
         # Agent calls tool
         result = await agent_client.emit_tool_call(
             computer=computer_name,
-            tool_name="mark_a",
+            tool_name="e2e-vrl-integration-server-2__mark_a",
             params={},
             timeout=15,
         )
@@ -529,7 +529,7 @@ async def test_async_integration_vrl_preserves_original_result(
         # Agent calls tool
         result = await agent_client.emit_tool_call(
             computer=computer_name,
-            tool_name="mark_a",
+            tool_name="e2e-vrl-integration-server-3__mark_a",
             params={},
             timeout=15,
         )

--- a/tests/e2e/test_v02_full_flow.py
+++ b/tests/e2e/test_v02_full_flow.py
@@ -194,7 +194,7 @@ async def test_v02_full_flow_compatible(compat_server: int) -> None:
         assert any(u.startswith("window://example.desktop.paged/p2") for u in uris)
 
         # —— 工具调用链路：Agent → Server → Computer 真实 MCP Server → 结果回传 ——
-        result = await agent.emit_tool_call(computer="comp-v02", tool_name="mark_a", params={}, timeout=15)
+        result = await agent.emit_tool_call(computer="comp-v02", tool_name="subscribe-srv__mark_a", params={}, timeout=15)
         assert result.isError is False, f"工具调用失败 / tool call failed: {result}"
         assert len(result.content) >= 1
         assert "ok:mark_a" in result.content[0].text

--- a/tests/e2e/test_v02_tool_call_binary_e2e.py
+++ b/tests/e2e/test_v02_tool_call_binary_e2e.py
@@ -64,7 +64,7 @@ async def test_oversize_image_tool_call_sideband_roundtrip(tmp_path) -> None:
     async with running_server() as base:
         agent, _comp_client = await connect_agent_and_computer(base, office_id, computer, agent_id="robot-bin")
         try:
-            ret = await agent.emit_tool_call(computer="comp-bin", tool_name="big_image", params={}, timeout=15)
+            ret = await agent.emit_tool_call(computer="comp-bin", tool_name="img-srv__big_image", params={}, timeout=15)
             assert ret.isError is False, f"工具调用失败 / tool call failed: {ret}"
             assert len(ret.content) == 1
             item = ret.content[0]
@@ -91,7 +91,7 @@ async def test_small_image_tool_call_inline(tmp_path) -> None:
     async with running_server() as base:
         agent, _comp_client = await connect_agent_and_computer(base, office_id, computer, agent_id="robot-bin-s")
         try:
-            ret = await agent.emit_tool_call(computer="comp-bin-s", tool_name="small_image", params={}, timeout=15)
+            ret = await agent.emit_tool_call(computer="comp-bin-s", tool_name="img-srv__small_image", params={}, timeout=15)
             assert ret.isError is False, f"工具调用失败 / tool call failed: {ret}"
             item = ret.content[0]
             assert item.type == "image"

--- a/tests/e2e/test_v02_update_tool_list_e2e.py
+++ b/tests/e2e/test_v02_update_tool_list_e2e.py
@@ -161,25 +161,25 @@ async def test_update_tool_list_live_refetch_add_change_remove(tmp_path) -> None
         )
         try:
             # —— 基线：enter_office 自动回拉 → 仅控制工具 set_phase ——
-            await _wait_until(lambda: "set_phase" in handler.names("comp-tl"))
-            assert "dynamic_tool" not in handler.names("comp-tl")
+            await _wait_until(lambda: "mutable-srv__set_phase" in handler.names("comp-tl"))
+            assert "mutable-srv__dynamic_tool" not in handler.names("comp-tl")
 
             # —— 新增（不伴随 config 变更）：set_phase(1) → dynamic_tool(schemaA: alpha) ——
-            await agent.emit_tool_call("comp-tl", "set_phase", {"phase": 1}, timeout=10)
-            await _wait_until(lambda: "dynamic_tool" in handler.names("comp-tl"))
-            assert handler.schema_props("comp-tl", "dynamic_tool") == {"alpha"}
+            await agent.emit_tool_call("comp-tl", "mutable-srv__set_phase", {"phase": 1}, timeout=10)
+            await _wait_until(lambda: "mutable-srv__dynamic_tool" in handler.names("comp-tl"))
+            assert handler.schema_props("comp-tl", "mutable-srv__dynamic_tool") == {"alpha"}
 
             # —— 同名换 schema：set_phase(2) → dynamic_tool(schemaB: beta，旧 alpha 须清） ——
-            await agent.emit_tool_call("comp-tl", "set_phase", {"phase": 2}, timeout=10)
-            await _wait_until(lambda: handler.schema_props("comp-tl", "dynamic_tool") == {"beta"})
-            assert "alpha" not in handler.schema_props("comp-tl", "dynamic_tool")
+            await agent.emit_tool_call("comp-tl", "mutable-srv__set_phase", {"phase": 2}, timeout=10)
+            await _wait_until(lambda: handler.schema_props("comp-tl", "mutable-srv__dynamic_tool") == {"beta"})
+            assert "alpha" not in handler.schema_props("comp-tl", "mutable-srv__dynamic_tool")
 
             # —— 移除：set_phase(0) → dynamic_tool 消失（唯预清回调生效才成立，加法式否则残留） ——
             # 注意等**正向终态** names=={set_phase}：预清会先清空注册表，若只等「dynamic_tool 不在」会命中
             # 「清空后、on_tools_received 重加 set_phase 前」的空窗而误判。
-            await agent.emit_tool_call("comp-tl", "set_phase", {"phase": 0}, timeout=10)
-            await _wait_until(lambda: handler.names("comp-tl") == {"set_phase"})
-            assert "dynamic_tool" not in handler.names("comp-tl")
+            await agent.emit_tool_call("comp-tl", "mutable-srv__set_phase", {"phase": 0}, timeout=10)
+            await _wait_until(lambda: handler.names("comp-tl") == {"mutable-srv__set_phase"})
+            assert "mutable-srv__dynamic_tool" not in handler.names("comp-tl")
 
             # 预清回调确实被触发过（新增/换 schema/移除 至少三次）/ pre-clean hook actually fired
             assert handler.preclean_calls >= 3
@@ -211,20 +211,20 @@ async def test_legacy_consumer_backward_compat_and_preclean_necessity(tmp_path) 
         )
         try:
             # 基线：enter_office 自动回拉 → 仅 set_phase / baseline
-            await _wait_until(lambda: "set_phase" in legacy.names("comp-tl-legacy"))
+            await _wait_until(lambda: "mutable-srv__set_phase" in legacy.names("comp-tl-legacy"))
 
             # 新增：旧消费方**仍**因 notify:update_tool_list 自动回拉看到 dynamic_tool（hasattr 守卫不破链路）
-            await agent.emit_tool_call("comp-tl-legacy", "set_phase", {"phase": 1}, timeout=10)
-            await _wait_until(lambda: legacy.schema_props("comp-tl-legacy", "dynamic_tool") == {"alpha"})
+            await agent.emit_tool_call("comp-tl-legacy", "mutable-srv__set_phase", {"phase": 1}, timeout=10)
+            await _wait_until(lambda: legacy.schema_props("comp-tl-legacy", "mutable-srv__dynamic_tool") == {"alpha"})
 
             # 同名换 schema：alpha→beta 正向可观测——证明 notify→回拉链对旧消费方**持续**生效（非一次性）
-            await agent.emit_tool_call("comp-tl-legacy", "set_phase", {"phase": 2}, timeout=10)
-            await _wait_until(lambda: legacy.schema_props("comp-tl-legacy", "dynamic_tool") == {"beta"})
+            await agent.emit_tool_call("comp-tl-legacy", "mutable-srv__set_phase", {"phase": 2}, timeout=10)
+            await _wait_until(lambda: legacy.schema_props("comp-tl-legacy", "mutable-srv__dynamic_tool") == {"beta"})
 
             # 移除：set_phase(0) → 同一链路已被证明生效，但旧消费方缺预清 → dynamic_tool 残留（仍带 beta schema）
-            await agent.emit_tool_call("comp-tl-legacy", "set_phase", {"phase": 0}, timeout=10)
+            await agent.emit_tool_call("comp-tl-legacy", "mutable-srv__set_phase", {"phase": 0}, timeout=10)
             await asyncio.sleep(3.0)  # 让 notify→回拉→on_tools_received 链完成（无 ack，确定性宽等）
-            assert legacy.schema_props("comp-tl-legacy", "dynamic_tool") == {"beta"}, (
+            assert legacy.schema_props("comp-tl-legacy", "mutable-srv__dynamic_tool") == {"beta"}, (
                 "旧消费方缺预清 → 移除的工具应残留（正是 on_computer_update_tool_list 预清回调要解决的问题）"
             )
         finally:

--- a/tests/integration_tests/computer/mcp_clients/test_manager.py
+++ b/tests/integration_tests/computer/mcp_clients/test_manager.py
@@ -13,7 +13,7 @@ Integration test: MCPServerManager manages multiple protocol clients
 import pytest
 from mcp import Tool
 
-from a2c_smcp.computer.mcp_clients.manager import MCPServerManager, ToolNameDuplicatedError
+from a2c_smcp.computer.mcp_clients.manager import MCPServerManager
 from a2c_smcp.computer.mcp_clients.model import SseServerConfig, StdioServerConfig, StreamableHttpServerConfig, ToolMeta
 
 
@@ -103,17 +103,19 @@ async def test_manager_remove_server(stdio_params, sse_params, sse_server):
 
 
 @pytest.mark.anyio
-async def test_manager_duplicate_tool_name(sse_params, http_params, sse_server, basic_server):
-    """
-    测试重复工具名异常
-    Test duplicate tool name error
-    """
+async def test_manager_same_tool_name_coexist_via_bundle_prefix(sse_params, http_params, sse_server, basic_server):
+    """BundleID：两 server 同名工具经 ``{bundle_id}__`` 前缀天然共存，不再抛 ToolNameDuplicatedError。"""
     manager = MCPServerManager(auto_connect=False)
     sse_cfg = SseServerConfig(name="sse_server", server_parameters=sse_params)
     http_cfg = StreamableHttpServerConfig(name="http_server", server_parameters=http_params)
-    with pytest.raises(ToolNameDuplicatedError):
-        await manager.ainitialize([sse_cfg, http_cfg])
-        await manager.astart_all()
+    await manager.ainitialize([sse_cfg, http_cfg])
+    await manager.astart_all()
+    assert len(manager._active_clients) == 2
+    names = [tool.name async for tool in manager.available_tools()]
+    # 所有暴露名都带 bundle 前缀，sse/http 各自成组、互不冲突
+    assert names and all(n.startswith("sse_server__") or n.startswith("http_server__") for n in names)
+    assert any(n.startswith("sse_server__") for n in names)
+    assert any(n.startswith("http_server__") for n in names)
 
 
 @pytest.mark.anyio
@@ -132,21 +134,23 @@ async def test_manager_invalid_server(stdio_params, sse_params, sse_server):
 
 
 @pytest.mark.anyio
-async def test_manager_disabled_tool(stdio_params, sse_params, sse_server):
-    """
-    测试禁用工具异常
-    Test disabled tool error
-    """
+async def test_manager_forbidden_tool_not_exposed(stdio_params, sse_server):
+    """forbid 工具后：不进 ExposedToolMapping、不可调用（未命中 → ValueError）。"""
     manager = MCPServerManager(auto_connect=False)
     stdio_cfg = StdioServerConfig(name="stdio_server", server_parameters=stdio_params)
-    sse_cfg = SseServerConfig(name="sse_server", server_parameters=sse_params)
-    await manager.ainitialize([stdio_cfg, sse_cfg])
+    await manager.ainitialize([stdio_cfg])
     await manager.astart_all()
-    tools = [tool async for tool in manager.available_tools()]
-    if tools:
-        manager._disabled_tools.add(tools[0].name)
-        with pytest.raises(PermissionError):
-            await manager.aexecute_tool(tools[0].name, {})
+    names = [tool.name async for tool in manager.available_tools()]
+    if names:
+        exposed = names[0]
+        _, original = await manager.avalidate_tool_call(exposed, {})
+        # forbid 该原始名并原地更新（auto_reconnect 默认 True → 重启刷新映射）
+        await manager.aadd_or_aupdate_server(
+            StdioServerConfig(name="stdio_server", forbidden_tools=[original], server_parameters=stdio_params),
+        )
+        assert exposed not in manager._exposed_tools
+        with pytest.raises(ValueError):
+            await manager.aexecute_tool(exposed, {})
 
 
 @pytest.mark.anyio

--- a/tests/integration_tests/computer/test_computer.py
+++ b/tests/integration_tests/computer/test_computer.py
@@ -33,7 +33,7 @@ async def test_computer_aexecute_tool_success(stdio_params, sse_params, sse_serv
     # 获取可用工具/Get available tools
     tools = await computer.aget_available_tools()
     assert tools, "No tools available"
-    tool_name = "hello"
+    tool_name = "stdio_server__hello"  # exposed_tool_name = {bundle_id}__hello（bundle_id == name）
     # 调用工具/Call tool
     result = await computer.aexecute_tool("reqid", tool_name, {"name": "China"})
     assert hasattr(result, "content")
@@ -55,7 +55,7 @@ async def test_computer_aexecute_tool_confirm_callback_called(stdio_params):
     computer = Computer(name="test", mcp_servers={stdio_cfg}, confirm_callback=confirm_mock)
     await computer.boot_up()
     await computer.aget_available_tools()
-    tool_name = "hello"
+    tool_name = "stdio_server__hello"  # exposed_tool_name = {bundle_id}__hello（bundle_id == name）
     result = await computer.aexecute_tool("reqid", tool_name, {"name": "China"})
     assert hasattr(result, "content")
     assert confirm_mock.called, "confirm_callback should be called"
@@ -126,9 +126,9 @@ async def test_dynamic_add_with_inputs_and_tool_call(stdio_params) -> None:
 
     # 获取工具并调用
     tools = await computer.aget_available_tools()
-    assert any(t["name"] == "hello" for t in tools)
+    assert any(t["name"] == "dyn_stdio__hello" for t in tools)
 
-    ret = await computer.aexecute_tool("reqid", "hello", {"name": "China"})
+    ret = await computer.aexecute_tool("reqid", "dyn_stdio__hello", {"name": "China"})
     assert ret.content and ret.content[0].text == "Hello, China!"
 
 
@@ -143,16 +143,16 @@ async def test_dynamic_update_forbid_tool_then_call_fails(stdio_params) -> None:
     await computer.aadd_or_aupdate_server(cfg)
 
     # 确认可调用
-    ret1 = await computer.aexecute_tool("reqid", "hello", {"name": "China"})
+    ret1 = await computer.aexecute_tool("reqid", "dyn_stdio2__hello", {"name": "China"})
     assert ret1.content and ret1.content[0].text == "Hello, China!"
 
-    # 更新：禁用工具
+    # 更新：禁用工具（按原始名 forbidden）
     cfg2 = StdioServerConfig(name="dyn_stdio2", server_parameters=stdio_params, forbidden_tools=["hello"])
     await computer.aadd_or_aupdate_server(cfg2)
 
-    # 调用应被 Manager 拒绝
-    with pytest.raises(PermissionError):
-        await computer.aexecute_tool("reqid", "hello", {"name": "China"})
+    # 调用应被拒绝：forbidden 后不进 ExposedToolMapping → 未命中 → ValueError（上层映射 4001）
+    with pytest.raises(ValueError):
+        await computer.aexecute_tool("reqid", "dyn_stdio2__hello", {"name": "China"})
 
 
 @pytest.mark.anyio
@@ -165,15 +165,15 @@ async def test_dynamic_remove_then_tool_not_found(stdio_params) -> None:
     await computer.aadd_or_aupdate_server(cfg)
 
     # 调用成功一次
-    ret1 = await computer.aexecute_tool("reqid", "hello", {"name": "China"})
+    ret1 = await computer.aexecute_tool("reqid", "dyn_stdio3__hello", {"name": "China"})
     assert ret1.content and ret1.content[0].text == "Hello, China!"
 
-    # 移除
+    # 移除（按 bundle_id）
     await computer.aremove_server("dyn_stdio3")
 
     # 再次调用应报错：工具不存在
     with pytest.raises(ValueError):
-        await computer.aexecute_tool("reqid", "hello", {"name": "China"})
+        await computer.aexecute_tool("reqid", "dyn_stdio3__hello", {"name": "China"})
 
 
 # -------------------- 新增：工具调用历史集成用例 --------------------
@@ -190,8 +190,8 @@ async def test_tool_call_history_records_success_and_order(stdio_params) -> None
     await computer.boot_up()
 
     # 进行两次调用/Two calls
-    r1 = await computer.aexecute_tool("req-1", "hello", {"name": "A"})
-    r2 = await computer.aexecute_tool("req-2", "hello", {"name": "B"})
+    r1 = await computer.aexecute_tool("req-1", "hist_stdio__hello", {"name": "A"})
+    r2 = await computer.aexecute_tool("req-2", "hist_stdio__hello", {"name": "B"})
     assert r1.content and r2.content
 
     hist = await computer.aget_tool_call_history()
@@ -221,7 +221,7 @@ async def test_tool_call_history_maxlen(stdio_params) -> None:
     # 执行12次，maxlen=10后应只保留后10次/Execute 12 times, keep last 10
     for i in range(12):
         rid = f"req-{i + 1}"
-        await computer.aexecute_tool(rid, "hello", {"name": str(i + 1)})
+        await computer.aexecute_tool(rid, "hist_maxlen__hello", {"name": str(i + 1)})
 
     hist = await computer.aget_tool_call_history()
     assert len(hist) == 10
@@ -244,7 +244,7 @@ async def test_tool_call_history_confirm_callback_exception(stdio_params) -> Non
     computer = Computer(name="test", mcp_servers={cfg}, confirm_callback=bad_confirm)
     await computer.boot_up()
 
-    result = await computer.aexecute_tool("req-X", "hello", {"name": "Err"})
+    result = await computer.aexecute_tool("req-X", "hist_confirm_err__hello", {"name": "Err"})
     assert result.isError is True
 
     hist = await computer.aget_tool_call_history()

--- a/tests/integration_tests/computer/test_smcp_tool_data_format.py
+++ b/tests/integration_tests/computer/test_smcp_tool_data_format.py
@@ -178,8 +178,8 @@ async def test_smcp_tool_data_with_per_tool_meta(stdio_params) -> None:
 
     assert tools, "工具列表不应为空"
 
-    # 找到 hello 工具验证合并结果
-    hello_tool = next((t for t in tools if t["name"] == "hello"), None)
+    # 找到 hello 工具验证合并结果（exposed_tool_name = {bundle_id}__hello；bundle_id == name）
+    hello_tool = next((t for t in tools if t["name"] == "merged_meta_server__hello"), None)
     assert hello_tool is not None, "应存在 hello 工具"
 
     meta = hello_tool.get("meta", {})

--- a/tests/integration_tests/computer/test_tool_list_refresh.py
+++ b/tests/integration_tests/computer/test_tool_list_refresh.py
@@ -54,27 +54,27 @@ async def test_get_tools_reflects_runtime_add_schema_change_remove() -> None:
     try:
         # 基线：仅控制工具 / baseline: only the control tool
         base = await computer.aget_available_tools()
-        assert _names(base) == {"set_phase"}
+        assert _names(base) == {"mutable-srv__set_phase"}
 
         # —— 新增：phase 1 → dynamic_tool(schemaA: alpha) ——
-        await computer.mcp_manager.aexecute_tool("set_phase", {"phase": 1})
+        await computer.mcp_manager.aexecute_tool("mutable-srv__set_phase", {"phase": 1})
         added = await computer.aget_available_tools()
-        assert "dynamic_tool" in _names(added), "运行期新增工具须出现在 get_tools / runtime-added tool must surface"
-        dyn_a = next(t for t in added if t["name"] == "dynamic_tool")
+        assert "mutable-srv__dynamic_tool" in _names(added), "运行期新增工具须出现在 get_tools / runtime-added tool must surface"
+        dyn_a = next(t for t in added if t["name"] == "mutable-srv__dynamic_tool")
         assert "alpha" in dyn_a["params_schema"].get("properties", {})
 
         # —— 同名换 schema：phase 2 → dynamic_tool(schemaB: beta，无 alpha) ——
-        await computer.mcp_manager.aexecute_tool("set_phase", {"phase": 2})
+        await computer.mcp_manager.aexecute_tool("mutable-srv__set_phase", {"phase": 2})
         changed = await computer.aget_available_tools()
-        dyn_b = next(t for t in changed if t["name"] == "dynamic_tool")
+        dyn_b = next(t for t in changed if t["name"] == "mutable-srv__dynamic_tool")
         props = dyn_b["params_schema"].get("properties", {})
         assert "beta" in props and "alpha" not in props, "同名工具须换到新 schema、无旧残留 / new schema, no stale"
 
         # —— 移除：phase 0 → dynamic_tool 消失 ——
-        await computer.mcp_manager.aexecute_tool("set_phase", {"phase": 0})
+        await computer.mcp_manager.aexecute_tool("mutable-srv__set_phase", {"phase": 0})
         removed = await computer.aget_available_tools()
-        assert "dynamic_tool" not in _names(removed), "移除的工具须从 get_tools 消失 / removed tool must disappear"
-        assert _names(removed) == {"set_phase"}
+        assert "mutable-srv__dynamic_tool" not in _names(removed), "移除的工具须从 get_tools 消失 / removed tool must disappear"
+        assert _names(removed) == {"mutable-srv__set_phase"}
     finally:
         await computer.shutdown()
 
@@ -87,16 +87,16 @@ async def test_manager_arefresh_tools_surfaces_added_tool() -> None:
     await manager.astart_all()
     try:
         base = {t.name async for t in manager.available_tools()}
-        assert base == {"set_phase"}
+        assert base == {"mutable-srv__set_phase"}
 
         # 运行期新增工具但**不**刷新映射 → available_tools 仍漏掉（复现 Bug B）
-        await manager.aexecute_tool("set_phase", {"phase": 1})
+        await manager.aexecute_tool("mutable-srv__set_phase", {"phase": 1})
         stale = {t.name async for t in manager.available_tools()}
-        assert "dynamic_tool" not in stale, "未刷新时 _tool_mapping 陈旧、新增工具被漏（Bug B 现象）"
+        assert "mutable-srv__dynamic_tool" not in stale, "未刷新时 _tool_mapping 陈旧、新增工具被漏（Bug B 现象）"
 
         # 显式刷新（Computer 服务 get_tools 时所做）→ 新增工具浮现
         await manager.arefresh_tools()
         fresh = {t.name async for t in manager.available_tools()}
-        assert "dynamic_tool" in fresh, "arefresh_tools() 后新增工具须可见（#127 修复）"
+        assert "mutable-srv__dynamic_tool" in fresh, "arefresh_tools() 后新增工具须可见（#127 修复）"
     finally:
         await manager.aclose()

--- a/tests/integration_tests/test_get_resources.py
+++ b/tests/integration_tests/test_get_resources.py
@@ -176,7 +176,7 @@ async def test_get_resources_unregistered_server_raises_4014(socketio_server: No
         with pytest.raises(SMCPProtocolError) as ei:
             await agent.get_resources(computer="comp-res-2", mcp_server="does-not-exist")
         assert ei.value.code == 4014
-        assert ei.value.mcp_server_name == "does-not-exist"
+        assert ei.value.mcp_server == "does-not-exist"
     finally:
         await agent.disconnect()
         await comp_client.disconnect()
@@ -210,7 +210,7 @@ async def test_get_resources_capability_missing_raises_4015(socketio_server: Non
         with pytest.raises(SMCPProtocolError) as ei:
             await agent.get_resources(computer="comp-res-3", mcp_server="tools-srv")
         assert ei.value.code == 4015
-        assert ei.value.mcp_server_name == "tools-srv"
+        assert ei.value.mcp_server == "tools-srv"
         assert ei.value.capability == "resources"
     finally:
         await agent.disconnect()
@@ -286,13 +286,13 @@ def _run_mock_computer_process(port: int, ready_q: multiprocessing.Queue, err_q:
             return {
                 "code": 4014,
                 "message": "MCP Server not found",
-                "mcp_server_name": "does-not-exist",
+                "mcp_server": "does-not-exist",
             }
         if mcp_server == "no-res":
             return {
                 "code": 4015,
                 "message": "MCP Server does not support 'resources' capability",
-                "mcp_server_name": "no-res",
+                "mcp_server": "no-res",
                 "capability": "resources",
             }
         if data.get("cursor") == "page2":
@@ -345,7 +345,7 @@ def _run_sync_agent_process(port: int, result_q: multiprocessing.Queue, err_q: m
             agent.get_resources(computer=_SYNC_COMPUTER, mcp_server="does-not-exist")
         except SMCPProtocolError as e:
             err4014_code = e.code
-            err4014_server = e.mcp_server_name
+            err4014_server = e.mcp_server
 
         result_q.put(
             {
@@ -398,7 +398,7 @@ def test_get_resources_sync_pagination_and_error_passthrough(sync_smcp_server: i
             # flat ErrorPayload（4015）经 SyncSMCPNamespace 原样透传 → SMCPProtocolError
             assert res["err_code"] == 4015
             assert res["capability"] == "resources"
-            # flat ErrorPayload（4014 未注册 server）同样透传 → SMCPProtocolError，含 mcp_server_name
+            # flat ErrorPayload（4014 未注册 server）同样透传 → SMCPProtocolError，含 mcp_server
             assert res["err4014_code"] == 4014
             assert res["err4014_server"] == "does-not-exist"
         finally:

--- a/tests/unit_tests/agent/test_v021_consume.py
+++ b/tests/unit_tests/agent/test_v021_consume.py
@@ -57,13 +57,13 @@ class TestSMCPProtocolErrorV021:
         assert ei.value.code == 4018
         assert ei.value.reason == "gone"
 
-    def test_4014_passthrough_keeps_mcp_server_name_top_level(self) -> None:
-        """v0.2.1 兼容性：4014 仍保留顶层 mcp_server_name（v0.2 已有）.
-        Backward-compat: 4014 keeps top-level mcp_server_name from v0.2."""
-        payload = {"code": 4014, "message": "x", "mcp_server_name": "absent"}
+    def test_4014_passthrough_keeps_mcp_server_top_level(self) -> None:
+        """0.3.0（协议 #18）：4014 顶层字段为 ``mcp_server``（值=bundle_id；由 mcp_server_name 改名）.
+        4014 keeps top-level ``mcp_server`` (renamed from ``mcp_server_name``; value = bundle_id)."""
+        payload = {"code": 4014, "message": "x", "mcp_server": "absent"}
         with pytest.raises(SMCPProtocolError) as ei:
             raise_for_error_payload(payload)
-        assert ei.value.mcp_server_name == "absent"
+        assert ei.value.mcp_server == "absent"
         # details 容器为空（4014 无 details）/ details container empty for 4014
         assert ei.value.details == {}
         assert ei.value.reason is None

--- a/tests/unit_tests/computer/mcp_clients/test_manager.py
+++ b/tests/unit_tests/computer/mcp_clients/test_manager.py
@@ -13,7 +13,7 @@ from mcp import StdioServerParameters, Tool
 from mcp.client.session_group import SseServerParameters, StreamableHttpParameters
 from mcp.types import CallToolResult
 
-from a2c_smcp.computer.mcp_clients.manager import MCPServerManager, ToolNameDuplicatedError
+from a2c_smcp.computer.mcp_clients.manager import MCPServerManager
 from a2c_smcp.computer.mcp_clients.model import (
     MCPClientProtocol,
     MCPServerConfig,
@@ -141,10 +141,10 @@ async def test_initialize_with_servers(manager):
     assert "sse_server" in manager._active_clients
     assert "server2" not in manager._active_clients
 
-    # 验证工具映射
-    assert manager._tool_mapping["tool1"] == "server1"
-    assert manager._tool_mapping["tool2"] == "server1"
-    assert "tool3" not in manager._tool_mapping  # 禁用的服务器
+    # 验证 ExposedToolMapping（exposed = {bundle_id}__{原始名}；此处 bundle_id == name）
+    assert manager._exposed_tools["server1__tool1"] == ("server1", "tool1")
+    assert manager._exposed_tools["server1__tool2"] == ("server1", "tool2")
+    assert "server2__tool3" not in manager._exposed_tools  # 禁用的服务器
 
     # 验证状态检查
     statuses = manager.get_server_status()
@@ -163,14 +163,14 @@ async def test_tool_execution(manager):
 
     # 执行工具
     params = {"key": "value"}
-    await manager.aexecute_tool("tool1", params)
+    await manager.aexecute_tool("server1__tool1", params)
 
-    # 验证调用
+    # 验证调用（透传原始名 tool1）
     client = manager._active_clients["server1"]
     client.call_tool.assert_awaited_once_with("tool1", params)
 
     with pytest.raises(Exception):
-        await manager.aexecute_tool("tool5", params)
+        await manager.aexecute_tool("server1__tool5", params)
 
 
 @pytest.mark.asyncio
@@ -183,7 +183,7 @@ async def test_tool_execution_with_ret_meta(manager):
 
     # 执行工具
     params = {"key": "value"}
-    ret = await manager.aexecute_tool("tool3", params)
+    ret = await manager.aexecute_tool("server2__tool3", params)
     assert ret.meta["test"] == "ret_meta"
 
     # 验证调用
@@ -199,13 +199,12 @@ async def test_tool_with_alias(manager):
     await manager.ainitialize(servers)
     await manager.astart_all()
 
-    # 验证别名映射
-    assert manager._alias_mapping["aliased_tool"] == ("alias_server", "tool5")
-    assert "tool5" not in manager._tool_mapping
-    assert manager._tool_mapping["aliased_tool"] == "alias_server"
+    # 验证 ExposedToolMapping：alias 仅替换工具名部分，仍带 {bundle_id}__ 前缀
+    assert manager._exposed_tools["alias_server__aliased_tool"] == ("alias_server", "tool5")
+    assert "alias_server__tool5" not in manager._exposed_tools
 
-    # 执行别名工具
-    await manager.aexecute_tool("aliased_tool", {})
+    # 执行别名工具（以 exposed 名寻址，解析回原始名 tool5）
+    await manager.aexecute_tool("alias_server__aliased_tool", {})
     client = manager._active_clients["alias_server"]
     print("Call args list:", client.call_tool.call_args_list)
     client.call_tool.assert_awaited_once_with("tool5", {})
@@ -218,35 +217,34 @@ async def test_disabled_tool(manager):
     await manager.ainitialize(servers)
     await manager.astart_all()
 
-    # 验证禁用状态
-    assert "tool2" in manager._disabled_tools
+    # forbidden 工具不进 ExposedToolMapping（不可见不可调用）
+    assert "server1__tool2" not in manager._exposed_tools
 
-    # 尝试执行禁用工具
-    with pytest.raises(PermissionError):
-        await manager.aexecute_tool("tool2", {})
+    # 尝试执行禁用工具 → 未命中 ExposedToolMapping → ValueError（上层映射 4001）
+    with pytest.raises(ValueError):
+        await manager.aexecute_tool("server1__tool2", {})
 
-    # #106 契约：禁用工具不应再出现在对外暴露面（不可见且不可调用），钉死避免被无意改回。
-    # Contract (#106): a disabled tool must not appear in the exposed tool list either.
+    # #106 契约：禁用工具不应再出现在对外暴露面（不可见且不可调用）
     names = [tool.name async for tool in manager.available_tools()]
-    assert "tool2" not in names
+    assert "server1__tool2" not in names
+    assert "server1__tool1" in names
 
 
 @pytest.mark.asyncio
-async def test_tool_name_conflict(manager):
-    """测试工具名冲突处理"""
+async def test_cross_server_same_name_coexist_via_bundle_prefix(manager):
+    """BundleID：跨 server 同名工具经 ``{bundle_id}__`` 前缀天然共存，不再抛 ToolNameDuplicatedError。"""
     servers = [
         create_server_config("server1"),
+        # duplicate_server 的 duplicate_tool 别名为 tool1；与 server1 的 tool1 因 bundle 前缀不同而共存
         create_server_config("duplicate_server", tool_meta={"duplicate_tool": ToolMeta(alias="tool1")}),
     ]
+    await manager.ainitialize(servers)
+    await manager.astart_all()
 
-    # 验证初始化时检测到冲突
-    with pytest.raises(ToolNameDuplicatedError):
-        await manager.ainitialize(servers)
-        await manager.astart_all()
-
-    # 工具重名导致的异常是在逐个启动Client的时候抛出的，因此只会回滚检测到异常的Client，
-    # 而不会回滚所有Client
-    assert len(manager._active_clients) == 1
+    assert len(manager._active_clients) == 2
+    # 两个 "tool1" 借 bundle 前缀共存于暴露面，互不冲突
+    assert manager._exposed_tools["server1__tool1"] == ("server1", "tool1")
+    assert manager._exposed_tools["duplicate_server__tool1"] == ("duplicate_server", "duplicate_tool")
 
 
 @pytest.mark.asyncio
@@ -276,8 +274,8 @@ async def test_dynamic_server_management(manager):
 
     old_client.adisconnect.assert_awaited()
 
-    # 验证更新应用
-    assert "tool1" in manager._disabled_tools
+    # 验证更新应用：forbid tool1 后不再暴露 server1__tool1
+    assert "server1__tool1" not in manager._exposed_tools
 
     # 移除服务器
     await manager.aremove_server("http_server")
@@ -315,7 +313,7 @@ async def test_get_available_tools(manager):
         tools.append(tool)
 
     assert len(tools) == 2
-    tool1 = next(t for t in tools if t.name == "tool1")
+    tool1 = next(t for t in tools if t.name == "server1__tool1")
     assert tool1.meta["a2c_tool_meta"].auto_apply
 
 
@@ -332,11 +330,11 @@ async def test_default_tool_meta_applies_when_missing_per_tool(manager):
     tools = []
     async for tool in manager.available_tools():
         tools.append(tool)
-    t1 = next(t for t in tools if t.name == "tool1")
+    t1 = next(t for t in tools if t.name == "server1__tool1")
     assert t1.meta["a2c_tool_meta"].auto_apply is True
 
     # 检查 aexecute_tool 返回元数据注入
-    ret = await manager.aexecute_tool("tool1", {})
+    ret = await manager.aexecute_tool("server1__tool1", {})
     assert ret.meta["a2c_tool_meta"].auto_apply is True
 
 
@@ -355,7 +353,7 @@ async def test_per_tool_overrides_default(manager):
     await manager.ainitialize(servers)
     await manager.astart_all()
 
-    ret = await manager.aexecute_tool("tool1", {})
+    ret = await manager.aexecute_tool("server1__tool1", {})
     assert ret.meta["a2c_tool_meta"].auto_apply is False
 
 
@@ -382,7 +380,7 @@ async def test_error_handling(manager):
     client.call_tool.side_effect = TimeoutError("Execution timed out")
 
     with pytest.raises(TimeoutError):
-        await manager.aexecute_tool("tool1", {}, timeout=0.1)
+        await manager.aexecute_tool("server1__tool1", {}, timeout=0.1)
 
 
 @pytest.mark.asyncio
@@ -394,7 +392,7 @@ async def test_meta_data_injection(manager):
     await manager.astart_all()
 
     # 执行工具
-    result = await manager.aexecute_tool("tool1", {})
+    result = await manager.aexecute_tool("server1__tool1", {})
 
     # 验证元数据注入
     assert "a2c_tool_meta" in result.meta
@@ -479,19 +477,15 @@ async def test_aexecute_tool_invalid_cases(manager):
     测试：执行被禁用工具/未注册工具/服务器未激活时报错。
     Test: Raise PermissionError/ValueError/RuntimeError for disabled tool, missing tool, or inactive server.
     """
-    # 工具被禁用
-    manager._disabled_tools.add("toolX")
-    with pytest.raises(PermissionError):
-        await manager.aexecute_tool("toolX", {})
-    # 工具未注册
+    # 未命中 ExposedToolMapping（含被 forbidden / 未注册工具）→ ValueError（上层映射 4001）
     with pytest.raises(ValueError):
-        await manager.aexecute_tool("no_tool", {})
-    # 工具所在服务器未激活
-    manager._tool_mapping["toolY"] = "serverY"
+        await manager.aexecute_tool("srv__no_tool", {})
+    # 映射命中但服务器未激活 → RuntimeError
+    manager._exposed_tools["serverY__toolY"] = ("serverY", "toolY")
     manager._active_clients.clear()
     manager._servers_config["serverY"] = create_server_config("serverY")
     with pytest.raises(RuntimeError):
-        await manager.aexecute_tool("toolY", {})
+        await manager.aexecute_tool("serverY__toolY", {})
 
 
 # 覆盖 aexecute_tool 的 TimeoutError/Exception 分支
@@ -503,53 +497,47 @@ async def test_aexecute_tool_timeout_and_exception(manager, monkeypatch):
     Test: Raise TimeoutError/RuntimeError when tool execution times out or raises.
     """
     config = create_server_config("server3")
-    manager._servers_config[config.name] = config
-    manager._active_clients[config.name] = cast(MCPClientProtocol, MagicMock(spec=MCPClientProtocol))
-    manager._tool_mapping["toolZ"] = config.name
-    mock_client = manager._active_clients[config.name]
+    manager._servers_config["server3"] = config
+    manager._active_clients["server3"] = cast(MCPClientProtocol, MagicMock(spec=MCPClientProtocol))
+    manager._exposed_tools["server3__toolZ"] = ("server3", "toolZ")
+    mock_client = manager._active_clients["server3"]
     # 超时
     mock_client.call_tool = AsyncMock(side_effect=asyncio.TimeoutError)
     with pytest.raises(TimeoutError):
-        await manager.aexecute_tool("toolZ", {}, timeout=0.01)
+        await manager.aexecute_tool("server3__toolZ", {}, timeout=0.01)
     # 其它异常
     mock_client.call_tool = AsyncMock(side_effect=Exception("fail"))
     with pytest.raises(RuntimeError):
-        await manager.aexecute_tool("toolZ", {})
+        await manager.aexecute_tool("server3__toolZ", {})
 
 
 # 覆盖 _arefresh_tool_mapping 的 ToolNameDuplicatedError 分支
 # Test _arefresh_tool_mapping ToolNameDuplicatedError branch
 @pytest.mark.asyncio
-async def test_arefresh_tool_mapping_duplicate(manager, monkeypatch):
-    """
-    测试：多个服务器存在同名工具时抛出 ToolNameDuplicatedError。
-    Test: Raise ToolNameDuplicatedError when duplicate tool name exists across servers.
-    """
-    # 两个 server 都返回同名工具 duplicate_tool
+async def test_arefresh_builds_exposed_mapping_coexist_same_tool(manager, monkeypatch):
+    """BundleID：两 server 同名 duplicate_tool 经 ``{bundle_id}__`` 前缀共存于 ExposedToolMapping，不再抛异常。"""
     config1 = create_server_config("duplicate_server1")
     config2 = create_server_config("duplicate_server2")
-    # 强制都只返回同名工具 duplicate_tool
 
     def always_duplicate_tool(_, message_handler=None):
         return MockMCPClient([create_mock_tool("duplicate_tool")], message_handler=message_handler)
 
     monkeypatch.setattr("a2c_smcp.computer.mcp_clients.manager.client_factory", always_duplicate_tool)
-    manager._servers_config = {config1.name: config1, config2.name: config2}
-    manager._active_clients = {config1.name: always_duplicate_tool(config1), config2.name: always_duplicate_tool(config2)}
-    with pytest.raises(ToolNameDuplicatedError):
-        await manager._arefresh_tool_mapping()
+    manager._servers_config = {"duplicate_server1": config1, "duplicate_server2": config2}
+    manager._active_clients = {
+        "duplicate_server1": always_duplicate_tool(config1),
+        "duplicate_server2": always_duplicate_tool(config2),
+    }
+    await manager._arefresh_tool_mapping()
+    assert manager._exposed_tools["duplicate_server1__duplicate_tool"] == ("duplicate_server1", "duplicate_tool")
+    assert manager._exposed_tools["duplicate_server2__duplicate_tool"] == ("duplicate_server2", "duplicate_tool")
 
 
 @pytest.mark.asyncio
-async def test_astart_client(manager, monkeypatch):
-    """
-    测试：多个服务器存在同名工具时抛出 ToolNameDuplicatedError。
-    Test: Raise ToolNameDuplicatedError when duplicate tool name exists across servers.
-    """
-    # 两个 server 都返回同名工具 duplicate_tool
+async def test_astart_client_same_tool_coexist(manager, monkeypatch):
+    """BundleID：两 server 同名工具可同时启动共存（bundle 前缀隔离），不再抛 ToolNameDuplicatedError。"""
     config1 = create_server_config("duplicate_server1")
     config2 = create_server_config("duplicate_server2")
-    # 强制都只返回同名工具 duplicate_tool
 
     def always_duplicate_tool(_, message_handler=None):
         return MockMCPClient([create_mock_tool("duplicate_tool")], message_handler=message_handler)
@@ -558,16 +546,12 @@ async def test_astart_client(manager, monkeypatch):
     await manager.aadd_or_aupdate_server(config1)
     await manager.aadd_or_aupdate_server(config2)
     assert not manager._active_clients
-    await manager.astart_client(config1.name)
-    assert manager._active_clients
+    await manager.astart_client("duplicate_server1")
     assert len(manager._active_clients) == 1
-    with pytest.raises(ToolNameDuplicatedError):
-        await manager.astart_client(config2.name)
-    await manager.astop_client(config1.name)
-    assert not manager._active_clients
-    await manager.astart_client(config2.name)
-    assert manager._active_clients
-    assert len(manager._active_clients) == 1
+    await manager.astart_client("duplicate_server2")  # 不再冲突，共存
+    assert len(manager._active_clients) == 2
+    assert "duplicate_server1__duplicate_tool" in manager._exposed_tools
+    assert "duplicate_server2__duplicate_tool" in manager._exposed_tools
 
 
 # 覆盖 aremove_server 的删除不存在服务器分支
@@ -583,71 +567,52 @@ async def test_aremove_server_not_exist(manager):
 
 
 @pytest.mark.asyncio
-async def test_astart_all_tool_name_duplicate(manager, monkeypatch):
-    """
-    覆盖 astart_all 的工具名重复异常分支。
-    Cover the duplicate tool name exception branch in astart_all.
-    """
-    # 确保 manager 状态干净
+async def test_astart_all_same_tool_coexist(manager, monkeypatch):
+    """BundleID：astart_all 启动两个同名工具 server，经 bundle 前缀共存，不再抛异常。"""
     await manager.aclose()
     config1 = create_server_config("dup_server1")
     config2 = create_server_config("dup_server2")
 
-    # 两个 server 都返回同名工具 duplicate_tool
     def always_duplicate_tool(_, message_handler=None):
         return MockMCPClient([create_mock_tool("duplicate_tool")], message_handler=message_handler)
 
     monkeypatch.setattr("a2c_smcp.computer.mcp_clients.manager.client_factory", always_duplicate_tool)
-    servers = [config1, config2]
-    # 因为首次初始化时配置未连接，也就不会检查工具名冲突，因此可以正常初始化
-    await manager.ainitialize(servers)
-    with pytest.raises(ToolNameDuplicatedError):
-        await manager.astart_all()
+    await manager.ainitialize([config1, config2])
+    await manager.astart_all()
+    assert len(manager._active_clients) == 2
+    assert "dup_server1__duplicate_tool" in manager._exposed_tools
+    assert "dup_server2__duplicate_tool" in manager._exposed_tools
 
 
 @pytest.mark.asyncio
-async def test_aadd_or_aupdate_server_with_duplicate_tool(manager, monkeypatch):
-    """
-    测试：在添加/更新服务器时遇到工具名重复会抛出ToolNameDuplicatedError
-    Test: Raise ToolNameDuplicatedError when adding/updating server with duplicate tool name
-    """
-    # 初始配置
+async def test_aadd_or_aupdate_server_same_tool_coexist(manager, monkeypatch):
+    """BundleID：add/update 遇同名工具不再抛 ToolNameDuplicatedError / 回滚——经 ``{bundle_id}__`` 前缀共存。"""
     await manager.enable_auto_connect()
     config1 = create_server_config("server1")
     await manager.ainitialize([config1])
     await manager.astart_all()
 
-    # 模拟工具名重复的情况
     def duplicate_tool_factory(config: MCPServerConfig, message_handler=None) -> Any:
-        if config.name == "server1":
-            return MockMCPClient([create_mock_tool("tool1")], message_handler=message_handler)
-        else:
-            return MockMCPClient([create_mock_tool("tool1")], message_handler=message_handler)  # 故意返回同名工具
+        return MockMCPClient([create_mock_tool("tool1")], message_handler=message_handler)  # 两 server 都返回 tool1
 
     monkeypatch.setattr("a2c_smcp.computer.mcp_clients.manager.client_factory", duplicate_tool_factory)
 
-    # 添加新服务器（会触发工具名冲突）
+    # 添加新服务器：不再冲突/回滚，直接共存
     config2 = create_server_config("server2")
-    with pytest.raises(ToolNameDuplicatedError):
-        await manager.aadd_or_aupdate_server(config2)
-
-    # 验证状态回滚
-    assert "server2" not in manager._active_clients
-    assert "server2" not in manager._servers_config  # 因为异常导致回滚
-
-    # 更新现有服务器（会触发工具名冲突）
-    config1_updated = create_server_config("server1", tool_meta={"tool1": ToolMeta(alias="new_alias")})
-    await manager.aadd_or_aupdate_server(config1_updated)
     await manager.aadd_or_aupdate_server(config2)
+    assert "server2" in manager._servers_config
+    assert "server2" in manager._active_clients
 
-    # 验证服务器仍然保持原状
-    assert manager._active_clients["server1"].list_tools.return_value[0].name == "tool1"
-    tools_list = [tool async for tool in manager.available_tools()]
-    # #106：alias 须反映到对外暴露的 Tool.name。server1 的 tool1 别名为 new_alias → 暴露名 new_alias；
-    # server2 的 tool1 无别名 → 暴露名 tool1。二者借 alias 不再同名冲突（正是本修复要达成的效果）。
-    assert any(tool.name == "new_alias" and tool.meta["a2c_tool_meta"].alias == "new_alias" for tool in tools_list) and any(
-        tool.name == "tool1" and not tool.meta for tool in tools_list
-    )
+    # server1 原客户端由 mock_client_factory 建（tool1/tool2），server2 由 duplicate_tool_factory 建（tool1）
+    names = {t.name async for t in manager.available_tools()}
+    assert {"server1__tool1", "server1__tool2", "server2__tool1"} <= names
+
+    # 借 alias 把 server2 的 tool1 改名（仍带 bundle 前缀）
+    config2_aliased = create_server_config("server2", tool_meta={"tool1": ToolMeta(alias="renamed")})
+    await manager.aadd_or_aupdate_server(config2_aliased)
+    names2 = {t.name async for t in manager.available_tools()}
+    assert "server2__renamed" in names2
+    assert "server2__tool1" not in names2
 
 
 @pytest.mark.asyncio
@@ -863,9 +828,9 @@ async def test_available_tools_exposes_alias_as_name(manager):
     await manager.astart_all()
 
     names = [tool.name async for tool in manager.available_tools()]
-    # 暴露面应为 alias，原始名不得出现 / exposed name must be the alias, never the original
-    assert "aliased_tool" in names
-    assert "tool5" not in names
+    # 暴露面应为 {bundle_id}__{alias}，原始名不得出现 / exposed name = {bundle_id}__{alias}, never the original
+    assert "alias_server__aliased_tool" in names
+    assert "alias_server__tool5" not in names
 
 
 @pytest.mark.asyncio
@@ -889,16 +854,15 @@ async def test_forbidden_tool_excluded_from_duplicate_detection(manager, monkeyp
     await manager.ainitialize(servers)
     await manager.astart_all()
 
-    # 冲突被消除：tool1 仅来自 server2 / conflict resolved: tool1 routes to server2 only
-    assert manager._tool_mapping["tool1"] == "server2"
-    # 存活侧（server2）的 tool1 仍可寻址；不被另一 server 的 forbid 误伤
-    # The surviving tool1 (server2) stays addressable; a forbid on another server must not disable it.
-    assert "tool1" not in manager._disabled_tools
-    server_name, original = await manager.avalidate_tool_call("tool1", {})
-    assert (server_name, original) == ("server2", "tool1")
-    # 暴露面只出现一次 tool1（server1 那份被禁用、不暴露）/ tool1 exposed exactly once
+    # server1 forbid tool1（不进表），server2 正常暴露 → 仅 server2__tool1
+    assert "server1__tool1" not in manager._exposed_tools
+    assert manager._exposed_tools["server2__tool1"] == ("server2", "tool1")
+    bundle_id, original = await manager.avalidate_tool_call("server2__tool1", {})
+    assert (bundle_id, original) == ("server2", "tool1")
+    # 暴露面只出现一次 server2__tool1（server1 那份被 forbid、不暴露）
     names = [tool.name async for tool in manager.available_tools()]
-    assert names.count("tool1") == 1
+    assert names.count("server2__tool1") == 1
+    assert "server1__tool1" not in names
 
 
 @pytest.mark.asyncio
@@ -915,24 +879,19 @@ async def test_forbidden_original_name_suppresses_alias(manager):
 
     # alias 与原始名都不暴露、不路由 / neither the alias nor the original is exposed/routed
     names = [tool.name async for tool in manager.available_tools()]
-    assert "aliased_tool" not in names
-    assert "tool5" not in names
-    assert "aliased_tool" not in manager._tool_mapping
-    assert "tool5" not in manager._tool_mapping
+    assert "alias_server__aliased_tool" not in names
+    assert "alias_server__tool5" not in names
+    assert "alias_server__aliased_tool" not in manager._exposed_tools
+    assert "alias_server__tool5" not in manager._exposed_tools
 
 
 @pytest.mark.asyncio
-async def test_forbidden_tool_without_provider_stays_disabled(manager):
-    """forbid 单 server 独有工具时，仍应保留 PermissionError 语义（_disabled_tools 命中）。
-
-    When the forbidden tool is not provided by any other server, it stays in _disabled_tools so a call
-    raises PermissionError (regression guard for the existing single-server forbid behavior).
-    """
+async def test_forbidden_tool_not_exposed_and_uncallable(manager):
+    """forbid 工具后：不进 ExposedToolMapping、不可调用（未命中 → ValueError，上层映射 4001）。"""
     servers = [create_server_config("server1", forbidden_tools=["tool2"])]
     await manager.ainitialize(servers)
     await manager.astart_all()
 
-    assert "tool2" in manager._disabled_tools
-    assert "tool2" not in manager._tool_mapping
-    with pytest.raises(PermissionError):
-        await manager.aexecute_tool("tool2", {})
+    assert "server1__tool2" not in manager._exposed_tools
+    with pytest.raises(ValueError):
+        await manager.aexecute_tool("server1__tool2", {})

--- a/tests/unit_tests/computer/mcp_clients/test_manager_skill_resources.py
+++ b/tests/unit_tests/computer/mcp_clients/test_manager_skill_resources.py
@@ -82,7 +82,7 @@ async def test_list_skill_resources_server_filter() -> None:
     mgr = MCPServerManager()
     mgr._active_clients = {"s1": c1, "s2": c2}  # type: ignore[assignment]
 
-    out = await mgr.list_skill_resources(server_name="s2")
+    out = await mgr.list_skill_resources(bundle_id="s2")
     assert [(s, str(r.uri)) for s, r in out] == [("s2", "skill://h/b")]
 
 

--- a/tests/unit_tests/computer/skills/test_staging.py
+++ b/tests/unit_tests/computer/skills/test_staging.py
@@ -24,6 +24,7 @@ import tarfile
 import zipfile
 from collections.abc import Iterator
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 from mcp.types import BlobResourceContents, ReadResourceResult, Resource, TextResourceContents
@@ -36,14 +37,19 @@ from a2c_smcp.computer.skills.staging import stage_mcp_skills, stage_user_skills
 # ── 测试替身 / doubles ───────────────────────────────────────────────────────
 class FakeManager:
     def __init__(self, pairs: list[tuple[str, Resource]], reads: dict[str, ReadResourceResult] | None = None) -> None:
+        # pairs 的第一元现按 bundle_id 语义（协议 #18）；本 stub 里 bundle_id 与 display name 取同值。
         self._pairs = pairs
         self._reads = reads or {}
 
-    async def list_skill_resources(self, server_name: str | None = None) -> list[tuple[str, Resource]]:
-        return [(s, r) for s, r in self._pairs if server_name is None or s == server_name]
+    async def list_skill_resources(self, bundle_id: str | None = None) -> list[tuple[str, Resource]]:
+        return [(s, r) for s, r in self._pairs if bundle_id is None or s == bundle_id]
 
     async def read_resource(self, server: str, uri: str) -> ReadResourceResult:
         return self._reads[str(uri)]
+
+    def get_server_config(self, bundle_id: str) -> SimpleNamespace:
+        # SKILL ``<server>`` 段取 server name（协议 #18 正交、不变）；stub 中 name == bundle_id。
+        return SimpleNamespace(name=bundle_id)
 
 
 def _skill_md(name: str = "my-skill", description: str = "聚合 CSV") -> str:

--- a/tests/unit_tests/computer/test_computer_skills.py
+++ b/tests/unit_tests/computer/test_computer_skills.py
@@ -66,8 +66,12 @@ class _FakeManager:
     def set_pairs(self, pairs: list[tuple[str, Resource]]) -> None:
         self._pairs = pairs
 
-    async def list_skill_resources(self, server_name: str | None = None) -> list[tuple[str, Resource]]:
-        return [(s, r) for s, r in self._pairs if server_name is None or s == server_name]
+    async def list_skill_resources(self, bundle_id: str | None = None) -> list[tuple[str, Resource]]:
+        return [(s, r) for s, r in self._pairs if bundle_id is None or s == bundle_id]
+
+    def get_server_config(self, bundle_id: str) -> SimpleNamespace:
+        # SKILL ``<server>`` 段取 server name（协议 #18 正交、不变）；stub 中 name == bundle_id。
+        return SimpleNamespace(name=bundle_id)
 
 
 def _mounted_skill_resource(uri: str, src_dir: Path) -> Resource:

--- a/tests/unit_tests/utils/fixtures/bundle_id_conformance_vectors.json
+++ b/tests/unit_tests/utils/fixtures/bundle_id_conformance_vectors.json
@@ -1,0 +1,28 @@
+{
+  "$schema_note": "A2C-SMCP 协议 0.3.0 BundleID 缺省生成一致性测试向量（跨 SDK 逐字节一致锚点）。source of truth = a2c-smcp-protocol docs/specification/data-structures.md §「MCP Tool 命名与路由（BundleID 模型）」。rust-sdk 首版提供，python-sdk 对拍锁定。任一 SDK 的 resolve_bundle_id(name, config) MUST 产出 expected_bundle_id 方为合规。",
+  "algorithm": {
+    "normalize": "按 Unicode 码点迭代 name：非 [A-Za-z0-9_-] → '_'；折叠连续 '_'（含原文 __）为单个、不折叠 '-'；裁首尾 [_-]；不做大小写折叠。",
+    "fallback": "normalize 结果为空 → 'bundle_' + lowercase_hex(SHA-256(connection_identity_tlv)[:8])（前 8 字节 = 16 hex）。",
+    "input_state": "connection-identity 取 raw / 未注入配置：${input:*} / ${env:*} / secret 占位按字面参与摘要，MUST NOT 先渲染。故 bundle_id（及 no-double-open 去重键）跨渲染阶段稳定一致。",
+    "connection_identity_tlv": "长度前缀字节帧（非 JSON）：字符串字段 = u32-BE 字节长度 ‖ UTF-8 字节；字符串列表 = u32-BE 元素数 ‖ 元素*；字符串映射 = 按 key 升序（UTF-8 字节序=码点序）u32-BE 条目数 ‖ (key‖value)*。stdio = type('stdio') ‖ command ‖ args-list ‖ env-map；streamable/sse = type('streamable'|'sse') ‖ url ‖ headers-map。",
+    "explicit": "config.bundle_id 显式给定时直接采用（不生成）；显式值须满足字符集 [A-Za-z0-9_-] 且无 '__'（否则 SDK 报配置错误，不在本向量覆盖）。"
+  },
+  "vectors": [
+    {"desc": "ASCII 名不变", "name": "everything", "config": {"type": "stdio", "command": "npx", "args": ["-y", "everything"], "env": {}}, "expected_bundle_id": "everything"},
+    {"desc": "空格/符号 → _，裁尾部 _", "name": "My Server!", "config": {"type": "stdio", "command": "npx", "args": [], "env": {}}, "expected_bundle_id": "My_Server"},
+    {"desc": "原文 __ 折叠为单个 _", "name": "a__b", "config": {"type": "stdio", "command": "x", "args": [], "env": {}}, "expected_bundle_id": "a_b"},
+    {"desc": ". → _（禁 . in bundle_id）", "name": "a.b.c", "config": {"type": "stdio", "command": "x", "args": [], "env": {}}, "expected_bundle_id": "a_b_c"},
+    {"desc": "- 不折叠", "name": "a-b--c", "config": {"type": "stdio", "command": "x", "args": [], "env": {}}, "expected_bundle_id": "a-b--c"},
+    {"desc": "裁首尾 [_-]", "name": "__lead_trail__", "config": {"type": "stdio", "command": "x", "args": [], "env": {}}, "expected_bundle_id": "lead_trail"},
+    {"desc": "不做大小写折叠", "name": "MyServer", "config": {"type": "stdio", "command": "x", "args": [], "env": {}}, "expected_bundle_id": "MyServer"},
+    {"desc": "显式 bundle_id 直接采用", "name": "whatever", "config": {"type": "stdio", "command": "x", "args": [], "env": {}, "bundle_id": "custom_id"}, "expected_bundle_id": "custom_id"},
+    {"desc": "CJK 名 → fallback（stdio，含 args 保序）", "name": "你好世界", "config": {"type": "stdio", "command": "npx", "args": ["-y", "everything"], "env": {}}, "expected_bundle_id": "bundle_8d2a9232fa76e8a5"},
+    {"desc": "全符号名 → fallback（stdio）", "name": "!!!@@@", "config": {"type": "stdio", "command": "uvx", "args": ["mcp-server-git"], "env": {}}, "expected_bundle_id": "bundle_62515edd7632e701"},
+    {"desc": "CJK 名 → fallback（stdio，env 按 key 排序纳入）", "name": "服务器", "config": {"type": "stdio", "command": "node", "args": ["a.js"], "env": {"TOKEN": "x", "DEBUG": "1"}}, "expected_bundle_id": "bundle_05020ad7c2cc048d"},
+    {"desc": "空名 → fallback（streamable http，空 headers）", "name": "", "config": {"type": "streamable", "url": "https://api.example.com/mcp", "headers": {}}, "expected_bundle_id": "bundle_b413b61fe2e77b15"},
+    {"desc": "空名 → fallback（streamable http，headers 纳入）", "name": "", "config": {"type": "streamable", "url": "https://api.example.com/mcp", "headers": {"Authorization": "Bearer z"}}, "expected_bundle_id": "bundle_0706e7b45613df7a"},
+    {"desc": "空名 → fallback（sse，与同 url 的 http 因 type 判别符不同而不同）", "name": "", "config": {"type": "sse", "url": "https://api.example.com/sse", "headers": {}}, "expected_bundle_id": "bundle_e1d7b1216a270815"},
+    {"desc": "无名 + stdio env 含 ${input:*} 占位 → fallback 取 raw（占位字面，MUST NOT 渲染；渲染实现会得不同值）", "name": "", "config": {"type": "stdio", "command": "node", "args": ["server.js"], "env": {"API_KEY": "${input:api_key}"}}, "expected_bundle_id": "bundle_68ae00fea9122c01"},
+    {"desc": "无名 + http header 含 ${input:*} 占位 → fallback 取 raw（占位字面）", "name": "", "config": {"type": "streamable", "url": "https://api.example.com/mcp", "headers": {"Authorization": "Bearer ${input:token}"}}, "expected_bundle_id": "bundle_6366b4fd89f56f6a"}
+  ]
+}

--- a/tests/unit_tests/utils/test_bundle_id.py
+++ b/tests/unit_tests/utils/test_bundle_id.py
@@ -1,0 +1,205 @@
+# -*- coding: utf-8 -*-
+# filename: test_bundle_id.py
+# @Time    : 2026/07/11
+# @Author  : JQQ
+# @Email   : jqq1716@gmail.com
+# @Software: PyCharm
+"""
+BundleID 生成 / 校验 / TLV 摘要单测（协议 0.3.0 BundleID 模型，a2c-smcp-protocol#15）。
+
+⚠️ 断言策略 / Assertion policy：fallback 摘要的**精确字节**由协议仓一致性测试向量「定死」（rust-sdk#117
+首版交付、python 对拍），向量落库前**不**硬编码具体 hex——本文件断言的是**性质**（确定性 / 稳定性 /
+stdio≠http / env 序无关 / args 序相关 / 格式），逐字节对拍留待向量到达（见 test_bundle_id.py 的
+``test_fallback_*`` 与 bundle_id.py 模块 docstring 的 ASSUMPTION[1..3]）。
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+from mcp import StdioServerParameters
+from mcp.client.session_group import SseServerParameters, StreamableHttpParameters
+
+from a2c_smcp.computer.mcp_clients.model import SseServerConfig, StdioServerConfig, StreamableHttpServerConfig
+from a2c_smcp.utils.bundle_id import (
+    connection_identity_tlv,
+    generate_bundle_id,
+    is_valid_bundle_id,
+    normalize_name,
+    resolve_bundle_id,
+    validate_explicit_bundle_id,
+)
+
+_FALLBACK_RE = re.compile(r"^bundle_[0-9a-f]{16}$")
+
+
+def _stdio(name: str, command: str = "node", args: list[str] | None = None, env: dict[str, str] | None = None) -> StdioServerConfig:
+    return StdioServerConfig(name=name, server_parameters=StdioServerParameters(command=command, args=args or [], env=env))
+
+
+def _sse(name: str, url: str = "https://example.com/sse", headers: dict[str, str] | None = None) -> SseServerConfig:
+    return SseServerConfig(name=name, server_parameters=SseServerParameters(url=url, headers=headers))
+
+
+def _http(name: str, url: str = "https://example.com/mcp", headers: dict[str, str] | None = None) -> StreamableHttpServerConfig:
+    return StreamableHttpServerConfig(name=name, server_parameters=StreamableHttpParameters(url=url, headers=headers))
+
+
+# ————————————————————————————————— normalize_name (Step 1) —————————————————————————————————
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        # 非 [A-Za-z0-9_-] → _
+        ("my server", "my_server"),
+        ("a.b.c", "a_b_c"),
+        # `-` 保留、不折叠、不替换
+        ("my-server", "my-server"),
+        ("a--b", "a--b"),
+        # `_` 折叠（含原文 __）
+        ("my_server", "my_server"),
+        ("a__b", "a_b"),
+        ("a___b", "a_b"),
+        # 裁首尾 [_-]
+        ("__lead", "lead"),
+        ("trail__", "trail"),
+        ("-x-", "x"),
+        ("_-x-_", "x"),
+        # 不做大小写折叠
+        ("MyServer", "MyServer"),
+        ("everything", "everything"),
+        # 非 ASCII → _（随后可能被裁）
+        ("café", "caf"),
+        ("服务器-1", "1"),
+        # 规范化为空 → 触发 fallback
+        ("", ""),
+        ("你好", ""),
+        ("!!!", ""),
+        ("___", ""),
+        ("---", ""),
+    ],
+)
+def test_normalize_name(raw: str, expected: str) -> None:
+    assert normalize_name(raw) == expected
+
+
+def test_normalize_name_non_injective() -> None:
+    """规范化非单射：`my server` / `my-server` 不同，但 `my server` / `my_server` 撞（规范注）。"""
+    assert normalize_name("my server") == normalize_name("my_server") == "my_server"
+    assert normalize_name("my-server") != normalize_name("my_server")
+
+
+# ————————————————————————————————— 显式 bundle_id 校验 —————————————————————————————————
+
+
+@pytest.mark.parametrize("valid", ["playwright", "playwright_isolated", "a-b_c", "A1", "bundle_0123456789abcdef"])
+def test_validate_explicit_bundle_id_ok(valid: str) -> None:
+    assert validate_explicit_bundle_id(valid) == valid
+    assert is_valid_bundle_id(valid) is True
+
+
+@pytest.mark.parametrize("invalid", ["", "a__b", "__", "a.b", "a/b", "a b", "café"])
+def test_validate_explicit_bundle_id_reject(invalid: str) -> None:
+    assert is_valid_bundle_id(invalid) is False
+    with pytest.raises(ValueError):
+        validate_explicit_bundle_id(invalid)
+
+
+# ————————————————————————————————— generate_bundle_id：规范化路径 (Step 2) —————————————————————————————————
+
+
+def test_generate_uses_normalized_name_when_non_empty() -> None:
+    assert generate_bundle_id(_stdio("My Server")) == "My_Server"
+    assert generate_bundle_id(_sse("everything")) == "everything"
+    # 连接身份对非空规范化路径无影响（不进 fallback）
+    assert generate_bundle_id(_stdio("everything", command="node")) == generate_bundle_id(_stdio("everything", command="python"))
+
+
+# ————————————————————————————————— generate_bundle_id：fallback 路径 (Step 3) —————————————————————————————————
+
+
+@pytest.mark.parametrize("empty_name", ["", "你好", "!!!", "___"])
+def test_fallback_format(empty_name: str) -> None:
+    """空规范化 → `bundle_` + 16 小写 hex。"""
+    bid = generate_bundle_id(_stdio(empty_name))
+    assert _FALLBACK_RE.match(bid), bid
+
+
+def test_fallback_deterministic() -> None:
+    """同 (name, 连接身份) → 同 bundle_id（确定性，重复调用稳定）。"""
+    a = generate_bundle_id(_stdio("你好", command="node", args=["x"], env={"A": "1"}))
+    b = generate_bundle_id(_stdio("你好", command="node", args=["x"], env={"A": "1"}))
+    assert a == b
+
+
+def test_fallback_stdio_differs_from_http() -> None:
+    """同为空名，stdio 与 http 连接身份不同 → bundle_id 不同。"""
+    assert generate_bundle_id(_stdio("你好")) != generate_bundle_id(_http("你好"))
+
+
+def test_fallback_env_order_independent() -> None:
+    """env 按 key 排序纳入 → 插入序不影响摘要。"""
+    a = generate_bundle_id(_stdio("你好", env={"A": "1", "B": "2"}))
+    b = generate_bundle_id(_stdio("你好", env={"B": "2", "A": "1"}))
+    assert a == b
+
+
+def test_fallback_args_order_dependent() -> None:
+    """args 保序纳入 → 顺序改变摘要。"""
+    a = generate_bundle_id(_stdio("你好", args=["a", "b"]))
+    b = generate_bundle_id(_stdio("你好", args=["b", "a"]))
+    assert a != b
+
+
+def test_fallback_headers_order_independent() -> None:
+    a = generate_bundle_id(_http("你好", headers={"X-A": "1", "X-B": "2"}))
+    b = generate_bundle_id(_http("你好", headers={"X-B": "2", "X-A": "1"}))
+    assert a == b
+
+
+def test_fallback_command_sensitive() -> None:
+    assert generate_bundle_id(_stdio("你好", command="node")) != generate_bundle_id(_stdio("你好", command="python"))
+
+
+# ————————————————————————————————— connection_identity_tlv 结构不变量 —————————————————————————————————
+
+
+def test_tlv_excludes_non_connection_fields() -> None:
+    """TLV 排除 disabled/forbidden_tools 等非连接字段 → 仅连接身份变化才改摘要。"""
+    base = _stdio("你好", command="node", args=["s"], env={"A": "1"})
+    variant = StdioServerConfig(
+        name="你好",
+        server_parameters=StdioServerParameters(command="node", args=["s"], env={"A": "1"}),
+        disabled=True,
+        forbidden_tools=["t"],
+    )
+    assert connection_identity_tlv(base) == connection_identity_tlv(variant)
+
+
+def test_tlv_empty_collections_are_zero_count() -> None:
+    """空 args/env → 计数 0，不报错，产合法 fallback。"""
+    bid = generate_bundle_id(_stdio("你好", args=[], env=None))
+    assert _FALLBACK_RE.match(bid)
+
+
+# ————————————————————————————————— resolve_bundle_id —————————————————————————————————
+
+
+def test_resolve_generates_when_omitted() -> None:
+    """当前 DTO 尚无 bundle_id 字段（Phase 2 加）→ getattr None → 走生成。"""
+    cfg = _stdio("My Server")
+    assert resolve_bundle_id(cfg) == "My_Server"
+
+
+def test_resolve_prefers_explicit() -> None:
+    """显式 bundle_id 优先且经校验（用 duck-typed 对象模拟 Phase 2 后的字段）。"""
+    import types as _types
+
+    cfg = _types.SimpleNamespace(bundle_id="playwright_isolated")
+    assert resolve_bundle_id(cfg) == "playwright_isolated"  # type: ignore[arg-type]
+
+    bad = _types.SimpleNamespace(bundle_id="bad__id")
+    with pytest.raises(ValueError):
+        resolve_bundle_id(bad)  # type: ignore[arg-type]

--- a/tests/unit_tests/utils/test_bundle_id_conformance.py
+++ b/tests/unit_tests/utils/test_bundle_id_conformance.py
@@ -1,0 +1,93 @@
+# -*- coding: utf-8 -*-
+# filename: test_bundle_id_conformance.py
+# @Time    : 2026/07/11
+# @Author  : JQQ
+# @Email   : jqq1716@gmail.com
+# @Software: PyCharm
+"""
+BundleID 缺省生成**跨 SDK 一致性对拍**（P0 硬门槛）/ Cross-SDK conformance for default bundle_id derivation.
+
+夹具来源 / Fixture source（唯一权威）：
+    a2c-smcp-protocol ``docs/specification/fixtures/bundle_id_conformance_vectors.json``
+    @ develop ``57c2f9f``（PR #16 首版 14 条 + #17 raw 决策补 2 条 ``${input:*}`` 占位向量 = 16 条）。
+    本文件旁的 ``fixtures/bundle_id_conformance_vectors.json`` 为该规范文件的**逐字节 vendored 副本**——
+    协议仓更新向量时须重新同步（``git show origin/develop:docs/specification/fixtures/... > fixtures/...``）。
+
+含义 / Meaning：任一 SDK 的 ``resolve_bundle_id(name, config)`` **MUST** 对每条向量产出 ``expected_bundle_id``
+方为合规。python 与 rust 逐字节一致是协议 §「MCP Tool 命名与路由（BundleID 模型）」的硬门槛（a2c-smcp-protocol#15）。
+
+**raw 语义（#17 已定）**：connection-identity 取 **raw / 未注入**配置——``${input:*}`` 占位**按字面**参与摘要
+（末 2 条向量钉住此点）。故本文件用字面占位值构造 config；真实注册链的 raw-derive 时机由 Computer
+``_arender_and_validate_server`` 在 ``ConfigRender.arender`` **之前**保证（见 Phase 3）。
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from mcp import StdioServerParameters
+from mcp.client.session_group import SseServerParameters, StreamableHttpParameters
+
+from a2c_smcp.computer.mcp_clients.model import (
+    MCPServerConfig,
+    SseServerConfig,
+    StdioServerConfig,
+    StreamableHttpServerConfig,
+)
+from a2c_smcp.utils.bundle_id import resolve_bundle_id
+
+_FIXTURE = Path(__file__).parent / "fixtures" / "bundle_id_conformance_vectors.json"
+
+
+def _load() -> dict[str, Any]:
+    return json.loads(_FIXTURE.read_text(encoding="utf-8"))
+
+
+def _build_config(name: str, cfg: dict[str, Any]) -> MCPServerConfig:
+    """由夹具的**扁平连接身份**形式构造 MCPServerConfig（含可选显式 bundle_id）。"""
+    bundle_id = cfg.get("bundle_id")
+    ctype = cfg["type"]
+    if ctype == "stdio":
+        return StdioServerConfig(
+            name=name,
+            bundle_id=bundle_id,
+            server_parameters=StdioServerParameters(command=cfg["command"], args=cfg.get("args", []), env=cfg.get("env")),
+        )
+    if ctype == "streamable":
+        return StreamableHttpServerConfig(
+            name=name,
+            bundle_id=bundle_id,
+            server_parameters=StreamableHttpParameters(url=cfg["url"], headers=cfg.get("headers")),
+        )
+    if ctype == "sse":
+        return SseServerConfig(
+            name=name,
+            bundle_id=bundle_id,
+            server_parameters=SseServerParameters(url=cfg["url"], headers=cfg.get("headers")),
+        )
+    raise ValueError(f"unknown fixture config type: {ctype!r}")
+
+
+_VECTORS: list[dict[str, Any]] = _load()["vectors"]
+
+
+def test_fixture_integrity() -> None:
+    """守卫 vendored 副本未被截断/损坏（14 条向量 + algorithm 段）。"""
+    data = _load()
+    assert "algorithm" in data
+    # #17 raw 决策：algorithm 段须声明 input_state=raw；向量数 16（14 首版 + 2 条 ${input:*} 占位）。
+    assert "raw" in data["algorithm"].get("input_state", "")
+    assert len(data["vectors"]) == 16
+    for v in _VECTORS:
+        assert {"name", "config", "expected_bundle_id"} <= v.keys()
+
+
+@pytest.mark.parametrize("vec", _VECTORS, ids=[v["expected_bundle_id"] for v in _VECTORS])
+def test_bundle_id_conformance(vec: dict[str, Any]) -> None:
+    """逐字节对拍：resolve_bundle_id(name, config) == expected_bundle_id（与 rust-sdk 一致）。"""
+    cfg = _build_config(vec["name"], vec["config"])
+    got = resolve_bundle_id(cfg)
+    assert got == vec["expected_bundle_id"], f"{vec['desc']}: got={got} expected={vec['expected_bundle_id']}"


### PR DESCRIPTION
## 概述

以 **bundle_id** 作为 MCP Server 唯一身份，统一 `exposed_tool_name` 的生成与路由，替代旧「tool name 全局去重 + alias 完全替换 + `name` 为身份键」方案。**破坏性 wire 变更**（0.3.0），与 exposed_tool_name 格式同批。

- 协议先行：`a2c-smcp-protocol` **#15**（BundleID 模型）/ **#17**（TLV 摘要取 raw）/ **#18**（server-facing wire 身份统一），规范 commit `899fdd0`（已合协议 develop）。
- 双 SDK 对齐：与 `rust-sdk#117` 逐字节一致（TLV 契约 + 一致性测试向量）。

## 关键改动

- **`utils/bundle_id.py`（单一权威）**：确定性缺省生成（Unicode 码点规范化 + 显式 ASCII 类 `[A-Za-z0-9_-]` + connection-identity TLV + `SHA-256[:8]`）。**逐字节对拍协议仓 16 条一致性向量**（vendored；含 #17 `${input:*}` raw 占位向量——占位**不渲染**参与摘要）。
- **DTO**：`BaseMCPServerConfig.bundle_id` + `field_validator`；Computer 注册边界在 **raw config**（渲染前）derive 并物化（`config.bundle_id` 解析后恒有值）。
- **manager**：身份键 `name → bundle_id`；`ExposedToolMapping`（`exposed = {bundle_id}__{alias ?? 原始名}`，整键查表**不 split**）；**no-double-open**（boot first-wins + WARN 本地诊断 / 运行期 update-in-place）；**移除**跨 server 重名对账与 `ToolNameDuplicatedError`（bundle 前缀天然唯一，净简化）。
- **wire flip（#131 / #18）**：`client:get_config` servers 字典 key、`client:get_resources.mcp_server`、`ErrorPayload.mcp_server`（4014/4015，`mcp_server_name`→`mcp_server`，值为 bundle_id）、desktop 窗口分组键 —— 全部 = **bundle_id**。`name` 降为纯 display（允许碰撞、不做键/寻址）。

## 正交不改（回归验证过）

- `window://host` / `skill://host` 的 `host`（**MCP Server 自选 id**，非 A2C 身份）。
- SKILL name `mcp:<server>:<skill>` 的 `<server>` 段（保 server **name**，staging 经 `get_server_config(bundle_id).name` 派生）。

## 测试

单元 **1590** + 集成 **298** + e2e **64** 全绿；`mypy`（103 files）+ `ruff` clean。旧「借 alias 消解跨 server 冲突」用例改写为 coexist；`_disabled_tools/_tool_mapping/_alias_mapping` → `_exposed_tools`；forbidden 调用语义 `PermissionError` → `ValueError`（未命中 ExposedToolMapping，上层映射 4001）。

## 下游影响

**破坏性 wire 变更**：对 `exposed_tool_name` / server 寻址（get_config key、get_resources.mcp_server、`mcp_server` 错误字段）做日志/持久化/路由的消费方（如 TFRobotServer / tfrobot-client）需随 0.3.0 同步迁移。

Closes #130, #131 · Refs #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)
