### PR TITLE
feat(#152): SMCPTool 增 bundle_id required 字段（D1）——工具归属显式化、禁前缀反推

### DIFF
--- a/a2c_smcp/computer/computer.py
+++ b/a2c_smcp/computer/computer.py
@@ -1254,8 +1254,8 @@ class Computer(BaseComputer[PromptSession]):
         # socketio on_get_tools 安全上下文（非 MCP 接收循环），可安全 await 刷新（内联刷新会话级死锁见 #127）。
         # #127: refresh the tool mapping before serving get_tools; runtime tool additions are otherwise missed.
         await self.mcp_manager.arefresh_tools()
-        # 从Manager获取全部工具
-        tools = [t async for t in self.mcp_manager.available_tools()]
+        # 从 Manager 获取全部工具，携带各自归属 bundle_id（#152 D1）。
+        tools = [(bundle_id, t) async for bundle_id, t in self.mcp_manager.available_tools()]
 
         def is_attr(v: Any) -> bool:
             """
@@ -1275,12 +1275,13 @@ class Computer(BaseComputer[PromptSession]):
                 logger.debug(f"非简单属性:{truncate(v)}", exc_info=e)
                 return False
 
-        def convert_tool(t: Tool) -> SMCPTool:
+        def convert_tool(bundle_id: str, t: Tool) -> SMCPTool:
             """
             将 MCP 工具定义转换为 SMCP 工具定义。
             Convert MCP tool definition to SMCP tool definition.
 
             Args:
+                bundle_id (str): 该工具所属 MCP Server 的**解析后** bundle_id（#152 D1，工具归属）。
                 t (Tool): MCP 工具。MCP tool.
 
             Returns:
@@ -1302,10 +1303,15 @@ class Computer(BaseComputer[PromptSession]):
             if t.annotations:
                 meta["MCP_TOOL_ANNOTATION"] = json.dumps(t.annotations.model_dump(mode="json"))
             return SMCPTool(
-                name=t.name, description=t.description or "None", params_schema=t.inputSchema, return_schema=t.outputSchema, meta=meta
+                name=t.name,
+                bundle_id=bundle_id,  # #152 D1：显式归属（解析后值，来自 available_tools 产出，非 config.bundle_id）
+                description=t.description or "None",
+                params_schema=t.inputSchema,
+                return_schema=t.outputSchema,
+                meta=meta,
             )
 
-        mcp_tools = [convert_tool(t) for t in tools]
+        mcp_tools = [convert_tool(bundle_id, t) for bundle_id, t in tools]
         return mcp_tools
 
     async def aexecute_tool(self, req_id: str, tool_name: str, parameters: dict, timeout: float | None = None) -> CallToolResult:

--- a/a2c_smcp/computer/mcp_clients/manager.py
+++ b/a2c_smcp/computer/mcp_clients/manager.py
@@ -490,11 +490,14 @@ class MCPServerManager:
             for bundle_id in self._servers_config
         ]
 
-    async def available_tools(self) -> AsyncGenerator[Tool, Any]:
-        """获取暴露给 Agent 的工具及其元数据；``Tool.name`` = **exposed_tool_name**（``{bundle_id}__{alias??原始名}``）。
+    async def available_tools(self) -> AsyncGenerator[tuple[BUNDLE_ID, Tool], Any]:
+        """获取暴露给 Agent 的工具及其归属；产出 ``(bundle_id, Tool)``，``Tool.name`` = **exposed_tool_name**。
 
