### PR TITLE
fix(#148): 删审批门档④借名绕过 P0 + F3 三消费者改 origin 判据 + bundled_mcp_server_names() 删除

### DIFF
--- a/a2c_smcp/computer/cli/commands/plugin.py
+++ b/a2c_smcp/computer/cli/commands/plugin.py
@@ -61,7 +61,6 @@ from a2c_smcp.computer.settings.mcp_config import (
     McpApprovalStatus,
     approve_all_project_mcp,
     approve_mcp_server,
-    bundled_mcp_server_names,
     deny_mcp_server,
     gate_mcp_servers,
     resolve_mcp_config,
@@ -528,7 +527,7 @@ async def run_mcp_approval(
 ) -> None:
     """启动期解析 ``.tfrobot/mcp.json`` 定义层 + 批准门控 + 挂载 ENABLED server（§9.2）/ Boot-time MCP approval + mount。
 
-    - bundled / user-flag-policy origin server → 门控判 ENABLED → 直挂（免批准框）；
+    - user/flag/policy origin server（trusted）→ 门控判 ENABLED → 直挂（免批准框）；
     - DISABLED（企业拒绝/不在白名单/显式 disabled）→ 跳过；
     - PENDING（工作区共享未决）→ TTY 弹 y/a/n 写 local scope；非 TTY → skip+WARN，``approve_all`` 全批（仅本次不落盘）。
 
@@ -552,8 +551,9 @@ async def run_mcp_approval(
         return
 
     settings = resolved_settings(env, flag_path=flag_config)
-    bundled = bundled_mcp_server_names(comp.skill_home, env)
-    statuses = gate_mcp_servers(resolved, settings, bundled)
+    # #148/F8：审批门 MUST NOT 依赖账本 bundled 名集；plugin 声明本就不入 resolve_mcp_config（走 transient
+    # amount_server 挂载、不落 mcp.json），迭代永不遇 plugin origin，无需显式过滤（详见 mcp_server_status）。
+    statuses = gate_mcp_servers(resolved, settings)
 
     # mcp.json 定义的 input 入池（无前缀），供 server config 的裸 ${input:} 解析（#69 Group B 风险 3）。
     for inp in resolved.inputs:

--- a/a2c_smcp/computer/computer.py
+++ b/a2c_smcp/computer/computer.py
@@ -69,7 +69,6 @@ from a2c_smcp.computer.settings.installer import migrate_legacy_installs
 from a2c_smcp.computer.settings.mcp_config import (
     McpWriteScope,
     McpWriteTargetError,
-    bundled_mcp_server_names,
     remove_mcp_server,
     resolve_mcp_config,
     upsert_mcp_server,
@@ -930,14 +929,13 @@ class Computer(BaseComputer[PromptSession]):
         次 render 结果 :meth:`_amount_rendered` 物化（不二次渲染）。落盘属 config 轴、物化属 capability 轴（分账见类内
         双路径块注释）。
 
-        :raises McpWriteTargetError: ``name`` 为 plugin-bundled server 名（其真相在 ledger，不可经 mcp.json 写）。
         :raises McpConfigCorruptError: 目标 ``mcp.json`` 结构损坏（① 拒绝覆盖以免销毁既有内容）。
         """
         # 1. 先渲染校验（早失败：损坏配置在落盘前抛出，绝不留下盘上声明而运行期未挂的半态）。
         validated = await self._arender_and_validate_server(server, session=session, plugin=plugin, marketplace=marketplace)
         # 2. 取未渲染 raw 落盘（D1：占位字面保留、绝不写 secret）。
         name, raw_body = self._raw_body_for_disk(server)
-        upsert_mcp_server(name, raw_body, scope=scope, env=os.environ, home=self.skill_home)
+        upsert_mcp_server(name, raw_body, scope=scope, env=os.environ)
         # 3. 复用 render 结果物化（capability 自动上报；config 上报由调用方驱动，见分账注释）。
         await self._amount_rendered(validated)
 
@@ -945,36 +943,51 @@ class Computer(BaseComputer[PromptSession]):
         """**持久删除**一个 MCP server 声明（bundle_id → 声明名 → 删所有可写 scope）+ 运行期停摘 / Durably remove。
 
         对齐 rust ``remove_server``（:2038）。**破坏性变更**（#135/#137）：历史仅运行期停摘（→ 复活 footgun：人写在
-        ``mcp.json`` 的 server 重启复活），现 flip 为持久删除。流程：
+        ``mcp.json`` 的 server 重启复活），现 flip 为持久删除。
 
-        1. **bundled 身份拒删**：目标 bundle_id 命中**运行期已挂载**的 bundled server（其真相在 ledger）→ 抛
-           :class:`McpWriteTargetError`（应经 ``plugin uninstall`` 而非 ``server rm``）。**边界**：拒删按运行期挂载态
-           判定；未挂载的 bundled 名不在任何 ``mcp.json``（bundled 从不入声明面）→ 本方法对其为无害 no-op（无声明可删、
-           无投影可停），无需拒绝——真正的 bundled 治理入口是 ``plugin`` 命令，不经此 MCP-CRUD 面。
-        2. 以本实例上下文 :func:`resolve_mcp_config` 取**快照** → 对每条声明算 :func:`resolve_bundle_id` 匹配
-           ``bundle_id`` → 收集声明名（去重）→ 经 ① :func:`remove_mcp_server` 删**所有可写 scope**。
-        3. :meth:`aunmount_server_by_id` 运行期停摘。**无声明匹配** → 落盘 no-op、**仍停摘**（运行期投影清理）。
+        **守卫按 origin 判定，不按账本名集**（#148 / 指南 §5，取代历史 name-keyed bundled 拒删——那会误伤与某已装
+        plugin bundled server 同名的用户 server）：
+
+        1. **声明优先**：经 :func:`resolve_mcp_config` 取**快照**，收集 ``bundle_id`` 匹配的**用户侧声明名**
+           （:func:`resolve_bundle_id` 逐条比对）。
+        2. **有用户侧声明 ⇒ 放行**：经 ① :func:`remove_mcp_server` 删**所有可写 scope** + :meth:`aunmount_server_by_id`
+           停摘。删的是用户自己那条声明——即便它与某 plugin bundled server 同 bundle_id，用户覆盖权优先（runtime-contract
+           §2.5「用户主权」），plugin 基线保留。
+        3. **无用户侧声明 ∧ 运行期仍有该 bundle_id 活跃投影 ⇒ 拒删**（抛 :class:`McpWriteTargetError`）：它是**纯运行期
+           投影**——「挂载却不落声明」的生产路径有 plugin/治理重挂（#137③）与 ``--config @file`` 预加载（``cli/main.py``），
+           均经 transient :meth:`amount_server` 挂载、不入 :func:`resolve_mcp_config`（层仅 FLAG/USER/PROJECT/LOCAL/POLICY，
+           **无 plugin origin**——boot 挂 mcp.json 声明的投影有盘上声明、落档 2）。durable rm 只操作声明面，对无声明的投影
+           拒删——若属 plugin 应经 ``plugin uninstall`` **整体**停用（单独打掉某 bundled server 产生 §2.4 禁止的半态），若
+           属纯 transient 应经 :meth:`aunmount_server_by_id` 停摘。**架构限制**：manager 不存 provenance，本 scope（#148 不依赖
+           #153/#154）下无法精确区分 ``origin == plugin``，故保守拒删——这即指南 §5「``origin == plugin`` ∧ 无用户侧声明」
+           在当前架构下的**可观测等价**（宁可拒删导向显式停用，也不越权停摘一个非用户声明的投影）。
+        4. **无用户侧声明 ∧ 未活跃 ⇒ no-op**（无声明可删、无投影可停；``aunmount_server_by_id`` 幂等 no-op）。
 
         Args:
             bundle_id (str): MCP Server 唯一身份 bundle_id（协议 #18）。REPL ``server rm <name>`` 在缺省身份下
                 （bundle_id = normalize(name)）以 name 寻址即可。
         """
         env = os.environ
-        # 1. bundled 身份拒删：运行期活跃集里该 bundle_id 的 name 命中 ledger 派生 bundled 集 → 拒。
-        bundled = bundled_mcp_server_names(home=self.skill_home, env=env)
-        if self.mcp_manager is not None and bundled:
-            for cfg in self.mcp_manager.server_configs():
-                if resolve_bundle_id(cfg) == bundle_id and cfg.name in bundled:
-                    raise McpWriteTargetError(
-                        f"bundle_id={bundle_id!r} (name={cfg.name!r}) is a plugin-bundled MCP server "
-                        "(its truth is the installed_plugins.json ledger); use 'plugin uninstall' instead of removing it via mcp.json",
-                    )
-        # 2. 快照解析声明名（未渲染 config，derive-on-raw 与注册边界同源）→ 删所有可写 scope。
+        # 1. 声明优先：快照解析用户侧声明名（未渲染 config，derive-on-raw 与注册边界同源）。
         snapshot = resolve_mcp_config(env=env)
         matched = {name for name, srv in snapshot.servers.items() if resolve_bundle_id(srv.config) == bundle_id}
-        for name in matched:
-            remove_mcp_server(name, env=env)
-        # 3. 运行期停摘（无声明匹配也停：清理纯运行期投影）。
+        if matched:
+            # 2. 有用户侧声明 ⇒ 放行：删所有可写 scope + 停摘（用户覆盖权，即便与某 bundled 同 bundle_id 亦可删）。
+            for name in matched:
+                remove_mcp_server(name, env=env)
+            await self.aunmount_server_by_id(bundle_id)
+            return
+        # 3. 无用户侧声明 ∧ 运行期仍活跃 ⇒ plugin/治理投影，拒删、导向 plugin uninstall（origin==plugin 的可观测等价）。
+        if self.mcp_manager is not None and any(
+            resolve_bundle_id(cfg) == bundle_id for cfg in self.mcp_manager.server_configs()
+        ):
+            raise McpWriteTargetError(
+                f"bundle_id={bundle_id!r} has no user-side mcp.json declaration but is active at runtime; "
+                "it is a runtime-only projection (a plugin/governance mount, or a '--config @file' preload), "
+                "not a durably-declared server—if it is plugin-provided use 'plugin uninstall' to disable the "
+                "whole plugin; otherwise unmount the transient projection directly instead of removing it via mcp.json",
+            )
+        # 4. 无声明且未活跃 ⇒ no-op（aunmount_server_by_id 幂等：manager None 或不含该 id 时安全 no-op）。
         await self.aunmount_server_by_id(bundle_id)
 
     def update_inputs(self, inputs: set[MCPServerInput], *, session: PromptSession | None = None) -> None:

--- a/a2c_smcp/computer/settings/mcp_config.py
+++ b/a2c_smcp/computer/settings/mcp_config.py
@@ -72,7 +72,7 @@ from a2c_smcp.computer.settings.scope import (
     workdir_local_settings_path,
     workdir_settings_dir,
 )
-from a2c_smcp.computer.settings.store import atomic_write_json, file_lock, load_installed_plugins
+from a2c_smcp.computer.settings.store import atomic_write_json, file_lock
 from a2c_smcp.utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -342,22 +342,28 @@ def _str_list(settings: Mapping[str, Any], key: str) -> list[str]:
     return [v for v in value if isinstance(v, str)] if isinstance(value, list) else []
 
 
-def mcp_server_status(name: str, *, settings: Mapping[str, Any], bundled: set[str], trusted_origin: bool) -> McpApprovalStatus:
+def mcp_server_status(name: str, *, settings: Mapping[str, Any], trusted_origin: bool) -> McpApprovalStatus:
     """
-    判定单个 MCP server 的批准状态（§9.2，**顺序即优先级**）/ Decide one server's approval status。
+    判定单个 MCP server 的批准状态（**顺序即优先级**）/ Decide one server's approval status。
 
     优先级（先到先决）/ Priority (first match wins):
     1. ``deniedMcpServers``（企业拒绝名单，policy）→ ``DISABLED``。
     2. ``allowedMcpServers`` 非空（企业白名单，policy）且不在其中 → ``DISABLED``。
     3. ``disabledMcpjsonServers`` → ``DISABLED``（**disabled 优先** over enabled）。
-    4. plugin-bundled（``bundled`` 并集，#63 显式 install = trusted）→ ``ENABLED``（免批准）。
-    5. ``trusted_origin``（user/flag/policy scope 自定义 server）→ ``ENABLED``（用户自己加的，不弹框）。
-    6. ``enabledMcpjsonServers`` → ``ENABLED``。
-    7. ``enableAllProjectMcpServers is True`` → ``ENABLED``。
-    8. 否则（工作区共享且未决）→ ``PENDING``。
+    4. ``trusted_origin``（user/flag/policy scope 自定义 server）→ ``ENABLED``（用户自己加的，不弹框）。
+    5. ``enabledMcpjsonServers`` → ``ENABLED``。
+    6. ``enableAllProjectMcpServers is True`` → ``ENABLED``。
+    7. 否则（工作区共享且未决）→ ``PENDING``。
+
+    **#148（P0 安全）**：历史「plugin-bundled 名集免批准」档位（`if name in bundled → ENABLED`）**已删除**。
+    真正的 plugin bundled server **从不进入** :func:`resolve_mcp_config`（走 transient ``amount_server`` 挂载、
+    不落 mcp.json），故该档**唯一可达路径** = project/local 声明的 server 借用了某已装 plugin 的 server 名 =
+    100% 借名跳过审批门。审批门 **MUST NOT 依赖物化账本的名集**，plugin 声明 **MUST NOT 进入迭代**（其可信性由
+    install ∧ enable 门保证，不走 settings 信任面）——见协议 ``runtime-contract.md §5 item 10`` 与
+    ``guides/mcp-approval-gate-alignment.md``。本函数只判 :func:`resolve_mcp_config` 产出的 mcp.json origin，
+    当前架构下这些 origin 恒非 plugin，无需在此额外过滤。
 
     :param settings: 六层合并后的 resolved settings（含 #56 落地的 MCP 门控字段）。
-    :param bundled: 已安装 plugin 携带的 bundled MCP server name 并集（见 :func:`bundled_mcp_server_names`）。
     :param trusted_origin: 该 server 是否来自预信任 scope（见 :attr:`ResolvedMcpServer.trusted_origin`）。
     """
     if name in _str_list(settings, FIELD_DENIED_MCP_SERVERS):
@@ -367,8 +373,6 @@ def mcp_server_status(name: str, *, settings: Mapping[str, Any], bundled: set[st
         return McpApprovalStatus.DISABLED
     if name in _str_list(settings, FIELD_DISABLED_MCPJSON_SERVERS):
         return McpApprovalStatus.DISABLED
-    if name in bundled:
-        return McpApprovalStatus.ENABLED
     if trusted_origin:
         return McpApprovalStatus.ENABLED
     if name in _str_list(settings, FIELD_ENABLED_MCPJSON_SERVERS):
@@ -381,27 +385,12 @@ def mcp_server_status(name: str, *, settings: Mapping[str, Any], bundled: set[st
 def gate_mcp_servers(
     resolved: ResolvedMcpConfig,
     settings: Mapping[str, Any],
-    bundled: set[str],
 ) -> dict[str, McpApprovalStatus]:
     """对全部已解析 server 套 :func:`mcp_server_status` / Apply the gate to all resolved servers。"""
     return {
-        name: mcp_server_status(name, settings=settings, bundled=bundled, trusted_origin=srv.trusted_origin)
+        name: mcp_server_status(name, settings=settings, trusted_origin=srv.trusted_origin)
         for name, srv in resolved.servers.items()
     }
-
-
-def bundled_mcp_server_names(home: Path | None = None, env: Mapping[str, str] | None = None) -> set[str]:
-    """
-    已安装 plugin 携带的 bundled MCP server name 并集（#64↔#63 账本接缝）/ Union of installed plugins' bundled servers。
-
-    读 ``installed_plugins.json``（#63 物化账本）全记录的 ``bundledMcpServers`` 字段——这些 server 因用户**显式
-    install plugin**而 trusted、门控免批准（§9.2 ``mcp_server_status`` 第 4 档）。
-    """
-    out: set[str] = set()
-    for records in load_installed_plugins(home=home, env=env)["plugins"].values():
-        for record in records:
-            out.update(record.get("bundledMcpServers", []) or [])
-    return out
 
 
 # ---------------------------------------------------------------------------
@@ -478,8 +467,10 @@ class McpWriteTargetError(RuntimeError):
     """
     写目标非法（对应 rust ``WriteTargetError::Synthesized``）/ Illegal write target。
 
-    目前唯一触发：``name`` 是 plugin ledger 派生的 **bundled** server 名——用户不应经 ``mcp.json`` 写/删
-    plugin 携带的 server（其真相在 ``installed_plugins.json`` 账本，见 :func:`bundled_mcp_server_names`）。
+    唯一触发点（#148 / 指南 §5）：:meth:`Computer.aremove_server` 试图 **durable 删除**一个「运行期活跃却
+    无任何用户侧 mcp.json 声明」的 server —— 它是 plugin / 治理**投影**（其真相在 ``installed_plugins.json``
+    账本，应经 ``plugin uninstall`` 整体停用，而非经 mcp.json CRUD 单独打掉，否则产生半态）。**写层不再**因
+    「同 bundle_id 已由 plugin 提供」拒写 upsert（用户覆盖权，见 :func:`upsert_mcp_server`）。
     """
 
 
@@ -554,7 +545,6 @@ def upsert_mcp_server(
     *,
     scope: McpWriteScope,
     env: Mapping[str, str] | None = None,
-    home: Path | None = None,
 ) -> McpUpsertResult:
     """
     持锁原子 upsert **单个** MCP server 定义到指定 / origin scope / Locked atomic upsert of one server def。
@@ -571,7 +561,9 @@ def upsert_mcp_server(
       写请求 scope——但该写会被 policy 定义在 :func:`resolve_mcp_config` 中**遮蔽**（``changed`` 为 ``True`` 而有效
       配置不变，属 rust parity 行为：policy 非可写目标、等同新声明）；``flag`` origin 优先级最低、user-写胜出、
       不被遮蔽。
-    - **bundled 名拒写**：``name`` 命中 plugin ledger 派生的 bundled 集 → 抛 :class:`McpWriteTargetError`。
+    - **不因「同 bundle_id 已由 plugin 提供」而拒写**（#148 / 指南 §5）：用户在 mcp.json 声明同 bundle_id 的 server
+      正是优先序赋予的**覆盖权**（用户侧 scope > plugin 声明基线），历史「bundled 名拒写」短路**已删除**。SDK MAY
+      在别处提示「该 bundle_id 已由 plugin 提供、你的声明将覆盖它」，但**写层不阻止**。
     - **损坏目标拒写**：目标 ``mcp.json`` 结构损坏（不可解析 / 根非对象 / ``servers``|``inputs`` 类型错）→ 抛
       :class:`McpConfigCorruptError`，**绝不覆盖**（否则销毁既有内容，见该异常文档）。
     - **内容未变 = no-op**：目标 scope 现存定义与 ``body`` 逐字相等 → 不落盘、``changed=False``（对齐 rust 仅
@@ -583,17 +575,9 @@ def upsert_mcp_server(
     :param body: **未渲染** server 定义体（不含 map key；``name`` 由 key 承载）/ the un-rendered server body.
     :param scope: 请求写 scope（仅新声明生效）/ requested write scope (honored only for a new declaration).
     :param env: 环境映射（解析 user config dir + origin 快照），默认 ``os.environ``。
-    :param home: SKILL Home（解析 bundled 账本），默认 ``$A2C_SKILL_HOME``。
-    :raises McpWriteTargetError: ``name`` 为 bundled server 名（不可经 config 写）。
     :raises McpConfigCorruptError: 目标 ``mcp.json`` 结构损坏（拒绝覆盖以免销毁既有内容）。
     :returns: :class:`McpUpsertResult`（实际落盘 scope + 是否真写）。
     """
-    if name in bundled_mcp_server_names(home=home, env=env):
-        raise McpWriteTargetError(
-            f"{name!r} is a plugin-bundled MCP server (its truth is the installed_plugins.json ledger); "
-            "refuse to write it via mcp.json",
-        )
-
     # 改已有恒落 origin scope；新声明（或 origin 只读 policy/flag）落请求 scope / existing → origin, else → requested.
     target = scope
     existing = resolve_mcp_config(env=env).servers.get(name)

--- a/tests/integration_tests/computer/settings/test_mcp_config.py
+++ b/tests/integration_tests/computer/settings/test_mcp_config.py
@@ -11,9 +11,9 @@
 SDK 设计 / Design: python-sdk docs/design-0.2.1-cli-marketplace-ux.md §9.1 / §9.2 / §5.1 / §5.5。
 
 测试意图 / Test intentions（无 git；真实跨 user(XDG) + active project/local(.tfrobot) + managed 目录铺 mcp.json，
-真实 installed_plugins.json 供 bundled 接缝；批准 roundtrip 经真实 ``resolve_settings`` 六层合并读回）:
-- resolve + gate 全栈：user→enabled(trusted) / project→pending(workspace) / bundled→enabled(免批准) /
-  policy deny→disabled。
+真实 installed_plugins.json 账本仍在但 **#148 起审批门不再感知它**；批准 roundtrip 经真实 ``resolve_settings`` 六层合并读回）:
+- resolve + gate 全栈：user→enabled(trusted) / project→pending(workspace) / **借用 bundled 名的 project server→pending
+  （#148 借名不再免批准）** / policy deny→disabled。
 - approve roundtrip：pending project server → ``approve_mcp_server`` 写 local → ``resolve_settings`` 读回 →
   重门控 → enabled（接缝验证、不重复造判定）。
 - scope 覆盖全栈：同名 server user+local 双定义，local 胜（origin=local、workspace 受门控）。
@@ -28,7 +28,6 @@ import pytest
 from a2c_smcp.computer.settings.mcp_config import (
     McpApprovalStatus,
     approve_mcp_server,
-    bundled_mcp_server_names,
     gate_mcp_servers,
     resolve_mcp_config,
 )
@@ -86,13 +85,14 @@ def test_resolve_and_gate_full_stack(tmp_path: Path, monkeypatch: pytest.MonkeyP
     assert set(resolved.servers) == {"user-srv", "proj-srv", "blender", "policy-srv"}
 
     settings = resolve_settings(env=env, policy_settings=policy).settings
-    bundled = bundled_mcp_server_names(env=env)
-    statuses = gate_mcp_servers(resolved, settings, bundled)
+    statuses = gate_mcp_servers(resolved, settings)
 
     assert statuses == {
         "user-srv": McpApprovalStatus.ENABLED,  # trusted origin（用户自己加）
         "proj-srv": McpApprovalStatus.PENDING,  # workspace 共享、未决 → 弹框（#69）
-        "blender": McpApprovalStatus.ENABLED,  # plugin-bundled 免批准（即便 workspace 声明）
+        # #148（P0 安全回归）：project scope 声明的 "blender" 借用了已装 plugin 的 bundled 名（账本已记，见上）。
+        # 档④删除后审批门**不再感知账本**，它当普通 untrusted workspace server 处理 → PENDING（弹框），杜绝借名绕过。
+        "blender": McpApprovalStatus.PENDING,
         "policy-srv": McpApprovalStatus.DISABLED,  # 企业拒绝名单
     }
 
@@ -106,15 +106,14 @@ def test_approve_roundtrip_flips_pending_to_enabled(tmp_path: Path, monkeypatch:
     monkeypatch.chdir(wd)
 
     resolved = resolve_mcp_config(env=env, managed_mcp_path=managed_mcp)
-    bundled = bundled_mcp_server_names(env=env)
 
-    before = gate_mcp_servers(resolved, resolve_settings(env=env).settings, bundled)
+    before = gate_mcp_servers(resolved, resolve_settings(env=env).settings)
     assert before == {"figma": McpApprovalStatus.PENDING}
 
     # 批准框 [y]es：写 cwd 的 local settings.local.json。
     approve_mcp_server("figma")
 
-    after = gate_mcp_servers(resolved, resolve_settings(env=env).settings, bundled)
+    after = gate_mcp_servers(resolved, resolve_settings(env=env).settings)
     assert after == {"figma": McpApprovalStatus.ENABLED}
 
 
@@ -131,5 +130,5 @@ def test_scope_override_full_stack(tmp_path: Path, monkeypatch: pytest.MonkeyPat
     assert srv.config.server_parameters.command == "local-cmd"  # 高 scope 整体覆盖
     assert srv.trusted_origin is False  # origin=local → workspace 共享、受门控
 
-    statuses = gate_mcp_servers(resolved, resolve_settings(env=env).settings, set())
+    statuses = gate_mcp_servers(resolved, resolve_settings(env=env).settings)
     assert statuses == {"shared": McpApprovalStatus.PENDING}

--- a/tests/unit_tests/computer/settings/test_mcp_config.py
+++ b/tests/unit_tests/computer/settings/test_mcp_config.py
@@ -15,10 +15,9 @@ SDK 设计 / Design: python-sdk docs/design-0.2.1-cli-marketplace-ux.md §9.1 / 
 - merge：scope 优先级 policy>local>project>user>flag；同名 server 高 scope 整体覆盖 + origin；无 active →
   仅 user+flag+policy；inputs 按 id 去重高胜。
 - ext 剥离：envFile 入 ext + 配置校验通过；含真未知 key 的 server → drop + err（字段容错、不 abort）。
-- gate：未知→pending；enabled/disabled（disabled 优先）；enableAll；plugin-bundled 免批准；user-origin 自动
-  enabled；policy deny→disabled；policy allow 白名单。
+- gate：未知→pending；enabled/disabled（disabled 优先）；enableAll；user-origin 自动 enabled；policy deny→disabled；
+  policy allow 白名单。**#148**：档④「bundled 名集免批准」已删除——审批门不再感知账本，借名不再绕过（签名无 bundled）。
 - 写助手：approve/deny/approveAll 写 active-workdir local（dedup、无 version/header）；缺 active → 抛。
-- bundled 接缝：bundled_mcp_server_names 跨多记录并集。
 """
 
 import json
@@ -34,11 +33,9 @@ from a2c_smcp.computer.settings.mcp_config import (
     McpConfigCorruptError,
     McpUpsertResult,
     McpWriteScope,
-    McpWriteTargetError,
     ResolvedMcpConfig,
     approve_all_project_mcp,
     approve_mcp_server,
-    bundled_mcp_server_names,
     deny_mcp_server,
     gate_mcp_servers,
     load_mcp_config_file,
@@ -52,7 +49,6 @@ from a2c_smcp.computer.settings.mcp_config import (
 from a2c_smcp.computer.settings.policy import LINUX_MANAGED_DIR, MACOS_MANAGED_DIR, WINDOWS_MANAGED_DIR
 from a2c_smcp.computer.settings.schema import SettingsScope
 from a2c_smcp.computer.settings.scope import workdir_local_settings_path
-from a2c_smcp.computer.settings.store import save_installed_plugins
 
 
 # ── 辅助 / helpers ───────────────────────────────────────────────────────────
@@ -223,48 +219,61 @@ def test_resolve_malformed_input_dropped(tmp_path: Path) -> None:
 
 # ── gate：mcp_server_status / gate_mcp_servers ────────────────────────────────
 def test_status_pending_when_unknown_workspace(tmp_path: Path) -> None:
-    assert mcp_server_status("x", settings={}, bundled=set(), trusted_origin=False) == McpApprovalStatus.PENDING
+    assert mcp_server_status("x", settings={}, trusted_origin=False) == McpApprovalStatus.PENDING
 
 
 def test_status_enabled_via_enabled_list() -> None:
     s = {"enabledMcpjsonServers": ["x"]}
-    assert mcp_server_status("x", settings=s, bundled=set(), trusted_origin=False) == McpApprovalStatus.ENABLED
+    assert mcp_server_status("x", settings=s, trusted_origin=False) == McpApprovalStatus.ENABLED
 
 
 def test_status_disabled_takes_priority_over_enabled() -> None:
     s = {"enabledMcpjsonServers": ["x"], "disabledMcpjsonServers": ["x"]}
-    assert mcp_server_status("x", settings=s, bundled=set(), trusted_origin=False) == McpApprovalStatus.DISABLED
+    assert mcp_server_status("x", settings=s, trusted_origin=False) == McpApprovalStatus.DISABLED
 
 
 def test_status_enable_all() -> None:
     s = {"enableAllProjectMcpServers": True}
-    assert mcp_server_status("x", settings=s, bundled=set(), trusted_origin=False) == McpApprovalStatus.ENABLED
+    assert mcp_server_status("x", settings=s, trusted_origin=False) == McpApprovalStatus.ENABLED
 
 
-def test_status_bundled_auto_enabled_even_if_not_listed() -> None:
-    assert mcp_server_status("x", settings={}, bundled={"x"}, trusted_origin=False) == McpApprovalStatus.ENABLED
+def test_status_no_bundled_param_borrowed_name_not_auto_enabled() -> None:
+    """#148（P0 安全）：档④「bundled 名集免批准」已删除。审批门**不再感知**账本 bundled 名——一个 untrusted
+    workspace（project/local）origin 且不在 enabled 名单的 server，无论是否与某已装 plugin 的 bundled server 同名，
+    一律走普通门控 → PENDING（弹框），杜绝借名绕过。签名收敛回归见 :func:`test_mcp_server_status_signature_has_no_bundled`。"""
+    # 即便调用方"以为"名叫 "audit-mcp" 的 server 被某 plugin bundle 过：纯函数无 bundled 入参、无从据此放行。
+    assert mcp_server_status("audit-mcp", settings={}, trusted_origin=False) == McpApprovalStatus.PENDING
 
 
-def test_status_disabled_overrides_bundled() -> None:
-    """disabled（显式拒绝）优先于 bundled 免批准。"""
-    s = {"disabledMcpjsonServers": ["x"]}
-    assert mcp_server_status("x", settings=s, bundled={"x"}, trusted_origin=False) == McpApprovalStatus.DISABLED
+def test_mcp_server_status_signature_has_no_bundled() -> None:
+    """F8 可验收信号：门函数签名 **MUST NOT** 含 ``bundled`` 入参（防档④以等价形状复活）。"""
+    import inspect
+
+    assert "bundled" not in inspect.signature(mcp_server_status).parameters
+    assert "bundled" not in inspect.signature(gate_mcp_servers).parameters
+
+
+def test_bundled_mcp_server_names_removed() -> None:
+    """F8 可验收信号：``bundled_mcp_server_names()`` **不存在**（"函数不存在"比"文档说别用"强）。"""
+    import a2c_smcp.computer.settings.mcp_config as mcp_config_mod
+
+    assert not hasattr(mcp_config_mod, "bundled_mcp_server_names")
 
 
 def test_status_trusted_origin_auto_enabled() -> None:
-    assert mcp_server_status("x", settings={}, bundled=set(), trusted_origin=True) == McpApprovalStatus.ENABLED
+    assert mcp_server_status("x", settings={}, trusted_origin=True) == McpApprovalStatus.ENABLED
 
 
 def test_status_policy_deny() -> None:
     s = {"deniedMcpServers": ["x"], "enabledMcpjsonServers": ["x"]}
-    assert mcp_server_status("x", settings=s, bundled={"x"}, trusted_origin=True) == McpApprovalStatus.DISABLED
+    assert mcp_server_status("x", settings=s, trusted_origin=True) == McpApprovalStatus.DISABLED
 
 
 def test_status_policy_allow_whitelist() -> None:
     s = {"allowedMcpServers": ["other"]}  # 非空白名单且 x 不在内 → disabled
-    assert mcp_server_status("x", settings=s, bundled=set(), trusted_origin=True) == McpApprovalStatus.DISABLED
+    assert mcp_server_status("x", settings=s, trusted_origin=True) == McpApprovalStatus.DISABLED
     s2 = {"allowedMcpServers": ["x"]}
-    assert mcp_server_status("x", settings=s2, bundled=set(), trusted_origin=False) == McpApprovalStatus.PENDING
+    assert mcp_server_status("x", settings=s2, trusted_origin=False) == McpApprovalStatus.PENDING
 
 
 def test_gate_mcp_servers_maps_all(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -273,26 +282,8 @@ def test_gate_mcp_servers_maps_all(tmp_path: Path, monkeypatch: pytest.MonkeyPat
     _write_json(tmp_path / ".tfrobot" / "mcp.json", _mcp_doc(servers={"proj-srv": _stdio()}))
     monkeypatch.chdir(tmp_path)
     out = resolve_mcp_config(env=env, managed_mcp_path=tmp_path / "absent.json")
-    statuses = gate_mcp_servers(out, settings={}, bundled=set())
+    statuses = gate_mcp_servers(out, settings={})
     assert statuses == {"user-srv": McpApprovalStatus.ENABLED, "proj-srv": McpApprovalStatus.PENDING}
-
-
-# ── bundled 接缝 ──────────────────────────────────────────────────────────────
-def test_bundled_mcp_server_names_union(tmp_path: Path) -> None:
-    save_installed_plugins(
-        {
-            "plugins": {
-                "a@mp": [{"scope": "user", "installPath": "/x", "bundledMcpServers": ["figma", "blender"]}],
-                "b@mp": [{"scope": "user", "installPath": "/y", "bundledMcpServers": ["blender", "godot"]}],
-            }
-        },
-        home=tmp_path,
-    )
-    assert bundled_mcp_server_names(home=tmp_path) == {"figma", "blender", "godot"}
-
-
-def test_bundled_mcp_server_names_empty(tmp_path: Path) -> None:
-    assert bundled_mcp_server_names(home=tmp_path) == set()
 
 
 # ── 批准写助手（local scope）─────────────────────────────────────────────────
@@ -326,10 +317,10 @@ def test_approve_all_sets_bool_local(tmp_path: Path, monkeypatch: pytest.MonkeyP
 def test_approve_then_resolve_settings_flips_status(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """approve roundtrip：写 local enabled → 再判定 status 由 pending→enabled（接缝验证）。"""
     monkeypatch.chdir(tmp_path)
-    assert mcp_server_status("figma", settings={}, bundled=set(), trusted_origin=False) == McpApprovalStatus.PENDING
+    assert mcp_server_status("figma", settings={}, trusted_origin=False) == McpApprovalStatus.PENDING
     approve_mcp_server("figma")
     enabled = _read_local_settings(tmp_path)["enabledMcpjsonServers"]
-    after = mcp_server_status("figma", settings={"enabledMcpjsonServers": enabled}, bundled=set(), trusted_origin=False)
+    after = mcp_server_status("figma", settings={"enabledMcpjsonServers": enabled}, trusted_origin=False)
     assert after == McpApprovalStatus.ENABLED
 
 
@@ -417,7 +408,7 @@ def test_upsert_new_lands_requested_scope(
     env = _env(tmp_path)
     monkeypatch.chdir(tmp_path)
     body = _stdio("node")
-    res = upsert_mcp_server("figma", body, scope=scope, env=env, home=tmp_path)
+    res = upsert_mcp_server("figma", body, scope=scope, env=env)
     assert res == McpUpsertResult(scope=scope, changed=True)
     doc = _read_mcp(path_of(tmp_path))  # type: ignore[operator]
     assert doc == {"servers": {"figma": body}, "inputs": []}
@@ -431,7 +422,7 @@ def test_upsert_writes_raw_unrendered_body(tmp_path: Path, monkeypatch: pytest.M
         "type": "stdio",
         "server_parameters": {"command": "node", "env": {"TOK": "${input:tok}", "HM": "${env:HOME}"}},
     }
-    upsert_mcp_server("srv", body, scope=McpWriteScope.LOCAL, env=env, home=tmp_path)
+    upsert_mcp_server("srv", body, scope=McpWriteScope.LOCAL, env=env)
     stored = _read_mcp(_local_mcp(tmp_path))["servers"]["srv"]
     assert stored["server_parameters"]["env"] == {"TOK": "${input:tok}", "HM": "${env:HOME}"}  # 未渲染
 
@@ -441,7 +432,7 @@ def test_upsert_existing_lands_origin_scope(tmp_path: Path, monkeypatch: pytest.
     env = _env(tmp_path)
     monkeypatch.chdir(tmp_path)
     _write_json(_user_mcp(tmp_path), _mcp_doc(servers={"figma": _stdio("old")}))  # origin=user
-    res = upsert_mcp_server("figma", _stdio("new"), scope=McpWriteScope.PROJECT, env=env, home=tmp_path)
+    res = upsert_mcp_server("figma", _stdio("new"), scope=McpWriteScope.PROJECT, env=env)
     assert res.scope == McpWriteScope.USER and res.changed is True  # 落 origin(user)，非请求(project)
     assert _read_mcp(_user_mcp(tmp_path))["servers"]["figma"]["server_parameters"]["command"] == "new"
     assert not _proj_mcp(tmp_path).exists()  # 请求的 project scope 未被创建（无 scope 漂移）
@@ -452,25 +443,12 @@ def test_upsert_unchanged_content_is_noop(tmp_path: Path, monkeypatch: pytest.Mo
     env = _env(tmp_path)
     monkeypatch.chdir(tmp_path)
     body = _stdio("node")
-    assert upsert_mcp_server("figma", body, scope=McpWriteScope.LOCAL, env=env, home=tmp_path).changed is True
+    assert upsert_mcp_server("figma", body, scope=McpWriteScope.LOCAL, env=env).changed is True
     path = _local_mcp(tmp_path)
     mtime = path.stat().st_mtime_ns
-    second = upsert_mcp_server("figma", dict(body), scope=McpWriteScope.LOCAL, env=env, home=tmp_path)
+    second = upsert_mcp_server("figma", dict(body), scope=McpWriteScope.LOCAL, env=env)
     assert second == McpUpsertResult(scope=McpWriteScope.LOCAL, changed=False)
     assert path.stat().st_mtime_ns == mtime  # 未重写、无 churn
-
-
-def test_upsert_bundled_name_rejected(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """bundled server 名（plugin ledger 派生）→ 拒写 McpWriteTargetError，且不落盘。"""
-    env = _env(tmp_path)
-    monkeypatch.chdir(tmp_path)
-    save_installed_plugins(
-        {"plugins": {"a@mp": [{"scope": "user", "installPath": "/x", "bundledMcpServers": ["figma"]}]}},
-        home=tmp_path,
-    )
-    with pytest.raises(McpWriteTargetError):
-        upsert_mcp_server("figma", _stdio(), scope=McpWriteScope.LOCAL, env=env, home=tmp_path)
-    assert not _local_mcp(tmp_path).exists()  # 拒写发生在落盘前
 
 
 def test_remove_clears_all_writable_scopes(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -517,7 +495,7 @@ def test_upsert_over_corrupt_target_refuses_no_clobber(tmp_path: Path, monkeypat
     lp.parent.mkdir(parents=True, exist_ok=True)
     lp.write_text(corrupt, encoding="utf-8")
     with pytest.raises(McpConfigCorruptError):
-        upsert_mcp_server("figma", _stdio(), scope=McpWriteScope.LOCAL, env=env, home=tmp_path)
+        upsert_mcp_server("figma", _stdio(), scope=McpWriteScope.LOCAL, env=env)
     assert lp.read_text(encoding="utf-8") == corrupt  # 逐字节未动（无覆盖、无备份丢失）
 
 
@@ -528,7 +506,7 @@ def test_upsert_over_malformed_field_refuses(tmp_path: Path, monkeypatch: pytest
     lp = _local_mcp(tmp_path)
     _write_json(lp, {"servers": ["oops-not-a-map"], "inputs": []})
     with pytest.raises(McpConfigCorruptError):
-        upsert_mcp_server("figma", _stdio(), scope=McpWriteScope.LOCAL, env=env, home=tmp_path)
+        upsert_mcp_server("figma", _stdio(), scope=McpWriteScope.LOCAL, env=env)
     assert _read_mcp(lp)["servers"] == ["oops-not-a-map"]  # 原样保留
 
 
@@ -543,7 +521,7 @@ def test_upsert_existing_policy_origin_falls_back_to_requested(tmp_path: Path, m
         "a2c_smcp.computer.settings.mcp_config.managed_mcp_config_path",
         lambda platform=None: managed,
     )
-    res = upsert_mcp_server("figma", _stdio("user-cmd"), scope=McpWriteScope.USER, env=env, home=tmp_path)
+    res = upsert_mcp_server("figma", _stdio("user-cmd"), scope=McpWriteScope.USER, env=env)
     assert res.scope == McpWriteScope.USER and res.changed is True  # 回落请求 scope（user）
     assert _read_mcp(_user_mcp(tmp_path))["servers"]["figma"]["server_parameters"]["command"] == "user-cmd"
     # shadow 语义：user 定义落盘了，但 policy 读优先级最高 → 有效配置仍是 policy-cmd（changed=True 却被遮蔽）。
@@ -557,7 +535,7 @@ def test_upsert_existing_same_scope_in_place_change(tmp_path: Path, monkeypatch:
     env = _env(tmp_path)
     monkeypatch.chdir(tmp_path)
     _write_json(_local_mcp(tmp_path), _mcp_doc(servers={"figma": _stdio("old"), "keep": _stdio()}))
-    res = upsert_mcp_server("figma", _stdio("new"), scope=McpWriteScope.LOCAL, env=env, home=tmp_path)
+    res = upsert_mcp_server("figma", _stdio("new"), scope=McpWriteScope.LOCAL, env=env)
     assert res == McpUpsertResult(scope=McpWriteScope.LOCAL, changed=True)
     doc = _read_mcp(_local_mcp(tmp_path))
     assert doc["servers"]["figma"]["server_parameters"]["command"] == "new"

--- a/tests/unit_tests/computer/test_computer_dual_path_crud.py
+++ b/tests/unit_tests/computer/test_computer_dual_path_crud.py
@@ -12,7 +12,8 @@
 - ``aadd_or_aupdate_server``：默认落 **Local**（``mcp.local.json``）、重投影可读、重启存活、**raw 未渲染**（D1）。
 - ``aadd_or_aupdate_server_in_scope(Project)``：落 git 共享层（``mcp.json``）。
 - ``amount_server``：**不落盘**（纯运行期投影）。
-- ``aremove_server``：删**所有可写 scope** 声明 + 运行期停摘；**bundled 身份拒删**；**改已有恒落 origin**。
+- ``aremove_server``：**声明优先 origin 判据**（#148）——有用户侧声明 ⇒ 删所有可写 scope + 停摘；无声明但运行期
+  活跃（plugin/治理投影）⇒ 拒删导向 ``plugin uninstall``；无声明且未活跃 ⇒ no-op。**改已有恒落 origin**。
 
 隔离：``monkeypatch.chdir(tmp)`` 锚 project/local（#116）、``XDG_CONFIG_HOME`` → tmp 锚 user；``auto_connect=False``
 免拉起真实进程（``_amount_rendered`` 仅入册配置、不 spawn）。
@@ -195,23 +196,50 @@ async def test_aremove_server_absent_is_noop(tmp_path: Path, monkeypatch: pytest
         assert not mcp_write_path(scope, env=os.environ).exists()
 
 
-# ── durable: aremove_server bundled 身份拒删 ────────────────────────────────────────────────────────
+# ── durable: aremove_server 无声明 + 运行期活跃 → 拒删（origin 判据，非账本名集）─────────────────────
 @pytest.mark.asyncio
-async def test_aremove_server_rejects_bundled(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    _isolate(tmp_path, monkeypatch)
-    # 令 "figma" 命中 ledger 派生 bundled 集（隔离 Computer 的拒删分支，不需真装 plugin）。
-    monkeypatch.setattr("a2c_smcp.computer.computer.bundled_mcp_server_names", lambda **_: {"figma"})
+async def test_aremove_server_rejects_undeclared_runtime_projection(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """#148/F3：durable rm 一个「运行期活跃却无用户侧 mcp.json 声明」的运行期投影 → 拒删、导向显式停用
+    （``origin == plugin`` 的可观测等价，**不**按账本名集判定）；拒删后投影仍在（未误停摘）。
 
+    **架构限制显式化**：manager 不存 provenance，本 scope（#148 不依赖 #153/#154）无法区分 plugin 投影 vs 纯 transient
+    （``--config @file`` 预加载 / 裸 ``amount_server``）。此处裸 ``amount_server`` 挂载即「非 plugin 的纯 transient」，
+    **同样被拒**——这是保守拒删的**已知过宽**（宁可拒删导向显式停用，也不越权停摘一个非用户声明的投影），非缺陷。"""
+    _isolate(tmp_path, monkeypatch)
     comp = _comp(tmp_path)
-    # 运行期投影一条 bundled server（transient；bundle_id("figma") == "figma"）。
+    # transient 投影一条**无盘声明**的 server（裸 amount_server = 非 plugin 纯 transient；bundle_id("figma") == "figma"）。
     await comp.amount_server(_stdio_dict("figma", "/bin/figma"))
+    assert "figma" not in resolve_mcp_config(env=os.environ).servers, "前置：盘上无任何 figma 声明"
 
     with pytest.raises(McpWriteTargetError):
         await comp.aremove_server("figma")
 
-    # 拒删后运行期投影仍在（未被误停摘）。
+    # 拒删后运行期投影仍在（未被误停摘）；且未产生任何落盘写。
     assert comp.mcp_manager is not None
     assert any(c.name == "figma" for c in comp.mcp_manager.server_configs())
+    for scope in (McpWriteScope.LOCAL, McpWriteScope.PROJECT, McpWriteScope.USER):
+        assert not mcp_write_path(scope, env=os.environ).exists()
+
+
+# ── durable: aremove_server 用户侧有声明 → 放行（误伤修复：即便名撞某 bundled）─────────────────────────
+@pytest.mark.asyncio
+async def test_aremove_server_allows_user_declared_even_if_name_shadows_bundled(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#148/F3 误伤修复：用户侧有声明 ⇒ **放行**（删的是用户自己那条声明 + 停摘），即便该 server 名与某 plugin
+    的 bundled server 同名——用户覆盖权优先（runtime-contract §2.5）。历史 name-keyed 守卫会误伤此路径（同名即拒）。"""
+    _isolate(tmp_path, monkeypatch)
+    comp = _comp(tmp_path)
+    # durable add：写 local mcp.json 声明 + 运行期挂载（用户自己加的 server）。
+    await comp.aadd_or_aupdate_server(_stdio_dict("figma", "/bin/figma"))
+    assert "figma" in resolve_mcp_config(env=os.environ).servers, "用户侧有声明"
+    assert comp.mcp_manager is not None
+    assert any(c.name == "figma" for c in comp.mcp_manager.server_configs())
+
+    # 放行：删所有可写 scope 声明 + 停摘（不抛）。
+    await comp.aremove_server("figma")
+    assert "figma" not in resolve_mcp_config(env=os.environ).servers, "用户声明已删净"
+    assert not any(c.name == "figma" for c in comp.mcp_manager.server_configs()), "运行期投影已停摘"
 
 
 # ── durable: 改已有 server 恒落其 origin scope（新 scope 只作用于新声明）─────────────────────────────
@@ -263,11 +291,14 @@ async def test_aunmount_server_manager_none_is_noop(tmp_path: Path, monkeypatch:
     assert comp.mcp_manager is None
 
 
-# ── durable: aremove_server 无盘上声明但仍停摘运行期投影 ─────────────────────────────────────────────
+# ── durable: aremove_server 对无声明的运行期投影不再静默停摘（#148 取代 #137 旧契约）──────────────────
 @pytest.mark.asyncio
-async def test_aremove_server_unmounts_runtime_projection_without_disk_declaration(
+async def test_aremove_server_no_longer_silently_unmounts_undeclared_projection(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """**契约变更（#148 取代 #137）**：durable ``aremove_server`` 对「运行期活跃却无盘声明」的投影**不再静默停摘**
+    （旧行为），改为**拒删**并导向 ``plugin uninstall``——纯运行期停摘是 :meth:`aunmount_server_by_id` 的职责，
+    durable rm 只操作声明面。这样才拦得住「借 durable rm 单独打掉某 bundled server 产生半态」（runtime-contract §2.4）。"""
     _isolate(tmp_path, monkeypatch)
     comp = _comp(tmp_path)
     # transient 投影一条（不落盘、无声明）；bundle_id("proj-only") == "proj-only"（连字符合法、不折叠）。
@@ -275,8 +306,9 @@ async def test_aremove_server_unmounts_runtime_projection_without_disk_declarati
     assert comp.mcp_manager is not None
     assert any(c.name == "proj-only" for c in comp.mcp_manager.server_configs())
 
-    # durable remove：盘上无匹配声明 → 落盘 no-op，但仍停摘运行期投影（文档承诺的关键分支）。
-    await comp.aremove_server("proj-only")
-    assert not any(c.name == "proj-only" for c in comp.mcp_manager.server_configs()), "无盘声明也须清运行期投影"
-    for scope in (McpWriteScope.LOCAL, McpWriteScope.PROJECT, McpWriteScope.USER):
-        assert not mcp_write_path(scope, env=os.environ).exists(), "无声明匹配 → 不产生任何落盘写"
+    with pytest.raises(McpWriteTargetError):
+        await comp.aremove_server("proj-only")
+    # 投影仍在（durable rm 未越权停摘）；纯运行期停摘须显式走 aunmount_server_by_id。
+    assert any(c.name == "proj-only" for c in comp.mcp_manager.server_configs())
+    await comp.aunmount_server_by_id("proj-only")
+    assert not any(c.name == "proj-only" for c in comp.mcp_manager.server_configs())

--- a/tests/unit_tests/computer/test_computer_inventory.py
+++ b/tests/unit_tests/computer/test_computer_inventory.py
@@ -219,7 +219,7 @@ async def test_inventory_marks_remounted_bundled_server_as_plugin(tmp_path: Path
     async with Computer(name="t", auto_connect=False, skill_home=home) as comp:
 
         async def register(cfg, record) -> None:
-            # #137 ③：治理重挂 = 投影，经 transient amount_server（bundled 名走 durable 会触 McpWriteTargetError）。
+            # #137 ③：治理重挂 = 投影，经 transient amount_server（治理投影不落声明面；durable 面属用户 CRUD）。
             await comp.amount_server(cfg, plugin=record.plugin, marketplace=record.marketplace)
 
         report = await comp.reconcile_governance(

--- a/tests/unit_tests/computer/test_python_rust_alignment.py
+++ b/tests/unit_tests/computer/test_python_rust_alignment.py
@@ -16,8 +16,8 @@ transient 不落盘 / 投影不回写——逐条与 rust 对应用例**同结�
   1. durable add 落盘对拍：``aadd_or_aupdate_server`` → ``mcp.local.json`` raw 未渲染；``_in_scope(PROJECT)`` → git 层；
      改已有落 origin。（rust ``add_or_update_server`` / ``add_or_update_server_in_scope``）
   2. 重启存活：durable 声明经模拟 boot（``run_mcp_approval``）后仍在运行期投影。（rust 重启存活断言）
-  3. remove 复活守护：人写 mcp.json 声明 → ``aremove_server`` 删所有可写 scope → 再 boot **不复活**；bundled 拒删。
-     （rust ``8f4229a`` 复活守护测试自足 + ``Synthesized`` 拒删）
+  3. remove 复活守护：人写 mcp.json 声明 → ``aremove_server`` 删所有可写 scope → 再 boot **不复活**；无声明的运行期
+     投影拒删（#148 origin 判据）。（rust ``8f4229a`` 复活守护测试自足 + ``Synthesized`` 拒删）
   4. transient 不落盘：``amount_server`` / ``aunmount_server`` 前后 mcp 文件字节不变、只运行期投影变。（rust ``mount_server``）
   5. 投影调用方不回写：boot 挂载已声明 server 后用户 mcp.json 层 diff 干净。（#138 ③ 守护）
 
@@ -41,6 +41,7 @@ from a2c_smcp.computer.settings.mcp_config import (
     McpWriteScope,
     McpWriteTargetError,
     mcp_write_path,
+    resolve_mcp_config,
 )
 
 
@@ -236,12 +237,13 @@ async def test_alignment_remove_deletes_all_scopes_and_no_resurrection(
 
 
 @pytest.mark.asyncio
-async def test_alignment_remove_rejects_bundled_identity(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """bundled 身份 ``aremove_server`` → 拒删（对应 rust ``WriteTargetError::Synthesized``）。"""
+async def test_alignment_remove_rejects_undeclared_runtime_projection(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """无用户侧声明却运行期活跃的投影（plugin/治理）``aremove_server`` → 拒删（**origin 判据**，不按账本名集；
+    对应 rust ``WriteTargetError::Synthesized``，#148/F3 取代历史 name-keyed bundled 拒删）。"""
     _isolate(tmp_path, monkeypatch)
-    monkeypatch.setattr("a2c_smcp.computer.computer.bundled_mcp_server_names", lambda **_: {"figma"})
     comp = _comp(tmp_path)
-    await comp.amount_server(_stdio_dict("figma", "/bin/figma"))  # 运行期投影一条 bundled（bundle_id=="figma"）
+    await comp.amount_server(_stdio_dict("figma", "/bin/figma"))  # 无盘声明的运行期投影（bundle_id=="figma"）
+    assert "figma" not in resolve_mcp_config(env=os.environ).servers, "前置：盘上无任何 figma 声明"
 
     with pytest.raises(McpWriteTargetError):
         await comp.aremove_server("figma")


### PR DESCRIPTION
Closes #148 ｜ 父 Epic #147（无阻塞批）

## 根因（P0 安全）

`settings/mcp_config.py::mcp_server_status` 档④ `if name in bundled: return ENABLED` 可被**借名**绕过审批门。真正的 plugin bundled server **从不进入** `resolve_mcp_config`（走 transient `amount_server` 挂载、不落 mcp.json），故该档**唯一可达路径** = project/local 的 mcp.json 声明借用了某已装 plugin 的 bundled server 名 = 100% 借名跳过批准门（攻击者猜中受害者装过的任一插件的 server 名，即可让恶意 command 免批准 boot 直挂）。

协议侧**已先落地**（`a2c-smcp-protocol` `runtime-contract.md §5 item 10` + `guides/mcp-approval-gate-alignment.md §2/§5`，Discussion #23 终审 F3/F8），本 PR 纯追平代码，**无协议先行、不依赖 #153/#154**。

## 修复内容

- **`mcp_server_status` / `gate_mcp_servers`**：删档④ + 去 `bundled` 入参（F8 可验收信号：门函数签名不含 `bundled`）。
- **`upsert_mcp_server`**：删「同 bundle_id 已由 plugin 提供」拒写短路 + 去 `home` 入参（用户覆盖权；指南 §5）。
- **`Computer.aremove_server`**：拒删守卫由 name-keyed 账本名集 → **声明优先 origin 判据**——用户侧有声明 ⇒ 放行（删自己那条声明，修复"同名即拒"误伤）；无声明 ∧ 运行期活跃 ⇒ 拒删导向 `plugin uninstall`（`origin==plugin` 在当前架构下的可观测等价；manager 无 provenance 故保守拒删，含 `--config @file` transient 的已知过宽）；无声明 ∧ 未活跃 ⇒ no-op。
- **删除 `bundled_mcp_server_names()`**（零消费者后整体删除；F8：函数不存在比文档说别用强）。

## 测试

- **安全回归红灯**：集成 `test_resolve_and_gate_full_stack` 翻转 CVE 断言 `blender` `ENABLED`→`PENDING`（真实 `save_installed_plugins` 账本、有效红灯非假绿）。
- **F8 守卫**：`test_mcp_server_status_signature_has_no_bundled`（inspect 签名）+ `test_bundled_mcp_server_names_removed`（hasattr）。
- 补误伤放行 / 无声明拒删 / no-op 分叉用例；rust 对拍 `test_python_rust_alignment.py` 同步更新。
- **全量 1942 passed，2 skipped，4 xfailed**；`uv run poe lint`（ruff + mypy）clean。

## 隔离审查

经 `code-reviewer` 子代理独立复审——**零 🔴**（安全洞真被堵死、红灯有效、协议逐条对齐）。🟡①（错误信息误标 `--config @file` 为 plugin）、🟡②（陈旧 docstring）已修；🟡③（抽 helper）按 no-over-engineering 主动跳过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)