### PR TITLE
feat(#137,#138): Computer 双路径 MCP-server CRUD + flip 为持久（对齐 rust）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -216,3 +216,6 @@ __marimo__/
 # Playwright MCP
 .playwright-mcp/
 /.claude/scheduled_tasks.lock
+
+# A2C MCP durable config (#137: `server add`/`rm` 落盘于 cwd/.tfrobot/；在仓库内跑 CLI/e2e 时防误纳)
+.tfrobot/

--- a/a2c_smcp/computer/cli/commands/__init__.py
+++ b/a2c_smcp/computer/cli/commands/__init__.py
@@ -48,21 +48,26 @@ def build_mcp_callbacks(comp: Computer) -> McpCallbacks:
     从 ``Computer`` 装配 installer / uninstall 级联所需的 MCP 注入回调 / Wire MCP callbacks from a live Computer。
 
     - ``existing_server_names``：当前已注册 MCP server 名集合（冲突预检用）；
-    - ``register_server``：注册 / 更新一个 ``MCPServerConfig``（enable / install remount 用）；
-    - ``remove_server``：按 name 停并摘除 server（disable / uninstall teardown 用）。
+    - ``register_server``：**运行期挂载**一个 ``MCPServerConfig``（enable / install remount 用）；
+    - ``remove_server``：按 name **运行期停摘** server（disable / uninstall teardown 用）。
 
     设计 §12.2：marketplace remove 的级联卸载（→ :func:`installer.uninstall_plugin`）与 #69 的 plugin
     enable/disable/install/uninstall 共用此接缝，避免各处重复装配。
+
+    **#137 ③ transient 分流**：本接缝**唯一**消费方是 plugin enable/disable/install/uninstall 与 marketplace
+    级联卸载——皆**治理投影**（bundled 真相在 ledger，非用户此刻声明），故走 transient
+    :meth:`Computer.amount_server` / :meth:`Computer.aunmount_server`，**不回写** mcp.json（否则 disable 后
+    复活 + scope 漂移，见 #138）。用户显式 ``server add``/``rm`` 是另一条（REPL）durable 路径，与此无关。
     """
 
     def _existing() -> set[str]:
         return {cfg.name for cfg in comp.mcp_servers}
 
     async def _register(cfg: MCPServerConfig) -> None:
-        await comp.aadd_or_aupdate_server(cfg)
+        await comp.amount_server(cfg)
 
     async def _remove(name: str) -> None:
-        await comp.aremove_server(name)
+        await comp.aunmount_server(name)
 
     return McpCallbacks(existing_server_names=_existing, register_server=_register, remove_server=_remove)
 

--- a/a2c_smcp/computer/cli/commands/plugin.py
+++ b/a2c_smcp/computer/cli/commands/plugin.py
@@ -22,8 +22,9 @@ REPL dispatcher 从活跃 ``Computer`` 装配后注入；Typer 非交互无 live
 
 **plugin 实时挂载 D2 上下文渲染（#69 Group A，§9.3 D2）**：plugin 的 ``mcp-servers/inputs.json`` 入池时 id
 前缀化为 ``<plugin>@<marketplace>/<id>``；enable 挂载 bundled server 时，``_plugin_register_cb`` 携
-plugin/marketplace 上下文调 :meth:`Computer.aadd_or_aupdate_server`，使 server config 的裸 ``${input:id}`` 经
-resolver D2 前缀回退解析。``_plugin_inject_inputs_cb`` 负责在 register 前把 inputs 注入 Computer 池。
+plugin/marketplace 上下文调 transient :meth:`Computer.amount_server`（#137 ③：治理投影不回写 mcp.json），使
+server config 的裸 ``${input:id}`` 经 resolver D2 前缀回退解析。``_plugin_inject_inputs_cb`` 负责在 register 前把
+inputs 注入 Computer 池。
 
 **MCP 批准框（#69 Group B，§9.2）**：:func:`run_mcp_approval` 在 REPL 启动期跑——解析 ``.tfrobot/mcp.json``
 定义层、套门控、对 ``PENDING`` server 弹 y/a/n（写 local scope）；非交互无 TTY → skip+WARN（``--approve-all-mcp``
@@ -120,10 +121,13 @@ def _split_plugin_id(plugin_id: str) -> tuple[str, str] | None:
 
 # ── plugin 实时挂载 D2 上下文渲染回调（#69 Group A）/ plugin-mount D2 context callbacks ──
 def _plugin_register_cb(comp: Any, plugin: str, marketplace: str) -> RegisterServer:
-    """携 plugin/marketplace 上下文的 register 回调：bundled server 的裸 ``${input:id}`` 经此解析到带前缀池条目。"""
+    """携 plugin/marketplace 上下文的 register 回调：bundled server 的裸 ``${input:id}`` 经此解析到带前缀池条目。
+
+    #137 ③：bundled 挂载 = 治理投影（ledger 是真相），走 transient :meth:`Computer.amount_server`，**不回写** mcp.json。
+    """
 
     async def _register(cfg: Any) -> None:
-        await comp.aadd_or_aupdate_server(cfg, plugin=plugin, marketplace=marketplace)
+        await comp.amount_server(cfg, plugin=plugin, marketplace=marketplace)
 
     return _register
 
@@ -164,7 +168,8 @@ async def run_governance_remount(comp: Any, *, flag_config: Path | None = None) 
     declared = resolved_settings(env, flag_path=flag_config)
 
     async def _register(cfg: Any, record: Any) -> None:
-        await comp.aadd_or_aupdate_server(cfg, plugin=record.plugin, marketplace=record.marketplace)
+        # #137 ③：治理重挂 = 投影（ledger 是真相），走 transient amount_server，不回写 mcp.json。
+        await comp.amount_server(cfg, plugin=record.plugin, marketplace=record.marketplace)
         console.print(f"[green]✓ restored bundled MCP server {cfg.name!r} (plugin {record.plugin_id})[/green]")
 
     async def _inject(record: Any) -> None:
@@ -558,7 +563,9 @@ async def run_mcp_approval(
 
     async def _mount(name: str) -> None:
         try:
-            await comp.aadd_or_aupdate_server(_mount_dict(resolved.servers[name]), session=session)
+            # #137 ③：boot 读**已声明** mcp.json 挂载 = 投影（盘上已是真相），走 transient amount_server，不回写
+            # （否则每 boot 重复回写用户声明层 / scope 漂移，见 #138）。
+            await comp.amount_server(_mount_dict(resolved.servers[name]), session=session)
             console.print(f"[green]✓ mounted MCP server {name!r}[/green]")
         except Exception as exc:  # 单个 server 挂载失败不阻断其余 / one failure must not block the rest
             console.print(f"[red]✗ failed to mount MCP server {name!r}: {exc}[/red]")

--- a/a2c_smcp/computer/cli/main.py
+++ b/a2c_smcp/computer/cli/main.py
@@ -280,7 +280,9 @@ def _run_impl(
 
                     async def _add_server(cfg_obj: dict[str, Any]) -> None:
                         validated: dict[str, Any] = TypeAdapter(SMCPServerConfigDict).validate_python(cfg_obj)
-                        await comp.aadd_or_aupdate_server(validated)
+                        # #137 ③：`--config @file` 加载既有声明 = 投影（加载 ≠ 用户此刻新声明），走 transient
+                        # amount_server，不回写 mcp.json（对齐 rust boot approval 用 mount_server，见 #138）。
+                        await comp.amount_server(validated)
 
                     if isinstance(data, list):
                         for cfg in data:

--- a/a2c_smcp/computer/computer.py
+++ b/a2c_smcp/computer/computer.py
@@ -66,6 +66,14 @@ from a2c_smcp.computer.inventory import McpOwnership, McpPluginOwnership, McpSer
 from a2c_smcp.computer.mcp_clients.manager import MCPServerManager
 from a2c_smcp.computer.mcp_clients.model import MCPServerConfig, MCPServerInput
 from a2c_smcp.computer.settings.installer import migrate_legacy_installs
+from a2c_smcp.computer.settings.mcp_config import (
+    McpWriteScope,
+    McpWriteTargetError,
+    bundled_mcp_server_names,
+    remove_mcp_server,
+    resolve_mcp_config,
+    upsert_mcp_server,
+)
 from a2c_smcp.computer.settings.recovery import (
     BundledServerRecord,
     GovernanceRecoveryReport,
@@ -780,6 +788,106 @@ class Computer(BaseComputer[PromptSession]):
             logger.error(f"动态渲染/校验MCP配置失败: {name} - {e}", exc_info=True)
             raise e
 
+    # ════════════════════════════════════════════════════════════════════════════
+    # 双路径 MCP-server CRUD（#137 ②，父 #135：对齐 rust-sdk ``crates/smcp-computer/src/computer.rs``）
+    # Dual-path MCP-server CRUD (aligns rust-sdk).
+    #
+    # 一句话分流规则（与 rust 完全同构）：**「用户此刻在声明一个 server」→ durable（落盘+重启存活）；
+    # 「把别处已是真相的东西投影进 runtime」→ transient（纯运行期、不落盘）。**
+    #   - durable  ：:meth:`aadd_or_aupdate_server` / :meth:`aadd_or_aupdate_server_in_scope` / :meth:`aremove_server`
+    #                （REPL ``server add``/``rm``、外部 API 用户显式增删）。对齐 rust ``add_or_update_server*`` / ``remove_server``。
+    #   - transient：:meth:`amount_server` / :meth:`aunmount_server` / :meth:`aunmount_server_by_id`
+    #                （boot 读已声明 mcp.json 挂载、``--config @file`` 加载、plugin/治理 D2 挂载/重挂）。对齐 rust
+    #                ``mount_server`` / ``unmount_server`` / ``unmount_server_by_id``。
+    #
+    # §12 R2 revision 分账（对齐 rust）：durable 落盘属 **config** 轴变化、transient 属纯 **capability** 轴。python 侧
+    #   **capability** 上报由 manager 物化经 ``_on_manager_change`` → ``emit_update_tool_list`` **自动**触发（两路径皆有）；
+    #   **config** 上报（``emit_update_config``/``notify:update_config``）由 **调用方（CLI/外部宿主）** 驱动——现状即
+    #   REPL durable 路径 emit、boot/plugin transient 路径不 emit，恰好满足分账，故 SDK 层**不在** CRUD 方法内 emit
+    #   config（保持既有「client owns Socket.IO 上报」分层，#93；rust 内部 bump 属实现细节，概念对齐即可，#135）。
+    # ════════════════════════════════════════════════════════════════════════════
+
+    async def _amount_rendered(self, validated: MCPServerConfig) -> None:
+        """物化**已渲染校验**的 config 进 manager（内存投影 + capability 上报）/ Mount an already-rendered config。
+
+        对齐 rust ``mount_rendered``：durable 与 transient 两路径的**共享核**——durable 落盘后复用同一次 render 结果
+        经此物化，**避免重复触发** input/secret resolver 副作用（不二次渲染）。manager 惰性初始化于此单点。
+        """
+        if self.mcp_manager is None:
+            self.mcp_manager = MCPServerManager(
+                auto_connect=self._auto_connect,
+                auto_reconnect=self._auto_reconnect,
+                message_handler=self._on_manager_change,
+            )
+        await self.mcp_manager.aadd_or_aupdate_server(validated)
+
+    @staticmethod
+    def _raw_body_for_disk(server: MCPServerConfig | dict[str, Any]) -> tuple[str, dict[str, Any]]:
+        """从入参取**未渲染 raw** server 定义体（map key = ``name``，body 不含 name）/ Extract the un-rendered raw body。
+
+        **D1 铁律**：durable 落盘取此 raw（占位 ``${input:}`` / ``${env:}`` 字面保留），**绝不写渲染后 secret**
+        （值不离 Computer，§9.1）。dict 入参原样、model 入参 ``model_dump(mode="json")``；剥离 ``name``（身份由
+        ``servers.<name>`` map key 承载，与 :func:`resolve_mcp_config` 读取契约一致，杜绝 name/key 冗余漂移）。
+        """
+        raw = dict(server) if isinstance(server, dict) else server.model_dump(mode="json")
+        name = raw.get("name")
+        if not name or not isinstance(name, str):
+            raise ValueError("server config must carry a non-empty 'name' for durable persistence")
+        body = {k: v for k, v in raw.items() if k != "name"}
+        return name, body
+
+    # ── transient 路径（纯运行期，不落盘）/ transient path (runtime-only, no disk write) ──────────────
+
+    async def amount_server(
+        self,
+        server: MCPServerConfig | dict[str, Any],
+        *,
+        session: PromptSession | None = None,
+        plugin: str | None = None,
+        marketplace: str | None = None,
+    ) -> None:
+        """**运行期挂载**一个 MCP server（渲染校验 → 物化，**不落盘**）/ Transient mount (no disk write)。
+
+        对齐 rust ``mount_server``。语义 = 本 SDK 历史 ``aadd_or_aupdate_server`` 的**原状**（现已 flip 为 durable，
+        故抽此新名承接纯运行期投影）。用于「把别处已是真相的东西投影进 runtime」：boot 读已声明 mcp.json 挂载、
+        ``--config @file`` 加载、plugin/治理 bundled 重挂——这些**不应回写** mcp.json（否则双源 / 每 boot 重写 /
+        scope 漂移，见 #138）。只 bump **capability**（manager 物化自动上报），不碰持久 config。
+
+        Args:
+            server: 待挂载配置，可为模型或原始字典。
+            session: Computer 管理 Session（交互式 input 解析用）。
+            plugin / marketplace: plugin 实时挂载 D2 上下文（#69 Group A）；非 None 时 bundled server 的裸
+                ``${input:id}`` 解析到带前缀池条目 ``<plugin>@<marketplace>/<id>``（§9.3 D2）。普通来源传 None。
+        """
+        validated = await self._arender_and_validate_server(server, session=session, plugin=plugin, marketplace=marketplace)
+        await self._amount_rendered(validated)
+
+    async def aunmount_server(self, name: str) -> None:
+        """按 **name** 纯运行期**停摘**一个 server（不删声明、不落盘）/ Transient unmount by name。
+
+        对齐 rust ``unmount_server``。manager 以 bundle_id 为键，故按 name 在运行期活跃集里解析出对应 bundle_id 再停摘
+        （同名多条则全摘，正常运行集内 name 唯一）。用于 plugin disable / uninstall / marketplace 级联的 bundled 停摘
+        （bundled 真相在 ledger，停进程而**不删** mcp.json 声明）。manager 未建 / 无匹配 → no-op。
+        """
+        if self.mcp_manager is None:
+            return
+        targets = {resolve_bundle_id(cfg) for cfg in self.mcp_manager.server_configs() if cfg.name == name}
+        for bundle_id in targets:
+            await self.mcp_manager.aremove_server(bundle_id)
+
+    async def aunmount_server_by_id(self, bundle_id: str) -> None:
+        """按 **bundle_id** 纯运行期**停摘**一个 server（不删声明、不落盘）/ Transient unmount by bundle_id。
+
+        对齐 rust ``unmount_server_by_id``。manager 未建 / 无匹配 → no-op（避免 ``manager.aremove_server`` 的
+        ``KeyError``）。durable :meth:`aremove_server` 停摘段复用本方法。
+        """
+        if self.mcp_manager is None:
+            return
+        if any(resolve_bundle_id(cfg) == bundle_id for cfg in self.mcp_manager.server_configs()):
+            await self.mcp_manager.aremove_server(bundle_id)
+
+    # ── durable 路径（落盘 raw + 重启存活）/ durable path (persist raw + survive restart) ─────────────
+
     async def aadd_or_aupdate_server(
         self,
         server: MCPServerConfig | dict[str, Any],
@@ -788,41 +896,84 @@ class Computer(BaseComputer[PromptSession]):
         plugin: str | None = None,
         marketplace: str | None = None,
     ) -> None:
-        """
-        动态添加或更新某个MCP Server配置（支持 inputs 占位符解析）。
-        Add or update a MCP Server config dynamically (supports inputs placeholder resolving).
+        """**持久声明**一个 MCP server（默认落 **Local**）并物化 / Durably declare a server (defaults to Local)。
 
-        Args:
-            session (PromptSession | None): Computer管理Session
-            server (MCPServerConfig | dict[str, Any]): 待添加/更新的配置，可为模型或原始字典。
-            plugin / marketplace (str | None): plugin 实时挂载上下文（#69 Group A）；非 None 时 bundled server 的裸
-                ``${input:id}`` 解析到带前缀池条目 ``<plugin>@<marketplace>/<id>``（§9.3 D2）。普通来源传 None=现状。
-                Plugin mount context; when set, a bundled server's bare ``${input:id}`` resolves to the prefixed pool entry.
-        """
-        # 确保 manager 已初始化
-        if self.mcp_manager is None:
-            self.mcp_manager = MCPServerManager(
-                auto_connect=self._auto_connect,
-                auto_reconnect=self._auto_reconnect,
-                message_handler=self._on_manager_change,
-            )
+        对齐 rust ``add_or_update_server``（:1978 ``add_or_update_server_in_scope(server, Local)``）。**破坏性变更**
+        （#135/#137）：历史此方法为纯运行期，现 flip 为持久——落盘 ``mcp.local.json``（不入 git、boot 读取、重启
+        存活）+ 运行期物化。用于「用户此刻在声明一个 server」（REPL ``server add``、外部 API 用户新增）。纯运行期
+        投影请改用 :meth:`amount_server`。
 
+        Args 同 :meth:`amount_server`（保留 ``plugin`` / ``marketplace`` D2 上下文 kwargs）。
+        """
+        await self.aadd_or_aupdate_server_in_scope(
+            server, McpWriteScope.LOCAL, session=session, plugin=plugin, marketplace=marketplace,
+        )
+
+    async def aadd_or_aupdate_server_in_scope(
+        self,
+        server: MCPServerConfig | dict[str, Any],
+        scope: McpWriteScope,
+        *,
+        session: PromptSession | None = None,
+        plugin: str | None = None,
+        marketplace: str | None = None,
+    ) -> None:
+        """**持久声明**一个 MCP server 到**显式 scope** 并物化 / Durably declare a server into an explicit scope。
+
+        对齐 rust ``add_or_update_server_in_scope``（:1992）。``scope`` ∈ ``Local``（``mcp.local.json`` 不入 git）/
+        ``Project``（``mcp.json`` 入 git、团队共享）/ ``User``（``$XDG_CONFIG_HOME/a2c`` 全局）。**改已有 server 恒落其
+        origin scope**（① :func:`upsert_mcp_server` 已保证，``scope`` 仅对新声明生效，杜绝跨 scope 漂移）。
+
+        流程（对齐 rust）：**先 render 校验**（早失败、不落盘）→ 取**未渲染 raw**（D1）→ 经 ① 落盘 raw → **复用**同一
+        次 render 结果 :meth:`_amount_rendered` 物化（不二次渲染）。落盘属 config 轴、物化属 capability 轴（分账见类内
+        双路径块注释）。
+
+        :raises McpWriteTargetError: ``name`` 为 plugin-bundled server 名（其真相在 ledger，不可经 mcp.json 写）。
+        :raises McpConfigCorruptError: 目标 ``mcp.json`` 结构损坏（① 拒绝覆盖以免销毁既有内容）。
+        """
+        # 1. 先渲染校验（早失败：损坏配置在落盘前抛出，绝不留下盘上声明而运行期未挂的半态）。
         validated = await self._arender_and_validate_server(server, session=session, plugin=plugin, marketplace=marketplace)
-        await self.mcp_manager.aadd_or_aupdate_server(validated)
+        # 2. 取未渲染 raw 落盘（D1：占位字面保留、绝不写 secret）。
+        name, raw_body = self._raw_body_for_disk(server)
+        upsert_mcp_server(name, raw_body, scope=scope, env=os.environ, home=self.skill_home)
+        # 3. 复用 render 结果物化（capability 自动上报；config 上报由调用方驱动，见分账注释）。
+        await self._amount_rendered(validated)
 
     async def aremove_server(self, bundle_id: str, *, session: PromptSession | None = None) -> None:
-        """
-        动态移除某个MCP Server配置（按 bundle_id）。
-        Remove a MCP Server config dynamically (by bundle_id).
+        """**持久删除**一个 MCP server 声明（bundle_id → 声明名 → 删所有可写 scope）+ 运行期停摘 / Durably remove。
+
+        对齐 rust ``remove_server``（:2038）。**破坏性变更**（#135/#137）：历史仅运行期停摘（→ 复活 footgun：人写在
+        ``mcp.json`` 的 server 重启复活），现 flip 为持久删除。流程：
+
+        1. **bundled 身份拒删**：目标 bundle_id 命中**运行期已挂载**的 bundled server（其真相在 ledger）→ 抛
+           :class:`McpWriteTargetError`（应经 ``plugin uninstall`` 而非 ``server rm``）。**边界**：拒删按运行期挂载态
+           判定；未挂载的 bundled 名不在任何 ``mcp.json``（bundled 从不入声明面）→ 本方法对其为无害 no-op（无声明可删、
+           无投影可停），无需拒绝——真正的 bundled 治理入口是 ``plugin`` 命令，不经此 MCP-CRUD 面。
+        2. 以本实例上下文 :func:`resolve_mcp_config` 取**快照** → 对每条声明算 :func:`resolve_bundle_id` 匹配
+           ``bundle_id`` → 收集声明名（去重）→ 经 ① :func:`remove_mcp_server` 删**所有可写 scope**。
+        3. :meth:`aunmount_server_by_id` 运行期停摘。**无声明匹配** → 落盘 no-op、**仍停摘**（运行期投影清理）。
 
         Args:
-            bundle_id (str): MCP Server 唯一身份 bundle_id（协议 #18）。
+            bundle_id (str): MCP Server 唯一身份 bundle_id（协议 #18）。REPL ``server rm <name>`` 在缺省身份下
+                （bundle_id = normalize(name)）以 name 寻址即可。
         """
-        if not self.mcp_manager:
-            # 未初始化则无操作
-            logger.warning("MCP 管理器尚未初始化，忽略移除操作 / MCP manager not initialized, skip remove")
-            return
-        await self.mcp_manager.aremove_server(bundle_id)
+        env = os.environ
+        # 1. bundled 身份拒删：运行期活跃集里该 bundle_id 的 name 命中 ledger 派生 bundled 集 → 拒。
+        bundled = bundled_mcp_server_names(home=self.skill_home, env=env)
+        if self.mcp_manager is not None and bundled:
+            for cfg in self.mcp_manager.server_configs():
+                if resolve_bundle_id(cfg) == bundle_id and cfg.name in bundled:
+                    raise McpWriteTargetError(
+                        f"bundle_id={bundle_id!r} (name={cfg.name!r}) is a plugin-bundled MCP server "
+                        "(its truth is the installed_plugins.json ledger); use 'plugin uninstall' instead of removing it via mcp.json",
+                    )
+        # 2. 快照解析声明名（未渲染 config，derive-on-raw 与注册边界同源）→ 删所有可写 scope。
+        snapshot = resolve_mcp_config(env=env)
+        matched = {name for name, srv in snapshot.servers.items() if resolve_bundle_id(srv.config) == bundle_id}
+        for name in matched:
+            remove_mcp_server(name, env=env)
+        # 3. 运行期停摘（无声明匹配也停：清理纯运行期投影）。
+        await self.aunmount_server_by_id(bundle_id)
 
     def update_inputs(self, inputs: set[MCPServerInput], *, session: PromptSession | None = None) -> None:
         """

--- a/a2c_smcp/computer/settings/installer.py
+++ b/a2c_smcp/computer/settings/installer.py
@@ -122,9 +122,10 @@ class MCPServerNameConflictError(Exception):
 # ---------------------------------------------------------------------------
 # 当前已注册 server 名集合（同步；CLI 包 ``{r[0] for r in mcp_manager.get_server_status()}``）。
 ExistingServerNames = Callable[[], set[str]]
-# 注册 / 更新一个 server（异步；CLI 包 ``Computer.aadd_or_aupdate_server``，含 ``${input:}`` 渲染）。
+# 运行期挂载一个 bundled server（异步；#137 ③ 起 CLI 包 transient ``Computer.amount_server``，含 ``${input:}`` 渲染；
+# 治理投影不回写 mcp.json——bundled 真相在 ledger）。
 RegisterServer = Callable[[MCPServerConfig], Awaitable[None]]
-# 停止并移除一个 server（异步；CLI 包 ``Computer.aremove_server``）。
+# 运行期停摘一个 bundled server（异步；#137 ③ 起 CLI 包 transient ``Computer.aunmount_server``，停进程不删声明）。
 RemoveServer = Callable[[str], Awaitable[None]]
 # 注入 plugin-scoped inputs 入池（异步；入参 plugin_root；CLI 包 ``load_plugin_inputs`` → ``Computer.add_or_update_input``）。
 # 在 register（→render bundled server 的 ${input:}）之前调，使裸 id 可经 D2 前缀回退解析（#69 Group A，§9.3 D2）。

--- a/a2c_smcp/computer/settings/recovery.py
+++ b/a2c_smcp/computer/settings/recovery.py
@@ -100,7 +100,7 @@ class BundledServerRecord:
 
     ``config`` 从账本 ``installPath`` 经 :func:`load_bundled_servers` **每次 boot 重新解析**（不信任
     存储态，§5.8 精神）；``plugin``/``marketplace`` 供 client 挂载时携带 D2 渲染上下文
-    （``Computer.aadd_or_aupdate_server(cfg, plugin=, marketplace=)``）。
+    （#137 ③ 起走 transient ``Computer.amount_server(cfg, plugin=, marketplace=)``——治理投影不回写 mcp.json）。
     """
 
     plugin_id: str

--- a/tests/e2e/computer/conftest.py
+++ b/tests/e2e/computer/conftest.py
@@ -80,6 +80,24 @@ def _spawn_cli(*extra_args: str, cwd: str | None = None) -> Iterator[pexpect.spa
     project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
     spawn_cwd = cwd or project_root
 
+    # #137 ②：REPL `server add`/`rm` 现为 durable，落盘于 spawn_cwd/.tfrobot/{mcp.local.json,mcp.json}
+    # （project/local 锚 cwd，#116）。e2e 默认 cwd=项目根、config 文件走相对路径（不便改 tmp cwd），故对两个 durable
+    # 落点做**字节级快照**，测试结束**精确还原**至运行前状态——防污染仓库 + 防跨 spawn 残留被下个进程 boot 审批读到
+    # （PENDING 提示导致 e2e 挂起，#110 同类死循环）。快照-还原对「仓库根已有真实 .tfrobot」亦安全（还原其原内容，
+    # 绝不删/改用户既有文件）。
+    tfrobot_dir = os.path.join(spawn_cwd, ".tfrobot")
+    tfrobot_preexisted = os.path.isdir(tfrobot_dir)
+    durable_targets = (os.path.join(tfrobot_dir, "mcp.local.json"), os.path.join(tfrobot_dir, "mcp.json"))
+
+    def _snapshot(path: str) -> bytes | None:
+        try:
+            with open(path, "rb") as fh:
+                return fh.read()
+        except OSError:
+            return None
+
+    durable_snapshot = {p: _snapshot(p) for p in durable_targets}
+
     print("a2c-computer starting...")
     # 保证每次发送前有一个时延保持稳定
     child = pexpect.spawn(args[0], args[1:], env=env, encoding="utf-8", timeout=60, cwd=spawn_cwd)
@@ -104,6 +122,17 @@ def _spawn_cli(*extra_args: str, cwd: str | None = None) -> Iterator[pexpect.spa
                 child.kill(signal.SIGKILL)
             except Exception:
                 pass
+        # #137 ②：精确还原 durable 落点至运行前状态——本次新建则删、原有则写回原字节（对既有真实 .tfrobot 亦安全）。
+        for path, original in durable_snapshot.items():
+            if original is None:
+                if os.path.exists(path):
+                    os.remove(path)
+            else:
+                with open(path, "wb") as fh:
+                    fh.write(original)
+        # 本次新建的空 .tfrobot 目录一并清走（原有目录保留）。
+        if not tfrobot_preexisted and os.path.isdir(tfrobot_dir):
+            shutil.rmtree(tfrobot_dir, ignore_errors=True)
 
 
 @pytest.fixture()

--- a/tests/integration_tests/computer/cli/test_desktop_command.py
+++ b/tests/integration_tests/computer/cli/test_desktop_command.py
@@ -41,11 +41,14 @@ def no_patch_stdout():
 
 
 @pytest.mark.asyncio
-async def test_cli_desktop_with_subscribe_resources_server(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_cli_desktop_with_subscribe_resources_server(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """
     中文: 使用 resources_subscribe_stdio_server 启动后，执行 desktop 命令应输出非空列表。
     英文: After starting resources_subscribe_stdio_server, 'desktop' should output a non-empty list.
     """
+    # #137 ②：REPL `server add` 现为 durable 落盘——隔离 cwd/XDG 到 tmp，防写真实仓库 .tfrobot/。
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "cfg"))
+    monkeypatch.chdir(tmp_path)
     server_py = Path(__file__).resolve().parents[2] / "computer" / "mcp_servers" / "resources_subscribe_stdio_server.py"
     assert server_py.exists()
 

--- a/tests/integration_tests/computer/cli/test_main.py
+++ b/tests/integration_tests/computer/cli/test_main.py
@@ -35,7 +35,9 @@ def no_patch_stdout():
 
 
 @pytest.mark.asyncio
-async def test_cli_with_real_stdio(stdio_params: StdioServerParameters, monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_cli_with_real_stdio(
+    stdio_params: StdioServerParameters, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """
     集成测试：通过 CLI 交互完成以下流程（使用真实 stdio MCP server 参数）：
     1) 添加 server 配置（disabled=false）
@@ -45,6 +47,9 @@ async def test_cli_with_real_stdio(stdio_params: StdioServerParameters, monkeypa
     5) 退出
     期望：流程执行无异常。
     """
+    # #137 ②：REPL `server add` 现为 durable 落盘——隔离 cwd/XDG 到 tmp，防写真实仓库 .tfrobot/。
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "cfg"))
+    monkeypatch.chdir(tmp_path)
     server_cfg = {
         "name": "it-stdio",
         "type": "stdio",

--- a/tests/integration_tests/computer/mcp_servers/test_param_server.py
+++ b/tests/integration_tests/computer/mcp_servers/test_param_server.py
@@ -54,7 +54,7 @@ async def test_param_server_dynamic_update() -> None:
             encoding_error_handler="strict",
         )
         new_cfg = StdioServerConfig(name="param_server", server_parameters=new_params)
-        await comp.aadd_or_aupdate_server(new_cfg)
+        await comp.amount_server(new_cfg)  # #137：运行期更新用 transient（不落盘）
 
         # 再次调用，验证已生效
         result2 = await comp.mcp_manager.acall_tool("param_server", "config_value", {})

--- a/tests/integration_tests/computer/test_computer.py
+++ b/tests/integration_tests/computer/test_computer.py
@@ -122,7 +122,7 @@ async def test_dynamic_add_with_inputs_and_tool_call(stdio_params) -> None:
     computer = Computer(name="test", auto_connect=True, input_resolver=resolver)
 
     # 动态添加
-    await computer.aadd_or_aupdate_server(cfg_dict)
+    await computer.amount_server(cfg_dict)
 
     # 获取工具并调用
     tools = await computer.aget_available_tools()
@@ -140,7 +140,7 @@ async def test_dynamic_update_forbid_tool_then_call_fails(stdio_params) -> None:
     computer = Computer(name="test", auto_connect=True, confirm_callback=lambda *_: True)
     # 先添加（直接用模型，不涉及 inputs）
     cfg = StdioServerConfig(name="dyn_stdio2", server_parameters=stdio_params)
-    await computer.aadd_or_aupdate_server(cfg)
+    await computer.amount_server(cfg)
 
     # 确认可调用
     ret1 = await computer.aexecute_tool("reqid", "dyn_stdio2__hello", {"name": "China"})
@@ -148,7 +148,7 @@ async def test_dynamic_update_forbid_tool_then_call_fails(stdio_params) -> None:
 
     # 更新：禁用工具（按原始名 forbidden）
     cfg2 = StdioServerConfig(name="dyn_stdio2", server_parameters=stdio_params, forbidden_tools=["hello"])
-    await computer.aadd_or_aupdate_server(cfg2)
+    await computer.amount_server(cfg2)
 
     # 调用应被拒绝：forbidden 后不进 ExposedToolMapping → 未命中 → ValueError（上层映射 4001）
     with pytest.raises(ValueError):
@@ -162,14 +162,14 @@ async def test_dynamic_remove_then_tool_not_found(stdio_params) -> None:
     """
     computer = Computer(name="test", auto_connect=True, confirm_callback=lambda *_: True)
     cfg = StdioServerConfig(name="dyn_stdio3", server_parameters=stdio_params)
-    await computer.aadd_or_aupdate_server(cfg)
+    await computer.amount_server(cfg)
 
     # 调用成功一次
     ret1 = await computer.aexecute_tool("reqid", "dyn_stdio3__hello", {"name": "China"})
     assert ret1.content and ret1.content[0].text == "Hello, China!"
 
     # 移除（按 bundle_id）
-    await computer.aremove_server("dyn_stdio3")
+    await computer.aunmount_server_by_id("dyn_stdio3")
 
     # 再次调用应报错：工具不存在
     with pytest.raises(ValueError):

--- a/tests/integration_tests/computer/test_smcp_tool_data_format.py
+++ b/tests/integration_tests/computer/test_smcp_tool_data_format.py
@@ -46,7 +46,7 @@ async def test_smcp_tool_data_without_default_tool_meta(stdio_params) -> None:
     }
 
     computer = Computer(name="test_no_meta", auto_connect=True)
-    await computer.aadd_or_aupdate_server(cfg_dict)
+    await computer.amount_server(cfg_dict)  # #137：测试挂载用 transient（不落盘、不依赖 skill_home）
 
     tools = await computer.aget_available_tools()
 
@@ -107,7 +107,7 @@ async def test_smcp_tool_data_with_default_tool_meta_tags(stdio_params) -> None:
     }
 
     computer = Computer(name="test_with_tags", auto_connect=True)
-    await computer.aadd_or_aupdate_server(cfg_dict)
+    await computer.amount_server(cfg_dict)  # #137：测试挂载用 transient（不落盘、不依赖 skill_home）
 
     tools = await computer.aget_available_tools()
 

--- a/tests/unit_tests/computer/cli/test_interactive_more.py
+++ b/tests/unit_tests/computer/cli/test_interactive_more.py
@@ -80,6 +80,9 @@ async def test_tools_and_inputs_update_single_and_list(tmp_path: Path, monkeypat
     - inputs get 不存在与存在
     - inputs value set: JSON 与 纯文本 两类
     """
+    # #137 ②：REPL `server add` 现为 durable 落盘——隔离 cwd/XDG 到 tmp，防写真实仓库 .tfrobot/。
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "cfg"))
+    monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(cli_main, "SMCPComputerClient", _Client)
 
     # 通过文件提供 inputs 数组

--- a/tests/unit_tests/computer/cli/test_main.py
+++ b/tests/unit_tests/computer/cli/test_main.py
@@ -358,6 +358,9 @@ def test_run_impl_inputs_and_servers_single_object(tmp_path: Path, monkeypatch: 
 @pytest.mark.asyncio
 async def test_cover_remaining_branches(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """覆盖 interactive_impl.py 中剩余未命中的分支。"""
+    # #137 ②：REPL `server add` 现为 durable 落盘——隔离 cwd/XDG 到 tmp，防写真实仓库 .tfrobot/。
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "cfg"))
+    monkeypatch.chdir(tmp_path)
     # 为 inputs update @file 准备文件（列表）
     upd_file = tmp_path / "upd.json"
     upd_file.write_text(
@@ -427,6 +430,9 @@ async def test_interactive_misc_and_file_paths(tmp_path: Path, monkeypatch: pyte
     - 未知子命令（server/socket/notify）与 render 内联 JSON
     - start/stop 单个名称（manager 初始化后触发路径）
     """
+    # #137 ②：REPL `server add` 现为 durable 落盘——隔离 cwd/XDG 到 tmp，防写真实仓库 .tfrobot/。
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "cfg"))
+    monkeypatch.chdir(tmp_path)
 
     # 预备文件：server 与 inputs
     server_file = tmp_path / "server.json"
@@ -712,7 +718,10 @@ def test_run_with_cli_url_auth_headers(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.mark.asyncio
-async def test_server_add_and_status_without_auto_connect(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_server_add_and_status_without_auto_connect(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # #137 ②：REPL `server add` 现为 durable 落盘——隔离 cwd/XDG 到 tmp，防写真实仓库 .tfrobot/。
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "cfg"))
+    monkeypatch.chdir(tmp_path)
     # Minimal stdio server config (disabled=true to avoid start operations later)
     stdio_cfg = {
         "name": "test-stdio",

--- a/tests/unit_tests/computer/cli/test_mcp_approval.py
+++ b/tests/unit_tests/computer/cli/test_mcp_approval.py
@@ -78,9 +78,10 @@ class _FakeComp:
     def add_or_update_input(self, inp: Any) -> None:
         self.injected.append(inp)
 
-    async def aadd_or_aupdate_server(
+    async def amount_server(
         self, cfg: dict[str, Any], *, session: Any = None, plugin: Any = None, marketplace: Any = None,
     ) -> None:
+        # #137 ③：run_mcp_approval 走 transient amount_server（boot 读已声明 mcp.json = 投影，不回写）。
         self.mounted.append(cfg)
 
 
@@ -156,10 +157,11 @@ async def test_pending_non_tty_approve_all_mounts_without_persist(tmp_path: Path
 
 # ── ENABLED（user origin trusted）直挂 ─────────────────────────────────────────
 @pytest.mark.asyncio
-async def test_user_origin_mounts_without_box(tmp_path: Path) -> None:
+async def test_user_origin_mounts_without_box(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     wd, home, env = tmp_path / "proj", tmp_path / "home", _env(tmp_path)
     wd.mkdir()
     home.mkdir()
+    monkeypatch.chdir(wd)  # #116：project/local 锚 cwd——chdir 到空 wd，隔离真实仓库 .tfrobot/（与 PENDING 用例一致）
     _user_mcp(env, {"mine": _stdio()})  # user origin → trusted_origin → ENABLED、免批准
     comp = _FakeComp(home)
     sess = _Session([])  # 不应被调用
@@ -173,10 +175,11 @@ async def test_user_origin_mounts_without_box(tmp_path: Path) -> None:
 
 # ── ext（envFile）合回挂载 dict（#69 Group B 风险 2）─────────────────────────────
 @pytest.mark.asyncio
-async def test_envfile_ext_merged_into_mount_dict(tmp_path: Path) -> None:
+async def test_envfile_ext_merged_into_mount_dict(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     wd, home, env = tmp_path / "proj", tmp_path / "home", _env(tmp_path)
     wd.mkdir()
     home.mkdir()
+    monkeypatch.chdir(wd)  # #116：project/local 锚 cwd——chdir 到空 wd，隔离真实仓库 .tfrobot/（与 PENDING 用例一致）
     envfile = str(wd / ".env")
     _user_mcp(env, {"mine": {**_stdio(), "envFile": envfile}})  # user origin → 直挂
     comp = _FakeComp(home)

--- a/tests/unit_tests/computer/cli/test_plugin.py
+++ b/tests/unit_tests/computer/cli/test_plugin.py
@@ -316,10 +316,12 @@ class _ReplComp:
     def add_or_update_input(self, inp: Any) -> None:
         self.injected.append(inp)
 
-    async def aadd_or_aupdate_server(self, cfg: Any, *, session: Any = None, plugin: Any = None, marketplace: Any = None) -> None:
+    async def amount_server(self, cfg: Any, *, session: Any = None, plugin: Any = None, marketplace: Any = None) -> None:
+        # #137 ③：plugin enable/install remount 经 build_mcp_callbacks → transient amount_server（治理投影）。
         self._servers.append(cfg)
 
-    async def aremove_server(self, name: str) -> None:
+    async def aunmount_server(self, name: str) -> None:
+        # #137 ③：plugin disable/uninstall teardown 经 build_mcp_callbacks → transient aunmount_server（停不删）。
         self._servers = [s for s in self._servers if getattr(s, "name", None) != name]
 
 
@@ -393,7 +395,7 @@ def _isolate_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
 
 @pytest.mark.asyncio
 async def test_run_governance_remount_wires_ownership_context(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """CLI 接线断言：register 经 comp.aadd_or_aupdate_server 携正确 plugin/marketplace 归属上下文。"""
+    """CLI 接线断言：register 经 transient comp.amount_server 携正确 plugin/marketplace 归属上下文（#137 ③）。"""
     from a2c_smcp.computer.computer import Computer
 
     _isolate_env(tmp_path, monkeypatch)
@@ -406,7 +408,7 @@ async def test_run_governance_remount_wires_ownership_context(tmp_path: Path, mo
         async def fake_register(server: Any, *, session: Any = None, plugin: str | None = None, marketplace: str | None = None) -> None:
             recorded.append((server.name, plugin, marketplace))
 
-        monkeypatch.setattr(comp, "aadd_or_aupdate_server", fake_register)
+        monkeypatch.setattr(comp, "amount_server", fake_register)  # #137 ③：治理重挂经 transient amount_server
         await plugin_cmd.run_governance_remount(comp)
 
         assert recorded == [("figma-mcp", "audit", "acme")]
@@ -429,7 +431,7 @@ async def test_run_governance_remount_flag_declared_disables(tmp_path: Path, mon
         async def fake_register(server: Any, *, session: Any = None, plugin: str | None = None, marketplace: str | None = None) -> None:
             recorded.append(server.name)
 
-        monkeypatch.setattr(comp, "aadd_or_aupdate_server", fake_register)
+        monkeypatch.setattr(comp, "amount_server", fake_register)  # #137 ③：治理重挂经 transient amount_server
         await plugin_cmd.run_governance_remount(comp, flag_config=flag_file)
 
         assert recorded == []
@@ -457,7 +459,7 @@ async def test_run_governance_remount_existing_from_comp_servers(tmp_path: Path,
         async def fake_register(server: Any, *, session: Any = None, plugin: str | None = None, marketplace: str | None = None) -> None:
             recorded.append(server.name)
 
-        monkeypatch.setattr(comp, "aadd_or_aupdate_server", fake_register)
+        monkeypatch.setattr(comp, "amount_server", fake_register)  # #137 ③：治理重挂经 transient amount_server
         await plugin_cmd.run_governance_remount(comp)
 
         assert recorded == []

--- a/tests/unit_tests/computer/test_computer.py
+++ b/tests/unit_tests/computer/test_computer.py
@@ -500,8 +500,11 @@ class DummyResolver(InputResolver):
         return self.mapping[input_id]
 
 
+# NOTE(#137 ②/③): 以下三例原测 ``aadd_or_aupdate_server`` 的「render + validate + manager 委派」——该语义已 flip
+# 为 durable（落盘）后**原状迁至 transient** ``amount_server``。此处改测 ``amount_server`` 以在**不触碰磁盘**下保持
+# 对渲染/校验/委派的等价覆盖；durable 落盘专属行为另见 ``test_computer_dual_path_crud.py``。
 @pytest.mark.asyncio
-async def test_aadd_or_aupdate_server_with_raw_dict_uses_inputs_and_validates(monkeypatch):
+async def test_amount_server_with_raw_dict_uses_inputs_and_validates(monkeypatch):
     # Arrange manager mock
     mock_manager = MagicMock(spec=MCPServerManager)
     mock_manager.aadd_or_aupdate_server = AsyncMock()
@@ -529,7 +532,7 @@ async def test_aadd_or_aupdate_server_with_raw_dict_uses_inputs_and_validates(mo
     }
 
     # Act
-    await computer.aadd_or_aupdate_server(cfg_dict)
+    await computer.amount_server(cfg_dict)
 
     # Assert: forwarded to manager with validated model instance and placeholders resolved
     mock_manager.aadd_or_aupdate_server.assert_called_once()
@@ -542,7 +545,7 @@ async def test_aadd_or_aupdate_server_with_raw_dict_uses_inputs_and_validates(mo
 
 
 @pytest.mark.asyncio
-async def test_aadd_or_aupdate_server_with_model_instance(monkeypatch):
+async def test_amount_server_with_model_instance(monkeypatch):
     # Arrange manager mock
     mock_manager = MagicMock(spec=MCPServerManager)
     mock_manager.aadd_or_aupdate_server = AsyncMock()
@@ -559,7 +562,7 @@ async def test_aadd_or_aupdate_server_with_model_instance(monkeypatch):
     )
 
     # Act
-    await computer.aadd_or_aupdate_server(cfg)
+    await computer.amount_server(cfg)
 
     # Assert: same model (after dump/render/validate) is sent
     mock_manager.aadd_or_aupdate_server.assert_called_once()
@@ -571,7 +574,7 @@ async def test_aadd_or_aupdate_server_with_model_instance(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_aadd_or_aupdate_server_missing_input_keeps_placeholder(monkeypatch):
+async def test_amount_server_missing_input_keeps_placeholder(monkeypatch):
     # Arrange manager mock (should be called with placeholder preserved)
     mock_manager = MagicMock(spec=MCPServerManager)
     mock_manager.aadd_or_aupdate_server = AsyncMock()
@@ -599,7 +602,7 @@ async def test_aadd_or_aupdate_server_missing_input_keeps_placeholder(monkeypatc
     }
 
     # Act: should not raise; placeholder remains
-    await computer.aadd_or_aupdate_server(cfg_dict)
+    await computer.amount_server(cfg_dict)
     mock_manager.aadd_or_aupdate_server.assert_called_once()
     (validated_cfg,), _ = mock_manager.aadd_or_aupdate_server.call_args
     # Assert placeholder preserved after rendering+validation
@@ -607,13 +610,19 @@ async def test_aadd_or_aupdate_server_missing_input_keeps_placeholder(monkeypatc
 
 
 @pytest.mark.asyncio
-async def test_aremove_server_delegates(monkeypatch):
+async def test_aunmount_server_by_id_delegates(monkeypatch):
+    # #137 ②：旧 ``aremove_server`` 的纯运行期停摘语义现为 transient ``aunmount_server_by_id``。
+    cfg = StdioServerConfig(
+        name="echo",
+        server_parameters=StdioServerParameters(command="/bin/echo", args=[], env=None, cwd=None),
+    )
     mock_manager = MagicMock(spec=MCPServerManager)
     mock_manager.aremove_server = AsyncMock()
+    mock_manager.server_configs = MagicMock(return_value=(cfg,))  # bundle_id("echo") == "echo"
     computer = Computer(name="test")
     computer.mcp_manager = mock_manager
 
-    await computer.aremove_server("echo")
+    await computer.aunmount_server_by_id("echo")
 
     mock_manager.aremove_server.assert_called_once_with("echo")
 

--- a/tests/unit_tests/computer/test_computer_dual_path_crud.py
+++ b/tests/unit_tests/computer/test_computer_dual_path_crud.py
@@ -1,0 +1,282 @@
+# -*- coding: utf-8 -*-
+# filename: test_computer_dual_path_crud.py
+# @Time    : 2026/07/14
+# @Author  : JQQ
+# @Email   : jqq1716@gmail.com
+# @Software: PyCharm
+"""
+#137 ② Computer 双路径 MCP-server CRUD 单元测试（父 #135：对齐 rust-sdk 双路径）。
+
+覆盖 flip 后的 **durable**（落盘 + 重启存活）与新增 **transient**（纯运行期、不落盘）两路径的语义边界：
+
+- ``aadd_or_aupdate_server``：默认落 **Local**（``mcp.local.json``）、重投影可读、重启存活、**raw 未渲染**（D1）。
+- ``aadd_or_aupdate_server_in_scope(Project)``：落 git 共享层（``mcp.json``）。
+- ``amount_server``：**不落盘**（纯运行期投影）。
+- ``aremove_server``：删**所有可写 scope** 声明 + 运行期停摘；**bundled 身份拒删**；**改已有恒落 origin**。
+
+隔离：``monkeypatch.chdir(tmp)`` 锚 project/local（#116）、``XDG_CONFIG_HOME`` → tmp 锚 user；``auto_connect=False``
+免拉起真实进程（``_amount_rendered`` 仅入册配置、不 spawn）。
+
+Dual-path MCP-server CRUD unit tests for #137 ② (aligns rust-sdk dual-path). All disk paths isolated to tmp via
+chdir + XDG; ``auto_connect=False`` avoids spawning real processes.
+"""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from a2c_smcp.computer.computer import Computer
+from a2c_smcp.computer.inputs.resolver import InputResolver
+from a2c_smcp.computer.settings.mcp_config import (
+    McpWriteScope,
+    McpWriteTargetError,
+    mcp_write_path,
+    resolve_mcp_config,
+)
+
+
+class _MapResolver(InputResolver):
+    """按 id 查表的最小 InputResolver stub（``${input:id}`` → 映射值）/ minimal id→value resolver stub。"""
+
+    def __init__(self, mapping: dict[str, Any]) -> None:
+        self.mapping = mapping
+
+    def clear_cache(self, key: str | None = None) -> None:  # pragma: no cover - 本测试不触发
+        pass
+
+    async def aresolve_by_id(
+        self, input_id: str, *, session: Any = None, plugin: str | None = None, marketplace: str | None = None,
+    ) -> Any:
+        return self.mapping[input_id]
+
+
+def _isolate(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """隔离落盘面：project/local 锚 cwd（#116），user 锚 XDG → tmp（不碰真实用户配置）。"""
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "cfg"))
+    monkeypatch.chdir(tmp_path)
+
+
+def _stdio_dict(name: str, command: str) -> dict[str, Any]:
+    return {
+        "type": "stdio",
+        "name": name,
+        "disabled": True,  # disabled 免 boot/auto_connect 拉起进程（本测试只验证配置态 + 落盘）
+        "server_parameters": {
+            "command": command,
+            "args": [],
+            "env": None,
+            "cwd": None,
+            "encoding": "utf-8",
+            "encoding_error_handler": "strict",
+        },
+        "forbidden_tools": [],
+        "tool_meta": {},
+    }
+
+
+def _write_mcp_file(path: Path, servers: dict[str, Any]) -> None:
+    """直写一个 scope 的 ``mcp.json``（绕开 upsert 的 existing→origin 重定向，用于多 scope 播种）。"""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"servers": servers, "inputs": []}), encoding="utf-8")
+
+
+def _read_servers(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    return json.loads(path.read_text(encoding="utf-8")).get("servers", {})
+
+
+def _comp(tmp_path: Path, resolver: InputResolver | None = None) -> Computer:
+    return Computer(
+        name="dual-path-test",
+        auto_connect=False,
+        auto_reconnect=False,
+        skill_home=tmp_path / "home",
+        input_resolver=resolver,
+    )
+
+
+# ── durable: aadd_or_aupdate_server 默认落 Local + 重投影 + 重启存活 + D1 raw ─────────────────────────
+@pytest.mark.asyncio
+async def test_aadd_or_aupdate_server_persists_local_reprojects_and_survives_restart(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _isolate(tmp_path, monkeypatch)
+    comp = _comp(tmp_path, resolver=_MapResolver({"cmd": "/bin/echo"}))
+
+    # command 带占位符 ${input:cmd}：证明 D1（盘上 raw 未渲染、内存投影已渲染）。
+    await comp.aadd_or_aupdate_server(_stdio_dict("echo", "${input:cmd}"))
+
+    # 1) 落 **Local**（mcp.local.json），非 project 层。
+    local_path = mcp_write_path(McpWriteScope.LOCAL, env=os.environ)
+    project_path = mcp_write_path(McpWriteScope.PROJECT, env=os.environ)
+    assert "echo" in _read_servers(local_path)
+    assert "echo" not in _read_servers(project_path), "默认 durable 落 Local，不碰 git 共享 project 层"
+
+    # 2) D1：盘上 raw **未渲染**（占位字面保留，绝不写渲染后 secret）。
+    disk = resolve_mcp_config(env=os.environ).servers["echo"]
+    assert disk.config.server_parameters.command == "${input:cmd}", "盘上必须是未渲染 raw（D1）"
+    assert disk.origin.value == "local"
+
+    # 3) 重投影：manager 运行期活跃集含该 server，且为**已渲染**结果。
+    assert comp.mcp_manager is not None
+    runtime = {c.name: c for c in comp.mcp_manager.server_configs()}
+    assert "echo" in runtime
+    assert runtime["echo"].server_parameters.command == "/bin/echo", "内存投影用渲染后结果"
+
+    # 4) 重启存活：新 Computer（同 cwd/XDG）经 resolve_mcp_config 仍读得该声明。
+    assert "echo" in resolve_mcp_config(env=os.environ).servers
+
+
+# ── durable: _in_scope(Project) 落 git 共享层 ───────────────────────────────────────────────────────
+@pytest.mark.asyncio
+async def test_aadd_or_aupdate_server_in_scope_project_persists_git_layer(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _isolate(tmp_path, monkeypatch)
+    comp = _comp(tmp_path)
+
+    await comp.aadd_or_aupdate_server_in_scope(_stdio_dict("shared", "/bin/true"), McpWriteScope.PROJECT)
+
+    project_path = mcp_write_path(McpWriteScope.PROJECT, env=os.environ)
+    local_path = mcp_write_path(McpWriteScope.LOCAL, env=os.environ)
+    assert "shared" in _read_servers(project_path), "显式 Project → 落 git 共享 mcp.json"
+    assert "shared" not in _read_servers(local_path)
+    assert resolve_mcp_config(env=os.environ).servers["shared"].origin.value == "project"
+
+
+# ── transient: amount_server 不落盘 ─────────────────────────────────────────────────────────────────
+@pytest.mark.asyncio
+async def test_amount_server_does_not_persist(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _isolate(tmp_path, monkeypatch)
+    comp = _comp(tmp_path, resolver=_MapResolver({"cmd": "/bin/echo"}))
+
+    await comp.amount_server(_stdio_dict("ephemeral", "${input:cmd}"))
+
+    # 无任一 scope 落盘（纯运行期投影）。
+    for scope in (McpWriteScope.LOCAL, McpWriteScope.PROJECT, McpWriteScope.USER):
+        assert not mcp_write_path(scope, env=os.environ).exists(), f"transient 不应写 {scope} mcp.json"
+    assert resolve_mcp_config(env=os.environ).servers == {}
+
+    # 但运行期活跃集里在（capability 面已投影）。
+    assert comp.mcp_manager is not None
+    assert any(c.name == "ephemeral" for c in comp.mcp_manager.server_configs())
+
+
+# ── durable: aremove_server 删所有可写 scope + 运行期停摘 ────────────────────────────────────────────
+@pytest.mark.asyncio
+async def test_aremove_server_deletes_all_writable_scopes(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _isolate(tmp_path, monkeypatch)
+    # 三个可写 scope 各播种同名 "multi" 声明（直写，绕 upsert 的 origin 重定向）。
+    for scope in (McpWriteScope.USER, McpWriteScope.PROJECT, McpWriteScope.LOCAL):
+        _write_mcp_file(mcp_write_path(scope, env=os.environ), {"multi": _stdio_dict("multi", "/bin/x")})
+    assert set(resolve_mcp_config(env=os.environ).servers) == {"multi"}
+
+    comp = _comp(tmp_path)
+    # bundle_id("multi") == normalize("multi") == "multi"
+    await comp.aremove_server("multi")
+
+    for scope in (McpWriteScope.USER, McpWriteScope.PROJECT, McpWriteScope.LOCAL):
+        assert "multi" not in _read_servers(mcp_write_path(scope, env=os.environ)), f"{scope} 声明必须删净"
+    assert resolve_mcp_config(env=os.environ).servers == {}
+
+
+@pytest.mark.asyncio
+async def test_aremove_server_absent_is_noop(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _isolate(tmp_path, monkeypatch)
+    comp = _comp(tmp_path)
+    # 无声明、无运行期投影 → 落盘 no-op、停摘 no-op，不抛。
+    await comp.aremove_server("ghost")
+    for scope in (McpWriteScope.LOCAL, McpWriteScope.PROJECT, McpWriteScope.USER):
+        assert not mcp_write_path(scope, env=os.environ).exists()
+
+
+# ── durable: aremove_server bundled 身份拒删 ────────────────────────────────────────────────────────
+@pytest.mark.asyncio
+async def test_aremove_server_rejects_bundled(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _isolate(tmp_path, monkeypatch)
+    # 令 "figma" 命中 ledger 派生 bundled 集（隔离 Computer 的拒删分支，不需真装 plugin）。
+    monkeypatch.setattr("a2c_smcp.computer.computer.bundled_mcp_server_names", lambda **_: {"figma"})
+
+    comp = _comp(tmp_path)
+    # 运行期投影一条 bundled server（transient；bundle_id("figma") == "figma"）。
+    await comp.amount_server(_stdio_dict("figma", "/bin/figma"))
+
+    with pytest.raises(McpWriteTargetError):
+        await comp.aremove_server("figma")
+
+    # 拒删后运行期投影仍在（未被误停摘）。
+    assert comp.mcp_manager is not None
+    assert any(c.name == "figma" for c in comp.mcp_manager.server_configs())
+
+
+# ── durable: 改已有 server 恒落其 origin scope（新 scope 只作用于新声明）─────────────────────────────
+@pytest.mark.asyncio
+async def test_aadd_or_aupdate_server_existing_lands_origin_scope(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _isolate(tmp_path, monkeypatch)
+    comp = _comp(tmp_path)
+
+    # 先在 Project 声明；再以**默认 Local** 更新同名 → 必须落回 Project（origin），不漂移到 Local。
+    await comp.aadd_or_aupdate_server_in_scope(_stdio_dict("origin-svc", "/bin/v1"), McpWriteScope.PROJECT)
+    await comp.aadd_or_aupdate_server(_stdio_dict("origin-svc", "/bin/v2"))  # 默认 Local
+
+    project_servers = _read_servers(mcp_write_path(McpWriteScope.PROJECT, env=os.environ))
+    local_servers = _read_servers(mcp_write_path(McpWriteScope.LOCAL, env=os.environ))
+    assert "origin-svc" in project_servers, "改已有恒落 origin（Project），不漂移"
+    assert "origin-svc" not in local_servers, "默认 Local 入参对已有声明无效"
+    assert project_servers["origin-svc"]["server_parameters"]["command"] == "/bin/v2", "内容已更新（整体替换）"
+
+
+# ── transient: aunmount_server(name) 只摘目标 + 守护 no-op ───────────────────────────────────────────
+@pytest.mark.asyncio
+async def test_aunmount_server_by_name_unmounts_only_target(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _isolate(tmp_path, monkeypatch)
+    comp = _comp(tmp_path)
+    await comp.amount_server(_stdio_dict("keep", "/bin/keep"))
+    await comp.amount_server(_stdio_dict("drop", "/bin/drop"))
+    assert comp.mcp_manager is not None
+    assert {c.name for c in comp.mcp_manager.server_configs()} == {"keep", "drop"}
+
+    await comp.aunmount_server("drop")
+    assert {c.name for c in comp.mcp_manager.server_configs()} == {"keep"}, "按 name 只摘目标，不误伤同侪"
+    # 纯运行期：不落任一 scope。
+    for scope in (McpWriteScope.LOCAL, McpWriteScope.PROJECT, McpWriteScope.USER):
+        assert not mcp_write_path(scope, env=os.environ).exists()
+    # 不存在的 name → no-op（不抛、不误摘）。
+    await comp.aunmount_server("ghost")
+    assert {c.name for c in comp.mcp_manager.server_configs()} == {"keep"}
+
+
+@pytest.mark.asyncio
+async def test_aunmount_server_manager_none_is_noop(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _isolate(tmp_path, monkeypatch)
+    comp = _comp(tmp_path)
+    # manager 未建（无任何挂载）→ no-op，不抛、不建 manager。
+    await comp.aunmount_server("anything")
+    await comp.aunmount_server_by_id("anything")
+    assert comp.mcp_manager is None
+
+
+# ── durable: aremove_server 无盘上声明但仍停摘运行期投影 ─────────────────────────────────────────────
+@pytest.mark.asyncio
+async def test_aremove_server_unmounts_runtime_projection_without_disk_declaration(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _isolate(tmp_path, monkeypatch)
+    comp = _comp(tmp_path)
+    # transient 投影一条（不落盘、无声明）；bundle_id("proj-only") == "proj-only"（连字符合法、不折叠）。
+    await comp.amount_server(_stdio_dict("proj-only", "/bin/x"))
+    assert comp.mcp_manager is not None
+    assert any(c.name == "proj-only" for c in comp.mcp_manager.server_configs())
+
+    # durable remove：盘上无匹配声明 → 落盘 no-op，但仍停摘运行期投影（文档承诺的关键分支）。
+    await comp.aremove_server("proj-only")
+    assert not any(c.name == "proj-only" for c in comp.mcp_manager.server_configs()), "无盘声明也须清运行期投影"
+    for scope in (McpWriteScope.LOCAL, McpWriteScope.PROJECT, McpWriteScope.USER):
+        assert not mcp_write_path(scope, env=os.environ).exists(), "无声明匹配 → 不产生任何落盘写"

--- a/tests/unit_tests/computer/test_computer_inventory.py
+++ b/tests/unit_tests/computer/test_computer_inventory.py
@@ -219,7 +219,8 @@ async def test_inventory_marks_remounted_bundled_server_as_plugin(tmp_path: Path
     async with Computer(name="t", auto_connect=False, skill_home=home) as comp:
 
         async def register(cfg, record) -> None:
-            await comp.aadd_or_aupdate_server(cfg, plugin=record.plugin, marketplace=record.marketplace)
+            # #137 ③：治理重挂 = 投影，经 transient amount_server（bundled 名走 durable 会触 McpWriteTargetError）。
+            await comp.amount_server(cfg, plugin=record.plugin, marketplace=record.marketplace)
 
         report = await comp.reconcile_governance(
             existing_server_names=lambda: {c.name for c in comp.mcp_servers},


### PR DESCRIPTION
> 子任务 ②+③ of #135（对齐 rust-sdk 双路径）。**依赖已合入的 ①（#136，持久写层）。** 含破坏性变更。合并一个 PR（#137 ② + #138 ③）避免中间态破坏 e2e。

## 背景
父 #135 parity epic：Computer 运行期 MCP-server CRUD 对齐 rust-sdk 双路径（declare-durable + transient-mount）。协议归属由 a2c-smcp-protocol#19 裁定 **out-of-scope**（本地约定，无协议门控）。对齐 rust-sdk `crates/smcp-computer/src/computer.rs @0960a61`（方法名+SHA 锚定，非行号）。

**破坏性变更**：`aadd_or_aupdate_server` / `aremove_server` 语义由纯运行期变为持久（落盘 + 重启存活 / 删声明）。

## ② 双路径 CRUD（`computer.py`）
| 路径 | 方法 | rust 对应 |
|---|---|---|
| **transient**（不落盘、只 bump capability） | `amount_server`（即历史 `aadd_or_aupdate_server` 原状语义抽出重命名）/ `aunmount_server(name)` / `aunmount_server_by_id(bundle_id)` + `_amount_rendered` 共享核 | `mount_server` / `unmount_server` / `unmount_server_by_id` / `mount_rendered` |
| **durable**（落盘 raw + 重启存活） | `aadd_or_aupdate_server`(flip→默认 Local) / `aadd_or_aupdate_server_in_scope(scope)`(新增) / `aremove_server`(flip→bundle_id→删所有可写 scope + 停摘，bundled 拒删) | `add_or_update_server` / `add_or_update_server_in_scope` / `remove_server` |

- **D1 铁律**：`_raw_body_for_disk` 落**未渲染 raw**（保留 `${input:}`/`${env:}` 占位，绝不写渲染后 secret）。
- **改已有 server 恒落其 origin scope**（由 ① `upsert_mcp_server` 保证）；`aremove_server` 经 `resolve_mcp_config` 快照按 `resolve_bundle_id` 匹配声明名删所有可写 scope；bundled 身份拒删（reuse `McpWriteTargetError`）；无匹配落盘 no-op、仍停摘运行期投影。

## ③ 内部调用方迁移（`plugin.py` / `commands/__init__.py` / `main.py`）
分流规则（rust 同构）：**「用户此刻声明」→ durable；「投影别处真相」→ transient**。
- **transient 化**：`build_mcp_callbacks._register/_remove`（治理级联唯一 seam）、`_plugin_register_cb`、`run_governance_remount`、`run_mcp_approval`（boot 读已声明 mcp.json）、`main.py --config @file`。
- **保持 durable**：REPL `interactive_impl.py` `server add`/`rm`（用户显式声明）。

## §12 R2 revision 分账
- **capability** bump：manager 物化经 `_on_manager_change` → `emit_update_tool_list` **自动**（两路径皆有）。
- **config** bump（`emit_update_config`）：**保持 CLI 驱动**——现状 REPL durable 路径 emit、boot/plugin transient 路径不 emit，恰好满足分账，SDK 层不在 CRUD 方法内 emit（保 client owns Socket.IO 上报 #93 分层）。
- **护栏**：未把 rust #124 治理事件 `emit_governance_config_change` 抄进 MCP-CRUD 路径（§12 R2 正交轴）。

## 测试
- 新增 `test_computer_dual_path_crud.py`（10 例）：Local 默认 / 显式 Project / 不落盘 / 删全 scope / absent no-op / bundled 拒删 / 改已有落 origin / `aunmount_server` 按 name / 无盘声明仍停摘 / manager-None no-op。
- **flip 落盘隔离**：投影语义测试改 `amount_server`；REPL-command 测试加 `chdir+XDG`；e2e conftest 对 `.tfrobot/{mcp.local,mcp}.json` **字节级快照+精确还原**（防污染仓库 + 防跨 spawn 残留触发 boot 审批 PENDING 挂起，#110 同类）；`.gitignore` 加 `.tfrobot/`。

## 门禁
- ✅ `mypy` 103 src + `ruff` clean
- ✅ unit+integration **1914 passed**
- ✅ e2e server-add 系列 pass，零 `.tfrobot` 污染
- ✅ 隔离 code-reviewer 零 🔴（5 项 🟡 已处理）

## 验收（#137/#138）
- [x] `aadd_or_aupdate_server` 落 Local、重投影可读、重启存活；`_in_scope(Project)` 落 git 层；`amount_server` 不落盘
- [x] `aremove_server` 删所有可写 scope、bundled 拒删；改已有落 origin
- [x] 内部投影调用方不再回写 mcp.json（无双源 / scope 漂移）
- [x] `uv run poe lint` + 单元/集成/e2e 全绿

后续：④ #139 `python_rust_alignment` 字节级对拍 + remove 复活 footgun 回归（依赖 ②/③）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)