-        Yield tools exposed to the Agent; each ``Tool.name`` is the exposed_tool_name (协议 §exposed_tool_name / #106)。
-        Agent 即以 exposed_tool_name 寻址，``aexecute_tool`` 经 ExposedToolMapping 解析回原始名调用上游。
+        Yield ``(bundle_id, Tool)`` exposed to the Agent; each ``Tool.name`` is the exposed_tool_name
+        (协议 §exposed_tool_name / #106)。``bundle_id`` = 该工具所属 server 的**解析后**身份（#152 D1，供
+        ``SMCPTool.bundle_id`` 填充，显式归属、禁前缀反推）。Agent 即以 exposed_tool_name 寻址，
+        ``aexecute_tool`` 经 ExposedToolMapping 解析回原始名调用上游。与 ``list_windows`` / ``list_resources``
+        返回 ``(bundle_id, X)`` 的既定约定一致。
         """
         async with self._lock:
             servers_cached_tools: dict[BUNDLE_ID, list[Tool]] = {}
@@ -516,7 +519,8 @@ class MCPServerManager:
                         merged_meta = dict(tool.meta) if tool.meta else {}
                         merged_meta[A2C_TOOL_META] = a2c_meta
                         update["meta"] = merged_meta
-                    yield tool.model_copy(update=update)
+                    # 携归属 bundle_id 产出（#152 D1）；bundle_id 即 _exposed_tools 键的解析后身份。
+                    yield bundle_id, tool.model_copy(update=update)
 
     async def list_windows(self, window_uri: str | None = None) -> list[tuple[BUNDLE_ID, Resource]]:
         """

--- a/a2c_smcp/smcp.py
+++ b/a2c_smcp/smcp.py
@@ -79,9 +79,18 @@ class GetToolsReq(AgentCallData):
 
 
 class SMCPTool(TypedDict):
-    """在Computer端侧管理多个MCP时，无法保证ToolName不重复。因此alias字段被添加以帮助用户进行区分不同工具。如果alias被设置，创建工具时将会使用alias。"""
+    """在Computer端侧管理多个MCP时，无法保证ToolName不重复。因此alias字段被添加以帮助用户进行区分不同工具。如果alias被设置，创建工具时将会使用alias。
+
+    #152 D1：``bundle_id`` 显式承载工具归属。``name`` 为聚合后 exposed_tool_name（恒 ``{bundle_id}__``
+    开头），Agent 据 ``bundle_id`` 把工具关联回具体 server（分组展示、关联 config/resources），
+    **MUST NOT** 切分 ``name`` 的 ``__`` 前缀反推归属（``name`` 对 Agent 不透明）。wire 字段名 = snake_case
+    ``bundle_id``（与 rust 逐字一致，协议 data-structures.md）。
+    """
 
     name: str
+    # 所属 MCP Server 的**解析后** bundle_id（resolve_bundle_id 产物，恒非空；非配置中的显式声明值）。
+    # 与 GetComputerConfigRet.servers 的 key、错误码 meta.mcp_server 属**同一身份空间**。
+    bundle_id: str
     description: str
     params_schema: dict
     return_schema: dict | None
@@ -297,7 +306,13 @@ MCPServerConfig = MCPServerStdioConfig | MCPServerStreamableHttpConfig | MCPSSEC
 
 
 class GetComputerConfigRet(TypedDict):
-    """完整的Computer配置文件类型"""
+    """完整的Computer配置文件类型。
+
+    #152 D1 不变量：``servers`` 的 **key = 解析后 bundle_id**，且每个 entry 的 ``bundle_id`` 字段 = 同值
+    （运行期注入，见 #149 on_get_config）——与 SMCPTool.bundle_id 属**同一身份空间**，Agent 据此把工具
+    归属回 server。注意 ``MCPServerConfig.bundle_id`` 类型为 ``str | None`` 承载的是**显式声明值**，
+    wire 投影 MUST 物化为解析后值（绝不直接序列化模型字段，缺省会得 null）。
+    """
 
     inputs: NotRequired[list[MCPServerInput] | None]
     servers: dict[str, MCPServerConfig]

--- a/tests/e2e/agent/conftest.py
+++ b/tests/e2e/agent/conftest.py
@@ -161,12 +161,14 @@ def _mock_computer_client(url: str) -> Iterator[socketio.Client]:
             "tools": [
                 {
                     "name": "echo",
+                    "bundle_id": "echosrv",  # #152 D1：required，name ≠ bundle_id 分叉
                     "description": "echo input",
                     "params_schema": {"type": "object", "properties": {"message": {"type": "string"}}},
                     "return_schema": {"type": "object"},
                 },
                 {
                     "name": "add",
+                    "bundle_id": "addsrv",  # #152 D1：required，name ≠ bundle_id 分叉
                     "description": "add two numbers",
                     "params_schema": {
                         "type": "object",
@@ -329,12 +331,14 @@ async def async_mock_computer_client(async_socketio_server, async_server_port: i
             "tools": [
                 {
                     "name": "echo",
+                    "bundle_id": "echosrv",  # #152 D1：required，name ≠ bundle_id 分叉
                     "description": "echo input",
                     "params_schema": {"type": "object", "properties": {"message": {"type": "string"}}},
                     "return_schema": {"type": "object"},
                 },
                 {
                     "name": "add",
+                    "bundle_id": "addsrv",  # #152 D1：required，name ≠ bundle_id 分叉
                     "description": "add two numbers",
                     "params_schema": {
                         "type": "object",

--- a/tests/e2e/server/test_async_server_e2e.py
+++ b/tests/e2e/server/test_async_server_e2e.py
@@ -123,6 +123,7 @@ async def test_async_server_end_to_end_flow(async_agent_client, async_computer_c
             "tools": [
                 {
                     "name": "echo",
+                    "bundle_id": "echosrv",  # #152 D1：required，name ≠ bundle_id 分叉
                     "description": "echo input",
                     "params_schema": {"type": "object"},
                     "return_schema": {"type": "object"},

--- a/tests/e2e/server/test_server_e2e.py
+++ b/tests/e2e/server/test_server_e2e.py
@@ -122,6 +122,7 @@ def test_server_end_to_end_flow(agent_client, computer_client):
             "tools": [
                 {
                     "name": "echo",
+                    "bundle_id": "echosrv",  # #152 D1：required，name ≠ bundle_id 分叉
                     "description": "echo input",
                     "params_schema": {"type": "object"},
                     "return_schema": {"type": "object"},

--- a/tests/integration_tests/agent/test_async_client.py
+++ b/tests/integration_tests/agent/test_async_client.py
@@ -86,6 +86,7 @@ async def test_agent_receives_enter_and_tools(socketio_server, basic_server_port
         tools: list[SMCPTool] = [
             {
                 "name": "echo",
+                "bundle_id": "echosrv",  # #152 D1：required，name ≠ bundle_id 分叉
                 "description": "echo text",
                 "params_schema": {"type": "object", "properties": {"text": {"type": "string"}}},
                 "return_schema": None,
@@ -202,7 +203,21 @@ async def test_agent_receives_update_config(socketio_server, basic_server_port: 
         nonlocal tools_req_count
         tools_req_count += 1
         tools_event.set()
-        return {"tools": [{"name": f"tool-{tools_req_count}"}], "req_id": data["req_id"]}
+        # #152 D1：返回 wire-valid SMCPTool（含 required bundle_id + description/params_schema/return_schema），
+        # 否则经 Server relay 的 TypeAdapter(GetToolsRet) 强校验会拒、tools_received 静默死亡（此前该 mock
+        # 仅有 name 即已 wire-invalid，靠末尾 `or` 弱断言短路掩盖）。bundle_id 取 name≠bundle_id 分叉。
+        return {
+            "tools": [
+                {
+                    "name": f"tool-{tools_req_count}",
+                    "bundle_id": "tool-srv",
+                    "description": "dynamic tool",
+                    "params_schema": {"type": "object"},
+                    "return_schema": None,
+                },
+            ],
+            "req_id": data["req_id"],
+        }
 
     handler = _EH()
     office_id = "office-3"

--- a/tests/integration_tests/agent/test_base.py
+++ b/tests/integration_tests/agent/test_base.py
@@ -427,12 +427,14 @@ def test_process_tools_response():
     tools = [
         SMCPTool(
             name="tool1",
+            bundle_id="srv1",  # #152 D1：name ≠ bundle_id 分叉
             description="Test tool 1",
             params_schema={"type": "object"},
             return_schema=None,
         ),
         SMCPTool(
             name="tool2",
+            bundle_id="srv1",  # #152 D1：name ≠ bundle_id 分叉（与 tool1 同 server）
             description="Test tool 2",
             params_schema={"type": "string"},
             return_schema=None,
@@ -547,6 +549,7 @@ def test_sio_param_passed_to_handlers():
     tools = [
         SMCPTool(
             name="tool1",
+            bundle_id="srv1",  # #152 D1：name ≠ bundle_id 分叉
             description="Test tool 1",
             params_schema={"type": "object"},
             return_schema=None,

--- a/tests/integration_tests/computer/mcp_clients/test_manager.py
+++ b/tests/integration_tests/computer/mcp_clients/test_manager.py
@@ -45,7 +45,7 @@ async def test_manager_available_tools(stdio_params, sse_params, sse_server):
     sse_cfg = SseServerConfig(name="sse_server", server_parameters=sse_params)
     await manager.ainitialize([stdio_cfg, sse_cfg])
     await manager.astart_all()
-    tools = [tool async for tool in manager.available_tools()]
+    tools = [tool async for _bid, tool in manager.available_tools()]
     assert isinstance(tools, list)
     assert any(isinstance(t, Tool) for t in tools)
 
@@ -60,7 +60,7 @@ async def test_manager_default_tool_meta_injection(stdio_params, sse_params, sse
     stdio_cfg = StdioServerConfig(name="stdio_server", server_parameters=stdio_params, default_tool_meta=ToolMeta(auto_apply=True))
     await manager.ainitialize([stdio_cfg])
     await manager.astart_all()
-    tools = [tool async for tool in manager.available_tools()]
+    tools = [tool async for _bid, tool in manager.available_tools()]
     assert tools, "Should list at least one tool"
     # 所有工具应该包含注入的 a2c_tool_meta.auto_apply == True 因为目前这些工具没有自定义元数据
     assert all(getattr(t.meta.get("a2c_tool_meta"), "auto_apply", False) is True for t in tools)
@@ -77,7 +77,7 @@ async def test_manager_execute_tool(stdio_params, sse_params, sse_server):
     sse_cfg = SseServerConfig(name="sse_server", server_parameters=sse_params)
     await manager.ainitialize([stdio_cfg, sse_cfg])
     await manager.astart_all()
-    tools = [tool async for tool in manager.available_tools()]
+    tools = [tool async for _bid, tool in manager.available_tools()]
     for tool in tools:
         try:
             result = await manager.aexecute_tool(tool.name, {})
@@ -111,7 +111,7 @@ async def test_manager_same_tool_name_coexist_via_bundle_prefix(sse_params, http
     await manager.ainitialize([sse_cfg, http_cfg])
     await manager.astart_all()
     assert len(manager._active_clients) == 2
-    names = [tool.name async for tool in manager.available_tools()]
+    names = [tool.name async for _bid, tool in manager.available_tools()]
     # 所有暴露名都带 bundle 前缀，sse/http 各自成组、互不冲突
     assert names and all(n.startswith("sse_server__") or n.startswith("http_server__") for n in names)
     assert any(n.startswith("sse_server__") for n in names)
@@ -140,7 +140,7 @@ async def test_manager_forbidden_tool_not_exposed(stdio_params, sse_server):
     stdio_cfg = StdioServerConfig(name="stdio_server", server_parameters=stdio_params)
     await manager.ainitialize([stdio_cfg])
     await manager.astart_all()
-    names = [tool.name async for tool in manager.available_tools()]
+    names = [tool.name async for _bid, tool in manager.available_tools()]
     if names:
         exposed = names[0]
         _, original = await manager.avalidate_tool_call(exposed, {})

--- a/tests/integration_tests/computer/test_smcp_tool_data_format.py
+++ b/tests/integration_tests/computer/test_smcp_tool_data_format.py
@@ -63,6 +63,11 @@ async def test_smcp_tool_data_without_default_tool_meta(stdio_params) -> None:
         assert "description" in tool
         assert "params_schema" in tool
         assert "return_schema" in tool
+        # #152 D1：SMCPTool 必含 bundle_id，且 == 路由该工具的 bundle_id（exposed name 前缀）
+        assert "bundle_id" in tool, "SMCPTool 必含 bundle_id 字段（协议 D1 required）"
+        assert tool["name"].startswith(tool["bundle_id"] + "__"), (
+            f"exposed name 必以 {{bundle_id}}__ 开头：bundle_id={tool['bundle_id']!r} name={tool['name']!r}"
+        )
         # default_tool_meta=null 时，meta 中不应有 a2c_tool_meta
         meta = tool.get("meta", {})
         assert "a2c_tool_meta" not in meta, (
@@ -124,6 +129,11 @@ async def test_smcp_tool_data_with_default_tool_meta_tags(stdio_params) -> None:
         assert "description" in tool
         assert "params_schema" in tool
         assert "return_schema" in tool
+        # #152 D1：SMCPTool 必含 bundle_id，且 == 路由该工具的 bundle_id（exposed name 前缀）
+        assert "bundle_id" in tool, "SMCPTool 必含 bundle_id 字段（协议 D1 required）"
+        assert tool["name"].startswith(tool["bundle_id"] + "__"), (
+            f"exposed name 必以 {{bundle_id}}__ 开头：bundle_id={tool['bundle_id']!r} name={tool['name']!r}"
+        )
 
         meta = tool.get("meta", {})
         assert "a2c_tool_meta" in meta, (
@@ -178,9 +188,14 @@ async def test_smcp_tool_data_with_per_tool_meta(stdio_params) -> None:
 
     assert tools, "工具列表不应为空"
 
-    # 找到 hello 工具验证合并结果（exposed_tool_name = {bundle_id}__hello；bundle_id == name）
+    # 找到 hello 工具验证合并结果（exposed_tool_name = {bundle_id}__hello；此夹具合法 name → bundle_id == name）
     hello_tool = next((t for t in tools if t["name"] == "merged_meta_server__hello"), None)
     assert hello_tool is not None, "应存在 hello 工具"
+
+    # #152 D1：bundle_id 显式化归属（此夹具 name 合法字符 → bundle_id == name == "merged_meta_server"）
+    assert hello_tool["bundle_id"] == "merged_meta_server", (
+        f"hello 工具 bundle_id 应为 'merged_meta_server'，实际={hello_tool['bundle_id']!r}"
+    )
 
     meta = hello_tool.get("meta", {})
     assert "a2c_tool_meta" in meta
@@ -190,5 +205,45 @@ async def test_smcp_tool_data_with_per_tool_meta(stdio_params) -> None:
     assert parsed.get("auto_apply") is True, f"per-tool auto_apply 应覆盖为 True，实际={parsed}"
     # tags 应从 default 回落得到 ["default_tag"]
     assert parsed.get("tags") == ["default_tag"], f"tags 应从 default 回落为 ['default_tag']，实际={parsed}"
+
+    await computer.shutdown()
+
+
+@pytest.mark.anyio
+async def test_smcp_tool_bundle_id_distinct_from_name(stdio_params) -> None:
+    """
+    #152 D1 核心验收：在 **name ≠ bundle_id** 前提下，验证 SMCPTool.bundle_id 填的是
+    该工具实际路由的**解析后 bundle_id**，而非 display name（消除 stub 同值假绿）。
+
+    D1 acceptance under name ≠ bundle_id: SMCPTool.bundle_id MUST carry the resolved bundle_id
+    that routes the tool, not the display name. Guards against the stub-collision false-green
+    where fixtures let name == bundle_id.
+
+    夹具显式声明 bundle_id='custombid'，name='Display Name Srv'（含空格，normalize 后 ≠ bundle_id）。
+    显式值经 resolve_bundle_id 优先 → 运行期身份 = 'custombid'，exposed = 'custombid__<tool>'。
+    """
+    cfg = StdioServerConfig(
+        name="Display Name Srv",  # display 名，含空格；与 bundle_id 刻意分叉
+        bundle_id="custombid",  # 显式声明 → 解析后身份，≠ name
+        server_parameters=stdio_params,
+    )
+    assert cfg.name != cfg.bundle_id, "夹具前提：name 必须 ≠ bundle_id"
+
+    computer = Computer(name="test_bundle_id_distinct", auto_connect=True)
+    await computer.amount_server(cfg)  # #137：transient 挂载（不落盘）
+
+    tools = await computer.aget_available_tools()
+
+    assert tools, "工具列表不应为空"
+    for tool in tools:
+        # bundle_id == 显式解析后身份，而非 display name
+        assert tool["bundle_id"] == "custombid", (
+            f"SMCPTool.bundle_id 应为解析后 'custombid'，实际={tool['bundle_id']!r}（若填成 name 即回归）"
+        )
+        assert tool["bundle_id"] != cfg.name, "bundle_id 绝不应等于 display name"
+        # exposed name 以 {bundle_id}__ 开头，佐证 bundle_id 即路由身份
+        assert tool["name"].startswith("custombid__"), (
+            f"exposed name 应以 'custombid__' 开头，实际={tool['name']!r}"
+        )
 
     await computer.shutdown()

--- a/tests/integration_tests/computer/test_tool_list_refresh.py
+++ b/tests/integration_tests/computer/test_tool_list_refresh.py
@@ -86,17 +86,17 @@ async def test_manager_arefresh_tools_surfaces_added_tool() -> None:
     await manager.ainitialize([_mutable_cfg()])
     await manager.astart_all()
     try:
-        base = {t.name async for t in manager.available_tools()}
+        base = {t.name async for _bid, t in manager.available_tools()}
         assert base == {"mutable-srv__set_phase"}
 
         # 运行期新增工具但**不**刷新映射 → available_tools 仍漏掉（复现 Bug B）
         await manager.aexecute_tool("mutable-srv__set_phase", {"phase": 1})
-        stale = {t.name async for t in manager.available_tools()}
+        stale = {t.name async for _bid, t in manager.available_tools()}
         assert "mutable-srv__dynamic_tool" not in stale, "未刷新时 _tool_mapping 陈旧、新增工具被漏（Bug B 现象）"
 
         # 显式刷新（Computer 服务 get_tools 时所做）→ 新增工具浮现
         await manager.arefresh_tools()
-        fresh = {t.name async for t in manager.available_tools()}
+        fresh = {t.name async for _bid, t in manager.available_tools()}
         assert "mutable-srv__dynamic_tool" in fresh, "arefresh_tools() 后新增工具须可见（#127 修复）"
     finally:
         await manager.aclose()

--- a/tests/integration_tests/mock_sync_smcp_server.py
+++ b/tests/integration_tests/mock_sync_smcp_server.py
@@ -119,12 +119,14 @@ class MockSyncSMCPNamespace(Namespace):
         tools = [
             SMCPTool(
                 name="echo",
+                bundle_id="mocksrv",  # #152 D1：name ≠ bundle_id 分叉（同 server 两工具共享 bundle_id）
                 description="echo text",
                 params_schema={"type": "object", "properties": {"text": {"type": "string"}}},
                 return_schema=None,
             ),
             SMCPTool(
                 name="test_tool",
+                bundle_id="mocksrv",
                 description="test tool",
                 params_schema={},
                 return_schema=None,

--- a/tests/integration_tests/server/test_namespace_async.py
+++ b/tests/integration_tests/server/test_namespace_async.py
@@ -277,6 +277,7 @@ async def test_get_tools_success_same_office(socketio_server, basic_server_port:
             "tools": [
                 {
                     "name": "echo",
+                    "bundle_id": "echosrv",  # #152 D1：required，name ≠ bundle_id 分叉
                     "description": "echo text",
                     "params_schema": {"type": "object", "properties": {"text": {"type": "string"}}},
                     "return_schema": None,

--- a/tests/integration_tests/server/test_namespace_sync.py
+++ b/tests/integration_tests/server/test_namespace_sync.py
@@ -182,6 +182,7 @@ def _run_computer_client_process(port: int, computer_name_queue: multiprocessing
             "tools": [
                 {
                     "name": "echo",
+                    "bundle_id": "echosrv",  # #152 D1：required，name ≠ bundle_id 分叉
                     "description": "echo text",
                     "params_schema": {"type": "object"},
                     "return_schema": None,

--- a/tests/unit_tests/agent/test_sync_client.py
+++ b/tests/unit_tests/agent/test_sync_client.py
@@ -162,6 +162,7 @@ class TestSMCPAgentClient:
             "tools": [
                 {
                     "name": "test_tool",
+                    "bundle_id": "srv_x",  # #152 D1：required，name ≠ bundle_id 分叉
                     "description": "Test tool",
                     "params_schema": {},
                     "return_schema": None,
@@ -313,6 +314,7 @@ class TestSMCPAgentClient:
         tools = [
             SMCPTool(
                 name="test_tool",
+                bundle_id="srv_x",  # #152 D1：夹具 name ≠ bundle_id 分叉
                 description="Test tool",
                 params_schema={},
                 return_schema=None,

--- a/tests/unit_tests/computer/mcp_clients/test_manager.py
+++ b/tests/unit_tests/computer/mcp_clients/test_manager.py
@@ -225,7 +225,7 @@ async def test_disabled_tool(manager):
         await manager.aexecute_tool("server1__tool2", {})
 
     # #106 契约：禁用工具不应再出现在对外暴露面（不可见且不可调用）
-    names = [tool.name async for tool in manager.available_tools()]
+    names = [tool.name async for _bid, tool in manager.available_tools()]
     assert "server1__tool2" not in names
     assert "server1__tool1" in names
 
@@ -309,7 +309,7 @@ async def test_get_available_tools(manager):
 
     # 获取工具
     tools = []
-    async for tool in manager.available_tools():
+    async for _bid, tool in manager.available_tools():
         tools.append(tool)
 
     assert len(tools) == 2
@@ -328,7 +328,7 @@ async def test_default_tool_meta_applies_when_missing_per_tool(manager):
 
     # 检查 available_tools 注入
     tools = []
-    async for tool in manager.available_tools():
+    async for _bid, tool in manager.available_tools():
         tools.append(tool)
     t1 = next(t for t in tools if t.name == "server1__tool1")
     assert t1.meta["a2c_tool_meta"].auto_apply is True
@@ -378,11 +378,11 @@ async def test_default_tool_meta_alias_ignored_no_collapse(manager, monkeypatch)
     await manager.ainitialize(servers)
     await manager.astart_all()
 
-    names = {tool.name async for tool in manager.available_tools()}
+    names = {tool.name async for _bid, tool in manager.available_tools()}
     # 塌名 Bug：现码只剩一个 'server1__custom'；修后两工具各以原始名暴露、无丢失。
     assert names == {"server1__tool1", "server1__tool2"}, f"default alias 不应塌名/丢工具，实际: {names}"
     # a2c_tool_meta.alias 亦为 None（default 位 alias 被忽略，输出与命名一致、不误导 Agent）。
-    tools = {t.name: t async for t in manager.available_tools()}
+    tools = {t.name: t async for _bid, t in manager.available_tools()}
     assert tools["server1__tool1"].meta["a2c_tool_meta"].alias is None
     # 响亮配置诊断：命中被忽略的 default alias 时 WARN 一次（方案 d）。
     assert any("default_tool_meta.alias" in w and "custom" in w for w in warns), (
@@ -407,7 +407,7 @@ async def test_per_tool_alias_wins_over_default_alias_no_collapse(manager):
     await manager.ainitialize(servers)
     await manager.astart_all()
 
-    names = {tool.name async for tool in manager.available_tools()}
+    names = {tool.name async for _bid, tool in manager.available_tools()}
     # tool1 用 per-tool alias 'renamed1'；tool2 无 per-tool → default alias 被弃 → 原始名 'tool2'。无塌名、无丢失。
     assert names == {"server1__renamed1", "server1__tool2"}, f"实际: {names}"
     # 路由回原始名可解析（per-tool alias 生效但路由目标仍是 tool1）。
@@ -661,13 +661,13 @@ async def test_aadd_or_aupdate_server_same_tool_coexist(manager, monkeypatch):
     assert "server2" in manager._active_clients
 
     # server1 原客户端由 mock_client_factory 建（tool1/tool2），server2 由 duplicate_tool_factory 建（tool1）
-    names = {t.name async for t in manager.available_tools()}
+    names = {t.name async for _bid, t in manager.available_tools()}
     assert {"server1__tool1", "server1__tool2", "server2__tool1"} <= names
 
     # 借 alias 把 server2 的 tool1 改名（仍带 bundle 前缀）
     config2_aliased = create_server_config("server2", tool_meta={"tool1": ToolMeta(alias="renamed")})
     await manager.aadd_or_aupdate_server(config2_aliased)
-    names2 = {t.name async for t in manager.available_tools()}
+    names2 = {t.name async for _bid, t in manager.available_tools()}
     assert "server2__renamed" in names2
     assert "server2__tool1" not in names2
 
@@ -884,7 +884,7 @@ async def test_available_tools_exposes_alias_as_name(manager):
     await manager.ainitialize(servers)
     await manager.astart_all()
 
-    names = [tool.name async for tool in manager.available_tools()]
+    names = [tool.name async for _bid, tool in manager.available_tools()]
     # 暴露面应为 {bundle_id}__{alias}，原始名不得出现 / exposed name = {bundle_id}__{alias}, never the original
     assert "alias_server__aliased_tool" in names
     assert "alias_server__tool5" not in names
@@ -917,7 +917,7 @@ async def test_forbidden_tool_excluded_from_duplicate_detection(manager, monkeyp
     bundle_id, original = await manager.avalidate_tool_call("server2__tool1", {})
     assert (bundle_id, original) == ("server2", "tool1")
     # 暴露面只出现一次 server2__tool1（server1 那份被 forbid、不暴露）
-    names = [tool.name async for tool in manager.available_tools()]
+    names = [tool.name async for _bid, tool in manager.available_tools()]
     assert names.count("server2__tool1") == 1
     assert "server1__tool1" not in names
 
@@ -935,7 +935,7 @@ async def test_forbidden_original_name_suppresses_alias(manager):
     await manager.astart_all()
 
     # alias 与原始名都不暴露、不路由 / neither the alias nor the original is exposed/routed
-    names = [tool.name async for tool in manager.available_tools()]
+    names = [tool.name async for _bid, tool in manager.available_tools()]
     assert "alias_server__aliased_tool" not in names
     assert "alias_server__tool5" not in names
     assert "alias_server__aliased_tool" not in manager._exposed_tools

--- a/tests/unit_tests/computer/test_computer.py
+++ b/tests/unit_tests/computer/test_computer.py
@@ -54,7 +54,8 @@ async def test_aget_available_tools(monkeypatch):
     tool = ToolFactory.build(description="mock_desc")
     # 构造mock manager/Build mock manager
     mock_manager = MagicMock(spec=MCPServerManager)
-    mock_manager.available_tools.return_value = DummyAsyncIterator([tool])
+    # #152 D1：available_tools 现产出 (bundle_id, Tool) 元组；夹具 bundle_id ≠ tool.name 分叉
+    mock_manager.available_tools.return_value = DummyAsyncIterator([("srv_mock", tool)])
     monkeypatch.setattr("a2c_smcp.computer.computer.MCPServerManager", lambda *a, **kw: mock_manager)
     # 实例化Computer/Instantiate Computer
     computer = Computer(name="test")
@@ -68,6 +69,7 @@ async def test_aget_available_tools(monkeypatch):
     # 检查SMCPTool结构/Check SMCPTool structure
     assert isinstance(t, dict)
     assert t["name"] == tool.name
+    assert t["bundle_id"] == "srv_mock"  # #152 D1：归属填的是 available_tools 产出的 bundle_id
     assert t["description"] == tool.description
     assert t["params_schema"] == tool.inputSchema
     assert t["return_schema"] == tool.outputSchema
@@ -95,7 +97,8 @@ async def test_aget_available_tools_meta_branches(monkeypatch):
     tool5.annotations = dummy_annotations
     # 构造mock manager
     mock_manager = MagicMock(spec=MCPServerManager)
-    mock_manager.available_tools.return_value = DummyAsyncIterator([tool1, tool2, tool3, tool4, tool5])
+    # #152 D1：available_tools 现产出 (bundle_id, Tool) 元组
+    mock_manager.available_tools.return_value = DummyAsyncIterator([("srv_mock", t) for t in (tool1, tool2, tool3, tool4, tool5)])
     monkeypatch.setattr("a2c_smcp.computer.computer.MCPServerManager", lambda *a, **kw: mock_manager)
     computer = Computer(name="test")
     await computer.boot_up()

--- a/tests/unit_tests/server/test_sync_smcp_namespace.py
+++ b/tests/unit_tests/server/test_sync_smcp_namespace.py
@@ -203,6 +203,7 @@ def test_on_server_tool_call_cancel_and_update_config_and_client_paths():
             "tools": [
                 {
                     "name": "t1",
+                    "bundle_id": "srv_t1",  # #152 D1：required，name ≠ bundle_id 分叉
                     "description": "d",
                     "params_schema": {"type": "object", "properties": {}, "required": []},
                     "return_schema": None,


### PR DESCRIPTION
Closes #152 · 母单 #147 · 共识 [protocol Discussion #23](https://github.com/A2C-SMCP/a2c-smcp-protocol/discussions/23) 终审 D1

## 协议门控（PASS）

a2c-smcp-protocol `develop` 已落 **PROTO-1** 文本（commit `7b27995`）：`data-structures.md` 定义 `SMCPTool.bundle_id: str`（**required**，snake_case，值为**解析后** bundle_id，与 `GetComputerConfigRet.servers` 的 key、错误码 `meta.mcp_server` 属**同一身份空间**）；`events.md` 明文 Agent **MUST NOT** 切 `name` 的 `__` 前缀反推归属。按「开发阶段看协议 develop 内容判可动」口径 → develop-actionable。

**三仓态势 🟢**：无 open PR 在推；rust-sdk#136 为 D1 镜像节点，双端各自追平同一协议文本、wire 字段名由协议锁死，天然一致、方案不冲突。

## 根因

`manager.available_tools()` 循环内**已持有解析后 bundle_id**（`_exposed_tools` 的 value，源自注册边界 `resolve_bundle_id` 产物），但 yield 时**丢弃**了它 → 下游 `computer.py::convert_tool` 拿不到，`SMCPTool` 无从填充。

修法 = `available_tools()` 改 yield `(bundle_id, Tool)`，与既有 `list_windows` / `list_resources` 返回 `(bundle_id, X)` 的**约定同构**（复用而非新造）。

> ⚠️ 填的是**解析后**值，**不是** `config.bundle_id`——后者是 `str | None` 的显式声明值，缺省序列化会得 `null`（#152 正文点名的「主动误导」陷阱）。

## 澄清：Agent 侧为 no-op（非遗漏）

python-sdk 的 Agent 侧**本就没有** `__` 前缀反推代码——工具名全程透传，归属靠独立的 `computer` 参数寻址；Computer 侧 `manager._exposed_tools` 亦为整键查表（`manager.py` 明文「禁 split 反解身份」）。故 D1 标题的「Agent 不再靠切前缀」在本 SDK 无拆除对象。

## 变更

**生产（3 文件）**
- `smcp.py`：`SMCPTool` 加 `bundle_id: str`（置 `name` 之后，对齐协议字段序）；`GetComputerConfigRet` 补「key = 解析后 bundle_id ∧ entry.bundle_id = 同值」不变量注释（D1 建议顺带）
- `manager.py`：`available_tools()` → `AsyncGenerator[tuple[BUNDLE_ID, Tool]]`
- `computer.py`：`aget_available_tools` 解构元组，`convert_tool(bundle_id, t)` 填充

**测试（15 文件）**——required + 签名变更的必然传导，覆盖三类构造面：
- `SMCPTool(...)` 字面量 5 处
- **dict 字面量 tools 9 处**（`grep "SMCPTool("` 抓不到，靠 `params_schema` 定位；经 server relay `TypeAdapter(GetToolsRet)` 强校验，不补则 ValidationError）
- 迭代消费点 `async for tool in available_tools()` → `async for _bid, tool in ...`；`test_computer.py` 两处 mock 造元组

## 验收（Epic 硬规：夹具 name ≠ bundle_id 分叉）

新增 **`test_smcp_tool_bundle_id_distinct_from_name`**：显式 `bundle_id="custombid"` ≠ `name="Display Name Srv"`，走真实构造路径（`amount_server` + `aget_available_tools`），断言每个 `SMCPTool.bundle_id == "custombid"` 且 `!= cfg.name`。

> 现有 3 条用例夹具恰好 `bundle_id == name`（合法名 normalize 后等于自身）——即 Epic 点名的 **stub 同值陷阱**，加了字段也验不出填充点对错，故必须新增分叉用例。

**连带闭合一处预存假绿**：`test_async_client.py::_on_get_tools_again` 的 mock 仅返回 `{"name": ...}`，本就 wire-invalid（relay 必拒 → `tools_received` 静默死亡），被末尾 `or` 弱断言短路掩盖 → 已补全为 wire-valid。

## 验证

- 单元 + 集成：**1959 passed / 0 failed**
- e2e（agent + server，含改动的 conftest）：**15 passed**
- `uv run poe lint`（ruff + mypy 103 files）：**clean**
- 隔离审查（`a2c-smcp-toolkit:code-reviewer`）：**零 🔴**，唯一 🟡（上述 relay 假绿）已闭合
- 不耦合 `PROTOCOL_VERSION` 具体值

> 全量中偶发的 `test_http_client.py` error 为环境 flaky（两次跑命中**不同**测试/不同 async backend，隔离重跑该文件 14 passed），与本变更无关。

🤖 Generated with [Claude Code](https://claude.com/claude-code)