### PR TITLE
fix(#153): [D3+F1] ledger 迁纯 bundle_id 依赖数组（删 provenance）+ 回收判据 + 冲突门改依赖模型 + 死快照修

### DIFF
--- a/.claude/skills/UAT/resources/scenarios/plugin-management.md
+++ b/.claude/skills/UAT/resources/scenarios/plugin-management.md
@@ -58,7 +58,7 @@ mkdir -p $A2C_SKILL_HOME
 - **预期结果**:
   - 退出码 0
   - 输出包含安装成功信息
-  - 含 scope、bundledMcpServers（figma-mcp）
+  - 含 scope、mcpServers（声明依赖的 bundle_id：figma-mcp）
 
 ### P-02: plugin list（列出已安装 plugin）
 
@@ -82,7 +82,7 @@ mkdir -p $A2C_SKILL_HOME
 - **预期结果**:
   - 退出码 0
   - JSON 包含 id: "foo@$MP_NAME"
-  - 包含 enabled、records（含 scope、installPath、version、bundledMcpServers）
+  - 包含 enabled、records（含 scope、installPath、version、mcpServers）
 
 ### P-04: plugin disable（禁用 plugin）
 

--- a/.claude/skills/UAT/resources/seeds/marketplace/plugin-with-bundled-mcp/README.md
+++ b/.claude/skills/UAT/resources/seeds/marketplace/plugin-with-bundled-mcp/README.md
@@ -13,5 +13,5 @@
 
 **期望被测行为**:
 - `plugin install foo@mp-bundled-mcp` 成功
-- `plugin info` 显示 `bundledMcpServers` 含 `figma-mcp`
+- `plugin info` 显示 `mcpServers`（声明依赖的 bundle_id 数组）含 `figma-mcp`
 - `plugin uninstall foo@mp-bundled-mcp` 级联移除捆绑 MCP server

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,40 @@ and this project adheres to [PEP 440](https://peps.python.org/pep-0440/) version
 > [#8](https://github.com/A2C-SMCP/python-sdk/issues/8).
 
 ### Breaking Changes
+- **plugin ↔ MCP Server is a dependency relation, not an ownership one** (#153, aligned
+  with a2c-smcp-protocol `runtime-contract.md` §2.5 / §4.9.1 / §5.6; adjudication record
+  in protocol Discussion #23 D3/F1; rust mirror rust-sdk#139 — **both SDKs share the same
+  on-disk ledger format, a divergence is data corruption**).
+  - **Ledger field renamed and re-typed**: `bundledMcpServers` (array of display **name**)
+    → **`mcpServers` (array of `bundle_id`)**, written unconditionally (`[]` when empty).
+    It records the MCP servers a plugin **declares a dependency on**. The ledger MUST NOT
+    store display names (they go stale when an explicit `bundleId` server is renamed) nor
+    point-in-time facts such as provenance/introduced (they rot as *other* plugins are
+    uninstalled — the transitive-leak source). **Legacy records are dropped wholesale and
+    rebuilt from the `installedPlugins` intent** (§4.9.1-4); no name→bundle_id migration
+    mapping is written.
+  - **Uninstall/disable/gc no longer reclaim unconditionally.** New criterion (§4.9.1-2,
+    a pure function in `reconciler.py`): **reclaim X ⟺ no other plugin declares a
+    dependency on X ∧ X is not user-declared**. Consequences: a user's own server is
+    **never** collaterally removed, and a dependency shared by several plugins survives
+    until its last dependent is uninstalled (no leak).
+  - **`MCPServerNameConflictError` removed**, along with `_conflict_check` and the whole
+    `owned` notion. Installing a plugin whose declared `bundle_id` already exists is
+    **dependency satisfied** → report and install normally (exit 0); it MUST NOT be
+    rejected. `plugin enable` **reuses** an already-satisfied dependency instead of
+    remounting over it. Same display name with a different `bundle_id` is legal
+    coexistence (§5.6). The CLI JSON error code `mcp_server_name_conflict` is gone.
+  - **Injected-callback seam is now bundle_id-keyed**: `ExistingServerNames` →
+    **`ExistingBundleIds`** (`install_plugin` / `enable_plugin` / `materialize_plugin`
+    kwarg `existing_server_names=` → **`existing_bundle_ids=`**); `RemoveServer` and
+    `gc_plugins(mcp_teardown=)` now take a **bundle_id**; `Computer.reconcile_governance`
+    kwarg `existing_server_names=` → **`existing_bundle_ids=`**.
+  - **Dependency prechecks and governance remount now read the runtime-authoritative
+    config set** (`manager.server_configs()`), never the construction-time snapshot
+    `Computer.mcp_servers` (§2.5-4) — under the CLI that snapshot is permanently empty,
+    so every "dependency satisfied" was misjudged as "unsatisfied".
+  - CLI output: `plugin install/list/info` field `bundledMcpServers` → **`mcpServers`**
+    (values are now bundle_ids).
 - **Plugin install/enable separation — install no longer activates** (#123, aligned
   with a2c-smcp-protocol **v0.3.0** `runtime-contract.md` §2.3/§2.4/§4.8; adjudication
   record in #120 / protocol#11; rust mirror rust-sdk#103).
@@ -21,12 +55,13 @@ and this project adheres to [PEP 440](https://peps.python.org/pep-0440/) version
   - New declarative intent **`installedPlugins`** (settings.json array of
     `<plugin>@<marketplace>`): the global install set. `install_plugin` now writes it
     config-first to the **user scope**, materializes (clone / manifest validation /
-    foreign MCP name-conflict precheck / ledger), and **does not activate** — no SKILL
+    MCP dependency precheck / ledger), and **does not activate** — no SKILL
     staging, no bundled-server mount, no `enabledPlugins` write → `installed_disabled`.
     Materialization failure atomically rolls the intent entry back.
   - `install_plugin` signature: **removed** `register_server=` / `remove_server=` /
-    `inject_inputs=` kwargs (install mounts nothing); `existing_server_names=` kept for
-    the conflict precheck. New `materialize_plugin()` exposes activation-free
+    `inject_inputs=` kwargs (install mounts nothing); the precheck kwarg is kept but was
+    since renamed to `existing_bundle_ids=` and demoted to report-only (see #153 above —
+    it no longer rejects). New `materialize_plugin()` exposes activation-free
     materialization (reused by boot re-materialization).
   - **`enable_plugin` is now atomic**: skills and bundled servers light up together;
     on mount failure it rolls back to `installed_disabled` (unregisters newly staged

--- a/a2c_smcp/computer/cli/commands/__init__.py
+++ b/a2c_smcp/computer/cli/commands/__init__.py
@@ -15,8 +15,8 @@ CLI 命令核心（REPL 与 Typer 非交互共用）/ CLI command core shared by
 Typer 子命令则构造轻量上下文（不 boot Computer、不连 socket）。
 
 本模块只放 **跨命令共享的接缝**：:func:`build_mcp_callbacks`——从 ``Computer`` 装配 installer / 卸载级联所需的
-MCP 注入回调（``existing_server_names`` / ``register_server`` / ``remove_server``）。plugin / settings 命令（#69）
-将复用本接缝。
+MCP 注入回调（``existing_bundle_ids`` / ``register_server`` / ``remove_server``，身份一律 **bundle_id**，
+数据源为**运行期权威配置集**，#153）。plugin / settings 命令（#69）将复用本接缝。
 This package holds the command business logic as pure-ish handlers (explicit resources, not the whole Computer)
 so they unit-test in isolation. Only the cross-command seam lives here: :func:`build_mcp_callbacks`.
 """
@@ -28,10 +28,12 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from a2c_smcp.utils.bundle_id import resolve_bundle_id
+
 if TYPE_CHECKING:  # 仅类型，避免运行时循环导入 / type-only to dodge runtime import cycle
     from a2c_smcp.computer.computer import Computer
     from a2c_smcp.computer.mcp_clients.model import MCPServerConfig
-    from a2c_smcp.computer.settings.installer import ExistingServerNames, RegisterServer, RemoveServer
+    from a2c_smcp.computer.settings.installer import ExistingBundleIds, RegisterServer, RemoveServer
     from a2c_smcp.computer.settings.schema import SettingsValidationError
     from a2c_smcp.computer.settings.scope import ResolvedSettings
 
@@ -40,7 +42,7 @@ if TYPE_CHECKING:  # 仅类型，避免运行时循环导入 / type-only to dodg
 class McpCallbacks:
     """installer / 卸载级联所需的三个 MCP 注入回调 / The three MCP injection callbacks installer/cascade needs。"""
 
-    existing_server_names: ExistingServerNames
+    existing_bundle_ids: ExistingBundleIds
     register_server: RegisterServer
     remove_server: RemoveServer
 
@@ -49,29 +51,37 @@ def build_mcp_callbacks(comp: Computer) -> McpCallbacks:
     """
     从 ``Computer`` 装配 installer / uninstall 级联所需的 MCP 注入回调 / Wire MCP callbacks from a live Computer。
 
-    - ``existing_server_names``：当前已注册 MCP server 名集合（冲突预检用）；
-    - ``register_server``：**运行期挂载**一个 ``MCPServerConfig``（enable / install remount 用）；
-    - ``remove_server``：按 name **运行期停摘** server（disable / uninstall teardown 用）。
+    - ``existing_bundle_ids``：当前**运行期活跃** server 的 bundle_id 集（依赖预检用）；
+    - ``register_server``：**运行期挂载**一个 ``MCPServerConfig``（enable / 治理重挂用）；
+    - ``remove_server``：按 **bundle_id** 运行期停摘 server（disable / uninstall 回收用）。
 
     设计 §12.2：marketplace remove 的级联卸载（→ :func:`installer.uninstall_plugin`）与 #69 的 plugin
     enable/disable/install/uninstall 共用此接缝，避免各处重复装配。
 
+    **#153 数据源 = 运行期权威配置集**：``existing`` 取 ``comp.mcp_manager.server_configs()``
+    （:meth:`MCPServerManager.server_configs`），**不是** ``comp.mcp_servers``——后者是**构造期快照**，
+    仅 ``Computer.__init__`` 赋值一次，而 CLI 恒传 ``mcp_servers=set()``、所有 server 走 ``amount_server`` /
+    ``aadd_or_aupdate_server`` 挂载 ⇒ 快照恒空 ⇒ 依赖预检把「已满足」全判成「未满足」（协议 §2.5-4 明禁）。
+    亦**不用** :meth:`Computer.active_server_configs`：它 fail-closed 省略缺 raw 记录的 server，用于预检会漏判。
+
     **#137 ③ transient 分流**：本接缝**唯一**消费方是 plugin enable/disable/install/uninstall 与 marketplace
-    级联卸载——皆**治理投影**（bundled 真相在 ledger，非用户此刻声明），故走 transient
-    :meth:`Computer.amount_server` / :meth:`Computer.aunmount_server`，**不回写** mcp.json（否则 disable 后
-    复活 + scope 漂移，见 #138）。用户显式 ``server add``/``rm`` 是另一条（REPL）durable 路径，与此无关。
+    级联卸载——皆**治理投影**（依赖声明的真相在 ledger，非用户此刻声明），故走 transient
+    :meth:`Computer.amount_server` / :meth:`Computer.aunmount_server_by_id`，**不回写** mcp.json（否则 disable
+    后复活 + scope 漂移，见 #138）。用户显式 ``server add``/``rm`` 是另一条（REPL）durable 路径，与此无关。
     """
 
     def _existing() -> set[str]:
-        return {cfg.name for cfg in comp.mcp_servers}
+        if comp.mcp_manager is None:  # pre-boot：无活跃集 → 空（预检只提示，不影响正确性）
+            return set()
+        return {resolve_bundle_id(cfg) for cfg in comp.mcp_manager.server_configs()}
 
     async def _register(cfg: MCPServerConfig) -> None:
         await comp.amount_server(cfg)
 
-    async def _remove(name: str) -> None:
-        await comp.aunmount_server(name)
+    async def _remove(bundle_id: str) -> None:
+        await comp.aunmount_server_by_id(bundle_id)
 
-    return McpCallbacks(existing_server_names=_existing, register_server=_register, remove_server=_remove)
+    return McpCallbacks(existing_bundle_ids=_existing, register_server=_register, remove_server=_remove)
 
 
 # ── 跨命令解析 / 视图接缝（marketplace / skill / plugin / settings 共用）/ shared parse & view seams ──

--- a/a2c_smcp/computer/cli/commands/plugin.py
+++ b/a2c_smcp/computer/cli/commands/plugin.py
@@ -12,11 +12,11 @@ Plugin command handlers + boot-time MCP approval box。
 
 与 marketplace.py 同范式：handler 取**显式资源**（``registry`` / ``home`` / ``env``）+ flags，返回退出码
 （0 成功 / 1 用户错 / 2 网络错），包裹 :mod:`...settings.installer` 四动词 + :mod:`...settings.reconciler`
-gc。MCP 注入回调（``existing_server_names`` / ``register_server`` / ``remove_server`` / ``inject_inputs``）由
+gc。MCP 注入回调（``existing_bundle_ids`` / ``register_server`` / ``remove_server`` / ``inject_inputs``）由
 REPL dispatcher 从活跃 ``Computer`` 装配后注入；Typer 非交互无 live Computer → 传 ``None``。
 
 **v0.3.0 语义（#123）**：``plugin install`` 只安装**不激活**（不挂 server、不投影 skills → ``installed_disabled``；
-仅传 ``existing_server_names`` 做冲突预检）；``plugin enable`` 才原子点亮 skills + bundled server（挂载失败
+仅传 ``existing_bundle_ids`` 做依赖预检）；``plugin enable`` 才原子点亮 skills + bundled server（挂载失败
 回滚 ``installed_disabled``，故 enable 也注入 ``remove_server``）。``plugin list`` 默认列出**全部已安装**
 （enabled 列呈现两态；install 后必须可见）。
 
@@ -51,9 +51,8 @@ from a2c_smcp.computer.cli.progress import clone_spinner
 from a2c_smcp.computer.cli.utils import console
 from a2c_smcp.computer.inputs.plugin_pool import load_plugin_inputs
 from a2c_smcp.computer.settings.installer import (
-    ExistingServerNames,
+    ExistingBundleIds,
     InjectInputs,
-    MCPServerNameConflictError,
     PluginInstallError,
     RegisterServer,
     RemoveServer,
@@ -165,9 +164,10 @@ async def run_governance_remount(comp: Any, *, flag_config: Path | None = None) 
       server）；bundled SKILL 已在 boot 期按无 flag 视图恢复且 additive-only 不撤销，flag-scope 的
       ``enabledPlugins=false`` 对 skill 跨 boot 不生效（可靠 disable 请写 user scope）；
     - inputs 注入先于 register（bundled server 的 ``${input:}`` 经 D2 前缀回退解析，与 install/enable 流一致）；
-    - ``existing_server_names`` **必传**（取自 ``comp.mcp_servers``）：与既有 server 同名 →
-      reconcile_governance 内部 skip+WARN（用户配置胜）；bundled **免批准**（§5.10 不走 project 信任门），
-      单点失败不阻断。
+    - ``existing_bundle_ids`` **必传**（#153：取 :func:`build_mcp_callbacks` 装配的**运行期权威**集，
+      **不是** ``comp.mcp_servers`` 构造期快照——后者 CLI 下恒空，会把已挂的用户 server 判成不存在、
+      令 bundled server 覆盖它）：同 bundle_id 已有 = 依赖已满足 → reconcile_governance 内部 skip（用户配置胜）；
+      bundled **免批准**（§5.10 不走 project 信任门），单点失败不阻断。
     """
     env = os.environ
     declared = resolved_settings(env, flag_path=flag_config)
@@ -181,13 +181,36 @@ async def run_governance_remount(comp: Any, *, flag_config: Path | None = None) 
         _inject_plugin_inputs(comp, record.install_path, record.plugin, record.marketplace)
 
     report = await comp.reconcile_governance(
-        existing_server_names=lambda: {cfg.name for cfg in comp.mcp_servers},
+        existing_bundle_ids=build_mcp_callbacks(comp).existing_bundle_ids,
         register_server=_register,
         inject_inputs=_inject,
         declared=declared,
     )
     for marketplace in report.failed_marketplaces:
         console.print(f"[yellow]⚠ marketplace {marketplace!r} degraded during governance recovery (skills/servers not restored)[/yellow]")
+
+
+def _satisfied_deps(deps: list[str], existing_bundle_ids: ExistingBundleIds | None) -> list[str]:
+    """本次声明的依赖里**已满足**（同 bundle_id 本地已有）的部分（协议 §2.5-1）/ Already-satisfied deps。"""
+    if existing_bundle_ids is None:
+        return []
+    existing = existing_bundle_ids()
+    return [d for d in deps if d in existing]
+
+
+def _print_satisfied_deps(satisfied: list[str]) -> None:
+    """
+    提示「依赖已满足」（协议 §2.5-1 SHOULD 提示）/ Report dependency-satisfied to the user。
+
+    D3 前此处是**硬失败**（``MCPServerNameConflictError``，退出码 1，「name 即身份、无逃生口」）——该裁决已被
+    协议推翻：plugin 与 MCP Server 是依赖关系，同 bundle_id 已有 = 依赖已满足，MUST NOT 拒绝。
+    """
+    for bundle_id in satisfied:
+        console.print(
+            f"[cyan]ℹ dependency satisfied: MCP server {bundle_id!r} already exists locally; this plugin reuses it "
+            f"rather than creating a new one. Configs reconcile by scope precedence. Uninstalling this plugin will "
+            f"not remove it.[/cyan]",
+        )
 
 
 # ── handlers ──────────────────────────────────────────────────────────────────
@@ -200,7 +223,7 @@ async def plugin_install(
     scope: str = "user",
     project_path: str | None = None,
     version: str | None = None,
-    existing_server_names: ExistingServerNames | None = None,
+    existing_bundle_ids: ExistingBundleIds | None = None,
     json_output: bool = False,
 ) -> int:
     """安装单个 plugin（**不激活**：写 installedPlugins + 物化 → ``installed_disabled``，v0.3.0 §2.4）/ Install。
@@ -214,21 +237,20 @@ async def plugin_install(
             record = await install_plugin(
                 plugin_id, registry, home,
                 scope=scope, project_path=project_path, version=version, env=env,
-                existing_server_names=existing_server_names,
+                existing_bundle_ids=existing_bundle_ids,
             )
-    except MCPServerNameConflictError as e:
-        # §10.6 硬抛、退出码 1 + JSON error（无 rename/force 逃生口）。
-        return _err(str(e), json_output=json_output, error_code="mcp_server_name_conflict")
     except PluginInstallError as e:
         return _err(str(e), json_output=json_output)
 
-    servers = record.get("bundledMcpServers") or []
+    deps = record.get("mcpServers") or []
     if json_output:
         console.print_json(
-            data={"installed": plugin_id, "scope": record.get("scope"), "state": "installed_disabled", "bundledMcpServers": servers},
+            data={"installed": plugin_id, "scope": record.get("scope"), "state": "installed_disabled", "mcpServers": deps},
         )
         return EXIT_OK
-    detail = f" ({len(servers)} MCP server(s) bundled, not mounted)" if servers else ""
+    # 依赖已满足提示（协议 §2.5-1）：install 不挂载 ⇒ 活跃集不变 ⇒ 事后算与事前算等价。
+    _print_satisfied_deps(_satisfied_deps(deps, existing_bundle_ids))
+    detail = f" ({len(deps)} MCP server(s) declared as dependencies, not mounted)" if deps else ""
     return _ok(f"installed {plugin_id!r}{detail} (disabled; run 'plugin enable {plugin_id}' to activate)")
 
 
@@ -258,7 +280,7 @@ async def plugin_enable(
     env: Mapping[str, str] | None,
     plugin_id: str,
     *,
-    existing_server_names: ExistingServerNames | None = None,
+    existing_bundle_ids: ExistingBundleIds | None = None,
     register_server: RegisterServer | None = None,
     remove_server: RemoveServer | None = None,
     inject_inputs: InjectInputs | None = None,
@@ -269,10 +291,14 @@ async def plugin_enable(
     **scope 契约**（installer §4.3）：从 ledger 逐 scope 读安装 scope 传入，绝不默认 ``user``，否则写错层、与 live
     态背离。多 scope 记录 → 逐 scope enable。挂载前先经 ``inject_inputs`` 把 plugin-scoped inputs 注入池（#69 Group A）；
     ``remove_server`` 供挂载失败时回滚摘除本次新增 server（v0.3.0 §2.4 enable 原子性）。
+
+    「依赖已满足」提示 **MUST 在 enable 之前算**（协议 §2.5-1）：enable 会挂载未满足的依赖、改变活跃集，
+    事后再算就分不清「本来就有」与「刚被自己挂上」——这与 install 路径（不挂载、事后算等价）不同。
     """
     records = _installed_records(home, env, plugin_id)
     if not records:
         return _err(f"plugin {plugin_id!r} not installed (install it first)", json_output=json_output)
+    satisfied = _satisfied_deps(sorted({s for r in records for s in (r.get("mcpServers") or [])}), existing_bundle_ids)
     try:
         for rec in records:
             install_path = rec.get("installPath")
@@ -281,15 +307,14 @@ async def plugin_enable(
             await enable_plugin(
                 plugin_id, registry, home,
                 scope=str(rec.get("scope", "user")), project_path=rec.get("projectPath"), env=env,
-                existing_server_names=existing_server_names, register_server=register_server, remove_server=remove_server,
+                existing_bundle_ids=existing_bundle_ids, register_server=register_server, remove_server=remove_server,
             )
-    except MCPServerNameConflictError as e:
-        return _err(str(e), json_output=json_output, error_code="mcp_server_name_conflict")
     except PluginInstallError as e:
         return _err(str(e), json_output=json_output)
     if json_output:
         console.print_json(data={"enabled": plugin_id, "scopes": [r.get("scope") for r in records]})
         return EXIT_OK
+    _print_satisfied_deps(satisfied)  # 用 enable 前的快照：此刻活跃集已含本次挂上的，事后算会失真
     return _ok(f"enabled {plugin_id!r}")
 
 
@@ -354,8 +379,8 @@ def plugin_list(
     for pid, records in installed.items():
         enabled = enabled_map.get(pid) is True  # 仅显式 true = 启用（缺省翻转，v0.3.0 §2.4）
         scopes = sorted({str(r.get("scope")) for r in records})
-        bundled = sorted({s for r in records for s in (r.get("bundledMcpServers") or [])})
-        rows.append({"id": pid, "enabled": enabled, "scopes": scopes, "bundledMcpServers": bundled})
+        deps = sorted({s for r in records for s in (r.get("mcpServers") or [])})
+        rows.append({"id": pid, "enabled": enabled, "scopes": scopes, "mcpServers": deps})
     rows.sort(key=lambda r: str(r["id"]))
 
     if json_output:
@@ -365,14 +390,14 @@ def plugin_list(
         console.print("[dim]No plugins installed. Install one: plugin install <plugin>@<marketplace>[/dim]")
         return EXIT_OK
     table = Table(title="Plugins", header_style="bold magenta")
-    for col in ("Plugin", "Enabled", "Scopes", "MCP servers"):
+    for col in ("Plugin", "Enabled", "Scopes", "MCP deps (bundle_id)"):
         table.add_column(col)
     for r in rows:
         table.add_row(
             str(r["id"]),
             "✓" if r["enabled"] else "—",
             ", ".join(r["scopes"]) or "—",
-            ", ".join(r["bundledMcpServers"]) or "—",
+            ", ".join(r["mcpServers"]) or "—",
         )
     console.print(table)
     return EXIT_OK
@@ -385,7 +410,7 @@ def plugin_info(
     *,
     json_output: bool = False,
 ) -> int:
-    """plugin 详情：scope / installPath / version / commitSha / enabled / bundledMcpServers / installedAt。"""
+    """plugin 详情：scope / installPath / version / commitSha / enabled / mcpServers / installedAt。"""
     records = _installed_records(home, env, plugin_id)
     if not records:
         return _err(f"plugin {plugin_id!r} not installed", json_output=json_output)
@@ -400,7 +425,7 @@ def plugin_info(
     table.add_row("enabled", "✓" if enabled else "—")
     for idx, rec in enumerate(records):
         prefix = f"[{rec.get('scope')}] " if len(records) > 1 else ""
-        for k in ("scope", "installPath", "version", "commitSha", "installedAt", "bundledMcpServers"):
+        for k in ("scope", "installPath", "version", "commitSha", "installedAt", "mcpServers"):
             if k in rec:
                 table.add_row(f"{prefix}{k}", str(rec[k]))
         if idx < len(records) - 1:
@@ -637,12 +662,12 @@ async def repl_dispatch(comp: Any, parts: list[str], *, session: Any) -> None:
             return
         scope = flag_value(args, "--scope") or "user"
         # v0.3.0（#123）：install 不激活——不注入 register/inject 回调、不 mark_skills_dirty（skills 无变化）；
-        # 仅传 existing_server_names 供冲突预检。激活走 `plugin enable`。
+        # 仅传 existing_bundle_ids 供依赖预检（只提示不拒绝）。激活走 `plugin enable`。
         await plugin_install(
             registry, home, env, plugin_id,
             scope=scope, project_path=project_path if scope in ("project", "local") else None,
             version=flag_value(args, "--version"),
-            existing_server_names=cbs.existing_server_names,
+            existing_bundle_ids=cbs.existing_bundle_ids,
             json_output=json_output,
         )
     elif sub == "uninstall":
@@ -666,7 +691,7 @@ async def repl_dispatch(comp: Any, parts: list[str], *, session: Any) -> None:
         plugin, marketplace = split
         code = await plugin_enable(
             registry, home, env, pos[0],
-            existing_server_names=cbs.existing_server_names,
+            existing_bundle_ids=cbs.existing_bundle_ids,
             register_server=_plugin_register_cb(comp, plugin, marketplace),
             remove_server=cbs.remove_server,  # enable 失败回滚摘除本次新增 server（v0.3.0 原子性）
             inject_inputs=_plugin_inject_inputs_cb(comp, plugin, marketplace),
@@ -706,10 +731,11 @@ async def repl_dispatch(comp: Any, parts: list[str], *, session: Any) -> None:
 
 
 def _batch_teardown(remove_server: RemoveServer) -> Callable[[list[str]], Awaitable[None]]:
-    """把单个 ``remove_server`` 包成批量 teardown 回调（gc_plugins 的 ``mcp_teardown`` 入参为 name 列表）。"""
+    """把单个 ``remove_server`` 包成批量 teardown 回调（gc_plugins 的 ``mcp_teardown`` 入参为 **bundle_id** 列表，
+    且已在 gc 内过完 §4.9.1-2 回收判据）/ Adapt single-remove into gc's batch teardown。"""
 
-    async def _teardown(names: list[str]) -> None:
-        for name in names:
-            await remove_server(name)
+    async def _teardown(bundle_ids: list[str]) -> None:
+        for bundle_id in bundle_ids:
+            await remove_server(bundle_id)
 
     return _teardown

--- a/a2c_smcp/computer/computer.py
+++ b/a2c_smcp/computer/computer.py
@@ -1606,7 +1606,7 @@ class Computer(BaseComputer[PromptSession]):
     async def reconcile_governance(
         self,
         *,
-        existing_server_names: Callable[[], set[str]] | None = None,
+        existing_bundle_ids: Callable[[], set[str]] | None = None,
         register_server: RegisterBundledServer | None = None,
         inject_inputs: Callable[[BundledServerRecord], Awaitable[None]] | None = None,
         declared: Mapping[str, Any] | None = None,
@@ -1620,16 +1620,19 @@ class Computer(BaseComputer[PromptSession]):
         阶段二（仅当给 ``register_server``）：client 显式重挂 bundled MCP server——逐 plugin 根先
         ``inject_inputs(record)``（携归属上下文做 plugin inputs 前缀化注入，bundled server 的
         ``${input:}`` D2 渲染前置；每 plugin 根仅一次），再逐 server 经 ``register_server(config, record)``
-        携归属上下文注册；与既有 server 同名 → **skip + WARN 不覆盖**（additive-only，用户配置胜）；
-        单 server 失败 → WARN 不阻断其余。
+        携归属上下文注册；**同 ``bundle_id`` 已存在 = 依赖已满足 → skip 不覆盖**（协议 §2.5-1「复用既有实例」，
+        additive-only，用户配置胜）；单 server 失败 → WARN 不阻断其余。
 
         boot 默认（``boot_up`` 内无 hooks 调用）= skills-only：bundled MCP server 不在 boot 拉进程
         （#93 client owns MCP config），仅经 :func:`collect_enabled_bundled_servers` 可查询；重挂永远是
         client 的显式意志（CLI 为参考 client 实现，外部 GUI/client 调用同一入口）。
 
-        :param existing_server_names: 现存 server 名集合工厂（冲突判定）。⚠️ ``None`` = **不判冲突**，
-            同名 bundled server 会经 ``register_server`` 覆盖既有配置——client 重挂时**应当传入**
-            （如 CLI 取 ``comp.mcp_servers`` 名集），仅在明确无冲突面的受控场景省略。
+        :param existing_bundle_ids: 现存 server 的 **bundle_id** 集工厂（依赖已满足判定）。数据源 MUST 是
+            **运行期权威配置集**（``{resolve_bundle_id(cfg) for cfg in comp.mcp_manager.server_configs()}``，
+            如 :func:`~a2c_smcp.computer.cli.commands.build_mcp_callbacks`），**MUST NOT** 读构造期快照
+            ``Computer.mcp_servers``——它在 CLI 下恒空（协议 §2.5-4），会把「依赖已满足」误判为「未满足」。
+            ⚠️ ``None`` = **不判**，同 bundle_id 的 server 会经 ``register_server`` 覆盖既有配置——client
+            重挂时**应当传入**，仅在明确无既有面的受控场景省略。
         :param register_server: 重挂回调 ``(config, record) -> Awaitable``；``None`` = skills-only。
         :param inject_inputs: plugin inputs 注入回调（入参含归属的 record）；每 plugin 根仅调一次。
         :param declared: 合并声明视图覆盖（``installedPlugins`` + ``enabledPlugins`` 两键权威；
@@ -1647,13 +1650,16 @@ class Computer(BaseComputer[PromptSession]):
         if register_server is None:
             return report
 
-        existing = set(existing_server_names()) if existing_server_names is not None else set()
+        existing = set(existing_bundle_ids()) if existing_bundle_ids is not None else set()
         injected_roots: set[Path] = set()
         for record in collect_enabled_bundled_servers(home, declared):
-            name = record.config.name
+            # 身份 = bundle_id：按 display name 判会误伤「同名异 id」——协议 §5.6 明定其为**合法共存**，
+            # MUST NOT 视为冲突；同 bundle_id 才是「依赖已满足」（§2.5-1），此时复用既有实例、不覆盖。
+            name = resolve_bundle_id(record.config)
             if name in existing:
-                logger.warning(
-                    "governance recovery: bundled server %r (plugin %s) conflicts with an existing server, skipped (existing wins)",
+                logger.info(
+                    "governance recovery: dependency satisfied for bundle_id %r (plugin %s); reusing the existing "
+                    "server instead of remounting (existing wins)",
                     name,
                     record.plugin_id,
                 )
@@ -1693,11 +1699,15 @@ class Computer(BaseComputer[PromptSession]):
         结果按 server 名排序（保证稳定可测输出）。**不**含运行期「进程是否已启动」状态——那由
         ``MCPServerManager.get_server_status`` 单独提供。
 
-        归属 join key = server 名（限制与非目标，rust #97 同文档化）：同名冲突会退化——用户配置一个与某启用
-        plugin bundled server **同名**的 server 会被标 ``plugin``（只读）；两个 plugin 的同名 bundled server 经
-        首见去重、后者身份不出现。这符合协议「name = 能力身份」语义，且**可靠的冲突拦截是安装期职责**（install
-        hook ``existing_server_names`` 冲突门），非本只读投影的职责。调用方若需强冲突保证，应经带 hooks 的安装
-        路径拦截，而非依赖本查询。
+        ⚠️ **归属 join key 仍是 server 名**（已知缺陷，迁 ``bundle_id`` 挂 #144；rust #97 同）：同名会退化——
+        用户配置一个与某启用 plugin 声明依赖的 server **同名但异 bundle_id** 的 server 会被误标 ``plugin``
+        （只读），而协议 §5.6 明定二者是**合法共存的不同身份**。
+
+        .. note::
+           此处原注称「name = 能力身份」且「可靠的冲突拦截是安装期职责（install hook 冲突门）」——**两句均已
+           作废**（#153/D3）：协议裁定身份是 ``bundle_id``、plugin 与 server 是**依赖关系**，安装期不再拦截
+           冲突（同 bundle_id 已有 = 依赖已满足 → 提示并复用）。故本投影的同名退化**不再有安装期兜底**，
+           修复须落在 join key 本身（#144）。
         """
         home = self.skill_home
         # ledger 派生的已启用 bundled server（归属纯函数，与 reconcile_governance 同解析视图）。

--- a/a2c_smcp/computer/computer.py
+++ b/a2c_smcp/computer/computer.py
@@ -1655,12 +1655,12 @@ class Computer(BaseComputer[PromptSession]):
         for record in collect_enabled_bundled_servers(home, declared):
             # 身份 = bundle_id：按 display name 判会误伤「同名异 id」——协议 §5.6 明定其为**合法共存**，
             # MUST NOT 视为冲突；同 bundle_id 才是「依赖已满足」（§2.5-1），此时复用既有实例、不覆盖。
-            name = resolve_bundle_id(record.config)
-            if name in existing:
+            bundle_id = resolve_bundle_id(record.config)
+            if bundle_id in existing:
                 logger.info(
                     "governance recovery: dependency satisfied for bundle_id %r (plugin %s); reusing the existing "
                     "server instead of remounting (existing wins)",
-                    name,
+                    bundle_id,
                     record.plugin_id,
                 )
                 continue
@@ -1670,10 +1670,15 @@ class Computer(BaseComputer[PromptSession]):
                     injected_roots.add(record.install_path)
                 await register_server(record.config, record)
             except Exception as e:  # 单 server 失败隔离 / per-server failure isolation
-                logger.warning("governance recovery: failed to remount bundled server %r (plugin %s): %s", name, record.plugin_id, e)
+                logger.warning(
+                    "governance recovery: failed to remount bundled server %r (plugin %s): %s",
+                    bundle_id,
+                    record.plugin_id,
+                    e,
+                )
                 continue
-            existing.add(name)
-            report.remounted_servers.append(name)
+            existing.add(bundle_id)
+            report.remounted_servers.append(bundle_id)
         return report
 
     def list_mcp_servers_with_metadata(self) -> list[McpServerWithMetadata]:

--- a/a2c_smcp/computer/settings/installer.py
+++ b/a2c_smcp/computer/settings/installer.py
@@ -66,7 +66,7 @@ from pathlib import Path
 from typing import Any
 
 from a2c_smcp.computer.mcp_clients.model import MCPServerConfig
-from a2c_smcp.computer.settings.mcp_config import user_declared_bundle_ids
+from a2c_smcp.computer.settings.mcp_config import mcp_json_declared_bundle_ids
 from a2c_smcp.computer.settings.reconciler import (
     ledger_mcp_deps_of,
     other_plugin_mcp_deps,
@@ -275,12 +275,6 @@ def _plugin_skill_names(registry: SkillRegistry, marketplace: str, plugin: str) 
     return names
 
 
-def _declared_mcp_deps_of(home: Path, plugin_id: str, env: Mapping[str, str] | None) -> set[str]:
-    """该 plugin 账本记录声明依赖的 MCP Server **bundle_id** 集（跨 scope 并集）/ Declared MCP deps of a plugin。"""
-    installed = load_installed_plugins(home=home, env=env)
-    return ledger_mcp_deps_of(installed.get("plugins", {}).get(plugin_id, []))
-
-
 def _resolve_marketplace_source(marketplace: str, home: Path, env: Mapping[str, str] | None) -> tuple[Mapping[str, Any], str | None]:
     """从 ``known_marketplaces.json`` 取 marketplace 的 git source + commitSha；未添加 → :class:`PluginInstallError`。"""
     known = load_known_marketplaces(home=home, env=env)
@@ -294,7 +288,7 @@ def _resolve_marketplace_source(marketplace: str, home: Path, env: Mapping[str, 
     return source, commit_sha if isinstance(commit_sha, str) else None
 
 
-def _log_satisfied_deps(servers: list[MCPServerConfig], existing: set[str]) -> list[str]:
+def _log_satisfied_deps(servers: list[MCPServerConfig], existing: set[str]) -> None:
     """
     依赖预检（协议 §2.5-1，**只提示不拒绝**）/ Dependency precheck: report, never reject。
 
@@ -304,16 +298,17 @@ def _log_satisfied_deps(servers: list[MCPServerConfig], existing: set[str]) -> l
     连同 ``owned``（所有权白名单）概念一并退役：依赖声明没有所有权，故无需区分「自有」与「外来」。
     display name 相同、``bundle_id`` 不同是**合法共存**（§5.6），MUST NOT 视为冲突。
 
-    :return: 依赖已满足的 bundle_id 列表（保序，供调用方提示用户）。
+    **只记日志、无返回值**：面向用户的提示由 CLI 层的 ``_satisfied_deps`` / ``_print_satisfied_deps`` 承担
+    （enable 路径 MUST 在挂载**之前**算——挂载会改变活跃集，事后算分不清「本来就有」与「刚被自己挂上」）。
     """
-    satisfied = [bid for cfg in servers if (bid := resolve_bundle_id(cfg)) in existing]
-    for bid in satisfied:
-        logger.info(
-            "dependency satisfied: MCP server %r already exists locally; reusing it rather than creating a new one "
-            "(configs reconcile by scope precedence; uninstalling this plugin will not remove it)",
-            bid,
-        )
-    return satisfied
+    for cfg in servers:
+        bid = resolve_bundle_id(cfg)
+        if bid in existing:
+            logger.info(
+                "dependency satisfied: MCP server %r already exists locally; reusing it rather than creating a new one "
+                "(configs reconcile by scope precedence; uninstalling this plugin will not remove it)",
+                bid,
+            )
 
 
 def _require_existing_ids_guard(
@@ -533,6 +528,7 @@ async def uninstall_plugin(
     **回收 X ⟺ 无其他 plugin 声明依赖 X ∧ X 非用户声明**。由此「用户自有 server 永不连坐」与「多 plugin 共享
     依赖不被提前摘除、最后一个依赖者卸载时回收（无泄漏）」两条同时成立。``--keep-servers`` 跳过整个回收环节。
 
+
     **v0.3.0 §2.4 uninstall 行**：当该 pid 的账本记录**全部**移除（回 ``available``）时，同步删除 user scope
     ``installedPlugins`` 意图条目 + 清 ``enabledPlugins`` 条目（user 必清；给了 ``project_path`` 时 project/local
     一并 best-effort——managed/policy 只读层不触碰）。指定 ``scope`` 仅删该 scope 记录且其余 scope 仍在 →
@@ -569,10 +565,11 @@ async def uninstall_plugin(
     #    ``retained``：scoped uninstall 时本 pid 其余 scope 的记录仍声明依赖 ⇒ 仍算依赖者，不可回收。
     deps = sorted(ledger_mcp_deps_of(targeted))
     retained = [r for r in records if r not in targeted]
+    ledger_plugins = installed.get("plugins", {})
     reclaim = reclaimable_mcp_deps(
         deps,
-        other_deps=other_plugin_mcp_deps(installed.get("plugins", {}), exclude_pid=plugin_id, retained_records=retained),
-        user_declared=user_declared_bundle_ids(env=env),
+        other_deps=other_plugin_mcp_deps(ledger_plugins, exclude_pid=plugin_id, retained_records=retained),
+        user_declared=mcp_json_declared_bundle_ids(env=env),
     )
 
     # ② 删树 → ③ 注销 skills → ④ 回收依赖 → ⑤ 删账本记录（⑤ 恒在末位，勿前移，见 §4.9.1-3）
@@ -693,6 +690,13 @@ async def disable_plugin(
        disable **不删账本记录**，故判据的「其他 plugin」须排除本 pid **全部**记录（``exclude_pid``，无 retained）
        ——否则自己的记录会把自己的依赖判成「他人仍依赖」而永不回收。
 
+       **已知驻留行为**（协议字面推论，与 rust-sdk#139 同口径）：「其他 plugin」= 账本 **installed** 记录
+       （**含 disabled**，§4.9.1-2 字面为「无其他 plugin **声明依赖**」= 账本有记录）。故 A、B 均声明 X 时，
+       **二者都 disable 后 X 仍驻留**（各自的账本记录互相替对方挡住回收），须等 uninstall 才回收。这是保守侧
+       ——X 多活一会儿，但不泄漏（最后一个依赖者 uninstall 时回收）。守卫见
+       ``test_disable_both_dependents_keeps_dep_resident``。
+
+
     ⚠️ **scope 契约**：``scope`` 须与该 plugin 的**安装 scope 一致**（调用方 / #69 CLI 从上下文传）——否则把
     ``enabledPlugins[id]=false`` 写到错误层，更高优先级层意图未动 → 六层合并后可能仍 enabled、下次 reconcile 复活，
     而 live 态已摘 server / orphan skill，造成背离。
@@ -703,11 +707,12 @@ async def disable_plugin(
     _write_enabled_plugin(plugin_id, False, scope, project_path, env)
     reclaim: list[str] = []
     if remove_server is not None:
-        installed = load_installed_plugins(home=home, env=env)
+        # 账本单次读：自己的声明与「其他 plugin 的声明」取自**同一快照**，消 TOCTOU（与 uninstall/gc 对称）。
+        ledger_plugins = load_installed_plugins(home=home, env=env).get("plugins", {})
         reclaim = reclaimable_mcp_deps(
-            sorted(_declared_mcp_deps_of(home, plugin_id, env)),
-            other_deps=other_plugin_mcp_deps(installed.get("plugins", {}), exclude_pid=plugin_id),
-            user_declared=user_declared_bundle_ids(env=env),
+            sorted(ledger_mcp_deps_of(ledger_plugins.get(plugin_id, []))),
+            other_deps=other_plugin_mcp_deps(ledger_plugins, exclude_pid=plugin_id),
+            user_declared=mcp_json_declared_bundle_ids(env=env),
         )
         for bundle_id in reclaim:
             await remove_server(bundle_id)

--- a/a2c_smcp/computer/settings/installer.py
+++ b/a2c_smcp/computer/settings/installer.py
@@ -30,11 +30,18 @@ gc/prune，本模块做**显式单 plugin** 增删启停，写 ``installed_plugi
 ``settings/__init__`` re-export（与 reconciler 同——见 #62 教训）；消费方直接
 ``from a2c_smcp.computer.settings.installer import install_plugin`` 等。
 
-**MCP 注入**：与 :func:`gc_plugins` 的 ``mcp_teardown`` 同款——bundled MCP server 的存在性查询 / 注册 / 摘除经
-注入回调（:data:`ExistingServerNames` / :data:`RegisterServer` / :data:`RemoveServer`），由 #69 CLI 层用
-``Computer.aadd_or_aupdate_server`` / ``Computer.aremove_server`` / ``mcp_manager.get_server_status`` 包装；
-回调 ``None`` = ledger-only（单测 / 无 server 场景）。**enable 注册经 Computer 路径渲染 ``${input:}``**
-（§9.3，inputs 池消歧归 #65）；v0.3.0 起 install 不再收挂载回调（不激活）。
+**MCP 注入**：与 :func:`gc_plugins` 的 ``mcp_teardown`` 同款——MCP server 的存在性查询 / 注册 / 摘除经注入
+回调（:data:`ExistingBundleIds` / :data:`RegisterServer` / :data:`RemoveServer`），由 #69 CLI 层的
+:func:`~a2c_smcp.computer.cli.commands.build_mcp_callbacks` 用 ``Computer.amount_server`` /
+``Computer.aunmount_server_by_id`` / ``mcp_manager.server_configs`` 包装；回调 ``None`` = ledger-only
+（单测 / 无 server 场景）。**enable 注册经 Computer 路径渲染 ``${input:}``**（§9.3，inputs 池消歧归 #65）；
+v0.3.0 起 install 不再收挂载回调（不激活）。
+
+**plugin ↔ MCP Server = 依赖关系，非所有关系**（协议 runtime-contract §2.5 / §4.9.1，#153/D3+F1）：plugin 以
+``bundle_id`` **声明依赖**，账本 ``mcpServers`` 记的是依赖声明。由此三条贯穿本模块：
+  1. **install/enable 不因「同 bundle_id 已有」拒绝**——那是「依赖已满足」，提示并复用既有实例（§2.5-1）；
+  2. **uninstall/disable 不无条件收回**——过 §4.9.1-2 判据「无其他 plugin 依赖 ∧ 非用户声明」才回收；
+  3. **身份一律 bundle_id**——display name 只给用户看。
 
 边界（文档化，非缺陷）/ Documented boundaries：
 - 本模块操作 **live session**；跨重启恢复（活跃集 = installed ∧ enabled）由治理启动恢复承担（#117/#123）：
@@ -59,6 +66,12 @@ from pathlib import Path
 from typing import Any
 
 from a2c_smcp.computer.mcp_clients.model import MCPServerConfig
+from a2c_smcp.computer.settings.mcp_config import user_declared_bundle_ids
+from a2c_smcp.computer.settings.reconciler import (
+    ledger_mcp_deps_of,
+    other_plugin_mcp_deps,
+    reclaimable_mcp_deps,
+)
 from a2c_smcp.computer.settings.schema import SettingsScope, is_valid_enabled_plugin_key
 from a2c_smcp.computer.settings.scope import (
     DELETE,
@@ -95,6 +108,7 @@ from a2c_smcp.computer.skills.staging import (
     locate_plugin_root,
     stage_marketplace_skills,
 )
+from a2c_smcp.utils.bundle_id import resolve_bundle_id
 from a2c_smcp.utils.logger import get_logger
 from a2c_smcp.utils.path import is_within
 
@@ -108,24 +122,21 @@ class PluginInstallError(Exception):
     """plugin install/enable 前置失败（marketplace 未添加 / catalog 未 clone / entry 缺失 / 非法 scope）。"""
 
 
-class MCPServerNameConflictError(Exception):
-    """
-    bundled MCP server 与**外来**同名 server 冲突（§7.2/§10.6）/ Foreign MCP server name conflict。
-
-    **硬抛、原子失败、无 rename/force 逃生口**（name 即身份）。判定排除 plugin 自有
-    （命中其 ``bundledMcpServers`` 记录）→ 幂等再物化不算冲突。
-    """
-
-
 # ---------------------------------------------------------------------------
 # MCP 注入接口 / Injected MCP interface（沿用 gc_plugins 的回调注入风格）
+#
+# **身份一律 bundle_id**（#153/D3）：账本记 bundle_id（§4.9.1-1）⇒ 依赖预检与停摘链全部收 bundle_id。
+# 历史上本接缝收 display name，与「name 给用户看、bundle_id 给代码」判据相悖，且令「同名异 id」误判。
 # ---------------------------------------------------------------------------
-# 当前已注册 server 名集合（同步；CLI 包 ``{r[0] for r in mcp_manager.get_server_status()}``）。
-ExistingServerNames = Callable[[], set[str]]
-# 运行期挂载一个 bundled server（异步；#137 ③ 起 CLI 包 transient ``Computer.amount_server``，含 ``${input:}`` 渲染；
-# 治理投影不回写 mcp.json——bundled 真相在 ledger）。
+# 当前运行期已注册 server 的 **bundle_id** 集（同步）。数据源 MUST 是**运行期权威配置集**
+# （CLI 包 ``{resolve_bundle_id(cfg) for cfg in comp.mcp_manager.server_configs()}``），
+# MUST NOT 读构造期快照（协议 §2.5-4：快照对运行期挂载不可见，会把「依赖已满足」误判为「未满足」）。
+ExistingBundleIds = Callable[[], set[str]]
+# 运行期挂载一个 plugin 声明依赖的 server（异步；#137 ③ 起 CLI 包 transient ``Computer.amount_server``，含
+# ``${input:}`` 渲染；治理投影不回写 mcp.json——依赖声明的真相在 ledger）。
 RegisterServer = Callable[[MCPServerConfig], Awaitable[None]]
-# 运行期停摘一个 bundled server（异步；#137 ③ 起 CLI 包 transient ``Computer.aunmount_server``，停进程不删声明）。
+# 运行期停摘一个 server（异步，入参 **bundle_id**；CLI 包 transient ``Computer.aunmount_server_by_id``，
+# 停进程不删声明）。仅对经 §4.9.1-2 回收判据判定**可回收**者调用。
 RemoveServer = Callable[[str], Awaitable[None]]
 # 注入 plugin-scoped inputs 入池（异步；入参 plugin_root；CLI 包 ``load_plugin_inputs`` → ``Computer.add_or_update_input``）。
 # 在 register（→render bundled server 的 ${input:}）之前调，使裸 id 可经 D2 前缀回退解析（#69 Group A，§9.3 D2）。
@@ -264,15 +275,10 @@ def _plugin_skill_names(registry: SkillRegistry, marketplace: str, plugin: str) 
     return names
 
 
-def _bundled_servers_of(home: Path, plugin_id: str, env: Mapping[str, str] | None) -> set[str]:
-    """该 plugin 物化记录里全部 ``bundledMcpServers`` 名（跨 scope 记录并集）/ All recorded bundled server names。"""
+def _declared_mcp_deps_of(home: Path, plugin_id: str, env: Mapping[str, str] | None) -> set[str]:
+    """该 plugin 账本记录声明依赖的 MCP Server **bundle_id** 集（跨 scope 并集）/ Declared MCP deps of a plugin。"""
     installed = load_installed_plugins(home=home, env=env)
-    out: set[str] = set()
-    for rec in installed.get("plugins", {}).get(plugin_id, []):
-        servers = rec.get("bundledMcpServers")
-        if isinstance(servers, list):
-            out.update(s for s in servers if isinstance(s, str))
-    return out
+    return ledger_mcp_deps_of(installed.get("plugins", {}).get(plugin_id, []))
 
 
 def _resolve_marketplace_source(marketplace: str, home: Path, env: Mapping[str, str] | None) -> tuple[Mapping[str, Any], str | None]:
@@ -288,36 +294,43 @@ def _resolve_marketplace_source(marketplace: str, home: Path, env: Mapping[str, 
     return source, commit_sha if isinstance(commit_sha, str) else None
 
 
-def _conflict_check(servers: list[MCPServerConfig], existing: set[str], owned: set[str]) -> None:
+def _log_satisfied_deps(servers: list[MCPServerConfig], existing: set[str]) -> list[str]:
     """
-    bundled server 同名冲突预检（§7.2/§10.6）/ Bundled-server name-conflict precheck。
+    依赖预检（协议 §2.5-1，**只提示不拒绝**）/ Dependency precheck: report, never reject。
 
-    外来同名（``cfg.name in existing`` 且 ``not in owned``）→ :class:`MCPServerNameConflictError`（硬抛、零变更）；
-    plugin 自有（命中 ``owned`` = 其 ``bundledMcpServers`` 记录）→ 幂等放行（overwrite 自有 server）。
+    同 ``bundle_id`` 本地已有 = **依赖已满足** → 复用既有实例、按来源优先序 reconcile、卸载本 plugin 不移除它。
+    **MUST NOT 拒绝安装**——plugin 与 MCP Server 是**依赖关系而非所有关系**（§2.5），历史的
+    ``MCPServerNameConflictError``「外来同名硬抛、name 即身份」已被协议正面推翻（Discussion #23 / D3），
+    连同 ``owned``（所有权白名单）概念一并退役：依赖声明没有所有权，故无需区分「自有」与「外来」。
+    display name 相同、``bundle_id`` 不同是**合法共存**（§5.6），MUST NOT 视为冲突。
+
+    :return: 依赖已满足的 bundle_id 列表（保序，供调用方提示用户）。
     """
-    for cfg in servers:
-        if cfg.name in existing and cfg.name not in owned:
-            raise MCPServerNameConflictError(
-                f"MCP server name conflict: {cfg.name!r} already exists and is not owned by this plugin. "
-                "Resolve by 'server rm' the existing server, or rename it in the plugin's own manifest "
-                "(no --rename / --force-override escape hatch: name is identity).",
-            )
+    satisfied = [bid for cfg in servers if (bid := resolve_bundle_id(cfg)) in existing]
+    for bid in satisfied:
+        logger.info(
+            "dependency satisfied: MCP server %r already exists locally; reusing it rather than creating a new one "
+            "(configs reconcile by scope precedence; uninstalling this plugin will not remove it)",
+            bid,
+        )
+    return satisfied
 
 
-def _require_existing_names_guard(
-    existing_server_names: ExistingServerNames | None,
+def _require_existing_ids_guard(
+    existing_bundle_ids: ExistingBundleIds | None,
     register_server: RegisterServer | None,
 ) -> None:
     """
-    护栏：给了 ``register_server`` 就**必须**给 ``existing_server_names`` / Guard: register implies existing-names。
+    护栏：给了 ``register_server`` 就**必须**给 ``existing_bundle_ids`` / Guard: register implies existing-ids。
 
-    否则冲突闸门以 ``existing=∅`` 运行被静默旁路——外来同名 server 会被 MCP manager **静默覆盖**（manager 对
-    同名是覆盖更新、不抛），违 §10.6「外来同名硬抛」铁律。三注入回调应「齐备或全无」，此处强制 register→existing。
+    D3 后 ``existing`` 不再是「拒绝闸门」而是 **skip-or-register 的判据**（§2.5-1「依赖已满足 → 复用既有实例」）：
+    缺它则以 ``existing=∅`` 运行 ⇒ 全量 register ⇒ 把用户既有的同 bundle_id server **静默覆盖**（manager 对同
+    bundle_id 是覆盖更新、不抛）。三注入回调应「齐备或全无」，此处强制 register→existing。
     """
-    if register_server is not None and existing_server_names is None:
+    if register_server is not None and existing_bundle_ids is None:
         raise PluginInstallError(
-            "existing_server_names is required when register_server is given "
-            "(else the MCP name-conflict gate is silently bypassed; design §10.6)",
+            "existing_bundle_ids is required when register_server is given "
+            "(else a dependency-satisfied server would be silently overwritten instead of reused; protocol §2.5-1)",
         )
 
 
@@ -334,10 +347,10 @@ async def materialize_plugin(
     refresh: bool = False,
     timeout: float = DEFAULT_GIT_TIMEOUT,
     env: Mapping[str, str] | None = None,
-    existing_server_names: ExistingServerNames | None = None,
+    existing_bundle_ids: ExistingBundleIds | None = None,
 ) -> InstalledPluginRecord:
     """
-    物化单个 plugin（clone/定位 + manifest 校验 + 冲突预检 + 写账本；**零激活**）/ Materialize one plugin。
+    物化单个 plugin（clone/定位 + manifest 校验 + 依赖预检 + 写账本；**零激活**）/ Materialize one plugin。
 
     协议 v0.3.0 §2.3「Fetch 资产：意图 → 物化账本 → 克隆缓存 → 活跃集」中**物化账本**一环的执行体：
     供 :func:`install_plugin`（显式安装）与治理启动恢复（账本删除后由 ``installedPlugins`` 意图重建，
@@ -348,10 +361,11 @@ async def materialize_plugin(
     2. 要求 catalog clone 已存在（``marketplace add`` 前置；缺失→抛）；读 marketplace.json 定位 entry。
     3. :func:`locate_plugin_root` 定位 plugin 根（必要时 clone 外部 plugin；失败→抛，零变更）。
     4. strict 冲突检测（§4.4，#80）+ :func:`load_bundled_servers` 全量解析（任一畸形→抛，写账本前）。
-    5. **★冲突预检**：外来同名→:class:`MCPServerNameConflictError`（零变更）；自有同名→幂等放行；
-       ``existing_server_names=None``（boot 重物化等无 live manager 场景）→ 跳过预检。
+    5. **依赖预检**（协议 §2.5-1）：同 ``bundle_id`` 已存在 = 依赖已满足 → **提示、不拒绝**（历史的外来同名
+       硬抛已被 D3 推翻，见 :func:`_log_satisfied_deps`）；``existing_bundle_ids=None``（boot 重物化等无 live
+       manager 场景）→ 跳过预检。**本步骤零副作用**——install ⊥ activate，挂载归 :func:`enable_plugin`。
     6. 写 ``installed_plugins.json``（仅全成功）：scope / installPath / version / commitSha /
-       installedAt / lastUpdated / bundledMcpServers。
+       installedAt / lastUpdated / **mcpServers（bundle_id 数组，§4.9.1-1）**。
 
     :param scope: 物化记录 scope（``managed|user|project|local``，默认 ``user``）。
     :param version: 记录版本覆盖（``--version``）；缺省按 entry > plugin.json > commitSha 解析。
@@ -390,13 +404,12 @@ async def materialize_plugin(
         raise PluginInstallError(str(e)) from e
     servers = load_bundled_servers(plugin_root)
 
-    # 5：★冲突预检（零变更）。owned = 自有同名白名单（其上次记录的 bundledMcpServers）。
-    owned = _bundled_servers_of(home, plugin_id, env)
-    existing = existing_server_names() if existing_server_names is not None else set()
-    _conflict_check(servers, existing, owned)
+    # 5：依赖预检（§2.5-1，只提示不拒绝；零变更）
+    existing = existing_bundle_ids() if existing_bundle_ids is not None else set()
+    _log_satisfied_deps(servers, existing)
 
     # 6：写账本（仅全成功）
-    bundled_names = [cfg.name for cfg in servers]
+    mcp_deps = [resolve_bundle_id(cfg) for cfg in servers]
     resolved_version = version if version else resolve_plugin_version(entry, plugin_manifest, version_fallback)
     now = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
     record: InstalledPluginRecord = {"scope": scope, "installPath": str(plugin_root)}
@@ -408,8 +421,8 @@ async def materialize_plugin(
         record["commitSha"] = version_fallback
     record["installedAt"] = now
     record["lastUpdated"] = now
-    if bundled_names:
-        record["bundledMcpServers"] = bundled_names
+    # 无条件写（空则 ``[]`）：格式明确、与 rust-sdk#139 磁盘形态逐字节一致，且「有该键」= 新格式正向标志。
+    record["mcpServers"] = mcp_deps
 
     def _put(data: InstalledPluginsFile, _rec: InstalledPluginRecord = record, _pid: str = plugin_id) -> None:
         plugins = data["plugins"]
@@ -433,7 +446,7 @@ async def install_plugin(
     refresh: bool = False,
     timeout: float = DEFAULT_GIT_TIMEOUT,
     env: Mapping[str, str] | None = None,
-    existing_server_names: ExistingServerNames | None = None,
+    existing_bundle_ids: ExistingBundleIds | None = None,
 ) -> InstalledPluginRecord:
     """
     显式安装单个 plugin = config-first 写意图 + 物化；**不激活**（v0.3.0 §2.4 install 行）/ Install ≠ activate。
@@ -441,7 +454,7 @@ async def install_plugin(
     顺序 / Order:
     1. cheap 预检（零变更）：``plugin_id`` 形态、marketplace 已添加、catalog 已 clone、manifest entry 存在。
     2. **config-first**（§2.3）：把 ``plugin_id`` 写入 **user scope** ``installedPlugins``（全局安装意图）。
-    3. :func:`materialize_plugin` 物化（clone/strict/bundled 解析/冲突预检/写账本）。
+    3. :func:`materialize_plugin` 物化（clone/strict/bundled 解析/依赖预检/写账本）。
     4. 物化失败 → **原子回滚**：撤销第 2 步新写的意图条目（重装场景原已在 → 保留）→ 上抛（#123 决策 #3：
        「失败 = 零变更」；协议对 install 失败未置可否，本 SDK 取更强不变量，rust-sdk#103 镜像）。
 
@@ -451,7 +464,8 @@ async def install_plugin(
     :param registry: 与其余三动词对称保留；install 自 v0.3.0 起不触碰 Registry。
     :param scope: 物化记录 scope（``managed|user|project|local``，默认 ``user``）——只影响账本记录归档，
         **不**影响意图落点（安装是全局一次的事实，意图恒写 user scope）。
-    :param existing_server_names: 可选冲突预检输入（``None`` = 跳过预检；enable 时仍有权威预检兜底）。
+    :param existing_bundle_ids: 可选依赖预检输入（``None`` = 跳过预检）。预检**只提示不拒绝**（§2.5-1），
+        故此处缺省不影响正确性；真正消费 ``existing`` 做 skip-or-register 决策的是 :func:`enable_plugin`。
     :return: 写入的 :class:`InstalledPluginRecord`。
     """
     plugin, marketplace = _split_plugin_id(plugin_id)
@@ -483,7 +497,7 @@ async def install_plugin(
             refresh=refresh,
             timeout=timeout,
             env=env,
-            existing_server_names=existing_server_names,
+            existing_bundle_ids=existing_bundle_ids,
         )
     except Exception:
         if not was_present:
@@ -494,9 +508,9 @@ async def install_plugin(
         raise
 
     logger.info(
-        "installed plugin %r (servers=%s; installed_disabled, run 'plugin enable' to activate)",
+        "installed plugin %r (MCP deps=%s; installed_disabled, run 'plugin enable' to activate)",
         plugin_id,
-        record.get("bundledMcpServers") or "none",
+        record.get("mcpServers") or "none",
     )
     return record
 
@@ -512,7 +526,12 @@ async def uninstall_plugin(
     remove_server: RemoveServer | None = None,
 ) -> bool:
     """
-    卸载单个 plugin（删 installPath 树 + 注销 skills + 级联 stop+remove bundled server + 删账本记录）/ Uninstall。
+    卸载单个 plugin（删 installPath 树 + 注销 skills + **按判据回收** MCP 依赖 + 删账本记录）/ Uninstall。
+
+    **MCP 依赖回收**（协议 §4.9.1-2，#153/D3+F1）：plugin 声明依赖的 server **不是**它的所有物，故卸载
+    **不无条件收回**——逐个过 :func:`~a2c_smcp.computer.settings.reconciler.reclaimable_mcp_deps`：
+    **回收 X ⟺ 无其他 plugin 声明依赖 X ∧ X 非用户声明**。由此「用户自有 server 永不连坐」与「多 plugin 共享
+    依赖不被提前摘除、最后一个依赖者卸载时回收（无泄漏）」两条同时成立。``--keep-servers`` 跳过整个回收环节。
 
     **v0.3.0 §2.4 uninstall 行**：当该 pid 的账本记录**全部**移除（回 ``available``）时，同步删除 user scope
     ``installedPlugins`` 意图条目 + 清 ``enabledPlugins`` 条目（user 必清；给了 ``project_path`` 时 project/local
@@ -545,21 +564,29 @@ async def uninstall_plugin(
     # （同 install 的标记误置风险，防迁移被抢跑关闭；置于此处保「未安装 = 真 no-op 零写盘」，审查 N1）。
     migrate_legacy_installs(home, env=env)
 
-    bundled: list[str] = []
+    # ① 停摘候选 + 回收判定，**先于任何删除**取得（§4.9.1-3：名单 MUST 在账本记录移除之前取得，且 MUST 仅依赖
+    #    账本自身字段——``installPath`` 指向的树在下面就被删了，「从 install_path 重解析」在本路径恒不成立）。
+    #    ``retained``：scoped uninstall 时本 pid 其余 scope 的记录仍声明依赖 ⇒ 仍算依赖者，不可回收。
+    deps = sorted(ledger_mcp_deps_of(targeted))
+    retained = [r for r in records if r not in targeted]
+    reclaim = reclaimable_mcp_deps(
+        deps,
+        other_deps=other_plugin_mcp_deps(installed.get("plugins", {}), exclude_pid=plugin_id, retained_records=retained),
+        user_declared=user_declared_bundle_ids(env=env),
+    )
+
+    # ② 删树 → ③ 注销 skills → ④ 回收依赖 → ⑤ 删账本记录（⑤ 恒在末位，勿前移，见 §4.9.1-3）
     for rec in targeted:
         install_path = rec.get("installPath")
         if isinstance(install_path, str) and install_path:
             _safe_rmtree(Path(install_path), home)
-        servers = rec.get("bundledMcpServers")
-        if isinstance(servers, list):
-            bundled.extend(s for s in servers if isinstance(s, str))
 
     for name in _plugin_skill_names(registry, marketplace, plugin):
         registry.unregister(name)
 
     if not keep_servers and remove_server is not None:
-        for sname in bundled:
-            await remove_server(sname)
+        for bundle_id in reclaim:
+            await remove_server(bundle_id)
 
     def _drop(data: InstalledPluginsFile, _pid: str = plugin_id, _scope: str | None = scope) -> None:
         plugins = data["plugins"]
@@ -582,10 +609,11 @@ async def uninstall_plugin(
         project_paths = {p for r in targeted if isinstance(p := r.get("projectPath"), str) and p}
         _clear_enabled_entries_visible_layers(plugin_id, project_paths, env)
     logger.info(
-        "uninstalled plugin %r (scope=%s, servers=%s)",
+        "uninstalled plugin %r (scope=%s, MCP deps declared=%s, reclaimed=%s)",
         plugin_id,
         scope or "all",
-        "kept" if keep_servers else (bundled or "none"),
+        deps or "none",
+        "kept" if keep_servers else (reclaim or "none"),
     )
     return True
 
@@ -656,9 +684,14 @@ async def disable_plugin(
     """
     禁用单个 plugin = 整 plugin 下线（§4.3 决策 #6）/ Disable = take the whole plugin offline。
 
-    ① 写 ``enabledPlugins[id]=false``；② 停并摘除其 bundled MCP server（读物化记录的 ``bundledMcpServers``）；
-    ③ 隐藏 skills（:meth:`SkillRegistry.mark_orphan`，**物化层不动**——clone 树 / installed 记录保留，
-    :func:`enable_plugin` 廉价复原）。区别于 :func:`uninstall_plugin`：disable 留 installed 记录、可一键回滚。
+    ① 写 ``enabledPlugins[id]=false``；② **按 §4.9.1-2 判据回收**其声明依赖的 MCP server（判据与 uninstall 同源
+    ——协议明列 disable / uninstall 二者共用；用户自有 / 他 plugin 仍依赖者 MUST NOT 被摘）；③ 隐藏 skills
+    （:meth:`SkillRegistry.mark_orphan`，**物化层不动**——clone 树 / installed 记录保留，:func:`enable_plugin`
+    廉价复原）。区别于 :func:`uninstall_plugin`：disable 留 installed 记录、可一键回滚。
+
+    .. note::
+       disable **不删账本记录**，故判据的「其他 plugin」须排除本 pid **全部**记录（``exclude_pid``，无 retained）
+       ——否则自己的记录会把自己的依赖判成「他人仍依赖」而永不回收。
 
     ⚠️ **scope 契约**：``scope`` 须与该 plugin 的**安装 scope 一致**（调用方 / #69 CLI 从上下文传）——否则把
     ``enabledPlugins[id]=false`` 写到错误层，更高优先级层意图未动 → 六层合并后可能仍 enabled、下次 reconcile 复活，
@@ -668,12 +701,19 @@ async def disable_plugin(
     """
     plugin, marketplace = _split_plugin_id(plugin_id)
     _write_enabled_plugin(plugin_id, False, scope, project_path, env)
+    reclaim: list[str] = []
     if remove_server is not None:
-        for sname in sorted(_bundled_servers_of(home, plugin_id, env)):
-            await remove_server(sname)
+        installed = load_installed_plugins(home=home, env=env)
+        reclaim = reclaimable_mcp_deps(
+            sorted(_declared_mcp_deps_of(home, plugin_id, env)),
+            other_deps=other_plugin_mcp_deps(installed.get("plugins", {}), exclude_pid=plugin_id),
+            user_declared=user_declared_bundle_ids(env=env),
+        )
+        for bundle_id in reclaim:
+            await remove_server(bundle_id)
     for name in _plugin_skill_names(registry, marketplace, plugin):
         registry.mark_orphan(name)
-    logger.info("disabled plugin %r (scope=%s, servers detached, skills orphaned)", plugin_id, scope)
+    logger.info("disabled plugin %r (scope=%s, MCP deps reclaimed=%s, skills orphaned)", plugin_id, scope, reclaim or "none")
 
 
 async def enable_plugin(
@@ -685,15 +725,21 @@ async def enable_plugin(
     project_path: str | None = None,
     timeout: float = DEFAULT_GIT_TIMEOUT,
     env: Mapping[str, str] | None = None,
-    existing_server_names: ExistingServerNames | None = None,
+    existing_bundle_ids: ExistingBundleIds | None = None,
     register_server: RegisterServer | None = None,
     remove_server: RemoveServer | None = None,
 ) -> None:
     """
     启用单个 plugin（**原子激活**：skills 与 bundled server 一并入投影，失败回滚 ``installed_disabled``）/ Enable。
 
+    **依赖已满足 ⇒ 复用既有实例**（协议 §2.5-1，#153/D3）：声明的 ``bundle_id`` 若已在运行期活跃集里，
+    **跳过 register**——既有实例（用户 mcp.json 声明的，或他 plugin 带入的）胜出，本 plugin 复用它而非覆盖。
+    与 :meth:`Computer.reconcile_governance` 的「existing wins → skip」同姿态。
+    完整来源优先序（``plugin < user < project < local < flag < policy``）属 #154 范围；此处「existing wins」
+    是其**可观测等价**（``origin=plugin`` 恒最低 ⇒ 任何既有声明都胜过 plugin 带入的）。
+
     v0.3.0 §2.4「enable 原子性」：顺序 ① 从物化记录的 ``installPath`` 重解析 bundled servers →
-    **★冲突预检（先于 settings 写）**；② 快照该 scope ``enabledPlugins`` 原值 + 本 plugin 已活跃 skills →
+    **依赖预检（先于 settings 写）**；② 快照该 scope ``enabledPlugins`` 原值 + 本 plugin 已活跃 skills →
     写 ``enabledPlugins[id]=true``；③ 复活 skills——re-stage（:func:`stage_marketplace_skills` 的
     :meth:`register_or_update` 把孤儿同名翻 ``orphaned=False``，``refresh=False`` 复用既有 clone）；
     ④ 重挂 servers。③/④ 任一失败 → **回滚**：注销本次新增 skill、摘除本次新增 server（经 ``remove_server``）、
@@ -704,21 +750,20 @@ async def enable_plugin(
     ``enabledPlugins[id]=true`` 写错层、与 live 态背离。
     """
     plugin, marketplace = _split_plugin_id(plugin_id)
-    _require_existing_names_guard(existing_server_names, register_server)
+    _require_existing_ids_guard(existing_bundle_ids, register_server)
     installed = load_installed_plugins(home=home, env=env)
     records = installed.get("plugins", {}).get(plugin_id)
     if not records:
         raise PluginInstallError(f"plugin {plugin_id!r} not installed; cannot enable (run 'plugin install' first)")
 
-    # ① 重解析 bundled servers（不重 clone，从记录 installPath 读）+ 冲突预检（零持久化变更前）
+    # ① 重解析 bundled servers（不重 clone，从记录 installPath 读）+ 依赖预检（零持久化变更前）
     servers: list[MCPServerConfig] = []
     for rec in records:
         install_path = rec.get("installPath")
         if isinstance(install_path, str) and install_path:
             servers.extend(load_bundled_servers(Path(install_path)))
-    owned = _bundled_servers_of(home, plugin_id, env)
-    existing = existing_server_names() if existing_server_names is not None else set()
-    _conflict_check(servers, existing, owned)
+    existing = existing_bundle_ids() if existing_bundle_ids is not None else set()
+    _log_satisfied_deps(servers, existing)
 
     # ② 快照回滚基线（该 scope 文件的原值：True/False/None=absent；本 plugin 已活跃 skill 集）→ 写 true
     settings_path, scope_enum = _settings_path_for_scope(scope, project_path, env)
@@ -742,24 +787,26 @@ async def enable_plugin(
             timeout=timeout,
             env=env,
         )
-        # ④ 重挂 servers
+        # ④ 挂载依赖：仅挂**尚未满足**者；已满足 → 复用既有实例，不覆盖（§2.5-1）
         if register_server is not None:
             for cfg in servers:
+                bundle_id = resolve_bundle_id(cfg)
+                if bundle_id in existing:
+                    continue
                 await register_server(cfg)
-                registered.append(cfg.name)
+                registered.append(bundle_id)  # 身份 = bundle_id：按 name 记会在「同名异 id」时回滚摘错对象
     except Exception:
         # 回滚（逆序，best-effort 不掩盖原异常）：撤销本次新增 skill / server，enabledPlugins 恢复原值。
+        # ``registered`` 只含本次真正挂上的（依赖已满足者已在 ④ skip），故此处无需再判「是否本来就在」。
         for name in _plugin_skill_names(registry, marketplace, plugin):
             if name not in skills_before:
                 registry.unregister(name)
         if remove_server is not None:
-            for sname in registered:
-                if sname in owned and sname in existing:
-                    continue  # 自有且 enable 前已挂：保留，不误摘
+            for bundle_id in registered:
                 try:
-                    await remove_server(sname)
+                    await remove_server(bundle_id)
                 except Exception as e:  # noqa: BLE001 - 回滚 best-effort
-                    logger.warning("enable rollback: remove_server(%r) failed: %s", sname, e)
+                    logger.warning("enable rollback: remove_server(%r) failed: %s", bundle_id, e)
         try:
             _write_enabled_plugin(plugin_id, prev_value, scope, project_path, env)
         except Exception as e:  # noqa: BLE001 - 回滚 best-effort
@@ -795,7 +842,12 @@ def migrate_legacy_installs(home: Path, *, env: Mapping[str, str] | None = None)
         if "installedPlugins" in existing:
             return []  # 已迁移（标记键在）→ 严格 no-op
 
-        ledger_pids = [pid for pid in load_installed_plugins(home=home, env=env).get("plugins", {}) if is_valid_enabled_plugin_key(pid)]
+        # ``drop_legacy=False`` 是**必须**的（#153）：v0.2.x 账本记录一律是旧格式（``bundledMcpServers``），
+        # 默认读法会把它们整条丢弃 ⇒ 带 MCP server 的 plugin 连 pid 一起消失 ⇒ 意图无从回填 ⇒ 升级后
+        # plugin 静默全丢。此处**只读 key**（pid），不碰旧格式的字段值，故安全；账本记录本身随后由
+        # recovery 从这里回填出的意图重建（协议 §4.9.1-4「丢弃 + 从 installedPlugins 意图重建」的前提）。
+        raw_ledger = load_installed_plugins(home=home, env=env, drop_legacy=False)
+        ledger_pids = [pid for pid in raw_ledger.get("plugins", {}) if is_valid_enabled_plugin_key(pid)]
         merged_enabled = resolve_settings(env=env).settings.get("enabledPlugins")
         merged_view: Mapping[str, Any] = merged_enabled if isinstance(merged_enabled, Mapping) else {}
 

--- a/a2c_smcp/computer/settings/mcp_config.py
+++ b/a2c_smcp/computer/settings/mcp_config.py
@@ -347,6 +347,9 @@ def mcp_json_declared_bundle_ids(*, env: Mapping[str, str] | None = None) -> set
     ``Computer(mcp_servers={...})`` 构造的 server 均走 transient ``amount_server`` 挂载，**进运行期活跃集
     但不进 mcp.json**（``cli/main.py`` `_add_server` / ``computer.py`` boot_up）。只读本视图会把它们误判为
     「非用户声明」而在 plugin 卸载时**连坐停摘**，正是 §4.9.1-2 与 Epic #147 北极星要根治的 P0。
+    根治需运行期 origin（#134 轴）或 ``--config`` 归一进 mcp.json flag 层（#154）——**方案求裁于
+    protocol Discussion #32**（https://github.com/A2C-SMCP/a2c-smcp-protocol/discussions/32）；在此之前本函数是回收判据「非用户声明」项的**唯一**数据源，
+    该缺口由 ``test_runtime_only_user_server_is_never_collateral``（xfail）钉住。
 
     ``origin`` 无需过滤：本视图的 origin 恒为 ``user/project/local/flag/policy``（plugin 声明依赖的 server
     从不回写 mcp.json），故 ``origin != plugin`` 在此恒真。同款推理见 :func:`mcp_server_status` 的 #148 注释。

--- a/a2c_smcp/computer/settings/mcp_config.py
+++ b/a2c_smcp/computer/settings/mcp_config.py
@@ -334,18 +334,22 @@ def resolve_mcp_config(
     return ResolvedMcpConfig(servers=servers, inputs=inputs, errors=errors)
 
 
-def user_declared_bundle_ids(*, env: Mapping[str, str] | None = None) -> set[str]:
+def mcp_json_declared_bundle_ids(*, env: Mapping[str, str] | None = None) -> set[str]:
     """
-    当前**用户声明面**（各 scope mcp.json）全部 server 的 bundle_id 集 / bundle_ids declared by the user。
+    **mcp.json 声明面**（各 scope）全部 server 的 bundle_id 集 / bundle_ids declared in mcp.json。
 
-    协议 runtime-contract §4.9.1-2 回收判据第二项「X **非用户声明**」的数据源（#153/F1）：plugin
-    disable/uninstall 时，用户自己在 mcp.json 里声明过的同 bundle_id server **永不连坐**。
+    这是回收判据「X 非用户声明」的**其中一个**来源，**不是全部**——完整判定集见
+    :func:`~a2c_smcp.computer.settings.reconciler.user_owned_bundle_ids`（协议 §4.9.1-2 的数据源是
+    **运行期权威配置集** + ``origin != plugin``，而 mcp.json 只覆盖其中「落了声明」的那部分）。
 
-    **为何不按 ``origin != plugin`` 过滤**（协议原文如此表述，此处刻意省略）：本 SDK 中
-    :func:`resolve_mcp_config` 产出的 ``origin`` 恒为 ``user/project/local/flag/policy``——plugin 声明依赖的
-    server 走 transient ``Computer.amount_server`` 挂载、**从不回写 mcp.json**，故不可能出现在本视图里。
-    即「出现在 mcp.json」⇔「用户声明」，额外过滤是恒真条件。同款推理见 :func:`mcp_server_status` 的 #148 注释。
-    ⚠️ 若将来 bundled server 改为回写 mcp.json（origin 可为 plugin），此函数 **MUST** 同步加 origin 过滤。
+    **⚠️ 勿单独用它当「用户声明」判据**（#153 隔离审查 🔴）：「出现在 mcp.json ⇒ 用户声明」成立，但
+    **反向不成立**——用户经 ``a2c-computer run --config @file`` 预加载、或 SDK 内嵌
+    ``Computer(mcp_servers={...})`` 构造的 server 均走 transient ``amount_server`` 挂载，**进运行期活跃集
+    但不进 mcp.json**（``cli/main.py`` `_add_server` / ``computer.py`` boot_up）。只读本视图会把它们误判为
+    「非用户声明」而在 plugin 卸载时**连坐停摘**，正是 §4.9.1-2 与 Epic #147 北极星要根治的 P0。
+
+    ``origin`` 无需过滤：本视图的 origin 恒为 ``user/project/local/flag/policy``（plugin 声明依赖的 server
+    从不回写 mcp.json），故 ``origin != plugin`` 在此恒真。同款推理见 :func:`mcp_server_status` 的 #148 注释。
     """
     snapshot = resolve_mcp_config(env=env)
     return {resolve_bundle_id(srv.config) for srv in snapshot.servers.values()}

--- a/a2c_smcp/computer/settings/mcp_config.py
+++ b/a2c_smcp/computer/settings/mcp_config.py
@@ -73,6 +73,7 @@ from a2c_smcp.computer.settings.scope import (
     workdir_settings_dir,
 )
 from a2c_smcp.computer.settings.store import atomic_write_json, file_lock
+from a2c_smcp.utils.bundle_id import resolve_bundle_id
 from a2c_smcp.utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -331,6 +332,23 @@ def resolve_mcp_config(
             inputs.append(resolved_input)
 
     return ResolvedMcpConfig(servers=servers, inputs=inputs, errors=errors)
+
+
+def user_declared_bundle_ids(*, env: Mapping[str, str] | None = None) -> set[str]:
+    """
+    当前**用户声明面**（各 scope mcp.json）全部 server 的 bundle_id 集 / bundle_ids declared by the user。
+
+    协议 runtime-contract §4.9.1-2 回收判据第二项「X **非用户声明**」的数据源（#153/F1）：plugin
+    disable/uninstall 时，用户自己在 mcp.json 里声明过的同 bundle_id server **永不连坐**。
+
+    **为何不按 ``origin != plugin`` 过滤**（协议原文如此表述，此处刻意省略）：本 SDK 中
+    :func:`resolve_mcp_config` 产出的 ``origin`` 恒为 ``user/project/local/flag/policy``——plugin 声明依赖的
+    server 走 transient ``Computer.amount_server`` 挂载、**从不回写 mcp.json**，故不可能出现在本视图里。
+    即「出现在 mcp.json」⇔「用户声明」，额外过滤是恒真条件。同款推理见 :func:`mcp_server_status` 的 #148 注释。
+    ⚠️ 若将来 bundled server 改为回写 mcp.json（origin 可为 plugin），此函数 **MUST** 同步加 origin 过滤。
+    """
+    snapshot = resolve_mcp_config(env=env)
+    return {resolve_bundle_id(srv.config) for srv in snapshot.servers.values()}
 
 
 # ---------------------------------------------------------------------------

--- a/a2c_smcp/computer/settings/reconciler.py
+++ b/a2c_smcp/computer/settings/reconciler.py
@@ -44,7 +44,7 @@ from collections.abc import Awaitable, Callable, Iterable, Mapping, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from a2c_smcp.computer.settings.mcp_config import user_declared_bundle_ids
+from a2c_smcp.computer.settings.mcp_config import mcp_json_declared_bundle_ids
 from a2c_smcp.computer.settings.schema import is_valid_enabled_plugin_key, is_valid_marketplace_name
 from a2c_smcp.computer.settings.store import (
     InstalledPluginsFile,
@@ -486,7 +486,13 @@ def reclaimable_mcp_deps(
 
     :param deps: 本次 disable/uninstall 的 plugin 所声明的依赖（``ledger_mcp_deps_of`` 产出）。
     :param other_deps: :func:`other_plugin_mcp_deps` 产出。
-    :param user_declared: :func:`~a2c_smcp.computer.settings.mcp_config.user_declared_bundle_ids` 产出。
+    :param user_declared: :func:`~a2c_smcp.computer.settings.mcp_config.mcp_json_declared_bundle_ids` 产出。
+        ⚠️ **已知未覆盖面**（#153 隔离审查 🔴，方案待三仓 Discussion 定案）：协议把本项的数据源写作「**运行期
+        权威配置集**中 ``origin != plugin`` 的条目」，而本 SDK 的 manager **不存 origin**——用户经
+        ``--config @file`` / SDK 内嵌 ``Computer(mcp_servers={...})`` 挂载的 server 走 transient
+        ``amount_server``、**不落 mcp.json**，与「plugin 自己挂的 server」在可观测信息上**完全同形**。
+        故若该 server 同时被某 plugin 声明依赖，卸载该 plugin 时仍会回收它。详见
+        :func:`~a2c_smcp.computer.settings.mcp_config.mcp_json_declared_bundle_ids`。
     :return: 可回收的 bundle_id（保 ``deps`` 迭代序）。
     """
     return [d for d in deps if d not in other_deps and d not in user_declared]
@@ -581,7 +587,7 @@ async def gc_plugins(
         reclaim = reclaimable_mcp_deps(
             sorted(deps),
             other_deps=other_plugin_mcp_deps(plugins, exclude_pid=pid),
-            user_declared=user_declared_bundle_ids(env=env),
+            user_declared=mcp_json_declared_bundle_ids(env=env),
         )
         for rec in records:
             install_path = rec.get("installPath")

--- a/a2c_smcp/computer/settings/reconciler.py
+++ b/a2c_smcp/computer/settings/reconciler.py
@@ -40,10 +40,11 @@ SDK 设计 / Design: python-sdk docs/design-0.2.1-cli-marketplace-ux.md §7.1（
 from __future__ import annotations
 
 import shutil
-from collections.abc import Awaitable, Callable, Mapping
+from collections.abc import Awaitable, Callable, Iterable, Mapping, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from a2c_smcp.computer.settings.mcp_config import user_declared_bundle_ids
 from a2c_smcp.computer.settings.schema import is_valid_enabled_plugin_key, is_valid_marketplace_name
 from a2c_smcp.computer.settings.store import (
     InstalledPluginsFile,
@@ -417,6 +418,80 @@ def ledger_entry_fully_materialized(records: object) -> bool:
     return all(ledger_record_materialized(rec) for rec in records)
 
 
+# ---------------------------------------------------------------------------
+# 账本 MCP 依赖 + 回收判据（协议 runtime-contract §4.9.1，#153/D3+F1）/ Ledger MCP deps & reclaim criterion
+# ---------------------------------------------------------------------------
+def ledger_mcp_deps_of(records: object) -> set[str]:
+    """
+    某 pid 全部账本记录声明依赖的 MCP Server bundle_id 并集（§4.9.1-1）/ Declared MCP deps (bundle_ids) of a pid。
+
+    值域是 **bundle_id**（身份），非 display name——账本 MUST NOT 记 name（§4.9.1-1）。跨 scope 记录取并集。
+    """
+    out: set[str] = set()
+    if not isinstance(records, list):
+        return out
+    for rec in records:
+        if not isinstance(rec, Mapping):
+            continue
+        deps = rec.get("mcpServers")
+        if isinstance(deps, list):
+            out.update(d for d in deps if isinstance(d, str))
+    return out
+
+
+def other_plugin_mcp_deps(
+    plugins: Mapping[str, object],
+    *,
+    exclude_pid: str,
+    retained_records: Sequence[object] = (),
+) -> set[str]:
+    """
+    **本次操作后**仍有 plugin 声明依赖的 bundle_id 并集（回收判据第一项的数据源，#153）/ Deps still declared by others。
+
+    :param plugins: 账本 ``plugins`` 映射（**移除本次记录之前**的视图——§4.9.1-3 要求停摘名单在账本移除前取得）。
+    :param exclude_pid: 正在 disable/uninstall/gc 的 plugin id（其记录不算「其他 plugin」）。
+    :param retained_records: ``exclude_pid`` 本次**未被移除**的记录（scoped uninstall 时的其余 scope）——它们
+        仍声明依赖，故仍算依赖者。整 pid 移除（disable / 全 scope uninstall / gc）时传空。
+
+    「其他 plugin」= 账本中的 **installed** 记录（**含 disabled**），不按 enabled 过滤：协议 §4.9.1-2 字面为
+    「无其他 plugin **声明依赖** X」（声明 = 账本有记录），``conformance-tests.md`` §285「**最后一个依赖者卸载**
+    时回收」亦印证判据看记录存在性而非启用态。后果是 installed-but-disabled 的依赖者会令 X 保留（保守），但其
+    卸载时仍回收 ⇒ **不泄漏**。与 rust-sdk#139 同字面。
+    """
+    out: set[str] = set()
+    for pid, records in plugins.items():
+        if pid == exclude_pid:
+            continue
+        out |= ledger_mcp_deps_of(records)
+    out |= ledger_mcp_deps_of(list(retained_records))
+    return out
+
+
+def reclaimable_mcp_deps(
+    deps: Iterable[str],
+    *,
+    other_deps: set[str],
+    user_declared: set[str],
+) -> list[str]:
+    """
+    §4.9.1-2 **回收判据**（纯函数、零落盘状态、零 IO）/ The reclaim criterion。
+
+    **回收 X ⟺ 无其他 plugin 声明依赖 X ∧ X 非用户声明**。disable / uninstall / gc **三个消费者全部委托本函数**，
+    MUST NOT 各写副本（判据分叉 = 用户 server 被连坐或 server 泄漏；#142 `is_valid_bundle_id` 同款教训）。
+
+    D5 措辞已由「只收回**自己带入**的」正式重写为「只收回**无人再依赖 ∧ 非用户声明**的」：前者把**时点快照**
+    （安装时谁带入）写进了**长期判据**，正是传递性泄漏之源——A 引入 X、B 装时已在、卸 A 后 A 的记录连同
+    「X 由 A 引入」这一事实一并消失 ⇒ 卸 B 时无人认领 X ⇒ **永久泄漏**。故账本 MUST NOT 存 provenance
+    （§4.9.1-1），判据只用**现时**事实。
+
+    :param deps: 本次 disable/uninstall 的 plugin 所声明的依赖（``ledger_mcp_deps_of`` 产出）。
+    :param other_deps: :func:`other_plugin_mcp_deps` 产出。
+    :param user_declared: :func:`~a2c_smcp.computer.settings.mcp_config.user_declared_bundle_ids` 产出。
+    :return: 可回收的 bundle_id（保 ``deps`` 迭代序）。
+    """
+    return [d for d in deps if d not in other_deps and d not in user_declared]
+
+
 # 悬挂意图 reason 分档（#125 任务 2；wire 值入 CLI JSON 输出，rust 镜像同字面）/ dangling reason tiers.
 DANGLING_MARKETPLACE_NOT_ADDED = "marketplace-not-added"
 DANGLING_CATALOG_MISSING = "catalog-missing"
@@ -481,13 +556,17 @@ async def gc_plugins(
     mcp_teardown: Callable[[list[str]], Awaitable[None]] | None = None,
 ) -> list[str]:
     """
-    清理孤儿 plugin（installPath 树 + installed_plugins.json 条目 + Registry SKILL + bundled MCP）/ GC plugins。
+    清理孤儿 plugin（installPath 树 + installed_plugins.json 条目 + Registry SKILL + MCP 依赖回收）/ GC plugins。
 
     y/N 确认交 CLI 层（#68）；``plugin_ids`` 应为 :func:`list_orphan_plugins` 的子集（用户确认后传入）。
-    每条记录的 ``installPath`` 仅在词法位于 SKILL Home 内才删（:func:`_safe_rmtree`）；``bundledMcpServers``
-    汇总后经 ``mcp_teardown`` 回调停/摘（真正接线由 computer.py 集成承担，#62 只触发回调）。
+    每条记录的 ``installPath`` 仅在词法位于 SKILL Home 内才删（:func:`_safe_rmtree`）；其声明依赖的 MCP Server
+    经 **§4.9.1-2 回收判据**（:func:`reclaimable_mcp_deps`）过滤后才交 ``mcp_teardown`` 停/摘——gc 是 uninstall
+    的批量形态，同样 **MUST NOT 连坐用户自有 server**（#153）。
 
-    :param mcp_teardown: 可选异步回调，入参为本次清理涉及的全部 bundled MCP server name；``None`` = 不处理。
+    逐 pid 处理且账本随之逐个删除 ⇒ 同批两 plugin 共享同一依赖时，先处理者因后者仍在账本而保留、后处理者
+    （前者已删）回收 —— 自动满足「最后一个依赖者回收」。
+
+    :param mcp_teardown: 可选异步回调，入参为本次**判定可回收**的 MCP Server **bundle_id** 列表；``None`` = 不处理。
     :return: 实际清理的 plugin id 列表。
     """
     installed = load_installed_plugins(home=home, env=env)
@@ -497,26 +576,32 @@ async def gc_plugins(
         records = plugins.get(pid)
         if records is None:
             continue
-        bundled: list[str] = []
+        # 停摘候选（账本字段自足，§4.9.1-3）须在删树/删账本前取得。
+        deps = ledger_mcp_deps_of(records)
+        reclaim = reclaimable_mcp_deps(
+            sorted(deps),
+            other_deps=other_plugin_mcp_deps(plugins, exclude_pid=pid),
+            user_declared=user_declared_bundle_ids(env=env),
+        )
         for rec in records:
             install_path = rec.get("installPath")
             if isinstance(install_path, str) and install_path:
                 _safe_rmtree(Path(install_path), home)
-            servers = rec.get("bundledMcpServers")
-            if isinstance(servers, list):
-                bundled.extend(s for s in servers if isinstance(s, str))
 
         plugin, _, marketplace = pid.partition("@")
         if marketplace:
             _unregister_marketplace_skills(registry, marketplace, plugin=plugin)
 
-        if mcp_teardown is not None and bundled:
-            await mcp_teardown(bundled)
+        if mcp_teardown is not None and reclaim:
+            await mcp_teardown(reclaim)
 
         def _drop(data: InstalledPluginsFile, _p: str = pid) -> None:
             data.get("plugins", {}).pop(_p, None)
 
         update_installed_plugins(_drop, home=home, env=env)
+        # 内存视图与磁盘同步：否则后续 pid 的 other_plugin_mcp_deps 会把**已 gc 的 pid** 误算作依赖者，
+        # 令同批共享的依赖永不回收（泄漏）。
+        plugins.pop(pid, None)
         removed.append(pid)
-        logger.info("gc: removed orphan plugin %r (bundled MCP: %s)", pid, bundled or "none")
+        logger.info("gc: removed orphan plugin %r (MCP deps reclaimed: %s)", pid, reclaim or "none")
     return removed

--- a/a2c_smcp/computer/settings/reconciler.py
+++ b/a2c_smcp/computer/settings/reconciler.py
@@ -492,7 +492,8 @@ def reclaimable_mcp_deps(
         ``--config @file`` / SDK 内嵌 ``Computer(mcp_servers={...})`` 挂载的 server 走 transient
         ``amount_server``、**不落 mcp.json**，与「plugin 自己挂的 server」在可观测信息上**完全同形**。
         故若该 server 同时被某 plugin 声明依赖，卸载该 plugin 时仍会回收它。详见
-        :func:`~a2c_smcp.computer.settings.mcp_config.mcp_json_declared_bundle_ids`。
+        :func:`~a2c_smcp.computer.settings.mcp_config.mcp_json_declared_bundle_ids`；
+        方案求裁于 protocol Discussion #32（https://github.com/A2C-SMCP/a2c-smcp-protocol/discussions/32）。
     :return: 可回收的 bundle_id（保 ``deps`` 迭代序）。
     """
     return [d for d in deps if d not in other_deps and d not in user_declared]

--- a/a2c_smcp/computer/settings/store.py
+++ b/a2c_smcp/computer/settings/store.py
@@ -70,6 +70,10 @@ MATERIALIZED_VERSION = 1
 KNOWN_MARKETPLACES_FILENAME = "known_marketplaces.json"
 INSTALLED_PLUGINS_FILENAME = "installed_plugins.json"
 
+# v0.2.x 账本的 bundled-server 字段（display **name** 数组）；v0.3.0 起为 ``mcpServers``（**bundle_id** 数组）。
+# 仅用于**识别并丢弃**旧记录（协议 §4.9.1-4）——MUST NOT 用于读取其值做迁移映射 / legacy key, detect-and-drop only.
+_LEGACY_MCP_DEPS_KEY = "bundledMcpServers"
+
 # 文件锁退避默认参数（指数退避，封顶）/ Default lock backoff knobs (exponential, capped).
 DEFAULT_LOCK_RETRIES = 10
 DEFAULT_LOCK_BACKOFF_BASE = 0.05  # 秒 / seconds
@@ -105,7 +109,15 @@ class InstalledPluginRecord(TypedDict):
     ``installed_plugins.json`` 单条安装记录（§6.2，对齐 CC V2 schema）/ a single plugin install record。
 
     数组化按 scope 维度（``scope`` + ``projectPath`` 精确匹配），为「user + workspace 同时装、不同版本」
-    预留；``bundledMcpServers`` 为 A2C 扩展字段（CC 无），供 uninstall 级联精准清理 bundled MCP server。
+    预留；``mcpServers`` 为 A2C 扩展字段（CC 无）。
+
+    **``mcpServers`` = 该 plugin 声明依赖的 MCP Server bundle_id 纯数组**（协议 runtime-contract §4.9.1-1，
+    #153/D3+F1）。三条硬约束，改动前务必读协议原文：
+      1. **只记 bundle_id**，MUST NOT 记 display ``name``（显式 ``bundleId`` 的 server 改名后账本名即过期）。
+      2. MUST NOT 记「安装时本地是否已有」一类**时点快照事实**（provenance/introduced）——它随其他 plugin 卸载
+         而失真，是传递性泄漏之源；回收/门控/归属判定 MUST NOT 依赖此类字段。
+      3. 语义是**依赖**而非**所有**（§2.5）：卸载本 plugin 不等于回收这些 server，须过
+         :func:`~a2c_smcp.computer.settings.reconciler.reclaimable_mcp_deps` 判据。
     """
 
     scope: str  # managed | user | project | local
@@ -115,7 +127,7 @@ class InstalledPluginRecord(TypedDict):
     commitSha: NotRequired[str]
     installedAt: NotRequired[str]
     lastUpdated: NotRequired[str]
-    bundledMcpServers: NotRequired[list[str]]  # A2C 扩展 / A2C extension
+    mcpServers: NotRequired[list[str]]  # A2C 扩展：声明依赖的 bundle_id 数组 / declared MCP deps (bundle_ids)
 
 
 class InstalledPluginsFile(TypedDict):
@@ -356,14 +368,48 @@ def _coerce_known_marketplaces(data: Mapping[str, Any], path: Path) -> KnownMark
     return {"version": MATERIALIZED_VERSION, "marketplaces": marketplaces}
 
 
-def _coerce_installed_plugins(data: Mapping[str, Any], path: Path) -> InstalledPluginsFile:
-    """把读到的 dict 规整为 :class:`InstalledPluginsFile`（容错 + 手编 WARN）/ Coerce to the typed shape。"""
+def _drop_legacy_mcp_dep_records(plugins: dict[str, Any], path: Path) -> dict[str, Any]:
+    """
+    丢弃旧格式（``bundledMcpServers`` = display name 数组）的账本记录（协议 §4.9.1-4，#153）/ Drop legacy records。
+
+    v0.2.x 账本以 display **name** 数组记 bundled server；v0.3.0 起改记 ``mcpServers``（**bundle_id** 数组，
+    语义为「声明依赖」而非「所有」）。协议 §4.9.1-4 定：检测到旧格式 **MUST 整条丢弃**、经 reconcile 从
+    ``installedPlugins`` 意图重建（§4.9「账本可弃、删除它无损」），**MUST NOT 编写 name→bundle_id 映射迁移
+    逻辑**——那正是本 Epic（#147）在拆的 name-join。
+
+    判据取「**含** ``bundledMcpServers`` 键」而非「**缺** ``mcpServers`` 键」：前者精确只打真旧记录；旧格式里
+    「无 bundled server」的记录本就不写该键，其依赖确实为空，保留无害。丢空的 pid 整条移除 → 使
+    :func:`~a2c_smcp.computer.settings.reconciler.ledger_entry_fully_materialized` 返 ``False`` → 触发重物化。
+    """
+    out: dict[str, Any] = {}
+    for pid, records in plugins.items():
+        if not isinstance(records, list):
+            out[pid] = records  # 非法结构原样透传（与本模块既有容错姿态一致，不在此处收敛）
+            continue
+        kept = [r for r in records if not (isinstance(r, Mapping) and _LEGACY_MCP_DEPS_KEY in r)]
+        if len(kept) != len(records):
+            logger.warning(
+                "Ledger record(s) for %r in %s use the legacy %r (display-name) format; discarded and will be "
+                "rebuilt from the installedPlugins intent (protocol runtime-contract §4.9.1-4)",
+                pid,
+                path,
+                _LEGACY_MCP_DEPS_KEY,
+            )
+        if kept:
+            out[pid] = kept
+    return out
+
+
+def _coerce_installed_plugins(data: Mapping[str, Any], path: Path, *, drop_legacy: bool = True) -> InstalledPluginsFile:
+    """把读到的 dict 规整为 :class:`InstalledPluginsFile`（容错 + 手编 WARN + 旧格式丢弃）/ Coerce to the typed shape。"""
     _warn_hand_edit(path, data.get("version"), {"version", "plugins"}, data)
     plugins = data.get("plugins")
     if not isinstance(plugins, dict):
         if plugins is not None:
             logger.warning("Materialized file %s field 'plugins' is not an object; treating as empty", path)
         plugins = {}
+    if drop_legacy:
+        plugins = _drop_legacy_mcp_dep_records(plugins, path)
     return {"version": MATERIALIZED_VERSION, "plugins": plugins}
 
 
@@ -393,13 +439,29 @@ def load_known_marketplaces(home: Path | None = None, env: Mapping[str, str] | N
     return _coerce_known_marketplaces(data, path)
 
 
-def load_installed_plugins(home: Path | None = None, env: Mapping[str, str] | None = None) -> InstalledPluginsFile:
-    """加载 ``installed_plugins.json``（缺失 / 损坏 → 空配置）/ Load installed_plugins.json (missing/corrupt → empty)。"""
+def load_installed_plugins(
+    home: Path | None = None,
+    env: Mapping[str, str] | None = None,
+    *,
+    drop_legacy: bool = True,
+) -> InstalledPluginsFile:
+    """
+    加载 ``installed_plugins.json``（缺失 / 损坏 → 空配置）/ Load installed_plugins.json (missing/corrupt → empty)。
+
+    :param drop_legacy: 是否丢弃旧格式记录（协议 §4.9.1-4，见 :func:`_drop_legacy_mcp_dep_records`）。默认 ``True``
+        ——**几乎所有调用方都应该用默认值**，旧格式记录的依赖信息（display name 数组）不可用于任何判定。
+
+        ⚠️ **唯一的例外是 v0.2.x→v0.3.0 意图迁移**（:func:`~a2c_smcp.computer.settings.installer
+        .migrate_legacy_installs`）：它从账本 **pid（key）** 回填 ``installedPlugins`` 意图，而账本格式迁移
+        （丢弃 → 从意图重建）**恰恰依赖该意图已存在**。两者顺序颠倒则 v0.2.x 存量用户的带 MCP server 的
+        plugin 会连 pid 一起消失、意图无从回填 ⇒ 升级后 plugin 静默全丢。故迁移路径 MUST 传 ``False``
+        （它只读 key，不碰旧格式的字段值）。
+    """
     path = installed_plugins_path(home, env)
     data = read_jsonc_with_recovery(path)
     if data is None:
         return empty_installed_plugins()
-    return _coerce_installed_plugins(data, path)
+    return _coerce_installed_plugins(data, path, drop_legacy=drop_legacy)
 
 
 def save_known_marketplaces(

--- a/docs/design-0.2.1-cli-marketplace-ux.md
+++ b/docs/design-0.2.1-cli-marketplace-ux.md
@@ -289,7 +289,7 @@ MCP server 走 **`<plugin>/mcp-servers/<name>.json`** 文件式（mcp-servers �
 
 | 命令 | 行为 |
 |---|---|
-| `plugin install <plugin>@<marketplace> [--version <v>]` | 安装单个 plugin。检查 MCP server 名冲突：bundled server name 已存在**且不归属本 plugin**（不在其 `bundledMcpServers` 记录里）→ **硬抛、原子失败、不留半装状态**（无 rename/force 逃生口）。`--version` 锁版本（暂用 git tag/SHA，v0.2.1 默认 latest）。 |
+| `plugin install <plugin>@<marketplace> [--version <v>]` | 安装单个 plugin。**MCP 依赖预检**（#153/D3）：声明依赖的 `bundle_id` 已存在于运行期权威配置集 → **依赖已满足 → 提示 + 正常安装**（MUST NOT 拒绝，§2.5-1；原「外来同名硬抛」已作废）。`--version` 锁版本（暂用 git tag/SHA，v0.2.1 默认 latest）。 |
 | `plugin uninstall <plugin>@<marketplace> [--keep-servers]` | 卸载。默认 stop+remove plugin 携带的 MCP server；`--keep-servers` 保留 MCP server config。 |
 | `plugin enable <plugin>@<marketplace>` | 写 `enabledPlugins[<id>] = true`；emit_update_skills。 |
 | `plugin disable <plugin>@<marketplace>` | 写 `enabledPlugins[<id>] = false`；**停掉并从生效 MCP 定义层摘除该 plugin 携带的 MCP server**（与 §7.1 步骤 5「禁用 plugin 不合并其 mcp_servers」对齐——禁用 = 整 plugin 贡献下线）；**物化层保留**（clone 树 + installed_plugins.json 记录不动），`enable` 可廉价复原（重新挂载 server + 暴露 skill），无需重 clone/重装；emit_update_skills（server 停所引发的 tools 变更经 `server:update_tool_list` 同步广播）。区别于 `uninstall`：disable 留 installed 记录、可一键回滚；uninstall 删 installed 记录、移除 server config。 |
@@ -558,16 +558,27 @@ settings.json（意图/治理层）独立按 §5.1/§5.4 合并。
         "commitSha": "abc1234",
         "installedAt": "2026-05-10T...",
         "lastUpdated": "2026-05-10T...",
-        "bundledMcpServers": ["figma-mcp"]
+        "mcpServers": ["figma-mcp"]
       }
     ]
   }
 }
 ```
 
-- `bundledMcpServers`：**A2C 扩展字段**（CC 的 installed_plugins.json **没有**此字段——CC 把 bundled MCP 存在 plugin 目录的 `.mcp.json` 里，uninstall 随 `deletePluginDataDir` 清）。A2C 为做 uninstall 级联（§4.3 决策 #19）显式记录该 plugin install 时注册的 MCP server name，用于精准清理。
+- `mcpServers`：**A2C 扩展字段**（CC 的 installed_plugins.json **没有**此字段）。语义 = 该 plugin **声明依赖**的
+  MCP Server **`bundle_id` 纯数组**（协议 runtime-contract §4.9.1-1，#153/D3+F1）。三条硬约束：
+  - **只记 `bundle_id`**，MUST NOT 记 display `name`（显式 `bundleId` 的 server 改名后账本名即过期）；
+  - MUST NOT 记「安装时本地是否已有」一类**时点快照事实**（provenance/introduced）——它随其他 plugin 卸载而
+    失真，是**传递性泄漏**之源（A 引入 X → B 装时已在 → 卸 A 后「X 由 A 引入」的事实随记录一起消失 → 卸 B 时
+    无人认领 ⇒ X 永久泄漏）。任何回收/门控/归属判定 MUST NOT 依赖此类字段；
+  - 语义是**依赖**而非**所有**：卸载 plugin **不等于**回收这些 server。
+- **回收判据**（§4.9.1-2，纯函数、零落盘状态）：disable/uninstall/gc 时对每个 `bundle_id` X ——
+  **回收 X ⟺ 无其他 plugin 声明依赖 X ∧ X 非用户声明**（`resolve_mcp_config()` 里无该 `bundle_id`）。
+  由此「用户自有 server 永不连坐」与「多 plugin 共享依赖不被提前摘、最后一个依赖者卸载时回收（无泄漏）」同时成立。
+  > 原字段名 `bundledMcpServers`（display **name** 数组，「uninstall 无条件级联清理」语义）已作废。旧格式账本
+  > **整条丢弃 + 从 `installedPlugins` 意图重建**（§4.9.1-4），**MUST NOT** 写 name→bundle_id 映射迁移逻辑。
 - 数组化：scope 维度（`scope`+`projectPath` 精确匹配），为「user + workspace 工作目录同时装、不同版本」预留（对齐 CC V2 schema，实际已支持多 scope 并存；v0.2.1 常见为单元素）。
-- 字段集对齐 CC：`scope`(managed|user|project|local) / `projectPath`(project/local 必填) / `installPath`(版本化路径) / `version` / `installedAt` / `lastUpdated` / `commitSha` + A2C 扩展 `bundledMcpServers`。
+- 字段集对齐 CC：`scope`(managed|user|project|local) / `projectPath`(project/local 必填) / `installPath`(版本化路径) / `version` / `installedAt` / `lastUpdated` / `commitSha` + A2C 扩展 `mcpServers`。
 
 ### 6.3 文件级写保护、原子写与损坏恢复
 
@@ -608,10 +619,13 @@ settings.json（意图/治理层）独立按 §5.1/§5.4 合并。
 ### 7.2 失败降级
 
 - git clone/pull 失败：记 ERROR、不阻断其余 marketplace、该 marketplace 标记为 `lastError`、对 Agent 不可见（Registry 不入册）。
-- **MCP server name 冲突（非对称处理）**：
-  - **冲突判定**：bundled server name 已存在 **且** 该 server 不在「待装 plugin 的 `bundledMcpServers` 记录」里（即不是它自己上次装的）。重装/重启时 plugin 自有的 server 命中自己 → **不算冲突**（幂等再物化）。
-  - **交互/CLI `plugin install`**：外来同名 → **硬抛**（`MCPServerNameConflictError`），原子失败、不留半装状态。用户自行解决（删/改自己的同名 server，或在自有 marketplace 仓库里改 plugin manifest 的 server name）。**不**提供 `--rename`/`--force-override`（类比「软件双开」：name 即身份，不给官方旁路；force-override 会静默毁用户配置，rename 会让 `mcp:<server>:*` 命名映射与 manifest 声明对不上）。
-  - **reconciler 启动自动加载**：外来同名 → **跳过该 plugin 加载 + WARN + 留意图层 `enabled` 不动**（不能让一个冲突 plugin 拖垮整个启动；冲突消解后重启即恢复）。
+- **MCP 依赖已满足（不是冲突）**——**已按 D3 重写，#153**：
+  - **判定**：plugin 声明依赖的 `bundle_id` 已存在于**运行期权威配置集** → **依赖已满足**。数据源 MUST 是
+    `manager.server_configs()`，**MUST NOT** 是构造期快照 `Computer.mcp_servers`（协议 §2.5-4）。
+  - **交互/CLI `plugin install`**：提示「依赖已满足、复用既有实例、卸载不移除它」→ **正常安装**（退出码 0）。
+    原「外来同名硬抛、原子失败、无 rename/force 逃生口」已作废（详见 §10.6）。
+  - **reconciler 启动自动加载 / 治理重挂**：同 `bundle_id` 已有 → **skip register**（复用既有实例，用户配置胜），
+    不覆盖、不阻断其余。
 - known_marketplaces.json 文件损坏：备份 `.corrupt-<ts>.bak` + 降级空配置 + 下次 reconcile 按 settings 声明重装（§6.3）。
 
 ### 7.3 显式 sync 与孤儿清理
@@ -938,26 +952,31 @@ a2c> marketplace add git@github.com:team/skills.git
 > **威胁模型有意只收紧非交互路径、放过交互 desync**：交互 add 必由在场真人敲入命令+URL，风险与非交互无人
 > 值守脚本不可同日而语，desync 由人把关。回归守卫见 `test_add_pretrusted_name_interactive_skips_prompt`。
 
-### 10.6 Plugin MCP server 冲突（硬抛、无逃生口）
+### 10.6 Plugin MCP 依赖已满足（提示、不拒绝）
 
-name 即身份，外来同名直接抛错——交互与非交互行为一致（无 prompt、无 flag 旁路）：
+> **⚠️ 本节已按协议 D3 重写（#153）**。原文为「name 即身份，外来同名硬抛、原子失败、无 rename/force 逃生口」
+> ——该裁决已被 [protocol Discussion #23](https://github.com/A2C-SMCP/a2c-smcp-protocol/discussions/23) 终审
+> **正面推翻**：plugin 与 MCP Server 是 **依赖关系而非所有关系**（runtime-contract §2.5）。
+> `MCPServerNameConflictError` 已退役。
+
+plugin 以 `bundle_id` **声明依赖**；同 `bundle_id` 本地已有 = **依赖已满足** → 提示 + 正常安装：
 
 ```
 a2c> plugin install frontend-design@my-team-skills
 
-  ✗ MCP server name conflict: 'figma-mcp'
-    Existing: figma-mcp (added manually 2026-05-19, owner=user)
-    Plugin brings: figma-mcp (transport=stdio, command=node)
-
-  Install aborted. No changes made.
-  Resolve by one of:
-    • rename/remove your existing server:  server rm figma-mcp
-    • or rename the server in the plugin's own manifest (if you own the repo)
+  ℹ dependency satisfied: MCP server 'figma-mcp' already exists locally; this plugin
+    reuses it rather than creating a new one. Configs reconcile by scope precedence.
+    Uninstalling this plugin will not remove it.
+  ✓ installed 'frontend-design@my-team-skills' (1 MCP server(s) declared as dependencies,
+    not mounted) (disabled; run 'plugin enable ...' to activate)
 ```
 
-- **原子失败**：抛 `MCPServerNameConflictError`，plugin 与其 skills 一个都不装、不写 `installed_plugins.json`。
-- **判定排除自有**：若 `figma-mcp` 本就是该 plugin 上次装的（命中 `bundledMcpServers`）→ 不算冲突，正常幂等再物化。
-- 非交互 / `--json`：同样硬抛，退出码 1 + JSON error（`{"error":"mcp_server_name_conflict","name":"figma-mcp","owner":"user"}`）。
+- **MUST NOT 拒绝**（协议 §2.5-1）；退出码 0，交互与非交互一致。
+- **复用既有实例**：`plugin enable` 对已满足的依赖 **skip register**，不覆盖既有 server 配置。
+- **display name 相同、`bundle_id` 不同 = 合法共存**（§5.6），MUST NOT 视为冲突。
+- **唯一硬错误**：同一声明文件内多 key 归一到同一 `bundle_id`（fail-fast，§2.5-2）——那是**声明面**写法错误，
+  与本处**依赖面**是两回事。
+- **卸载不连坐**：见 §6.2 回收判据。
 
 ---
 
@@ -1063,7 +1082,7 @@ a2c_smcp/computer/
 ### 13.2 集成
 
 - `marketplace add` 全链路：trust prompt → 写 settings.json `trustedMarketplaces` → git clone → known_marketplaces.json（**无 trusted 字段**）落盘 → emit_update_skills。
-- `plugin install` 外来同名 MCP server → 硬抛 + 原子失败（不留半装）；自有同名 → 幂等放行；`plugin uninstall` 清理 bundledMcpServers。
+- `plugin install` 同 bundle_id 已有 → **依赖已满足：提示 + 正常安装**（#153/D3）；`plugin uninstall` 按 §4.9.1-2 回收判据处理 `mcpServers` 声明的依赖（无人再依赖 ∧ 非用户声明才回收）。
 - **MCP 批准门控**：workspace `.tfrobot/mcp.json` 未知 server → pending → 批准框 → 写 **local** `enabledMcpjsonServers`；plugin-bundled server 免批准直连。
 - **inputs 解析链**：env `A2C_INPUT_<ID>` 命中 → 不落盘；password prompt → keyring 存 → 重启不再问；非密钥 → 明文 state；keyring 不可用 + 无 env + 无 TTY → 硬错误。
 - File watcher：user/project 目录 SKILL.md 增删改 → debounce → emit；CLI 写回 settings 经 `markInternalWrite` 不触发重载循环。
@@ -1081,7 +1100,7 @@ a2c_smcp/computer/
 
 - Sandbox 穿越 / `.skillenv` forbidden / `too_large` 不铸句柄 / staging 隔离 / name 寻址防越权。
 - Trust 拒绝：`strictKnownMarketplaces=true` + 不在 `trustedMarketplaces` + 非交互 `--json` → 退出码 1 + JSON error。
-- MCP server 外来同名冲突（交互/非交互一致）→ 硬抛 `MCPServerNameConflictError`、退出码 1、不留半装状态；自有同名 → 不触发。
+- MCP 依赖已满足（交互/非交互一致）→ 提示 + 退出码 0 正常安装；`enable` 复用既有实例不覆盖（#153/D3，原 `MCPServerNameConflictError` 已退役）。
 - **密钥不落明文**：`password:true` 值绝不出现在 `.tfrobot/mcp.json`/`input-values.json`/日志；keyring 不可用且无 env → 硬错误而非明文落盘。
 - **占位符不外泄**：`get_config`/`get_skills` payload 中 `${input:}`/`${env:}` 不展开，密钥不离开 Computer。
 
@@ -1137,7 +1156,7 @@ A ⫫ B（并行）；C 依赖 A+B；D 依赖 A；E 依赖 A/B/C/D；F 依赖 A/
 - [ ] **inputs/secret（VS Code 对标）**：解析链 env→keyring→明文 state→prompt→default；password 走 keyring 重启不再问；keyring 不可用降级 env，**绝不写明文**。
 - [ ] Trust：CC 风格 settings.json policy 字段计算（`strictKnownMarketplaces`/`trustedMarketplaces`/`blockedMarketplaces`）；known_marketplaces.json **无** trusted 字段。
 - [ ] `marketplace add/list/info/remove/refresh/set` 六命令完整；trust prompt 流程红→绿。
-- [ ] `plugin install/uninstall/enable/disable/list/info` + `plugin gc` 完整；MCP server 外来同名硬抛 + 原子失败、自有同名幂等放行；bundledMcpServers 联动卸载。
+- [ ] `plugin install/uninstall/enable/disable/list/info` + `plugin gc` 完整；MCP 依赖已满足 → 提示不拒绝、enable 复用不覆盖；`mcpServers` 依赖按回收判据卸载（用户自有永不连坐）。
 - [ ] **Reconciler additive-only**：物化多于声明不自动清理；孤儿靠 `plugin gc`/`marketplace prune`。
 - [ ] 物化文件**原子写 + 锁 + .corrupt 备份**（优于 CC writeFileSync）。
 - [ ] `skill list/info` 跨三源扁平视图。

--- a/tests/integration_tests/computer/settings/test_installer.py
+++ b/tests/integration_tests/computer/settings/test_installer.py
@@ -125,9 +125,9 @@ async def test_install_end_to_end(tmp_path: Path) -> None:
     async def _register(cfg) -> None:
         captured.append(cfg.name)
 
-    record = await install_plugin("audit@acme-skills", reg, home, env=env, existing_server_names=lambda: set())
+    record = await install_plugin("audit@acme-skills", reg, home, env=env, existing_bundle_ids=lambda: set())
 
-    assert record["bundledMcpServers"] == ["figma"]
+    assert record["mcpServers"] == ["figma"]
     assert record["version"] == "1.2.0"
     assert reg.resolve("audit:lint") is None  # install ≠ activate：skill 不注册
     assert "audit@acme-skills" in load_installed_plugins(home=home)["plugins"]
@@ -136,7 +136,7 @@ async def test_install_end_to_end(tmp_path: Path) -> None:
     assert "enabledPlugins" not in settings
 
     # enable：真 staging 注册 skill + 重挂 server（原子点亮）
-    await enable_plugin("audit@acme-skills", reg, home, env=env, existing_server_names=lambda: set(), register_server=_register)
+    await enable_plugin("audit@acme-skills", reg, home, env=env, existing_bundle_ids=lambda: set(), register_server=_register)
     assert reg.resolve("audit:lint") is not None
     assert captured == ["figma"]
 
@@ -156,8 +156,8 @@ async def test_uninstall_end_to_end(tmp_path: Path) -> None:
     async def _remove(name: str) -> None:
         removed.append(name)
 
-    await install_plugin("audit@acme-skills", reg, home, env=env, existing_server_names=lambda: set())
-    await enable_plugin("audit@acme-skills", reg, home, env=env, existing_server_names=lambda: set(), register_server=_register)
+    await install_plugin("audit@acme-skills", reg, home, env=env, existing_bundle_ids=lambda: set())
+    await enable_plugin("audit@acme-skills", reg, home, env=env, existing_bundle_ids=lambda: set(), register_server=_register)
     install_path = Path(load_installed_plugins(home=home)["plugins"]["audit@acme-skills"][0]["installPath"])
     assert install_path.exists() and reg.resolve("audit:lint") is not None
 
@@ -189,8 +189,8 @@ async def test_install_enable_disable_enable_no_reclone(tmp_path: Path) -> None:
     async def _remove(name: str) -> None:
         removed.append(name)
 
-    await install_plugin("audit@acme-skills", reg, home, env=env, existing_server_names=lambda: set())
-    await enable_plugin("audit@acme-skills", reg, home, env=env, existing_server_names=lambda: set(), register_server=_register)
+    await install_plugin("audit@acme-skills", reg, home, env=env, existing_bundle_ids=lambda: set())
+    await enable_plugin("audit@acme-skills", reg, home, env=env, existing_bundle_ids=lambda: set(), register_server=_register)
     assert reg.resolve("audit:lint") is not None
     captured.clear()
     # 哨兵：植入 catalog clone 内 plugin 根，用于检测 enable 是否误重 clone（重 clone 会 wipe）。
@@ -202,7 +202,7 @@ async def test_install_enable_disable_enable_no_reclone(tmp_path: Path) -> None:
     assert reg.is_orphan("audit:lint") and removed == ["figma"]
 
     # enable：复活 skill + 重挂 server，且不重 clone
-    await enable_plugin("audit@acme-skills", reg, home, env=env, existing_server_names=lambda: set(), register_server=_register)
+    await enable_plugin("audit@acme-skills", reg, home, env=env, existing_bundle_ids=lambda: set(), register_server=_register)
 
     assert sentinel.exists()  # 未重 clone（哨兵保留 → 复用既有 clone 树）
     assert reg.resolve("audit:lint") is not None  # 孤儿复活
@@ -243,7 +243,7 @@ async def test_install_strict_false_conflict_hard_fails_atomically(tmp_path: Pat
 
     # 早检拦截 → PluginInstallError（硬错误，conflicting manifests）
     with pytest.raises(PluginInstallError, match="conflicting manifests"):
-        await install_plugin("audit@acme-skills", reg, home, env=env, existing_server_names=lambda: set())
+        await install_plugin("audit@acme-skills", reg, home, env=env, existing_bundle_ids=lambda: set())
 
     # 原子失败：未挂 server、未注册 skill、未写 installed 记录、意图回滚
     assert captured == []

--- a/tests/integration_tests/computer/settings/test_mcp_config.py
+++ b/tests/integration_tests/computer/settings/test_mcp_config.py
@@ -75,7 +75,7 @@ def test_resolve_and_gate_full_stack(tmp_path: Path, monkeypatch: pytest.MonkeyP
 
     # bundled 账本：plugin 携带 "blender" → 即使在 workspace mcp.json 出现，也免批准。
     save_installed_plugins(
-        {"plugins": {"3d@mp": [{"scope": "user", "installPath": "/x", "bundledMcpServers": ["blender"]}]}},
+        {"plugins": {"3d@mp": [{"scope": "user", "installPath": "/x", "mcpServers": ["blender"]}]}},
         home=_home(tmp_path),
     )
 

--- a/tests/unit_tests/computer/cli/test_plugin.py
+++ b/tests/unit_tests/computer/cli/test_plugin.py
@@ -11,7 +11,7 @@
 
 测试意图 / Test intentions（相对源 plugin → locate_plugin_root 无 git；monkeypatch stage；XDG 重定向隔离）:
 - install（v0.3.0 #123 不激活）：happy（写 installedPlugins 意图 + 账本；**不**挂 server、不 stage skills）/
-  外来同名硬抛退出码 1 + JSON error code / 非法 id 退出码 1；
+  **依赖已满足 → 退出码 0 正常安装**（#153/D3，原「外来同名硬抛 + error code」已退役）/ 非法 id 退出码 1；
 - enable/disable：**scope 从 ledger 读**（seed project scope → 写 project settings，不写 user）；
 - uninstall / list（默认列全部已安装，enabled 两态）/ info / gc（孤儿 = 账本 ∉ installedPlugins）退出码与输出形态；
 - ``_plugin_inject_inputs_cb``：读 ``mcp-servers/inputs.json`` → 前缀化 → 注入 fake comp 池（#69 Group A）。
@@ -31,6 +31,7 @@ from a2c_smcp.computer.settings.scope import user_settings_path, workdir_project
 from a2c_smcp.computer.settings.store import load_installed_plugins, save_installed_plugins, save_known_marketplaces
 from a2c_smcp.computer.skills.home import SOURCE_MARKETPLACE, marketplace_skill_dir
 from a2c_smcp.computer.skills.registry import SkillRegistry
+from a2c_smcp.utils.bundle_id import resolve_bundle_id
 
 _SRC = {"type": "git", "url": "https://example.com/acme.git"}
 _STAGE = "a2c_smcp.computer.settings.installer.stage_marketplace_skills"
@@ -103,7 +104,7 @@ class _FakeMCP:
         self.registered: list[Any] = []
         self.removed: list[str] = []
 
-    def existing_names(self) -> set[str]:
+    def existing_bundle_ids(self) -> set[str]:
         return set(self.existing)
 
     async def register(self, cfg: Any) -> None:
@@ -126,7 +127,7 @@ async def test_install_happy_writes_intent_and_ledger_without_activation(
 
     code = await plugin_cmd.plugin_install(
         reg, home, env, "audit@acme",
-        existing_server_names=mcp.existing_names, json_output=True,
+        existing_bundle_ids=mcp.existing_bundle_ids, json_output=True,
     )
     assert code == 0
     assert json.loads(capsys.readouterr().out)["state"] == "installed_disabled"
@@ -138,25 +139,29 @@ async def test_install_happy_writes_intent_and_ledger_without_activation(
 
 
 @pytest.mark.asyncio
-async def test_install_foreign_name_conflict_exit1_json_error(
+async def test_install_dependency_satisfied_exit0_and_installs(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str],
 ) -> None:
+    """
+    同 bundle_id 已有 = 依赖已满足 → **退出码 0 + 正常安装**（协议 §2.5-1，#153/D3）。
+
+    原名 ``test_install_foreign_name_conflict_exit1_json_error``：断言退出码 1 + JSON
+    ``error=mcp_server_name_conflict``。该错误码连同 ``MCPServerNameConflictError`` 已随 D3 退役——
+    plugin 与 MCP Server 是依赖关系，本地已有即依赖满足，复用而非拒绝。
+    """
     home, env, reg = _home(tmp_path), _env(tmp_path), SkillRegistry()
     _setup_catalog(home, "acme", "audit", servers=["figma-mcp"])
     monkeypatch.setattr(_STAGE, _fake_stage())
-    # 外来同名（已存在且非自有）→ 硬抛、退出码 1、不写账本/意图（§10.6 + v0.3.0 原子回滚）
-    mcp = _FakeMCP(existing={"figma-mcp"})
+    mcp = _FakeMCP(existing={"figma-mcp"})  # 本地已有同 bundle_id
 
     code = await plugin_cmd.plugin_install(
         reg, home, env, "audit@acme",
-        existing_server_names=mcp.existing_names, json_output=True,
+        existing_bundle_ids=mcp.existing_bundle_ids, json_output=True,
     )
-    assert code == 1
-    assert json.loads(capsys.readouterr().out)["error"] == "mcp_server_name_conflict"
-    assert "audit@acme" not in load_installed_plugins(home=home, env=env)["plugins"]
-    user_file = user_settings_path(env)
-    if user_file.exists():
-        assert "audit@acme" not in json.loads(user_file.read_text(encoding="utf-8")).get("installedPlugins", [])
+    assert code == 0
+    assert json.loads(capsys.readouterr().out)["mcpServers"] == ["figma-mcp"]
+    assert "audit@acme" in load_installed_plugins(home=home, env=env)["plugins"]
+    assert "audit@acme" in json.loads(user_settings_path(env).read_text(encoding="utf-8"))["installedPlugins"]
 
 
 @pytest.mark.asyncio
@@ -180,7 +185,7 @@ async def test_enable_reads_scope_from_ledger_writes_project_not_user(tmp_path: 
     )
     mcp = _FakeMCP()
     code = await plugin_cmd.plugin_enable(
-        reg, home, env, "audit@acme", existing_server_names=mcp.existing_names, register_server=mcp.register,
+        reg, home, env, "audit@acme", existing_bundle_ids=mcp.existing_bundle_ids, register_server=mcp.register,
     )
     assert code == 0
     # enabledPlugins[audit@acme]=true 写 project scope（active workdir），user scope 不动
@@ -201,7 +206,7 @@ async def test_disable_reads_scope_from_ledger(tmp_path: Path) -> None:
     home, env, reg = _home(tmp_path), _env(tmp_path), SkillRegistry()
     plugin_root = _setup_catalog(home, "acme", "audit", servers=["figma-mcp"])
     save_installed_plugins(
-        {"version": 1, "plugins": {"audit@acme": [{"scope": "user", "installPath": str(plugin_root), "bundledMcpServers": ["figma-mcp"]}]}},
+        {"version": 1, "plugins": {"audit@acme": [{"scope": "user", "installPath": str(plugin_root), "mcpServers": ["figma-mcp"]}]}},
         home=home,
     )
     mcp = _FakeMCP()
@@ -222,7 +227,7 @@ async def test_uninstall_not_installed_exit1(tmp_path: Path) -> None:
 def test_list_and_info(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     home, env = _home(tmp_path), _env(tmp_path)
     save_installed_plugins(
-        {"version": 1, "plugins": {"audit@acme": [{"scope": "user", "installPath": "/x", "bundledMcpServers": ["figma-mcp"]}]}},
+        {"version": 1, "plugins": {"audit@acme": [{"scope": "user", "installPath": "/x", "mcpServers": ["figma-mcp"]}]}},
         home=home,
     )
     # v0.3.0 缺省翻转：无 enabledPlugins 条目 = installed_disabled——默认列表仍可见，但 enabled=False
@@ -294,8 +299,24 @@ async def test_inject_inputs_cb_prefixes_and_injects(tmp_path: Path) -> None:
 
 
 # ── repl_dispatch（REPL 解析胶水层；fix-review #2）/ REPL parse glue ────────────
+class _FakeManager:
+    """``Computer.mcp_manager`` 的最小替身：**运行期权威配置集**（#153 的 existing 数据源）。"""
+
+    def __init__(self) -> None:
+        self._servers: list[Any] = []
+
+    def server_configs(self) -> tuple[Any, ...]:
+        return tuple(self._servers)
+
+
 class _ReplComp:
-    """plugin repl_dispatch 所需最小 fake（build_mcp_callbacks + register/inject 闭包所需接口）。"""
+    """
+    plugin repl_dispatch 所需最小 fake（build_mcp_callbacks + register/inject 闭包所需接口）。
+
+    **形状须与生产同构**（#153 / Epic #147 桩陷阱）：运行期挂载落 ``mcp_manager``（权威），而 ``mcp_servers``
+    是**构造期快照**——CLI 下恒空。旧版本此桩让 ``mcp_servers`` 随 ``amount_server`` 增长，把生产中**恒假**的
+    前提固化为真，使读死快照的 bug 在测试里看起来是活的。
+    """
 
     def __init__(self, home: Path, registry: SkillRegistry) -> None:
         self.skill_home = home
@@ -303,12 +324,13 @@ class _ReplComp:
         self._registered_workdirs: tuple[Path, ...] = ()
         self.active_workdir: Path | None = None
         self.dirty = 0
-        self._servers: list[Any] = []
+        self.mcp_manager = _FakeManager()
         self.injected: list[Any] = []
 
     @property
-    def mcp_servers(self) -> list[Any]:
-        return list(self._servers)
+    def mcp_servers(self) -> tuple[Any, ...]:
+        """构造期快照：CLI 恒传 ``mcp_servers=set()`` ⇒ **恒空**，与生产一致（勿让它随挂载增长）。"""
+        return ()
 
     def mark_skills_dirty(self) -> None:
         self.dirty += 1
@@ -318,11 +340,11 @@ class _ReplComp:
 
     async def amount_server(self, cfg: Any, *, session: Any = None, plugin: Any = None, marketplace: Any = None) -> None:
         # #137 ③：plugin enable/install remount 经 build_mcp_callbacks → transient amount_server（治理投影）。
-        self._servers.append(cfg)
+        self.mcp_manager._servers.append(cfg)
 
-    async def aunmount_server(self, name: str) -> None:
-        # #137 ③：plugin disable/uninstall teardown 经 build_mcp_callbacks → transient aunmount_server（停不删）。
-        self._servers = [s for s in self._servers if getattr(s, "name", None) != name]
+    async def aunmount_server_by_id(self, bundle_id: str) -> None:
+        # #153：停摘链收 bundle_id（账本记 bundle_id）；#137 ③ transient（停进程不删声明）。
+        self.mcp_manager._servers = [s for s in self.mcp_manager._servers if resolve_bundle_id(s) != bundle_id]
 
 
 @pytest.mark.asyncio
@@ -336,7 +358,7 @@ async def test_repl_install_is_lazy_no_mount_no_dirty(tmp_path: Path, monkeypatc
     await plugin_cmd.repl_dispatch(comp, ["plugin", "install", "audit@acme"], session=None)
     assert comp.dirty == 0  # skills 无变化 → 不触发去抖 emit
     assert "audit@acme" in load_installed_plugins(home=home)["plugins"]
-    assert comp._servers == []  # 不实时挂载（enable 才点亮）
+    assert comp.mcp_manager.server_configs() == ()  # 不实时挂载（enable 才点亮）
     assert len(reg) == 0
 
 
@@ -379,7 +401,7 @@ def _seed_recovery_home(home: Path, *, servers: list[str], skills: list[str]) ->
             "version": 1,
             "plugins": {
                 "audit@acme": [
-                    {"scope": "user", "installPath": str(plugin_root), "version": "1.2.0", "bundledMcpServers": list(servers)},
+                    {"scope": "user", "installPath": str(plugin_root), "version": "1.2.0", "mcpServers": list(servers)},
                 ],
             },
         },
@@ -438,8 +460,17 @@ async def test_run_governance_remount_flag_declared_disables(tmp_path: Path, mon
 
 
 @pytest.mark.asyncio
-async def test_run_governance_remount_existing_from_comp_servers(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """existing_server_names 取自 comp.mcp_servers：同名已存在 → skip 不覆盖（用户配置胜）。"""
+async def test_run_governance_remount_skips_dependency_satisfied_from_runtime_set(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    治理重挂的 existing 取自**运行期权威配置集**：同 bundle_id 已挂 → 依赖已满足 → skip 不覆盖（#153）。
+
+    **F7 真实构造路径**（协议 conformance §2.0 / Epic #147）：用户 server 经 ``amount_server`` 挂载——这正是
+    生产里 server 到达 Computer 的唯一途径（CLI 恒 ``mcp_servers=set()``）。原用例用 ``comp._mcp_servers.add()``
+    直接塞构造期快照建立前提，而该快照在生产中**恒空**：于是「读死快照」的 bug 在测试里看起来是活的，
+    这条守卫也就从未真正守过任何东西。
+    """
     from pydantic import TypeAdapter
 
     from a2c_smcp.computer.computer import Computer
@@ -449,20 +480,22 @@ async def test_run_governance_remount_existing_from_comp_servers(tmp_path: Path,
     home = _home(tmp_path)
     _seed_recovery_home(home, servers=["figma-mcp"], skills=["lint"])
 
-    async with Computer(name="t", skill_home=home) as comp:
-        # 用户已有同名 server（仅入配置集，不挂载进程）/ pre-existing user config, no process spawn
+    # auto_connect=False：config-only 挂载（不起子进程），与 #150 的 F7 范式一致（test_client.py:169-216）。
+    async with Computer(name="t", mcp_servers=set(), auto_connect=False, skill_home=home) as comp:
         user_cfg = TypeAdapter(MCPServerConfig).validate_python(_stdio("figma-mcp"))
-        comp._mcp_servers.add(user_cfg)
-
         recorded: list[str] = []
 
         async def fake_register(server: Any, *, session: Any = None, plugin: str | None = None, marketplace: str | None = None) -> None:
             recorded.append(server.name)
 
+        # 先按真实路径挂载用户 server（占住 bundle_id），再 monkeypatch 掉 amount_server 观测治理重挂。
+        await comp.amount_server(user_cfg)
+        assert comp.mcp_servers == ()  # 构造期快照恒空 —— 对照组：读它必然判「未满足」
         monkeypatch.setattr(comp, "amount_server", fake_register)  # #137 ③：治理重挂经 transient amount_server
+
         await plugin_cmd.run_governance_remount(comp)
 
-        assert recorded == []
+        assert recorded == []  # 依赖已满足 → 复用既有实例，MUST NOT 覆盖用户配置
 
 
 # ── #125 任务 1：危害链回归——重物化推回后 disable 跨 boot 有效 ─────────────────

--- a/tests/unit_tests/computer/cli/test_plugin.py
+++ b/tests/unit_tests/computer/cli/test_plugin.py
@@ -36,6 +36,23 @@ from a2c_smcp.utils.bundle_id import resolve_bundle_id
 _SRC = {"type": "git", "url": "https://example.com/acme.git"}
 _STAGE = "a2c_smcp.computer.settings.installer.stage_marketplace_skills"
 
+# 夹具身份对（#153 隔离审查 🔴2 + 协议 conformance §2.0）：原夹具 "figma-mcp" 的 bundle_id **恰等于自身**
+# （normalize_name 字符集含 `-` 且不折 `-`）⇒ 「误用 name 当身份」的实现无法被鉴别（Epic #147 陷阱 (b)
+# 第五例）。改用含 `.` 的 display 名令两者分叉。/ Forked so name-as-identity bugs cannot pass.
+FIGMA_NAME, FIGMA_BID = "figma.mcp", "figma_mcp"
+
+
+@pytest.fixture(autouse=True)
+def _isolate_cwd(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """
+    隔离 cwd / Isolate the process cwd。
+
+    #153 起 disable / gc 经回收判据读 **cwd 锚定**的 ``.tfrobot/mcp[.local].json``（project/local scope，
+    #116）。不 chdir 则读进真实仓库的工作区配置 → 断言随开发者本地环境漂移（#137 同款；本文件的泄漏由
+    #153 隔离审查 🟡 实测发现）。
+    """
+    monkeypatch.chdir(tmp_path)
+
 
 # ── 辅助（镜像 test_installer.py）/ helpers mirroring test_installer.py ─────────
 def _home(tmp_path: Path) -> Path:
@@ -121,7 +138,7 @@ async def test_install_happy_writes_intent_and_ledger_without_activation(
 ) -> None:
     """v0.3.0：install 只写 installedPlugins 意图 + 账本 → installed_disabled（无挂载、无 skills）。"""
     home, env, reg = _home(tmp_path), _env(tmp_path), SkillRegistry()
-    _setup_catalog(home, "acme", "audit", servers=["figma-mcp"])
+    _setup_catalog(home, "acme", "audit", servers=[FIGMA_NAME])
     monkeypatch.setattr(_STAGE, _fake_stage())
     mcp = _FakeMCP()
 
@@ -150,16 +167,16 @@ async def test_install_dependency_satisfied_exit0_and_installs(
     plugin 与 MCP Server 是依赖关系，本地已有即依赖满足，复用而非拒绝。
     """
     home, env, reg = _home(tmp_path), _env(tmp_path), SkillRegistry()
-    _setup_catalog(home, "acme", "audit", servers=["figma-mcp"])
+    _setup_catalog(home, "acme", "audit", servers=[FIGMA_NAME])
     monkeypatch.setattr(_STAGE, _fake_stage())
-    mcp = _FakeMCP(existing={"figma-mcp"})  # 本地已有同 bundle_id
+    mcp = _FakeMCP(existing={FIGMA_BID})  # 本地已有同 bundle_id（身份 = bundle_id，非 display 名）
 
     code = await plugin_cmd.plugin_install(
         reg, home, env, "audit@acme",
         existing_bundle_ids=mcp.existing_bundle_ids, json_output=True,
     )
     assert code == 0
-    assert json.loads(capsys.readouterr().out)["mcpServers"] == ["figma-mcp"]
+    assert json.loads(capsys.readouterr().out)["mcpServers"] == [FIGMA_BID]  # wire 值 = bundle_id
     assert "audit@acme" in load_installed_plugins(home=home, env=env)["plugins"]
     assert "audit@acme" in json.loads(user_settings_path(env).read_text(encoding="utf-8"))["installedPlugins"]
 
@@ -174,7 +191,7 @@ async def test_install_invalid_id_exit1(tmp_path: Path) -> None:
 @pytest.mark.asyncio
 async def test_enable_reads_scope_from_ledger_writes_project_not_user(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     home, env, reg = _home(tmp_path), _env(tmp_path), SkillRegistry()
-    plugin_root = _setup_catalog(home, "acme", "audit", servers=["figma-mcp"])
+    plugin_root = _setup_catalog(home, "acme", "audit", servers=[FIGMA_NAME])
     monkeypatch.setattr(_STAGE, _fake_stage())
     wd = tmp_path / "proj"
     wd.mkdir()
@@ -204,15 +221,15 @@ async def test_enable_not_installed_exit1(tmp_path: Path) -> None:
 @pytest.mark.asyncio
 async def test_disable_reads_scope_from_ledger(tmp_path: Path) -> None:
     home, env, reg = _home(tmp_path), _env(tmp_path), SkillRegistry()
-    plugin_root = _setup_catalog(home, "acme", "audit", servers=["figma-mcp"])
+    plugin_root = _setup_catalog(home, "acme", "audit", servers=[FIGMA_NAME])
     save_installed_plugins(
-        {"version": 1, "plugins": {"audit@acme": [{"scope": "user", "installPath": str(plugin_root), "mcpServers": ["figma-mcp"]}]}},
+        {"version": 1, "plugins": {"audit@acme": [{"scope": "user", "installPath": str(plugin_root), "mcpServers": [FIGMA_NAME]}]}},
         home=home,
     )
     mcp = _FakeMCP()
     code = await plugin_cmd.plugin_disable(reg, home, env, "audit@acme", remove_server=mcp.remove)
     assert code == 0
-    assert mcp.removed == ["figma-mcp"]  # 整 plugin 下线：摘 bundled server
+    assert mcp.removed == [FIGMA_NAME]  # 整 plugin 下线：摘 bundled server
     user = json.loads(user_settings_path(env).read_text(encoding="utf-8"))
     assert user["enabledPlugins"]["audit@acme"] is False
 
@@ -227,7 +244,7 @@ async def test_uninstall_not_installed_exit1(tmp_path: Path) -> None:
 def test_list_and_info(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     home, env = _home(tmp_path), _env(tmp_path)
     save_installed_plugins(
-        {"version": 1, "plugins": {"audit@acme": [{"scope": "user", "installPath": "/x", "mcpServers": ["figma-mcp"]}]}},
+        {"version": 1, "plugins": {"audit@acme": [{"scope": "user", "installPath": "/x", "mcpServers": [FIGMA_NAME]}]}},
         home=home,
     )
     # v0.3.0 缺省翻转：无 enabledPlugins 条目 = installed_disabled——默认列表仍可见，但 enabled=False
@@ -283,7 +300,7 @@ async def test_gc_no_orphans(tmp_path: Path, capsys: pytest.CaptureFixture[str])
 async def test_inject_inputs_cb_prefixes_and_injects(tmp_path: Path) -> None:
     home = _home(tmp_path)
     plugin_root = _setup_catalog(
-        home, "acme", "audit", servers=["figma-mcp"],
+        home, "acme", "audit", servers=[FIGMA_NAME],
         inputs=[{"id": "figma_token", "type": "promptString", "description": "tok", "password": True}],
     )
     injected: list[Any] = []
@@ -352,7 +369,7 @@ async def test_repl_install_is_lazy_no_mount_no_dirty(tmp_path: Path, monkeypatc
     """v0.3.0：REPL install 不激活——不挂载 bundled server、skills 无变化不 mark dirty；账本 + 意图照写。"""
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "cfg"))
     home, reg = _home(tmp_path), SkillRegistry()
-    _setup_catalog(home, "acme", "audit", servers=["figma-mcp"])
+    _setup_catalog(home, "acme", "audit", servers=[FIGMA_NAME])
     monkeypatch.setattr(_STAGE, _fake_stage())
     comp = _ReplComp(home, reg)
     await plugin_cmd.repl_dispatch(comp, ["plugin", "install", "audit@acme"], session=None)
@@ -422,7 +439,7 @@ async def test_run_governance_remount_wires_ownership_context(tmp_path: Path, mo
 
     _isolate_env(tmp_path, monkeypatch)
     home = _home(tmp_path)
-    _seed_recovery_home(home, servers=["figma-mcp"], skills=["lint"])
+    _seed_recovery_home(home, servers=[FIGMA_NAME], skills=["lint"])
 
     async with Computer(name="t", skill_home=home) as comp:
         recorded: list[tuple[str, str | None, str | None]] = []
@@ -433,7 +450,7 @@ async def test_run_governance_remount_wires_ownership_context(tmp_path: Path, mo
         monkeypatch.setattr(comp, "amount_server", fake_register)  # #137 ③：治理重挂经 transient amount_server
         await plugin_cmd.run_governance_remount(comp)
 
-        assert recorded == [("figma-mcp", "audit", "acme")]
+        assert recorded == [(FIGMA_NAME, "audit", "acme")]
 
 
 @pytest.mark.asyncio
@@ -443,7 +460,7 @@ async def test_run_governance_remount_flag_declared_disables(tmp_path: Path, mon
 
     _isolate_env(tmp_path, monkeypatch)
     home = _home(tmp_path)
-    _seed_recovery_home(home, servers=["figma-mcp"], skills=["lint"])
+    _seed_recovery_home(home, servers=[FIGMA_NAME], skills=["lint"])
     flag_file = tmp_path / "flag-settings.json"
     flag_file.write_text(json.dumps({"enabledPlugins": {"audit@acme": False}}), encoding="utf-8")
 
@@ -478,11 +495,11 @@ async def test_run_governance_remount_skips_dependency_satisfied_from_runtime_se
 
     _isolate_env(tmp_path, monkeypatch)
     home = _home(tmp_path)
-    _seed_recovery_home(home, servers=["figma-mcp"], skills=["lint"])
+    _seed_recovery_home(home, servers=[FIGMA_NAME], skills=["lint"])
 
     # auto_connect=False：config-only 挂载（不起子进程），与 #150 的 F7 范式一致（test_client.py:169-216）。
     async with Computer(name="t", mcp_servers=set(), auto_connect=False, skill_home=home) as comp:
-        user_cfg = TypeAdapter(MCPServerConfig).validate_python(_stdio("figma-mcp"))
+        user_cfg = TypeAdapter(MCPServerConfig).validate_python(_stdio(FIGMA_NAME))
         recorded: list[str] = []
 
         async def fake_register(server: Any, *, session: Any = None, plugin: str | None = None, marketplace: str | None = None) -> None:
@@ -508,7 +525,7 @@ async def test_disable_effective_across_boot_after_rematerialization(
 
     _isolate_env(tmp_path, monkeypatch)
     home, env, reg = _home(tmp_path), dict(os.environ), SkillRegistry()
-    _setup_catalog(home, "acme", "audit", servers=["figma-mcp"])
+    _setup_catalog(home, "acme", "audit", servers=[FIGMA_NAME])
     workdir = Path.cwd()
     # 模拟 project scope 安装+启用后账本丢失：仅 settings 意图在
     _write_json(user_settings_path(env), {"installedPlugins": ["audit@acme"]})

--- a/tests/unit_tests/computer/settings/test_install_enable_separation.py
+++ b/tests/unit_tests/computer/settings/test_install_enable_separation.py
@@ -28,7 +28,6 @@ from pathlib import Path
 import pytest
 
 from a2c_smcp.computer.settings.installer import (
-    MCPServerNameConflictError,
     enable_plugin,
     install_plugin,
     uninstall_plugin,
@@ -42,10 +41,14 @@ from a2c_smcp.computer.settings.scope import user_settings_path, workdir_local_s
 from a2c_smcp.computer.settings.store import load_installed_plugins, save_installed_plugins, save_known_marketplaces
 from a2c_smcp.computer.skills.home import SOURCE_MARKETPLACE, marketplace_skill_dir
 from a2c_smcp.computer.skills.registry import SkillRegistry
+from a2c_smcp.utils.bundle_id import resolve_bundle_id
 
 _SRC = {"type": "git", "url": "https://example.com/acme.git"}
 _STAGE = "a2c_smcp.computer.settings.installer.stage_marketplace_skills"
 _PID = "audit@acme"
+
+# 夹具身份对（#153 + 协议 conformance §2.0）：display name 含 `.` → bundle_id 折 `_`，两者**必须分叉**。
+FIGMA_NAME, FIGMA_BID = "figma.mcp", "figma_mcp"
 
 
 # ── 辅助（与 test_installer.py / test_recovery.py 同构）/ helpers ─────────────
@@ -120,8 +123,8 @@ def _record(plugin_root: Path, *, scope: str = "user", servers: Sequence[str] = 
         "commitSha": "abc123",
         "installedAt": "2026-07-06T00:00:00Z",
     }
-    if servers:
-        rec["bundledMcpServers"] = list(servers)
+    # 无条件写（生产 installer 亦然）：`mcpServers` 是新格式的正向标志，条件写会与旧格式记录难辨。
+    rec["mcpServers"] = list(servers)
     return rec
 
 
@@ -151,26 +154,26 @@ def _fake_stage(calls: list[dict], *, fail: bool = False, register_skill: bool =
 
 
 class _FakeMCP:
-    """记录 MCP 注入回调调用 / Records injected MCP callback invocations。"""
+    """记录 MCP 注入回调调用；**身份一律 bundle_id**（#153）/ Records callbacks; identity is bundle_id。"""
 
     def __init__(self, existing: set[str] | None = None) -> None:
-        self.existing: set[str] = set(existing or ())
-        self.registered: list[str] = []
-        self.removed: list[str] = []
-        self.fail_on: str | None = None
+        self.existing: set[str] = set(existing or ())  # bundle_id 集
+        self.registered: list[str] = []  # bundle_id
+        self.removed: list[str] = []  # bundle_id
+        self.fail_on: str | None = None  # 该 display name 的 server 注册时抛错
 
-    def existing_names(self) -> set[str]:
+    def existing_bundle_ids(self) -> set[str]:
         return set(self.existing)
 
     async def register(self, cfg) -> None:
         if self.fail_on is not None and cfg.name == self.fail_on:
             raise RuntimeError(f"register {cfg.name} boom")
-        self.registered.append(cfg.name)
-        self.existing.add(cfg.name)
+        self.registered.append(resolve_bundle_id(cfg))
+        self.existing.add(resolve_bundle_id(cfg))
 
-    async def remove(self, name: str) -> None:
-        self.removed.append(name)
-        self.existing.discard(name)
+    async def remove(self, bundle_id: str) -> None:
+        self.removed.append(bundle_id)
+        self.existing.discard(bundle_id)
 
 
 # ── install：不激活 + config-first 意图（§2.4 操作表 install 行）─────────────
@@ -179,7 +182,7 @@ async def test_install_only_writes_intent_and_ledger_without_activation(tmp_path
     """install-only：写 user ``installedPlugins`` + 账本；不 stage SKILL、不写 enabledPlugins → installed_disabled。"""
     home = _home(tmp_path)
     env = _env(tmp_path)
-    _setup_catalog(home, "acme", "audit", servers=["figma"], skills=["lint"])
+    _setup_catalog(home, "acme", "audit", servers=[FIGMA_NAME], skills=["lint"])
     calls: list[dict] = []
     monkeypatch.setattr(_STAGE, _fake_stage(calls))
     reg = SkillRegistry()
@@ -187,7 +190,7 @@ async def test_install_only_writes_intent_and_ledger_without_activation(tmp_path
     record = await install_plugin(_PID, reg, home, env=env)
 
     # 物化照旧：账本 + bundled server 解析记录
-    assert record["bundledMcpServers"] == ["figma"]
+    assert record["mcpServers"] == [FIGMA_BID]
     assert _PID in load_installed_plugins(home=home)["plugins"]
     # config-first：安装意图落 user scope settings.json
     settings = _read_user_settings(env)
@@ -233,19 +236,23 @@ async def test_install_materialize_failure_rolls_back_intent(tmp_path: Path, mon
 
 
 @pytest.mark.asyncio
-async def test_install_foreign_conflict_precheck_survives_separation(tmp_path: Path, monkeypatch) -> None:
-    """外来同名冲突预检保留（§2.4 install 行「预检 foreign MCP name 冲突」）：硬抛 + 意图/账本零变更。"""
+async def test_install_dependency_precheck_survives_separation(tmp_path: Path, monkeypatch) -> None:
+    """
+    依赖预检在 install⊥enable 分离后仍在，但**只提示不拒绝**（协议 §2.5-1，#153/D3）。
+
+    原名 ``test_install_foreign_conflict_precheck_survives_separation``：断言「外来同名硬抛 + 意图/账本零变更」。
+    D3 推翻该语义后，本例改为守护相反的不变量——**依赖已满足不得阻断安装**（意图与账本都要写成）。
+    """
     home = _home(tmp_path)
     env = _env(tmp_path)
-    _setup_catalog(home, "acme", "audit", servers=["figma"])
+    _setup_catalog(home, "acme", "audit", servers=[FIGMA_NAME])
     monkeypatch.setattr(_STAGE, _fake_stage([]))
-    mcp = _FakeMCP(existing={"figma"})
+    mcp = _FakeMCP(existing={FIGMA_BID})
 
-    with pytest.raises(MCPServerNameConflictError, match="figma"):
-        await install_plugin(_PID, SkillRegistry(), home, env=env, existing_server_names=mcp.existing_names)
+    await install_plugin(_PID, SkillRegistry(), home, env=env, existing_bundle_ids=mcp.existing_bundle_ids)
 
-    assert _PID not in _read_user_settings(env).get("installedPlugins", [])
-    assert _PID not in load_installed_plugins(home=home)["plugins"]
+    assert _PID in _read_user_settings(env).get("installedPlugins", [])
+    assert _PID in load_installed_plugins(home=home)["plugins"]
 
 
 # ── enable：原子激活失败回滚（§2.4「enable 原子性」blockquote）────────────────
@@ -266,7 +273,7 @@ async def test_enable_mount_failure_rolls_back_to_installed_disabled(tmp_path: P
     with pytest.raises(RuntimeError, match="beta"):
         await enable_plugin(
             _PID, reg, home, env=env,
-            existing_server_names=mcp.existing_names, register_server=mcp.register, remove_server=mcp.remove,
+            existing_bundle_ids=mcp.existing_bundle_ids, register_server=mcp.register, remove_server=mcp.remove,
         )
 
     settings = _read_user_settings(env)
@@ -281,17 +288,17 @@ async def test_enable_mount_failure_restores_previous_false(tmp_path: Path, monk
     """enable 失败且原值为显式 false → 恢复 false（不残留 true、不误删原禁用意图）。"""
     home = _home(tmp_path)
     env = _env(tmp_path)
-    root = _setup_catalog(home, "acme", "audit", servers=["figma"], skills=["lint"])
-    _seed_installed(home, {_PID: [_record(root, servers=["figma"])]})
+    root = _setup_catalog(home, "acme", "audit", servers=[FIGMA_NAME], skills=["lint"])
+    _seed_installed(home, {_PID: [_record(root, servers=[FIGMA_NAME])]})
     _write_json(user_settings_path(env), {"installedPlugins": [_PID], "enabledPlugins": {_PID: False}})
     monkeypatch.setattr(_STAGE, _fake_stage([]))
     mcp = _FakeMCP()
-    mcp.fail_on = "figma"
+    mcp.fail_on = FIGMA_NAME
 
     with pytest.raises(RuntimeError, match="figma"):
         await enable_plugin(
             _PID, SkillRegistry(), home, env=env,
-            existing_server_names=mcp.existing_names, register_server=mcp.register, remove_server=mcp.remove,
+            existing_bundle_ids=mcp.existing_bundle_ids, register_server=mcp.register, remove_server=mcp.remove,
         )
 
     assert _read_user_settings(env)["enabledPlugins"][_PID] is False
@@ -303,8 +310,8 @@ async def test_uninstall_clears_intent_and_enabled_entries(tmp_path: Path, monke
     """uninstall → installedPlugins 删 pid + enabledPlugins 清条目 + 账本删除（回 available）。"""
     home = _home(tmp_path)
     env = _env(tmp_path)
-    root = _setup_catalog(home, "acme", "audit", servers=["figma"], skills=["lint"])
-    _seed_installed(home, {_PID: [_record(root, servers=["figma"])]})
+    root = _setup_catalog(home, "acme", "audit", servers=[FIGMA_NAME], skills=["lint"])
+    _seed_installed(home, {_PID: [_record(root, servers=[FIGMA_NAME])]})
     _write_json(user_settings_path(env), {"installedPlugins": [_PID], "enabledPlugins": {_PID: True}})
     monkeypatch.setattr(_STAGE, _fake_stage([]))
     mcp = _FakeMCP()
@@ -370,7 +377,7 @@ async def test_recover_installed_and_enabled_restores(tmp_path: Path) -> None:
 async def test_recover_rematerializes_missing_ledger_from_intent(tmp_path: Path) -> None:
     """账本删除 → boot 从 installedPlugins 重物化重建（§4.9「删除无损」；conformance §5 账本删除条目）。"""
     home = _home(tmp_path)
-    _setup_catalog(home, "acme", "audit", servers=["figma"], skills=["lint"])  # 账本刻意不 seed
+    _setup_catalog(home, "acme", "audit", servers=[FIGMA_NAME], skills=["lint"])  # 账本刻意不 seed
     reg = SkillRegistry()
     declared = {"installedPlugins": [_PID], "enabledPlugins": {_PID: True}}
 
@@ -379,16 +386,16 @@ async def test_recover_rematerializes_missing_ledger_from_intent(tmp_path: Path)
     assert report.rematerialized == [_PID]
     rebuilt = load_installed_plugins(home=home)["plugins"][_PID][0]
     assert rebuilt["installPath"].replace("\\", "/").endswith("marketplace/acme/plugins/audit")
-    assert rebuilt["bundledMcpServers"] == ["figma"]
+    assert rebuilt["mcpServers"] == [FIGMA_BID]
     assert "audit:lint" in report.restored_skills  # enabled → 重物化后照常激活
-    assert collect_enabled_bundled_servers(home, declared, env=_env(tmp_path))[0].config.name == "figma"
+    assert collect_enabled_bundled_servers(home, declared, env=_env(tmp_path))[0].config.name == FIGMA_NAME
 
 
 @pytest.mark.asyncio
 async def test_recover_rematerializes_disabled_installs_without_activation(tmp_path: Path) -> None:
     """installed_disabled 的重物化也执行（installed = materialized 不变量；enable 无需重 clone），但不激活。"""
     home = _home(tmp_path)
-    _setup_catalog(home, "acme", "audit", servers=["figma"], skills=["lint"])
+    _setup_catalog(home, "acme", "audit", servers=[FIGMA_NAME], skills=["lint"])
     reg = SkillRegistry()
     declared = {"installedPlugins": [_PID]}
 
@@ -403,14 +410,14 @@ async def test_recover_rematerializes_disabled_installs_without_activation(tmp_p
 def test_collect_gates_on_installed_and_enabled(tmp_path: Path) -> None:
     """collect：intent 有但未启用 → 空；installed ∧ true → 可查询（§4.8 blockquote 的 enabled 门槛翻转）。"""
     home = _home(tmp_path)
-    root = _setup_catalog(home, "acme", "audit", servers=["figma"])
-    _seed_installed(home, {_PID: [_record(root, servers=["figma"])]})
+    root = _setup_catalog(home, "acme", "audit", servers=[FIGMA_NAME])
+    _seed_installed(home, {_PID: [_record(root, servers=[FIGMA_NAME])]})
 
     assert collect_enabled_bundled_servers(home, {"installedPlugins": [_PID]}, env=_env(tmp_path)) == []
     records = collect_enabled_bundled_servers(
         home, {"installedPlugins": [_PID], "enabledPlugins": {_PID: True}}, env=_env(tmp_path),
     )
-    assert [r.config.name for r in records] == ["figma"]
+    assert [r.config.name for r in records] == [FIGMA_NAME]
 
 
 # ── migrate_legacy_installs：一次性迁移（迁移指南「保住既有用户现状」）─────────
@@ -563,7 +570,7 @@ async def test_enable_mount_failure_restores_previous_true(tmp_path: Path, monke
     with pytest.raises(RuntimeError, match="beta"):
         await enable_plugin(
             _PID, SkillRegistry(), home, env=env,
-            existing_server_names=mcp.existing_names, register_server=mcp.register, remove_server=mcp.remove,
+            existing_bundle_ids=mcp.existing_bundle_ids, register_server=mcp.register, remove_server=mcp.remove,
         )
 
     assert _read_user_settings(env)["enabledPlugins"][_PID] is True
@@ -578,7 +585,7 @@ async def test_recover_rematerialize_infers_project_scope_from_enabled_layer(tmp
     workdir = tmp_path / "proj"
     workdir.mkdir()
     monkeypatch.chdir(workdir)
-    _setup_catalog(home, "acme", "audit", servers=["figma"], skills=["lint"])
+    _setup_catalog(home, "acme", "audit", servers=[FIGMA_NAME], skills=["lint"])
     _write_json(workdir_project_settings_path(workdir), {"enabledPlugins": {_PID: True}})
     declared = {"installedPlugins": [_PID], "enabledPlugins": {_PID: True}}
 
@@ -598,7 +605,7 @@ async def test_recover_rematerialize_multi_layer_clues_rebuild_multi_records(tmp
     workdir = tmp_path / "proj"
     workdir.mkdir()
     monkeypatch.chdir(workdir)
-    _setup_catalog(home, "acme", "audit", servers=["figma"], skills=["lint"])
+    _setup_catalog(home, "acme", "audit", servers=[FIGMA_NAME], skills=["lint"])
     _write_json(user_settings_path(env), {"installedPlugins": [_PID], "enabledPlugins": {_PID: False}})
     _write_json(workdir_local_settings_path(workdir), {"enabledPlugins": {_PID: True}})
     declared = {"installedPlugins": [_PID], "enabledPlugins": {_PID: True}}
@@ -622,7 +629,7 @@ async def test_recover_rematerialize_no_clue_falls_back_user_and_reports(tmp_pat
     workdir = tmp_path / "proj"
     workdir.mkdir()
     monkeypatch.chdir(workdir)
-    _setup_catalog(home, "acme", "audit", servers=["figma"], skills=["lint"])
+    _setup_catalog(home, "acme", "audit", servers=[FIGMA_NAME], skills=["lint"])
     declared = {"installedPlugins": [_PID]}
 
     # 项目 logger "a2c_smcp" 关闭 propagate → caplog.handler 直挂源模块 logger（同 test_window_uri 惯例）
@@ -647,7 +654,7 @@ async def test_recover_rematerialize_project_installed_declaration_is_clue(tmp_p
     workdir = tmp_path / "proj"
     workdir.mkdir()
     monkeypatch.chdir(workdir)
-    _setup_catalog(home, "acme", "audit", servers=["figma"], skills=["lint"])
+    _setup_catalog(home, "acme", "audit", servers=[FIGMA_NAME], skills=["lint"])
     _write_json(workdir_project_settings_path(workdir), {"installedPlugins": [_PID]})
     declared = {"installedPlugins": [_PID]}
 
@@ -667,7 +674,7 @@ async def test_recover_rematerialize_replaces_dead_records_of_stale_scopes(tmp_p
     workdir = tmp_path / "proj"
     workdir.mkdir()
     monkeypatch.chdir(workdir)
-    _setup_catalog(home, "acme", "audit", servers=["figma"], skills=["lint"])
+    _setup_catalog(home, "acme", "audit", servers=[FIGMA_NAME], skills=["lint"])
     _seed_installed(home, {_PID: [{"scope": "project", "installPath": str(tmp_path / "gone"), "projectPath": str(workdir)}]})
     _write_json(user_settings_path(env), {"installedPlugins": [_PID], "enabledPlugins": {_PID: True}})
     declared = {"installedPlugins": [_PID], "enabledPlugins": {_PID: True}}
@@ -728,7 +735,7 @@ async def test_recover_rematerialize_ignores_project_false_override(tmp_path: Pa
     workdir = tmp_path / "proj"
     workdir.mkdir()
     monkeypatch.chdir(workdir)
-    _setup_catalog(home, "acme", "audit", servers=["figma"], skills=["lint"])
+    _setup_catalog(home, "acme", "audit", servers=[FIGMA_NAME], skills=["lint"])
     _write_json(user_settings_path(env), {"installedPlugins": [_PID], "enabledPlugins": {_PID: True}})
     _write_json(workdir_project_settings_path(workdir), {"enabledPlugins": {_PID: False}})  # 团队禁用覆盖
     declared = {"installedPlugins": [_PID], "enabledPlugins": {_PID: False}}  # merged：project false 获胜
@@ -748,13 +755,13 @@ async def test_recover_repairs_mixed_health_records(tmp_path: Path, monkeypatch)
     home = _home(tmp_path)
     env = _env(tmp_path)
     monkeypatch.chdir(tmp_path)
-    root = _setup_catalog(home, "acme", "audit", servers=["figma"], skills=["lint"])
+    root = _setup_catalog(home, "acme", "audit", servers=[FIGMA_NAME], skills=["lint"])
     stale = home / "stale-project-copy"
     (stale / "mcp-servers").mkdir(parents=True)
     (stale / "mcp-servers" / "bad.json").write_text("{not json", encoding="utf-8")
     _seed_installed(
         home,
-        {_PID: [_record(root, servers=["figma"]), {"scope": "project", "installPath": str(stale), "projectPath": "/elsewhere"}]},
+        {_PID: [_record(root, servers=[FIGMA_NAME]), {"scope": "project", "installPath": str(stale), "projectPath": "/elsewhere"}]},
     )
     _write_json(user_settings_path(env), {"installedPlugins": [_PID], "enabledPlugins": {_PID: True}})
     declared = {"installedPlugins": [_PID], "enabledPlugins": {_PID: True}}
@@ -764,7 +771,7 @@ async def test_recover_repairs_mixed_health_records(tmp_path: Path, monkeypatch)
     assert report.rematerialized == [_PID]  # ∀ 判据：混合健康度触发重物化
     records = load_installed_plugins(home=home)["plugins"][_PID]
     assert [(r["scope"], r["installPath"]) for r in records] == [("user", str(root))]  # 损坏 project 残留被清扫
-    assert [r.config.name for r in collect_enabled_bundled_servers(home, declared, env=env)] == ["figma"]  # 无半态
+    assert [r.config.name for r in collect_enabled_bundled_servers(home, declared, env=env)] == [FIGMA_NAME]  # 无半态
 
 
 # ── #125 任务 2：悬挂意图 prune 执行入口（installer 是 settings 意图唯一写者）──
@@ -841,7 +848,7 @@ def test_prune_plugin_intent_warns_on_residual_project_declaration(tmp_path: Pat
 async def test_recover_rematerializes_on_corrupt_bundled_json(tmp_path: Path) -> None:
     """账本 installPath 目录在、bundled JSON 损坏 → 判失效走重物化（catalog 完好 → 修复指回 catalog root）。"""
     home = _home(tmp_path)
-    _setup_catalog(home, "acme", "audit", servers=["figma"], skills=["lint"])
+    _setup_catalog(home, "acme", "audit", servers=[FIGMA_NAME], skills=["lint"])
     stale = home / "stale-copy"
     (stale / "mcp-servers").mkdir(parents=True)
     (stale / "mcp-servers" / "bad.json").write_text("{not json", encoding="utf-8")
@@ -855,7 +862,7 @@ async def test_recover_rematerializes_on_corrupt_bundled_json(tmp_path: Path) ->
     rebuilt = load_installed_plugins(home=home)["plugins"][_PID]
     assert all(r["installPath"] != str(stale) for r in rebuilt)  # 修复：不再指向损坏副本
     assert "audit:lint" in report.restored_skills
-    assert collect_enabled_bundled_servers(home, declared, env=_env(tmp_path))[0].config.name == "figma"  # server 可查询（无半态）
+    assert collect_enabled_bundled_servers(home, declared, env=_env(tmp_path))[0].config.name == FIGMA_NAME  # server 可查询（无半态）
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/computer/settings/test_installer.py
+++ b/tests/unit_tests/computer/settings/test_installer.py
@@ -8,16 +8,22 @@
 Plugin installer 单元测试（v0.2.1 #63）—— install/uninstall/enable/disable 编排（mock git staging + 注入 MCP）
 Plugin installer unit tests: install/uninstall/enable/disable orchestration (stage mocked, MCP injected).
 
-SDK 设计 / Design: python-sdk docs/design-0.2.1-cli-marketplace-ux.md §3.3/§4.3/§6.2/§7.2/§10.6。
+SDK 设计 / Design: python-sdk docs/design-0.2.1-cli-marketplace-ux.md §3.3/§4.3/§6.2/§7.2。
+协议 / Protocol: runtime-contract §2.5（依赖模型）/ §4.9.1（账本 ``mcpServers`` + 回收判据），#153/D3+F1。
 
 测试意图 / Test intentions（不依赖 git——用相对路径 plugin（locate_plugin_root 无 git）+ monkeypatch
 ``stage_marketplace_skills`` + 注入回调记录 MCP 调用；settings 写经 ``XDG_CONFIG_HOME`` 重定向隔离）:
-- install（v0.3.0 #123 不激活）：happy 写 installedPlugins 意图 + 账本（不 stage、不挂 server）/ 外来同名硬抛+
-  原子（零变更）/ 自有同名幂等 / 重装失败不丢既有意图与账本 / 未添加 mp / catalog 未 clone / 非法 id。
+- install（v0.3.0 #123 不激活）：happy 写 installedPlugins 意图 + 账本（不 stage、不挂 server）/ **依赖已满足
+  不拒绝**（D3）/ 重装幂等 / 重装失败不丢既有意图与账本 / 未添加 mp / catalog 未 clone / 非法 id。
   install-only 目标行为与回滚细节另见 test_install_enable_separation.py。
-- uninstall：级联 stop+remove + 注销 + 删记录 + 删 installPath 树 / --keep-servers / 未安装 no-op。
-- disable：写 enabledPlugins=false + 摘 server + orphan skill（可复原）/ scope 路由 / 非法 scope。
-- enable：写 true + 复活 skill + 重挂 server / 未安装抛 / 外来同名冲突且 settings 未写（原子）。
+- uninstall：**按判据**回收 + 注销 + 删记录 + 删 installPath 树 / --keep-servers / 未安装 no-op。
+- disable：写 enabledPlugins=false + 按判据回收 + orphan skill（可复原）/ scope 路由 / 非法 scope。
+- enable：写 true + 复活 skill + 挂载未满足的依赖 / 未安装抛 / **依赖已满足 → 复用不覆盖**（D3）。
+
+.. note::
+   原「外来同名硬抛 + 原子零变更」「自有同名（``owned``）幂等放行」两组用例已按 D3 改写——协议裁定 plugin 与
+   MCP Server 是**依赖关系**，同 ``bundle_id`` 已有 = 依赖已满足，MUST NOT 拒绝，故「冲突」与「所有权」概念
+   双双退役。回收判据五场景（用户自有永不连坐 / 共享依赖无泄漏）见 test_mcp_dependency_model.py。
 """
 
 import json
@@ -27,7 +33,6 @@ from pathlib import Path
 import pytest
 
 from a2c_smcp.computer.settings.installer import (
-    MCPServerNameConflictError,
     PluginInstallError,
     disable_plugin,
     enable_plugin,
@@ -38,9 +43,27 @@ from a2c_smcp.computer.settings.scope import user_settings_path, workdir_project
 from a2c_smcp.computer.settings.store import load_installed_plugins, save_installed_plugins, save_known_marketplaces
 from a2c_smcp.computer.skills.home import SOURCE_MARKETPLACE, marketplace_skill_dir
 from a2c_smcp.computer.skills.registry import SkillRegistry
+from a2c_smcp.utils.bundle_id import resolve_bundle_id
 
 _SRC = {"type": "git", "url": "https://example.com/acme.git"}
 _STAGE = "a2c_smcp.computer.settings.installer.stage_marketplace_skills"
+
+# 夹具身份对（#153 + 协议 conformance §2.0）：display name 含 `.` → normalize_name 折成 `_`，故 **name ≠
+# bundle_id**。原夹具用 "figma"（两者恰好同值）令「误用 name 当身份」的实现无法被鉴别——Epic #147 记录的同类
+# 致盲已四例。/ Fixture identity pair kept forked so name-as-identity bugs cannot pass.
+FIGMA_NAME, FIGMA_BID = "figma.mcp", "figma_mcp"
+
+
+@pytest.fixture(autouse=True)
+def _isolate_cwd(tmp_path: Path, monkeypatch) -> None:
+    """
+    隔离 cwd / Isolate the process cwd。
+
+    #153 起 uninstall/disable 的回收判据经 ``user_declared_bundle_ids`` → ``resolve_mcp_config`` 读
+    **cwd 锚定**的 ``.tfrobot/mcp[.local].json``（project/local scope，#116）。不 chdir 则读进真实仓库的
+    工作区配置——开发者本地一旦有该文件，断言即随环境漂移（#137 同款教训）。
+    """
+    monkeypatch.chdir(tmp_path)
 
 
 # ── 辅助 / helpers ───────────────────────────────────────────────────────────
@@ -114,26 +137,26 @@ def _fake_stage(calls: list[dict], *, fail: bool = False, register_skill: bool =
 
 
 class _FakeMCP:
-    """记录 MCP 注入回调调用 / Records injected MCP callback invocations。"""
+    """记录 MCP 注入回调调用；**身份一律 bundle_id**（#153：账本记 bundle_id ⇒ 预检/停摘链收 bundle_id）。"""
 
     def __init__(self, existing: set[str] | None = None) -> None:
-        self.existing: set[str] = set(existing or ())
-        self.registered: list[str] = []
-        self.removed: list[str] = []
-        self.fail_on: str | None = None  # 该 server 注册时抛错
+        self.existing: set[str] = set(existing or ())  # bundle_id 集
+        self.registered: list[str] = []  # bundle_id
+        self.removed: list[str] = []  # bundle_id
+        self.fail_on: str | None = None  # 该 display name 的 server 注册时抛错
 
-    def existing_names(self) -> set[str]:
+    def existing_bundle_ids(self) -> set[str]:
         return set(self.existing)
 
     async def register(self, cfg) -> None:
         if self.fail_on is not None and cfg.name == self.fail_on:
             raise RuntimeError(f"register {cfg.name} boom")
-        self.registered.append(cfg.name)
-        self.existing.add(cfg.name)
+        self.registered.append(resolve_bundle_id(cfg))
+        self.existing.add(resolve_bundle_id(cfg))
 
-    async def remove(self, name: str) -> None:
-        self.removed.append(name)
-        self.existing.discard(name)
+    async def remove(self, bundle_id: str) -> None:
+        self.removed.append(bundle_id)
+        self.existing.discard(bundle_id)
 
 
 # ── install ──────────────────────────────────────────────────────────────────
@@ -141,68 +164,73 @@ async def test_install_happy_writes_intent_and_ledger(tmp_path: Path, monkeypatc
     """happy：记录字段完整（scope/version/commitSha/installPath/bundled）+ 意图落 user；不激活（v0.3.0）。"""
     home = _home(tmp_path)
     env = _env(tmp_path)
-    _setup_catalog(home, "acme", "audit", servers=["figma"])
+    _setup_catalog(home, "acme", "audit", servers=[FIGMA_NAME])
     calls: list[dict] = []
     monkeypatch.setattr(_STAGE, _fake_stage(calls))
     mcp = _FakeMCP()
     reg = SkillRegistry()
 
-    record = await install_plugin("audit@acme", reg, home, env=env, existing_server_names=mcp.existing_names)
+    record = await install_plugin("audit@acme", reg, home, env=env, existing_bundle_ids=mcp.existing_bundle_ids)
 
     assert record["scope"] == "user"
     assert record["version"] == "1.2.0"  # entry.version 胜
     assert record["commitSha"] == "abc123"
-    assert record["bundledMcpServers"] == ["figma"]
+    assert record["mcpServers"] == [FIGMA_BID]
     assert record["installPath"].replace("\\", "/").endswith("marketplace/acme/plugins/audit")
     assert calls == []  # 不 stage（install ≠ activate）
     assert reg.resolve("audit:lint") is None
     ipf = load_installed_plugins(home=home)["plugins"]
-    assert ipf["audit@acme"][0]["bundledMcpServers"] == ["figma"]
+    assert ipf["audit@acme"][0]["mcpServers"] == [FIGMA_BID]
     user = json.loads(user_settings_path(env).read_text(encoding="utf-8"))
     assert user["installedPlugins"] == ["audit@acme"]
 
 
-async def test_install_foreign_conflict_is_atomic(tmp_path: Path, monkeypatch) -> None:
+async def test_install_dependency_satisfied_does_not_reject(tmp_path: Path, monkeypatch) -> None:
+    """
+    D3：同 bundle_id 已存在 = **依赖已满足** → 正常安装（协议 §2.5-1 MUST NOT 拒绝）。
+
+    本例取代原 ``test_install_foreign_conflict_is_atomic``：「外来同名硬抛、原子失败、name 即身份、无
+    rename/force 逃生口」那套裁决已被协议**正面推翻**（Discussion #23 / D3）——plugin 与 MCP Server 是
+    **依赖关系**，本地已有即依赖满足，复用而非新建。判据五场景另见 test_mcp_dependency_model.py。
+    """
     home = _home(tmp_path)
     env = _env(tmp_path)
-    _setup_catalog(home, "acme", "audit", servers=["figma"])
-    calls: list[dict] = []
-    monkeypatch.setattr(_STAGE, _fake_stage(calls))
-    mcp = _FakeMCP(existing={"figma"})  # 外来 figma 已存在
-    reg = SkillRegistry()
-
-    with pytest.raises(MCPServerNameConflictError, match="figma"):
-        await install_plugin("audit@acme", reg, home, env=env, existing_server_names=mcp.existing_names)
-
-    assert calls == []  # stage 未调用
-    assert reg.resolve("audit:lint") is None
-    assert "audit@acme" not in load_installed_plugins(home=home)["plugins"]  # 不写账本
-    user = json.loads(user_settings_path(env).read_text(encoding="utf-8"))
-    assert user.get("installedPlugins", []) == []  # 意图原子回滚（零变更）
-
-
-async def test_install_own_same_name_is_idempotent(tmp_path: Path, monkeypatch) -> None:
-    home = _home(tmp_path)
-    install_path = _setup_catalog(home, "acme", "audit", servers=["figma"])
-    _seed_installed(home, {"audit@acme": [{"scope": "user", "installPath": str(install_path), "bundledMcpServers": ["figma"]}]})
+    _setup_catalog(home, "acme", "audit", servers=[FIGMA_NAME])
     monkeypatch.setattr(_STAGE, _fake_stage([]))
-    mcp = _FakeMCP(existing={"figma"})  # figma 存在但归本 plugin 自有 → 不冲突
+    mcp = _FakeMCP(existing={FIGMA_BID})  # 本地已有同 bundle_id
     reg = SkillRegistry()
 
-    record = await install_plugin("audit@acme", reg, home, env=_env(tmp_path), existing_server_names=mcp.existing_names)
+    record = await install_plugin("audit@acme", reg, home, env=env, existing_bundle_ids=mcp.existing_bundle_ids)
 
-    assert record["bundledMcpServers"] == ["figma"]  # 幂等重物化（自有同名放行）
+    assert record["mcpServers"] == [FIGMA_BID]
+    assert "audit@acme" in load_installed_plugins(home=home)["plugins"]  # 写了账本 = 真装上了
+    user = json.loads(user_settings_path(env).read_text(encoding="utf-8"))
+    assert user["installedPlugins"] == ["audit@acme"]  # 意图已写（非「原子回滚」）
+
+
+async def test_install_reinstall_is_idempotent(tmp_path: Path, monkeypatch) -> None:
+    """幂等重物化：已有账本记录 + 同 bundle_id 已挂 → 正常覆盖记录（原 ``owned`` 白名单概念随 D3 退役）。"""
+    home = _home(tmp_path)
+    install_path = _setup_catalog(home, "acme", "audit", servers=[FIGMA_NAME])
+    _seed_installed(home, {"audit@acme": [{"scope": "user", "installPath": str(install_path), "mcpServers": [FIGMA_BID]}]})
+    monkeypatch.setattr(_STAGE, _fake_stage([]))
+    mcp = _FakeMCP(existing={FIGMA_BID})
+    reg = SkillRegistry()
+
+    record = await install_plugin("audit@acme", reg, home, env=_env(tmp_path), existing_bundle_ids=mcp.existing_bundle_ids)
+
+    assert record["mcpServers"] == [FIGMA_BID]
 
 
 async def test_install_ledger_only_without_injection(tmp_path: Path, monkeypatch) -> None:
     home = _home(tmp_path)
-    _setup_catalog(home, "acme", "audit", servers=["figma"])
+    _setup_catalog(home, "acme", "audit", servers=[FIGMA_NAME])
     monkeypatch.setattr(_STAGE, _fake_stage([]))
     reg = SkillRegistry()
 
     record = await install_plugin("audit@acme", reg, home, env=_env(tmp_path))  # 无注入 → 跳过冲突预检
 
-    assert record["bundledMcpServers"] == ["figma"]  # 解析+记录（即使未注册 server）
+    assert record["mcpServers"] == [FIGMA_BID]  # 解析+记录（即使未注册 server）
     assert "audit@acme" in load_installed_plugins(home=home)["plugins"]
 
 
@@ -229,8 +257,8 @@ async def test_install_reinstall_failure_preserves_existing(tmp_path: Path, monk
     env = _env(tmp_path)
     mcp = _FakeMCP()
     reg = SkillRegistry()
-    await _install(home, tmp_path, monkeypatch, mcp, reg, servers=["figma"])  # 首装+enable：figma + audit:lint 活跃
-    assert reg.resolve("audit:lint") is not None and mcp.registered == ["figma"]
+    await _install(home, tmp_path, monkeypatch, mcp, reg, servers=[FIGMA_NAME])  # 首装+enable：figma + audit:lint 活跃
+    assert reg.resolve("audit:lint") is not None and mcp.registered == [FIGMA_BID]
 
     # 重装：plugin 新增一个畸形 bundled JSON（zeta）→ 物化失败；意图/账本/live 态须保持首装状态
     plugin_root = marketplace_skill_dir(home, "acme") / "plugins" / "audit"
@@ -239,13 +267,13 @@ async def test_install_reinstall_failure_preserves_existing(tmp_path: Path, monk
     mcp.removed.clear()
 
     with pytest.raises(Exception, match="zeta"):
-        await install_plugin("audit@acme", reg, home, env=env, existing_server_names=mcp.existing_names)
+        await install_plugin("audit@acme", reg, home, env=env, existing_bundle_ids=mcp.existing_bundle_ids)
 
     assert reg.resolve("audit:lint") is not None  # 既有 skill 未被误注销
     assert mcp.removed == []  # 自有 figma 未被误摘
-    assert "figma" in mcp.existing  # figma 仍挂在 manager
+    assert FIGMA_BID in mcp.existing  # figma 仍挂在 manager
     rec = load_installed_plugins(home=home)["plugins"]["audit@acme"][0]
-    assert rec["bundledMcpServers"] == ["figma"]  # 账本仍为首装记录（本次失败未改写）
+    assert rec["mcpServers"] == [FIGMA_BID]  # 账本仍为首装记录（本次失败未改写）
     user = json.loads(user_settings_path(env).read_text(encoding="utf-8"))
     assert user["installedPlugins"] == ["audit@acme"]  # 重装失败不误删既有意图（was_present → 不回滚）
 
@@ -256,10 +284,10 @@ async def _install(home: Path, tmp_path: Path, monkeypatch, mcp: _FakeMCP, reg: 
     install_path = _setup_catalog(home, "acme", "audit", servers=servers)
     monkeypatch.setattr(_STAGE, _fake_stage([]))
     env = _env(tmp_path)
-    await install_plugin("audit@acme", reg, home, env=env, existing_server_names=mcp.existing_names)
+    await install_plugin("audit@acme", reg, home, env=env, existing_bundle_ids=mcp.existing_bundle_ids)
     await enable_plugin(
         "audit@acme", reg, home, env=env,
-        existing_server_names=mcp.existing_names, register_server=mcp.register, remove_server=mcp.remove,
+        existing_bundle_ids=mcp.existing_bundle_ids, register_server=mcp.register, remove_server=mcp.remove,
     )
     return install_path
 
@@ -269,14 +297,14 @@ async def test_uninstall_default_cascades(tmp_path: Path, monkeypatch) -> None:
     env = _env(tmp_path)
     mcp = _FakeMCP()
     reg = SkillRegistry()
-    install_path = await _install(home, tmp_path, monkeypatch, mcp, reg, servers=["figma"])
+    install_path = await _install(home, tmp_path, monkeypatch, mcp, reg, servers=[FIGMA_NAME])
     assert install_path.exists()
     mcp.removed.clear()
 
     ok = await uninstall_plugin("audit@acme", reg, home, env=env, remove_server=mcp.remove)
 
     assert ok is True
-    assert mcp.removed == ["figma"]  # 级联 stop+remove
+    assert mcp.removed == [FIGMA_BID]  # 级联 stop+remove
     assert reg.resolve("audit:lint") is None  # skills 注销
     assert "audit@acme" not in load_installed_plugins(home=home)["plugins"]  # 记录删除
     assert not install_path.exists()  # installPath 树清除
@@ -290,7 +318,7 @@ async def test_uninstall_keep_servers_skips_teardown(tmp_path: Path, monkeypatch
     env = _env(tmp_path)
     mcp = _FakeMCP()
     reg = SkillRegistry()
-    await _install(home, tmp_path, monkeypatch, mcp, reg, servers=["figma"])
+    await _install(home, tmp_path, monkeypatch, mcp, reg, servers=[FIGMA_NAME])
     mcp.removed.clear()
 
     ok = await uninstall_plugin("audit@acme", reg, home, env=env, keep_servers=True, remove_server=mcp.remove)
@@ -313,14 +341,14 @@ async def test_disable_writes_flag_detaches_servers_orphans_skills(tmp_path: Pat
     env = _env(tmp_path)
     mcp = _FakeMCP()
     reg = SkillRegistry()
-    await _install(home, tmp_path, monkeypatch, mcp, reg, servers=["figma"])
+    await _install(home, tmp_path, monkeypatch, mcp, reg, servers=[FIGMA_NAME])
     mcp.removed.clear()
 
     await disable_plugin("audit@acme", reg, home, env=env, remove_server=mcp.remove)
 
     settings = json.loads(user_settings_path(env).read_text(encoding="utf-8"))
     assert settings["enabledPlugins"]["audit@acme"] is False
-    assert mcp.removed == ["figma"]  # 停+摘 bundled server
+    assert mcp.removed == [FIGMA_BID]  # 停+摘 bundled server
     assert reg.is_orphan("audit:lint") is True  # 隐藏（孤儿）
     assert reg.resolve("audit:lint") is None  # 活跃集排除
     assert "audit:lint" in reg  # 物化层保留（仍注册、可复原）
@@ -358,20 +386,20 @@ async def test_enable_recovers_skills_and_remounts_servers(tmp_path: Path, monke
     env = _env(tmp_path)
     mcp = _FakeMCP()
     reg = SkillRegistry()
-    await _install(home, tmp_path, monkeypatch, mcp, reg, servers=["figma"])
+    await _install(home, tmp_path, monkeypatch, mcp, reg, servers=[FIGMA_NAME])
     await disable_plugin("audit@acme", reg, home, env=env, remove_server=mcp.remove)
     assert reg.is_orphan("audit:lint")
     mcp.registered.clear()
 
     await enable_plugin(
         "audit@acme", reg, home, env=env,
-        existing_server_names=mcp.existing_names, register_server=mcp.register,
+        existing_bundle_ids=mcp.existing_bundle_ids, register_server=mcp.register,
     )
 
     settings = json.loads(user_settings_path(env).read_text(encoding="utf-8"))
     assert settings["enabledPlugins"]["audit@acme"] is True
     assert reg.resolve("audit:lint") is not None  # 孤儿复活
-    assert mcp.registered == ["figma"]  # server 重挂
+    assert mcp.registered == [FIGMA_BID]  # server 重挂
 
 
 async def test_enable_not_installed_raises(tmp_path: Path) -> None:
@@ -379,28 +407,35 @@ async def test_enable_not_installed_raises(tmp_path: Path) -> None:
         await enable_plugin("ghost@acme", SkillRegistry(), _home(tmp_path), env=_env(tmp_path))
 
 
-async def test_enable_foreign_conflict_leaves_settings_untouched(tmp_path: Path, monkeypatch) -> None:
+async def test_enable_dependency_satisfied_reuses_and_succeeds(tmp_path: Path, monkeypatch) -> None:
+    """
+    D3：enable 时同 bundle_id 已在活跃集 → **复用既有实例、skip register**，enable 照常成功（§2.5-1）。
+
+    本例取代原 ``test_enable_foreign_conflict_leaves_settings_untouched``（「外来同名 → 硬抛、settings 原子未写」）
+    ——该语义已被协议推翻。关键断言是 **不覆盖**：既有 server 是用户的或他 plugin 的，覆盖它即毁其配置。
+    """
     home = _home(tmp_path)
     env = _env(tmp_path)
-    install_path = marketplace_skill_dir(home, "acme") / "plugins" / "audit"
-    _write_json(install_path / "mcp-servers" / "figma.json", _stdio("figma"))
-    # 记录无 bundledMcpServers → owned 空；外来 figma 占名 → enable 应硬抛
-    _seed_installed(home, {"audit@acme": [{"scope": "user", "installPath": str(install_path)}]})
+    # 夹具须完整（含 known_marketplaces）：D3 前本例硬抛在冲突门、根本走不到 stage 阶段；现在 enable 会一路
+    # 跑完 re-stage，故需要真 marketplace 记录。
+    install_path = _setup_catalog(home, "acme", "audit", servers=[FIGMA_NAME])
+    _seed_installed(home, {"audit@acme": [{"scope": "user", "installPath": str(install_path), "mcpServers": [FIGMA_BID]}]})
     monkeypatch.setattr(_STAGE, _fake_stage([]))
-    mcp = _FakeMCP(existing={"figma"})
+    mcp = _FakeMCP(existing={FIGMA_BID})  # 依赖已被既有实例满足
 
-    with pytest.raises(MCPServerNameConflictError, match="figma"):
-        await enable_plugin(
-            "audit@acme", SkillRegistry(), home, env=env,
-            existing_server_names=mcp.existing_names, register_server=mcp.register,
-        )
+    await enable_plugin(
+        "audit@acme", SkillRegistry(), home, env=env,
+        existing_bundle_ids=mcp.existing_bundle_ids, register_server=mcp.register,
+    )
 
-    assert not user_settings_path(env).exists()  # 冲突先于 settings 写 → 原子（未写）
+    assert mcp.registered == []  # 复用既有实例，MUST NOT 覆盖
+    settings = json.loads(user_settings_path(env).read_text(encoding="utf-8"))
+    assert settings["enabledPlugins"]["audit@acme"] is True  # enable 成功（不再因「同名」失败）
 
 
 async def test_enable_register_without_existing_names_raises(tmp_path: Path) -> None:
-    """护栏：enable 给了 register_server 但缺 existing_server_names → 抛（先于读记录/写 settings）。"""
+    """护栏：enable 给了 register_server 但缺 existing_bundle_ids → 抛（先于读记录/写 settings）。"""
     home = _home(tmp_path)
     mcp = _FakeMCP()
-    with pytest.raises(PluginInstallError, match="existing_server_names is required"):
+    with pytest.raises(PluginInstallError, match="existing_bundle_ids is required"):
         await enable_plugin("audit@acme", SkillRegistry(), home, env=_env(tmp_path), register_server=mcp.register)

--- a/tests/unit_tests/computer/settings/test_mcp_dependency_model.py
+++ b/tests/unit_tests/computer/settings/test_mcp_dependency_model.py
@@ -1,0 +1,402 @@
+# -*- coding: utf-8 -*-
+# filename: test_mcp_dependency_model.py
+# @Time    : 2026/07/16
+# @Author  : JQQ
+# @Email   : jqq1716@gmail.com
+# @Software: PyCharm
+"""
+plugin ↔ MCP Server 依赖模型 + 账本回收判据单元测试（#153，D3+F1）
+Plugin↔MCP-Server dependency model + ledger reclaim criterion unit tests.
+
+协议 / Protocol: a2c-smcp-protocol ``computer-management/runtime-contract.md`` §2.5（依赖关系而非所有关系）、
+§4.9.1（账本 ``mcpServers`` 纯 bundle_id 数组 + 回收判据 + 停摘自足 + 旧格式丢弃重建）、§5.6（合法共存）；
+``conformance-tests.md`` §2.0（夹具 name/bundle_id 分叉）。共识 Discussion #23 终审 D3 / F1。
+
+测试意图 / Test intentions:
+- **回收判据五场景**（§4.9.1-2「回收 X ⟺ 无其他 plugin 声明依赖 X ∧ X 非用户声明」）：
+  ① 独占依赖 → 卸载回收；② 用户 mcp.json 也声明 → **永不连坐**；③ 他 plugin 仍依赖 → 保留；
+  ④ 最后一个依赖者卸载 → 回收（**传递性无泄漏**——删 provenance 的正当性所系）；⑤ 事后用户声明 → 不回收。
+- **scoped uninstall**：自己剩余 scope 记录仍算依赖者 → 不回收。
+- **依赖模型（D3）**：同 bundle_id 已有 = 依赖已满足 → **MUST NOT 拒绝**；display 同名异 bundle_id = 合法共存；
+  enable 时依赖已满足 → 复用既有实例、不重挂覆盖。
+- **账本 schema（F1）**：``mcpServers`` 存 **bundle_id** 非 display name；旧格式 ``bundledMcpServers`` 丢弃重建。
+- **gc**：孤儿清理同样过回收判据（用户自有 server 不被连坐）。
+
+夹具铁律（协议 conformance §2.0 + #150）：**display name 与 bundle_id 必须分叉**——本模块 server 名一律带 ``.``
+（``figma.mcp`` → bundle_id ``figma_mcp``），令「误用 name 当身份」的实现无法蒙混通过。
+"""
+
+import json
+import os
+from pathlib import Path
+
+from a2c_smcp.computer.settings.installer import (
+    disable_plugin,
+    enable_plugin,
+    install_plugin,
+    uninstall_plugin,
+)
+from a2c_smcp.computer.settings.reconciler import gc_plugins
+from a2c_smcp.computer.settings.store import (
+    load_installed_plugins,
+    load_known_marketplaces,
+    save_installed_plugins,
+    save_known_marketplaces,
+)
+from a2c_smcp.computer.skills.home import SOURCE_MARKETPLACE, marketplace_skill_dir
+from a2c_smcp.computer.skills.registry import SkillRegistry
+
+_SRC = {"type": "git", "url": "https://example.com/acme.git"}
+_STAGE = "a2c_smcp.computer.settings.installer.stage_marketplace_skills"
+
+# 夹具身份对：display name 含 `.` → normalize_name 折成 `_`，故 name ≠ bundle_id（协议 conformance §2.0）。
+FIGMA_NAME, FIGMA_BID = "figma.mcp", "figma_mcp"
+SHARED_NAME, SHARED_BID = "shared.fs", "shared_fs"
+
+
+# ── 辅助 / helpers ───────────────────────────────────────────────────────────
+def _home(tmp_path: Path) -> Path:
+    h = tmp_path / "skill-home"
+    h.mkdir()
+    return h
+
+
+def _env(tmp_path: Path) -> dict[str, str]:
+    """重定向 XDG_CONFIG_HOME → tmp，隔离 user settings.json / mcp.json 写。"""
+    return {**os.environ, "XDG_CONFIG_HOME": str(tmp_path / "cfg")}
+
+
+def _write_json(path: Path, obj: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(obj), encoding="utf-8")
+
+
+def _stdio(name: str, command: str = "node") -> dict:
+    return {"name": name, "type": "stdio", "server_parameters": {"command": command}}
+
+
+def _setup_catalog(home: Path, mp: str, plugin: str, *, servers: list[str], commit: str = "abc123") -> Path:
+    """造 catalog 树（相对源 plugin，无 git）+ marketplace.json + plugin mcp-servers/ + seed known_marketplaces。"""
+    catalog = marketplace_skill_dir(home, mp)
+    manifest = {
+        "name": mp,
+        "owner": {"name": "X"},
+        "metadata": {"pluginRoot": "./plugins"},
+        "plugins": [{"name": plugin, "source": plugin, "version": "1.2.0"}],
+    }
+    _write_json(catalog / ".tfrobot-plugin" / "marketplace.json", manifest)
+    plugin_root = catalog / "plugins" / plugin
+    plugin_root.mkdir(parents=True, exist_ok=True)
+    for sname in servers:
+        _write_json(plugin_root / "mcp-servers" / f"{sname}.json", _stdio(sname))
+    # 合并而非替换：多 marketplace 场景（③④ 共享依赖）须共存。
+    known = load_known_marketplaces(home=home)
+    known["marketplaces"][mp] = {"source": _SRC, "installLocation": str(catalog.resolve()), "commitSha": commit}
+    save_known_marketplaces(known, home=home)
+    return plugin_root
+
+
+def _user_mcp_json(tmp_path: Path, servers: dict[str, dict]) -> None:
+    """在 user scope mcp.json 声明 server（= 用户自有声明，回收判据第二项的唯一来源）。"""
+    _write_json(tmp_path / "cfg" / "a2c" / "mcp.json", {"servers": servers, "inputs": []})
+
+
+def _fake_stage(calls: list[dict] | None = None):
+    async def _stage(name, source, registry, home, *, plugin_filter=None, auto_update=False, refresh=False, timeout=0.0, env=None):
+        if calls is not None:
+            calls.append({"name": name, "plugin_filter": set(plugin_filter or ())})
+        for plugin in plugin_filter or set():
+            registry.register_or_update(
+                {
+                    "name": f"{plugin}:lint",
+                    "source": f"{SOURCE_MARKETPLACE}:{name}",
+                    "path": str(marketplace_skill_dir(home, name).resolve()),
+                },
+            )
+        return [f"{p}:lint" for p in plugin_filter or set()]
+
+    return _stage
+
+
+class _FakeMCP:
+    """记录 MCP 注入回调调用；**身份一律 bundle_id**（#153：账本存 bundle_id ⇒ 停摘链收 bundle_id）。"""
+
+    def __init__(self, existing: set[str] | None = None) -> None:
+        self.existing: set[str] = set(existing or ())  # bundle_id 集
+        self.registered: list[str] = []  # 本次 register 的 bundle_id（由 cfg 解析）
+        self.removed: list[str] = []  # 被停摘的 bundle_id
+
+    def existing_bundle_ids(self) -> set[str]:
+        return set(self.existing)
+
+    async def register(self, cfg) -> None:
+        from a2c_smcp.utils.bundle_id import resolve_bundle_id
+
+        bid = resolve_bundle_id(cfg)
+        self.registered.append(bid)
+        self.existing.add(bid)
+
+    async def remove(self, bundle_id: str) -> None:
+        self.removed.append(bundle_id)
+        self.existing.discard(bundle_id)
+
+
+async def _install(home: Path, env: dict, pid: str, mcp: _FakeMCP) -> dict:
+    plugin, mp = pid.split("@")
+    return await install_plugin(pid, SkillRegistry(), home, env=env, existing_server_names=mcp.existing_bundle_ids)
+
+
+# ── F1：账本 schema —— 存 bundle_id 而非 display name ─────────────────────────
+async def test_ledger_stores_bundle_id_not_display_name(tmp_path: Path, monkeypatch) -> None:
+    """§4.9.1-1：``mcpServers`` 只记 bundle_id，MUST NOT 记 display name（夹具 name≠bundle_id 方能鉴别）。"""
+    monkeypatch.chdir(tmp_path)  # 隔离 project/local scope（resolve_mcp_config 锚 cwd，#116）
+    home, env = _home(tmp_path), _env(tmp_path)
+    _setup_catalog(home, "acme", "audit", servers=[FIGMA_NAME])
+    monkeypatch.setattr(_STAGE, _fake_stage())
+
+    record = await install_plugin("audit@acme", SkillRegistry(), home, env=env, existing_server_names=lambda: set())
+
+    assert record["mcpServers"] == [FIGMA_BID]  # bundle_id，非 "figma.mcp"
+    assert "bundledMcpServers" not in record  # 旧字段不存在
+    assert load_installed_plugins(home=home)["plugins"]["audit@acme"][0]["mcpServers"] == [FIGMA_BID]
+
+
+async def test_ledger_writes_empty_array_when_no_deps(tmp_path: Path, monkeypatch) -> None:
+    """无 bundled server → ``mcpServers: []``（无条件写，与 rust#139 磁盘格式逐字节一致）。"""
+    monkeypatch.chdir(tmp_path)
+    home, env = _home(tmp_path), _env(tmp_path)
+    _setup_catalog(home, "acme", "audit", servers=[])
+    monkeypatch.setattr(_STAGE, _fake_stage())
+
+    record = await install_plugin("audit@acme", SkillRegistry(), home, env=env)
+
+    assert record["mcpServers"] == []
+
+
+# ── F1：回收判据五场景（§4.9.1-2）────────────────────────────────────────────
+async def test_scenario1_sole_dependent_uninstall_reclaims(tmp_path: Path, monkeypatch) -> None:
+    """① A 引入 X、无他人依赖、非用户声明 → 卸 A 回收 X。"""
+    monkeypatch.chdir(tmp_path)
+    home, env = _home(tmp_path), _env(tmp_path)
+    _setup_catalog(home, "acme", "audit", servers=[FIGMA_NAME])
+    monkeypatch.setattr(_STAGE, _fake_stage())
+    mcp = _FakeMCP()
+    await _install(home, env, "audit@acme", mcp)
+
+    await uninstall_plugin("audit@acme", SkillRegistry(), home, env=env, remove_server=mcp.remove)
+
+    assert mcp.removed == [FIGMA_BID]  # 停摘身份 = bundle_id
+
+
+async def test_scenario2_user_declared_server_is_never_collateral(tmp_path: Path, monkeypatch) -> None:
+    """② 用户 mcp.json 声明 X + A 依赖 X → 卸 A **不回收**（用户自有 server 永不连坐）。"""
+    monkeypatch.chdir(tmp_path)
+    home, env = _home(tmp_path), _env(tmp_path)
+    _setup_catalog(home, "acme", "audit", servers=[FIGMA_NAME])
+    _user_mcp_json(tmp_path, {FIGMA_NAME: _stdio(FIGMA_NAME)})  # 用户自有同 bundle_id
+    monkeypatch.setattr(_STAGE, _fake_stage())
+    mcp = _FakeMCP(existing={FIGMA_BID})
+    await _install(home, env, "audit@acme", mcp)
+
+    await uninstall_plugin("audit@acme", SkillRegistry(), home, env=env, remove_server=mcp.remove)
+
+    assert mcp.removed == []  # 用户声明 → 非本 plugin 可回收之物
+
+
+async def test_scenario3_and_4_shared_dependency_no_leak(tmp_path: Path, monkeypatch) -> None:
+    """③ A+B 共依赖 X → 卸 A 保留；④ 续卸 B → 回收（**传递性无泄漏**，删 provenance 的正当性所系）。"""
+    monkeypatch.chdir(tmp_path)
+    home, env = _home(tmp_path), _env(tmp_path)
+    _setup_catalog(home, "acme", "audit", servers=[FIGMA_NAME])
+    _setup_catalog(home, "beta", "review", servers=[FIGMA_NAME])  # 同 bundle_id，另一 plugin
+    monkeypatch.setattr(_STAGE, _fake_stage())
+    mcp = _FakeMCP()
+    await _install(home, env, "audit@acme", mcp)
+    await _install(home, env, "review@beta", mcp)
+
+    # ③ 卸 A —— B 仍声明依赖 X → 保留
+    await uninstall_plugin("audit@acme", SkillRegistry(), home, env=env, remove_server=mcp.remove)
+    assert mcp.removed == []
+
+    # ④ 续卸 B —— 最后一个依赖者 → 回收，X 不泄漏
+    await uninstall_plugin("review@beta", SkillRegistry(), home, env=env, remove_server=mcp.remove)
+    assert mcp.removed == [FIGMA_BID]
+
+
+async def test_scenario5_user_declares_after_install_blocks_reclaim(tmp_path: Path, monkeypatch) -> None:
+    """⑤ A 引入 X 后用户又在 mcp.json 声明 X → 卸 A 不回收（判据是**现时**事实，非安装时点快照）。"""
+    monkeypatch.chdir(tmp_path)
+    home, env = _home(tmp_path), _env(tmp_path)
+    _setup_catalog(home, "acme", "audit", servers=[FIGMA_NAME])
+    monkeypatch.setattr(_STAGE, _fake_stage())
+    mcp = _FakeMCP()
+    await _install(home, env, "audit@acme", mcp)  # 安装时用户尚未声明
+
+    _user_mcp_json(tmp_path, {FIGMA_NAME: _stdio(FIGMA_NAME)})  # 事后声明
+
+    await uninstall_plugin("audit@acme", SkillRegistry(), home, env=env, remove_server=mcp.remove)
+
+    assert mcp.removed == []
+
+
+async def test_scoped_uninstall_keeps_dep_for_remaining_scope(tmp_path: Path, monkeypatch) -> None:
+    """scoped uninstall：自己剩余 scope 记录仍声明依赖 → 不回收（判据须排除本次移除的记录、而非整个 pid）。"""
+    monkeypatch.chdir(tmp_path)
+    home, env = _home(tmp_path), _env(tmp_path)
+    install_path = _setup_catalog(home, "acme", "audit", servers=[FIGMA_NAME])
+    save_installed_plugins(
+        {
+            "version": 1,
+            "plugins": {
+                "audit@acme": [
+                    {"scope": "user", "installPath": str(install_path), "mcpServers": [FIGMA_BID]},
+                    {"scope": "project", "installPath": str(install_path), "projectPath": str(tmp_path), "mcpServers": [FIGMA_BID]},
+                ],
+            },
+        },
+        home=home,
+    )
+    monkeypatch.setattr(_STAGE, _fake_stage())
+    mcp = _FakeMCP()
+
+    await uninstall_plugin("audit@acme", SkillRegistry(), home, env=env, scope="user", remove_server=mcp.remove)
+
+    assert mcp.removed == []  # project scope 记录仍依赖 X
+
+
+async def test_disable_applies_reclaim_criterion(tmp_path: Path, monkeypatch) -> None:
+    """disable 与 uninstall 同判据（§4.9.1-2 明列二者）：用户声明的 X 不因 disable 被摘。"""
+    monkeypatch.chdir(tmp_path)
+    home, env = _home(tmp_path), _env(tmp_path)
+    _setup_catalog(home, "acme", "audit", servers=[FIGMA_NAME])
+    _user_mcp_json(tmp_path, {FIGMA_NAME: _stdio(FIGMA_NAME)})
+    monkeypatch.setattr(_STAGE, _fake_stage())
+    mcp = _FakeMCP(existing={FIGMA_BID})
+    await _install(home, env, "audit@acme", mcp)
+
+    await disable_plugin("audit@acme", SkillRegistry(), home, env=env, remove_server=mcp.remove)
+
+    assert mcp.removed == []
+
+
+# ── D3：依赖模型（§2.5 / §5.6）────────────────────────────────────────────────
+async def test_install_same_bundle_id_is_dependency_satisfied_not_conflict(tmp_path: Path, monkeypatch) -> None:
+    """§2.5-1：同 bundle_id 已存在 = 依赖已满足 → **MUST NOT 拒绝**，正常安装并写账本。"""
+    monkeypatch.chdir(tmp_path)
+    home, env = _home(tmp_path), _env(tmp_path)
+    _setup_catalog(home, "acme", "audit", servers=[FIGMA_NAME])
+    monkeypatch.setattr(_STAGE, _fake_stage())
+    mcp = _FakeMCP(existing={FIGMA_BID})  # 本地已有（用户自有或他 plugin 带入）
+
+    record = await install_plugin("audit@acme", SkillRegistry(), home, env=env, existing_server_names=mcp.existing_bundle_ids)
+
+    assert record["mcpServers"] == [FIGMA_BID]  # 不抛、正常写账本
+    assert "audit@acme" in load_installed_plugins(home=home)["plugins"]
+    user = json.loads((tmp_path / "cfg" / "a2c" / "settings.json").read_text(encoding="utf-8"))
+    assert user["installedPlugins"] == ["audit@acme"]  # 意图已写 = 真的装上了
+
+
+async def test_install_same_display_name_different_bundle_id_coexists(tmp_path: Path, monkeypatch) -> None:
+    """§5.6：display name 相同、bundle_id 不同 = 合法共存，MUST NOT 视为冲突。"""
+    monkeypatch.chdir(tmp_path)
+    home, env = _home(tmp_path), _env(tmp_path)
+    _setup_catalog(home, "acme", "audit", servers=[FIGMA_NAME])
+    monkeypatch.setattr(_STAGE, _fake_stage())
+    # 已有 server 的 display 名相同，但显式 bundle_id 不同 → 两个身份
+    mcp = _FakeMCP(existing={"other_identity"})
+
+    record = await install_plugin("audit@acme", SkillRegistry(), home, env=env, existing_server_names=mcp.existing_bundle_ids)
+
+    assert record["mcpServers"] == [FIGMA_BID]
+
+
+async def test_enable_reuses_existing_instance_instead_of_remounting(tmp_path: Path, monkeypatch) -> None:
+    """§2.5-1「复用既有实例」：enable 时依赖已满足 → **不重挂**（否则覆盖用户既有 server 配置）。"""
+    monkeypatch.chdir(tmp_path)
+    home, env = _home(tmp_path), _env(tmp_path)
+    _setup_catalog(home, "acme", "audit", servers=[FIGMA_NAME, SHARED_NAME])
+    monkeypatch.setattr(_STAGE, _fake_stage())
+    mcp = _FakeMCP()
+    await _install(home, env, "audit@acme", mcp)
+    mcp.existing.add(FIGMA_BID)  # 用户/他 plugin 已挂 figma_mcp
+
+    await enable_plugin(
+        "audit@acme", SkillRegistry(), home, env=env,
+        existing_server_names=mcp.existing_bundle_ids, register_server=mcp.register, remove_server=mcp.remove,
+    )
+
+    assert mcp.registered == [SHARED_BID]  # figma_mcp 依赖已满足 → 复用，不重挂
+
+
+# ── F1：旧格式丢弃重建（§4.9.1-4）────────────────────────────────────────────
+def test_legacy_ledger_record_is_discarded_on_load(tmp_path: Path) -> None:
+    """§4.9.1-4：检测到旧格式（``bundledMcpServers`` name 数组）→ 整条丢弃（交 reconcile 从意图重建）。"""
+    home = _home(tmp_path)
+    save_installed_plugins(
+        {"version": 1, "plugins": {"audit@acme": [{"scope": "user", "installPath": "/x", "bundledMcpServers": [FIGMA_NAME]}]}},
+        home=home,
+    )
+
+    loaded = load_installed_plugins(home=home)
+
+    assert "audit@acme" not in loaded["plugins"]  # 整条丢弃，MUST NOT 做 name→bundle_id 映射迁移
+
+
+def test_legacy_and_new_records_mixed_only_legacy_dropped(tmp_path: Path) -> None:
+    """混合账本：仅旧格式记录被丢，新格式记录保留（丢弃粒度 = 记录级）。"""
+    home = _home(tmp_path)
+    save_installed_plugins(
+        {
+            "version": 1,
+            "plugins": {
+                "old@acme": [{"scope": "user", "installPath": "/x", "bundledMcpServers": [FIGMA_NAME]}],
+                "new@acme": [{"scope": "user", "installPath": "/y", "mcpServers": [FIGMA_BID]}],
+            },
+        },
+        home=home,
+    )
+
+    plugins = load_installed_plugins(home=home)["plugins"]
+
+    assert "old@acme" not in plugins
+    assert plugins["new@acme"][0]["mcpServers"] == [FIGMA_BID]
+
+
+# ── gc：孤儿清理同样过回收判据 ───────────────────────────────────────────────
+async def test_gc_does_not_reclaim_user_declared_server(tmp_path: Path, monkeypatch) -> None:
+    """gc 是 uninstall 的批量形态 → 同判据；用户自有 server MUST NOT 被孤儿清理连坐。"""
+    monkeypatch.chdir(tmp_path)
+    home, env = _home(tmp_path), _env(tmp_path)
+    install_path = _setup_catalog(home, "acme", "audit", servers=[FIGMA_NAME])
+    _user_mcp_json(tmp_path, {FIGMA_NAME: _stdio(FIGMA_NAME)})
+    save_installed_plugins(
+        {"version": 1, "plugins": {"audit@acme": [{"scope": "user", "installPath": str(install_path), "mcpServers": [FIGMA_BID]}]}},
+        home=home,
+    )
+    torn: list[list[str]] = []
+
+    async def _teardown(ids: list[str]) -> None:
+        torn.append(ids)
+
+    await gc_plugins(["audit@acme"], SkillRegistry(), home, env=env, mcp_teardown=_teardown)
+
+    assert torn == []  # 用户声明 → 不回收
+
+
+async def test_gc_reclaims_unreferenced_server(tmp_path: Path, monkeypatch) -> None:
+    """gc 对照组：无人依赖 ∧ 非用户声明 → 回收（守卫非永真）。"""
+    monkeypatch.chdir(tmp_path)
+    home, env = _home(tmp_path), _env(tmp_path)
+    install_path = _setup_catalog(home, "acme", "audit", servers=[FIGMA_NAME])
+    save_installed_plugins(
+        {"version": 1, "plugins": {"audit@acme": [{"scope": "user", "installPath": str(install_path), "mcpServers": [FIGMA_BID]}]}},
+        home=home,
+    )
+    torn: list[list[str]] = []
+
+    async def _teardown(ids: list[str]) -> None:
+        torn.append(ids)
+
+    await gc_plugins(["audit@acme"], SkillRegistry(), home, env=env, mcp_teardown=_teardown)
+
+    assert torn == [[FIGMA_BID]]

--- a/tests/unit_tests/computer/settings/test_mcp_dependency_model.py
+++ b/tests/unit_tests/computer/settings/test_mcp_dependency_model.py
@@ -245,7 +245,8 @@ async def test_scenario5_user_declares_after_install_blocks_reclaim(tmp_path: Pa
     reason="已知未覆盖面（#153 隔离审查 🔴）：协议 §4.9.1-2 的数据源是**运行期权威配置集** + origin != plugin，"
     "而本 SDK 的 manager 不存 origin —— 用户经 `--config @file` / SDK 内嵌 Computer(mcp_servers=) 挂载的 "
     "server 与 plugin 自己挂的在可观测信息上完全同形，无法区分。根治需运行期 origin（#134 轴）或 --config "
-    "归一进 mcp.json flag 层（#154）。**方案求裁中：protocol Discussion #32**（https://github.com/A2C-SMCP/a2c-smcp-protocol/discussions/32）。本用例钉住缺口：修好后 XPASS 提醒。",
+    "归一进 mcp.json flag 层（#154）。**方案求裁中：protocol Discussion #32** "
+    "（https://github.com/A2C-SMCP/a2c-smcp-protocol/discussions/32）。本用例钉住缺口：修好后 XPASS 提醒。",
     strict=False,
 )
 async def test_runtime_only_user_server_is_never_collateral(tmp_path: Path, monkeypatch) -> None:

--- a/tests/unit_tests/computer/settings/test_mcp_dependency_model.py
+++ b/tests/unit_tests/computer/settings/test_mcp_dependency_model.py
@@ -245,7 +245,7 @@ async def test_scenario5_user_declares_after_install_blocks_reclaim(tmp_path: Pa
     reason="已知未覆盖面（#153 隔离审查 🔴）：协议 §4.9.1-2 的数据源是**运行期权威配置集** + origin != plugin，"
     "而本 SDK 的 manager 不存 origin —— 用户经 `--config @file` / SDK 内嵌 Computer(mcp_servers=) 挂载的 "
     "server 与 plugin 自己挂的在可观测信息上完全同形，无法区分。根治需运行期 origin（#134 轴）或 --config "
-    "归一进 mcp.json flag 层（#154），方案待三仓 Discussion 定案。本用例钉住缺口：修好后会 XPASS 提醒。",
+    "归一进 mcp.json flag 层（#154）。**方案求裁中：protocol Discussion #32**（https://github.com/A2C-SMCP/a2c-smcp-protocol/discussions/32）。本用例钉住缺口：修好后 XPASS 提醒。",
     strict=False,
 )
 async def test_runtime_only_user_server_is_never_collateral(tmp_path: Path, monkeypatch) -> None:
@@ -260,7 +260,8 @@ async def test_runtime_only_user_server_is_never_collateral(tmp_path: Path, monk
     **为何不在 #153 内根治**：「用户 --config 挂的 X」与「plugin enable 挂的 X」在 manager 层信息完全相同
     （无 origin / 无归属），不新增运行期归属就无法同时满足场景①（A 引入 X 无人依赖 → 回收）与本例。
     补运行期归属 = #134「ownership 归属混源」轴（Epic #147 明载「共识未覆盖该轴」）；
-    ``--config`` 归一进 mcp.json flag 层 = #154。二者择一，交三仓 Discussion 定案。
+    ``--config`` 归一进 mcp.json flag 层 = #154。二者择一，求裁于 protocol Discussion #32：
+    https://github.com/A2C-SMCP/a2c-smcp-protocol/discussions/32
 
     **注**：本 PR 相对 develop 仍是净改善——develop 是「卸载**无条件**摘」（连 mcp.json 声明的用户 server 都摘），
     本 PR 已保护住 mcp.json 各 scope 声明面，仅剩本例这条路径。

--- a/tests/unit_tests/computer/settings/test_mcp_dependency_model.py
+++ b/tests/unit_tests/computer/settings/test_mcp_dependency_model.py
@@ -143,7 +143,7 @@ class _FakeMCP:
 
 async def _install(home: Path, env: dict, pid: str, mcp: _FakeMCP) -> dict:
     plugin, mp = pid.split("@")
-    return await install_plugin(pid, SkillRegistry(), home, env=env, existing_server_names=mcp.existing_bundle_ids)
+    return await install_plugin(pid, SkillRegistry(), home, env=env, existing_bundle_ids=mcp.existing_bundle_ids)
 
 
 # ── F1：账本 schema —— 存 bundle_id 而非 display name ─────────────────────────
@@ -154,7 +154,7 @@ async def test_ledger_stores_bundle_id_not_display_name(tmp_path: Path, monkeypa
     _setup_catalog(home, "acme", "audit", servers=[FIGMA_NAME])
     monkeypatch.setattr(_STAGE, _fake_stage())
 
-    record = await install_plugin("audit@acme", SkillRegistry(), home, env=env, existing_server_names=lambda: set())
+    record = await install_plugin("audit@acme", SkillRegistry(), home, env=env, existing_bundle_ids=lambda: set())
 
     assert record["mcpServers"] == [FIGMA_BID]  # bundle_id，非 "figma.mcp"
     assert "bundledMcpServers" not in record  # 旧字段不存在
@@ -288,7 +288,7 @@ async def test_install_same_bundle_id_is_dependency_satisfied_not_conflict(tmp_p
     monkeypatch.setattr(_STAGE, _fake_stage())
     mcp = _FakeMCP(existing={FIGMA_BID})  # 本地已有（用户自有或他 plugin 带入）
 
-    record = await install_plugin("audit@acme", SkillRegistry(), home, env=env, existing_server_names=mcp.existing_bundle_ids)
+    record = await install_plugin("audit@acme", SkillRegistry(), home, env=env, existing_bundle_ids=mcp.existing_bundle_ids)
 
     assert record["mcpServers"] == [FIGMA_BID]  # 不抛、正常写账本
     assert "audit@acme" in load_installed_plugins(home=home)["plugins"]
@@ -305,7 +305,7 @@ async def test_install_same_display_name_different_bundle_id_coexists(tmp_path: 
     # 已有 server 的 display 名相同，但显式 bundle_id 不同 → 两个身份
     mcp = _FakeMCP(existing={"other_identity"})
 
-    record = await install_plugin("audit@acme", SkillRegistry(), home, env=env, existing_server_names=mcp.existing_bundle_ids)
+    record = await install_plugin("audit@acme", SkillRegistry(), home, env=env, existing_bundle_ids=mcp.existing_bundle_ids)
 
     assert record["mcpServers"] == [FIGMA_BID]
 
@@ -322,7 +322,7 @@ async def test_enable_reuses_existing_instance_instead_of_remounting(tmp_path: P
 
     await enable_plugin(
         "audit@acme", SkillRegistry(), home, env=env,
-        existing_server_names=mcp.existing_bundle_ids, register_server=mcp.register, remove_server=mcp.remove,
+        existing_bundle_ids=mcp.existing_bundle_ids, register_server=mcp.register, remove_server=mcp.remove,
     )
 
     assert mcp.registered == [SHARED_BID]  # figma_mcp 依赖已满足 → 复用，不重挂
@@ -340,6 +340,25 @@ def test_legacy_ledger_record_is_discarded_on_load(tmp_path: Path) -> None:
     loaded = load_installed_plugins(home=home)
 
     assert "audit@acme" not in loaded["plugins"]  # 整条丢弃，MUST NOT 做 name→bundle_id 映射迁移
+
+
+def test_legacy_ledger_pids_survive_for_intent_migration(tmp_path: Path) -> None:
+    """
+    ⚠️ **顺序依赖守卫**：v0.2.x→v0.3.0 意图迁移 MUST 能读到旧格式记录的 pid（``drop_legacy=False``）。
+
+    两个迁移方向相反、互为前提：①「意图迁移」从**账本 pid** 回填 ``installedPlugins``；②「账本格式迁移」丢弃
+    旧记录并**从该意图重建**。若 ② 的丢弃对 ① 也生效，v0.2.x 存量用户**带 MCP server 的 plugin 会连 pid 一起
+    消失**（无 bundled server 的记录无该键、不受影响）⇒ 意图无从回填 ⇒ 升级后 plugin 静默全丢。
+    本例实测曾红（`test_boot_migrates_legacy_ledger_installs_and_stays_active` 同时红）。
+    """
+    home = _home(tmp_path)
+    save_installed_plugins(
+        {"version": 1, "plugins": {"audit@acme": [{"scope": "user", "installPath": "/x", "bundledMcpServers": [FIGMA_NAME]}]}},
+        home=home,
+    )
+
+    assert "audit@acme" not in load_installed_plugins(home=home)["plugins"]  # 默认读法：丢弃
+    assert "audit@acme" in load_installed_plugins(home=home, drop_legacy=False)["plugins"]  # 迁移读法：pid 仍在
 
 
 def test_legacy_and_new_records_mixed_only_legacy_dropped(tmp_path: Path) -> None:

--- a/tests/unit_tests/computer/settings/test_mcp_dependency_model.py
+++ b/tests/unit_tests/computer/settings/test_mcp_dependency_model.py
@@ -30,6 +30,8 @@ import json
 import os
 from pathlib import Path
 
+import pytest
+
 from a2c_smcp.computer.settings.installer import (
     disable_plugin,
     enable_plugin,
@@ -237,6 +239,66 @@ async def test_scenario5_user_declares_after_install_blocks_reclaim(tmp_path: Pa
     await uninstall_plugin("audit@acme", SkillRegistry(), home, env=env, remove_server=mcp.remove)
 
     assert mcp.removed == []
+
+
+@pytest.mark.xfail(
+    reason="已知未覆盖面（#153 隔离审查 🔴）：协议 §4.9.1-2 的数据源是**运行期权威配置集** + origin != plugin，"
+    "而本 SDK 的 manager 不存 origin —— 用户经 `--config @file` / SDK 内嵌 Computer(mcp_servers=) 挂载的 "
+    "server 与 plugin 自己挂的在可观测信息上完全同形，无法区分。根治需运行期 origin（#134 轴）或 --config "
+    "归一进 mcp.json flag 层（#154），方案待三仓 Discussion 定案。本用例钉住缺口：修好后会 XPASS 提醒。",
+    strict=False,
+)
+async def test_runtime_only_user_server_is_never_collateral(tmp_path: Path, monkeypatch) -> None:
+    """
+    ⚠️ **已知缺口守卫**（xfail）：用户经 ``--config @file`` 挂的 server 在运行期活跃集、**不在 mcp.json**。
+
+    协议 §4.9.1-2 把「X 非用户声明」的数据源定为**运行期权威配置集**（``origin != plugin``），**不是** mcp.json。
+    ``a2c-computer run --config @servers.json``（``cli/main.py`` `_add_server`）与 SDK 内嵌
+    ``Computer(mcp_servers={...})`` 都走 transient ``amount_server``、**从不回写 mcp.json** ⇒ 本 SDK 只读
+    mcp.json 声明面就会把它们判成「非用户声明」⇒ 若该 server 同时被某 plugin 声明依赖，卸载该 plugin 时**连坐停摘**。
+
+    **为何不在 #153 内根治**：「用户 --config 挂的 X」与「plugin enable 挂的 X」在 manager 层信息完全相同
+    （无 origin / 无归属），不新增运行期归属就无法同时满足场景①（A 引入 X 无人依赖 → 回收）与本例。
+    补运行期归属 = #134「ownership 归属混源」轴（Epic #147 明载「共识未覆盖该轴」）；
+    ``--config`` 归一进 mcp.json flag 层 = #154。二者择一，交三仓 Discussion 定案。
+
+    **注**：本 PR 相对 develop 仍是净改善——develop 是「卸载**无条件**摘」（连 mcp.json 声明的用户 server 都摘），
+    本 PR 已保护住 mcp.json 各 scope 声明面，仅剩本例这条路径。
+    """
+    monkeypatch.chdir(tmp_path)
+    home, env = _home(tmp_path), _env(tmp_path)
+    _setup_catalog(home, "acme", "audit", servers=[FIGMA_NAME])
+    monkeypatch.setattr(_STAGE, _fake_stage())
+    # 用户自己挂的 figma.mcp：进运行期活跃集，但**没有** _user_mcp_json（不落 mcp.json 声明）
+    mcp = _FakeMCP(existing={FIGMA_BID})
+    await _install(home, env, "audit@acme", mcp)
+
+    await uninstall_plugin("audit@acme", SkillRegistry(), home, env=env, remove_server=mcp.remove)
+
+    assert mcp.removed == [], "用户经 --config @file / 内嵌构造挂载的 server 被连坐停摘（协议 §4.9.1-2）"
+
+
+async def test_disable_both_dependents_keeps_dep_resident(tmp_path: Path, monkeypatch) -> None:
+    """
+    驻留行为守卫（协议字面推论，rust-sdk#139 须同口径）：A、B 均声明 X，**二者都 disable 后 X 仍驻留**。
+
+    §4.9.1-2 的「其他 plugin」= 账本 **installed** 记录（**含 disabled**，字面为「无其他 plugin **声明依赖**」）。
+    故 disable A 时 B 的记录替 X 挡住回收，disable B 时 A 的记录同样挡住 ⇒ X 驻留至 uninstall。
+    这是**保守侧**：X 多活一会儿，但不泄漏（最后一个依赖者 uninstall 时回收，见场景③④）。
+    """
+    monkeypatch.chdir(tmp_path)
+    home, env = _home(tmp_path), _env(tmp_path)
+    _setup_catalog(home, "acme", "audit", servers=[FIGMA_NAME])
+    _setup_catalog(home, "beta", "review", servers=[FIGMA_NAME])
+    monkeypatch.setattr(_STAGE, _fake_stage())
+    mcp = _FakeMCP()
+    await _install(home, env, "audit@acme", mcp)
+    await _install(home, env, "review@beta", mcp)
+
+    await disable_plugin("audit@acme", SkillRegistry(), home, env=env, remove_server=mcp.remove)
+    await disable_plugin("review@beta", SkillRegistry(), home, env=env, remove_server=mcp.remove)
+
+    assert mcp.removed == []  # 两者账本记录仍在 → 互相替对方挡住回收（驻留，非泄漏）
 
 
 async def test_scoped_uninstall_keeps_dep_for_remaining_scope(tmp_path: Path, monkeypatch) -> None:

--- a/tests/unit_tests/computer/settings/test_reconciler.py
+++ b/tests/unit_tests/computer/settings/test_reconciler.py
@@ -24,6 +24,8 @@ from collections.abc import Awaitable, Callable, Mapping
 from pathlib import Path
 from typing import Any
 
+import pytest
+
 from a2c_smcp.computer.settings.reconciler import (
     ReconcileReport,
     declared_installed_plugin_ids,
@@ -313,6 +315,20 @@ def test_prune_skips_invalid_marketplace_name(tmp_path: Path) -> None:
 # ── plugin gc ────────────────────────────────────────────────────────────────
 def _seed_installed(home: Path, plugins: dict[str, list[dict]]) -> None:
     save_installed_plugins({"version": 1, "plugins": plugins}, home=home)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_cwd_and_user_config(tmp_path: Path, monkeypatch) -> None:
+    """
+    隔离 cwd + user config / Isolate cwd and user config。
+
+    #153 起 :func:`gc_plugins` 经回收判据（``mcp_json_declared_bundle_ids`` → ``resolve_mcp_config``）读
+    **cwd 锚定**的 ``.tfrobot/mcp[.local].json``（project/local scope，#116）与 user scope mcp.json。
+    不隔离则读进真实仓库 / 开发者 home——本地一旦存在这些文件，断言即随环境漂移（#137 同款教训；本文件的
+    泄漏由 #153 隔离审查 🟡 实测发现）。
+    """
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "cfg"))
 
 
 async def test_list_and_gc_plugins(tmp_path: Path) -> None:

--- a/tests/unit_tests/computer/settings/test_reconciler.py
+++ b/tests/unit_tests/computer/settings/test_reconciler.py
@@ -324,7 +324,7 @@ async def test_list_and_gc_plugins(tmp_path: Path) -> None:
     _seed_installed(
         home,
         {
-            "audit@acme": [{"scope": "user", "installPath": str(audit_path), "bundledMcpServers": ["figma", "blender"]}],
+            "audit@acme": [{"scope": "user", "installPath": str(audit_path), "mcpServers": ["figma", "blender"]}],
             "keep@acme": [{"scope": "user", "installPath": str(keep_path)}],
         },
     )
@@ -350,7 +350,7 @@ async def test_list_and_gc_plugins(tmp_path: Path) -> None:
     assert "audit@acme" not in ipf and "keep@acme" in ipf
     assert reg.resolve("audit:lint") is None  # 孤儿 plugin 的 SKILL 注销
     assert reg.resolve("keep:do") is not None  # 保留 plugin 的 SKILL 不动
-    assert teardown == [["figma", "blender"]]  # bundled MCP 经回调下线
+    assert teardown == [["blender", "figma"]]  # 可回收的 MCP 依赖经回调下线（#153：判据过滤后 sorted，确定序）
 
 
 async def test_gc_guards_installpath_outside_home(tmp_path: Path) -> None:
@@ -372,7 +372,7 @@ async def test_gc_without_teardown_callback(tmp_path: Path) -> None:
     home = _home(tmp_path)
     p = marketplace_skill_dir(home, "acme") / "audit"
     p.mkdir(parents=True)
-    _seed_installed(home, {"audit@acme": [{"scope": "user", "installPath": str(p), "bundledMcpServers": ["x"]}]})
+    _seed_installed(home, {"audit@acme": [{"scope": "user", "installPath": str(p), "mcpServers": ["x"]}]})
 
     removed = await gc_plugins(["audit@acme"], SkillRegistry(), home, mcp_teardown=None)
 

--- a/tests/unit_tests/computer/settings/test_recovery.py
+++ b/tests/unit_tests/computer/settings/test_recovery.py
@@ -112,7 +112,7 @@ def _record(plugin_root: Path, *, scope: str = "user", servers: Sequence[str] = 
         "version": "1.2.0",
         "commitSha": "abc123",
         "installedAt": "2026-07-06T00:00:00Z",
-        "bundledMcpServers": list(servers),
+        "mcpServers": list(servers),
     }
 
 

--- a/tests/unit_tests/computer/settings/test_store.py
+++ b/tests/unit_tests/computer/settings/test_store.py
@@ -297,7 +297,7 @@ def test_installed_plugins_roundtrip(tmp_path: Path) -> None:
                     "commitSha": "abc1234",
                     "installedAt": "2026-05-10T00:00:00Z",
                     "lastUpdated": "2026-05-10T00:00:00Z",
-                    "bundledMcpServers": ["figma-mcp"],
+                    "mcpServers": ["figma-mcp"],
                 }
             ]
         },

--- a/tests/unit_tests/computer/test_computer_governance_recovery.py
+++ b/tests/unit_tests/computer/test_computer_governance_recovery.py
@@ -26,6 +26,12 @@ from a2c_smcp.computer.settings.recovery import BundledServerRecord
 from a2c_smcp.computer.settings.store import save_installed_plugins, save_known_marketplaces
 from a2c_smcp.computer.skills.home import marketplace_skill_dir
 
+# 夹具身份对（#153 隔离审查 🔴2 + 协议 conformance §2.0）：原 "figma"/"blender" 的 bundle_id 恰等于自身
+# ⇒ `resolve_bundle_id(record.config)` 换成 `record.config.name` 也测不出来（变异存活）。含 `.` 令两者分叉。
+FIGMA_NAME, FIGMA_BID = "figma.mcp", "figma_mcp"
+BLENDER_NAME, BLENDER_BID = "blender.3d", "blender_3d"
+
+
 _SRC = {"type": "git", "url": "https://example.com/acme.git"}
 # v0.3.0（#123）：活跃 = installed ∧ enabledPlugins=true（缺省翻转）→ hooks 用例显式给足两键意图。
 _DECLARED_ENABLED = {"installedPlugins": ["audit@acme"], "enabledPlugins": {"audit@acme": True}}
@@ -124,7 +130,7 @@ async def test_boot_up_does_not_restore_disabled_plugin(tmp_path: Path, monkeypa
 async def test_reconcile_governance_remounts_via_hooks_and_idempotent(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """hooks 重挂：register 收到 (config, 归属记录)；inject_inputs 先于 register；二次调用幂等。"""
     _isolate_declared_env(tmp_path, monkeypatch)
-    home, plugin_root = _seed_home(tmp_path, servers=["figma"], skills=["lint"])
+    home, plugin_root = _seed_home(tmp_path, servers=[FIGMA_NAME], skills=["lint"])
 
     calls: list[tuple[str, str, str]] = []
     injected: list[Path] = []
@@ -142,8 +148,8 @@ async def test_reconcile_governance_remounts_via_hooks_and_idempotent(tmp_path: 
             inject_inputs=inject,
             declared=_DECLARED_ENABLED,
         )
-        assert report.remounted_servers == ["figma"]
-        assert calls == [("figma", "audit", "acme")]
+        assert report.remounted_servers == [FIGMA_BID]  # 值域 = bundle_id（#153）
+        assert calls == [(FIGMA_NAME, "audit", "acme")]  # register 回调收 config（display 名）
         assert injected == [plugin_root]
 
         report2 = await comp.reconcile_governance(
@@ -152,14 +158,14 @@ async def test_reconcile_governance_remounts_via_hooks_and_idempotent(tmp_path: 
             inject_inputs=inject,
             declared=_DECLARED_ENABLED,
         )
-        assert report2.remounted_servers == ["figma"]  # 幂等：结果一致
+        assert report2.remounted_servers == [FIGMA_BID]  # 幂等：结果一致
 
 
 @pytest.mark.asyncio
 async def test_reconcile_governance_injects_once_per_plugin_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """同一 plugin 根下多个 bundled server → inject_inputs 仅调一次，所有 server 均重挂。"""
     _isolate_declared_env(tmp_path, monkeypatch)
-    home, plugin_root = _seed_home(tmp_path, servers=["blender", "figma"], skills=["lint"])
+    home, plugin_root = _seed_home(tmp_path, servers=[BLENDER_NAME, FIGMA_NAME], skills=["lint"])
 
     mounted: list[str] = []
     injected: list[Path] = []
@@ -177,8 +183,8 @@ async def test_reconcile_governance_injects_once_per_plugin_root(tmp_path: Path,
             inject_inputs=inject,
             declared=_DECLARED_ENABLED,
         )
-        assert sorted(mounted) == ["blender", "figma"]
-        assert sorted(report.remounted_servers) == ["blender", "figma"]
+        assert sorted(mounted) == [BLENDER_NAME, FIGMA_NAME]
+        assert sorted(report.remounted_servers) == [BLENDER_BID, FIGMA_BID]
         assert injected == [plugin_root]  # 每 plugin 根仅一次
 
 
@@ -186,7 +192,7 @@ async def test_reconcile_governance_injects_once_per_plugin_root(tmp_path: Path,
 async def test_reconcile_governance_register_failure_non_blocking(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """register 抛错 → 不阻断（不抛出），失败 server 不入 remounted，skills 恢复不受影响。"""
     _isolate_declared_env(tmp_path, monkeypatch)
-    home, _ = _seed_home(tmp_path, servers=["figma"], skills=["lint"])
+    home, _ = _seed_home(tmp_path, servers=[FIGMA_NAME], skills=["lint"])
 
     async def register(cfg, record) -> None:
         raise RuntimeError("mount boom")
@@ -205,7 +211,7 @@ async def test_reconcile_governance_register_failure_non_blocking(tmp_path: Path
 async def test_reconcile_governance_conflict_skips_existing_name(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """existing 已有同名 server → skip 不覆盖（additive-only，用户配置胜），register 不被调用。"""
     _isolate_declared_env(tmp_path, monkeypatch)
-    home, _ = _seed_home(tmp_path, servers=["figma"], skills=["lint"])
+    home, _ = _seed_home(tmp_path, servers=[FIGMA_NAME], skills=["lint"])
 
     calls: list[str] = []
 
@@ -214,7 +220,7 @@ async def test_reconcile_governance_conflict_skips_existing_name(tmp_path: Path,
 
     async with Computer(name="t", skill_home=home) as comp:
         report = await comp.reconcile_governance(
-            existing_bundle_ids=lambda: {"figma"},
+            existing_bundle_ids=lambda: {FIGMA_BID},
             register_server=register,
             declared=_DECLARED_ENABLED,
         )

--- a/tests/unit_tests/computer/test_computer_governance_recovery.py
+++ b/tests/unit_tests/computer/test_computer_governance_recovery.py
@@ -79,7 +79,7 @@ def _seed_home(tmp_path: Path, *, servers: Sequence[str] = (), skills: Sequence[
                         "version": "1.2.0",
                         "commitSha": "abc123",
                         "installedAt": "2026-07-06T00:00:00Z",
-                        "bundledMcpServers": list(servers),
+                        "mcpServers": list(servers),
                     },
                 ],
             },
@@ -137,7 +137,7 @@ async def test_reconcile_governance_remounts_via_hooks_and_idempotent(tmp_path: 
 
     async with Computer(name="t", skill_home=home) as comp:
         report = await comp.reconcile_governance(
-            existing_server_names=lambda: set(),
+            existing_bundle_ids=lambda: set(),
             register_server=register,
             inject_inputs=inject,
             declared=_DECLARED_ENABLED,
@@ -147,7 +147,7 @@ async def test_reconcile_governance_remounts_via_hooks_and_idempotent(tmp_path: 
         assert injected == [plugin_root]
 
         report2 = await comp.reconcile_governance(
-            existing_server_names=lambda: set(),
+            existing_bundle_ids=lambda: set(),
             register_server=register,
             inject_inputs=inject,
             declared=_DECLARED_ENABLED,
@@ -172,7 +172,7 @@ async def test_reconcile_governance_injects_once_per_plugin_root(tmp_path: Path,
 
     async with Computer(name="t", skill_home=home) as comp:
         report = await comp.reconcile_governance(
-            existing_server_names=lambda: set(),
+            existing_bundle_ids=lambda: set(),
             register_server=register,
             inject_inputs=inject,
             declared=_DECLARED_ENABLED,
@@ -193,7 +193,7 @@ async def test_reconcile_governance_register_failure_non_blocking(tmp_path: Path
 
     async with Computer(name="t", skill_home=home) as comp:
         report = await comp.reconcile_governance(
-            existing_server_names=lambda: set(),
+            existing_bundle_ids=lambda: set(),
             register_server=register,
             declared=_DECLARED_ENABLED,
         )
@@ -214,7 +214,7 @@ async def test_reconcile_governance_conflict_skips_existing_name(tmp_path: Path,
 
     async with Computer(name="t", skill_home=home) as comp:
         report = await comp.reconcile_governance(
-            existing_server_names=lambda: {"figma"},
+            existing_bundle_ids=lambda: {"figma"},
             register_server=register,
             declared=_DECLARED_ENABLED,
         )

--- a/tests/unit_tests/computer/test_computer_install_enable_v030.py
+++ b/tests/unit_tests/computer/test_computer_install_enable_v030.py
@@ -79,7 +79,7 @@ def _seed_home(tmp_path: Path, *, servers: Sequence[str] = (), skills: Sequence[
                         "version": "1.2.0",
                         "commitSha": "abc123",
                         "installedAt": "2026-07-06T00:00:00Z",
-                        "bundledMcpServers": list(servers),
+                        "mcpServers": list(servers),
                     },
                 ],
             },

--- a/tests/unit_tests/computer/test_computer_inventory.py
+++ b/tests/unit_tests/computer/test_computer_inventory.py
@@ -32,6 +32,7 @@ from a2c_smcp.computer.inventory import McpPluginOwnership, McpUserOwnership
 from a2c_smcp.computer.mcp_clients.model import StdioServerConfig
 from a2c_smcp.computer.settings.store import save_installed_plugins, save_known_marketplaces
 from a2c_smcp.computer.skills.home import marketplace_skill_dir
+from a2c_smcp.utils.bundle_id import resolve_bundle_id
 
 _SRC = {"type": "git", "url": "https://example.com/acme.git"}
 
@@ -223,7 +224,11 @@ async def test_inventory_marks_remounted_bundled_server_as_plugin(tmp_path: Path
             await comp.amount_server(cfg, plugin=record.plugin, marketplace=record.marketplace)
 
         report = await comp.reconcile_governance(
-            existing_bundle_ids=lambda: {c.name for c in comp.mcp_servers},
+            # #153：身份 = bundle_id + 数据源 = 运行期权威集（`comp.mcp_servers` 是构造期快照，CLI 下恒空，
+            # 协议 §2.5-4 明禁）——与生产 build_mcp_callbacks 同构。
+            existing_bundle_ids=lambda: (
+                {resolve_bundle_id(c) for c in comp.mcp_manager.server_configs()} if comp.mcp_manager else set()
+            ),
             register_server=register,
             declared={"installedPlugins": ["audit@acme"], "enabledPlugins": {"audit@acme": True}},
         )

--- a/tests/unit_tests/computer/test_computer_inventory.py
+++ b/tests/unit_tests/computer/test_computer_inventory.py
@@ -83,7 +83,7 @@ def _seed_home(
                         "version": "1.2.0",
                         "commitSha": "abc123",
                         "installedAt": "2026-07-06T00:00:00Z",
-                        "bundledMcpServers": all_servers,
+                        "mcpServers": all_servers,
                     },
                 ],
             },
@@ -223,7 +223,7 @@ async def test_inventory_marks_remounted_bundled_server_as_plugin(tmp_path: Path
             await comp.amount_server(cfg, plugin=record.plugin, marketplace=record.marketplace)
 
         report = await comp.reconcile_governance(
-            existing_server_names=lambda: {c.name for c in comp.mcp_servers},
+            existing_bundle_ids=lambda: {c.name for c in comp.mcp_servers},
             register_server=register,
             declared={"installedPlugins": ["audit@acme"], "enabledPlugins": {"audit@acme": True}},
         )


### PR DESCRIPTION
Closes #153。母单 Epic #147；共识 [protocol Discussion #23](https://github.com/A2C-SMCP/a2c-smcp-protocol/discussions/23) 终审 D3/F1。
rust 镜像 rust-sdk#139（**共享同一磁盘账本格式，分叉即数据损坏**）。

## 根因

plugin 与 MCP Server 的关系被实现成「**所有关系**」——账本 `bundledMcpServers` 记 display name、卸载无条件收回、外来同名硬抛拒装。协议裁定二者是「**依赖关系**」（runtime-contract §2.5）：plugin 以 `bundle_id` **声明依赖**，同 bundle_id 已有 = 「依赖已满足」。

**协议门控 🟢**：PROTO-2 / PROTO-4 文本已在 a2c-smcp-protocol `develop`（commit `fe6ef87`）。

## 变更

| 层 | 内容 |
|---|---|
| `store.py` | `bundledMcpServers`(name[]) → `mcpServers`(bundle_id[]，无条件写)；load 层单点丢弃旧格式 + WARN（§4.9.1-4，**MUST NOT** 写 name→bundle_id 映射迁移） |
| `mcp_config.py` | 新增 `user_declared_bundle_ids`（回收判据第二项数据源） |
| `reconciler.py` | **回收判据单点**（纯函数、零落盘状态）：`ledger_mcp_deps_of` / `other_plugin_mcp_deps` / `reclaimable_mcp_deps`；`gc_plugins` 应用判据 |
| `installer.py` | 删 `MCPServerNameConflictError` + `_conflict_check` + `owned` 概念；`ExistingServerNames` → `ExistingBundleIds`；`RemoveServer` 收 bundle_id；uninstall/disable 应用判据；enable 依赖已满足 → **skip register**（复用既有实例） |
| `computer.py` | `reconcile_governance` 判据 name → bundle_id（同名异 id 是**合法共存**，§5.6） |
| `cli/` | **两处死快照齐修**；UX 提示「依赖已满足」；JSON/表格字段迁移 |

### 回收判据（§4.9.1-2）

> **回收 X ⟺ 无其他 plugin 声明依赖 X ∧ X 非用户声明**

disable / uninstall / gc **三个消费者全部委托同一纯函数**，无 DRY 副本。由此「用户自有 server 永不连坐」与「多 plugin 共享依赖不被提前摘、最后一个依赖者卸载时回收（无泄漏）」同时成立。

## 超出 issue 正文的三项发现

1. **死快照有两处**。issue 只点了 `cli/commands/plugin.py:184`（治理重挂）；`cli/commands/__init__.py:66` 用**同一个死快照**喂 **install/enable 的门**。只修 issue 点名那处，install/enable 仍读恒空集。
2. **冲突门在 CLI 下从未触发过**（`existing` 恒空）⇒ 文档承诺的「外来同名硬抛」生产中从未发生，实际是**静默覆盖**。故 D3 对真实用户不是行为回退，而是「静默覆盖 → 显式提示」的净改善。
3. **`origin == plugin` 在 python 里不存在**（bundled server 走 transient mount、永不回写 mcp.json），故判据第二项无需 origin 过滤——已在 `user_declared_bundle_ids` 注明推理与失效条件。

## 🔴 实施中发现并修复的回归（本 PR 自引入、已修）

**旧格式丢弃与 v0.2.x→v0.3.0 意图迁移存在顺序依赖**：`migrate_legacy_installs` 从账本 pid 回填 `installedPlugins` 意图，而账本格式迁移**恰恰依赖该意图重建**。丢弃若对迁移也生效 ⇒ v0.2.x 存量用户**带 MCP server 的 plugin 连 pid 一起消失** ⇒ 升级后静默全丢。

修法 = `load_installed_plugins(drop_legacy=False)` 仅供迁移读 key。守卫：`test_legacy_ledger_pids_survive_for_intent_migration`。

## 协议未覆盖处的取舍（rust#139 须对齐，避免双端分叉）

1. **「其他 plugin」= 账本 installed 记录（含 disabled）**，不按 enabled 过滤。依据：§4.9.1-2 字面为「无其他 plugin **声明依赖**」，conformance §285「**最后一个依赖者卸载**时回收」印证判据看记录存在性。
2. **旧格式丢弃判据 = 「含 `bundledMcpServers` 键」**（非「缺 `mcpServers` 键」）：精确只打真旧记录。
3. **`mcpServers` 无条件写**（空则 `[]`）：与 rust#139 示例磁盘形态一致，且「有该键」= 新格式正向标志。

## 测试

- 新增 `test_mcp_dependency_model.py`：**回收判据五场景** ①②③④⑤ + scoped uninstall + D3 依赖模型 + 旧格式迁移 + gc 判据
- **夹具去伪**：`test_installer.py` 从 `"figma"`（name == bundle_id **同值致盲**）改分叉（`figma.mcp` / `figma_mcp`）；`_ReplComp` 桩改与生产同构（`mcp_servers` 恒空、运行期落 `mcp_manager`）；治理重挂用例改走 **F7 真实构造路径**（原用 `comp._mcp_servers.add()` = 生产不可能的姿势）
- **autouse chdir 隔离**：回收判据读 cwd 锚定的 project/local mcp.json，不 chdir 即随开发者本地环境漂移

### 变异验证（守卫非永真）

| 变异 | 转红的守卫 |
|---|---|
| 去掉 `user_declared` 判据 | 场景②⑤ + disable + gc 连坐（4 条） |
| 去掉 `other_deps` 判据 | 场景③④共享依赖 + scoped uninstall（2 条） |
| existing 改回构造期死快照 | 治理重挂守卫（1 条） |
| 账本回退存 display name | **16 条**（夹具分叉的价值实证） |

## 验收

- [x] 五场景 ①②③④⑤ 全绿 + scoped uninstall
- [x] 冲突门/重挂数据源 = `manager.server_configs()`
- [x] `MCPServerNameConflictError` 不存在（读取点 = 0）
- [x] 账本无 `bundledMcpServers` / 无 provenance / 无 name
- [x] 无 name→bundle_id 映射迁移代码
- [x] 夹具 name ≠ bundle_id
- [x] 单元+集成 **1991 passed** / e2e **65 passed** / `poe lint` clean（ruff + mypy 103 files）

## 后续

- **#144 解除 SDK 内部 blocked-by**（其 `managedBy` 纯推导本次不做，issue 正文已标「供 #144」）
- `computer.py` inventory 归属 join key 仍是 name（#144）——本 PR 已订正其 docstring 的事实错误（原称「可靠的冲突拦截是安装期职责」，而冲突门已不存在）
- **rust-sdk#139 须同步上述三项取舍**
- #134（嵌入式多实例混源）：回收判据新增一处 `resolve_mcp_config()` 读取，会扩大其混源面（Epic 已识别）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
