### PR TITLE
fix(#154/#164)!: 两套 scope 层序统一（SCOPE_ORDER 单一权威 + flag 次高 + embed 层）+ --mcp-config 归一 + 回收判据锚定 origin

### DIFF
--- a/.claude/skills/uat-scenario/resources/guides/blob-transfer.md
+++ b/.claude/skills/uat-scenario/resources/guides/blob-transfer.md
@@ -77,11 +77,15 @@ blob 传输场景需要完整的 Agent ↔ Server ↔ Computer 链路，且 Comp
 ```
 tmux session: a2c-uat
 ├── window: server     →  Server
-├── window: computer   →  a2c-computer run --url <URL> --config <blob-test-mcp.json>
+├── window: computer   →  a2c-computer run --url <URL> --mcp-config <blob-test-mcp.json>
 └── window: agent      →  Agent 测试脚本
 ```
 
 `blob-test-mcp.json` 需要配置一个能返回多种大小资源的 MCP server。
+
+> **#154 起格式为 flag 层 mcp.json**（旧 `--config` 的裸 server 形状已废止，旧文件会 fail-fast）：
+> `{"servers": {"<server-name>": {"type": "stdio", "server_parameters": {…}}}, "inputs": []}`
+> —— server 身份由 map key 承载，**body 里不要写 `name` 字段**（`name` ≠ key 会被丢弃）。
 
 ## 验证清单补充项
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,50 @@ and this project adheres to [PEP 440](https://peps.python.org/pep-0440/) version
 > [#8](https://github.com/A2C-SMCP/python-sdk/issues/8).
 
 ### Breaking Changes
+- **The two scope-layering orders are unified; `--config` → `--mcp-config`; `--inputs` removed**
+  (#154 + #164, aligned with a2c-smcp-protocol `runtime-contract.md` §2.5-3 / §2.5-5 and
+  Discussion #23 F6 / Discussion #32; rust mirror rust-sdk#137 / #147).
+  - **One source-priority order, low → high — `settings.json` and `mcp.json` MUST agree**:
+    `plugin declaration < user < project < local < embed < flag < policy`.
+    Previously `settings.json` ranked `flag` **second-highest** while `mcp.json` ranked it
+    **lowest** (a `--config` legacy artifact) — four positions apart. The protocol abolishes
+    the latter. The order now has a single authority, `SCOPE_ORDER` in `settings/schema.py`,
+    which both resolvers iterate; the two hand-written list literals that drifted are gone.
+  - **`--config` → `--mcp-config`** (short `-c` kept). It is now the **flag-layer `mcp.json`**,
+    forming the flag-scope *file pair* with `--settings` (the flag-layer `settings.json`),
+    symmetric with every other scope.
+    - **File shape hard-cut**: a bare server object / an array of server objects →
+      the `mcp.json` shape `{"servers": {...}, "inputs": [...]}`. Server identity is the
+      **map key**; drop the `name` field from the body (a body `name` ≠ key is rejected).
+      Old-format files **fail fast with exit code 2** and a rewrite hint — deliberately
+      reversing the old silently-degrading behaviour, where a typo'd `--config` path booted
+      you into an empty REPL. Validation now also runs **before** any connection is opened.
+    - **Precedence flips**: previously overridden by `user`/`project`/`local`; now overrides them.
+    - **Now passes the approval gate** (it used to bypass scope merge, origin tracking and the
+      gate entirely, mounting directly). `flag` is a trusted origin ⇒ still no prompt, so the
+      common case is unchanged — but a `policy` deny-list / allow-list / `disabledMcpjsonServers`
+      can now block a `--mcp-config` server. This is protocol-correct (`policy > flag`).
+  - **`--inputs` (and `-i`) removed.** The `inputs` segment of the `--mcp-config` file carries
+    that role; it is consumed on the same path as every other scope's `inputs`. The legacy
+    `--config` schema had **no** `inputs` field, which is why a separate flag existed at all.
+    The REPL `inputs` command is a different surface and is unaffected.
+  - **`--settings` help text corrected**: it claimed "最低优先级" (lowest priority) while the
+    implementation has always ranked it second-highest.
+  - **New `embed` scope** — the embedding host's `Computer(mcp_servers=...)` constructor
+    argument, a code-level explicit intent ranked between `local` and `flag`, and a trusted
+    origin (no approval prompt). It still enters the gate iteration, so `policy` deny-lists and
+    the generic disable switch apply to it. **Known gap** (tracked separately): a pure embedded
+    host (`Computer(...)` + `boot_up`, no REPL) has no approval gate at all, so `policy`
+    deny-lists do not reach it.
+  - **Reclaim criterion re-anchored** (closes a #153 gap): "X is not user-declared" is now
+    evaluated on the **origin-carrying** declaration set, which covers *every* non-plugin mount
+    path (durable scopes + `flag` + `embed`). Servers mounted via `--mcp-config` or via the host
+    constructor are consequently **never** collaterally torn down when a plugin is uninstalled.
+    `mcp_json_declared_bundle_ids` → **`non_plugin_declared_bundle_ids`**.
+  - **`Computer.aremove_server` now raises `McpWriteTargetError`** when the winning declaration
+    lives in a **read-only scope** (`policy` / `flag` / `embed`) instead of reporting success
+    while deleting nothing and resurrecting the server on the next boot. Note this **also fixes
+    a pre-existing defect** for `policy`-origin servers.
 - **plugin ↔ MCP Server is a dependency relation, not an ownership one** (#153, aligned
   with a2c-smcp-protocol `runtime-contract.md` §2.5 / §4.9.1 / §5.6; adjudication record
   in protocol Discussion #23 D3/F1; rust mirror rust-sdk#139 — **both SDKs share the same

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,9 +44,15 @@ and this project adheres to [PEP 440](https://peps.python.org/pep-0440/) version
   - **New `embed` scope** — the embedding host's `Computer(mcp_servers=...)` constructor
     argument, a code-level explicit intent ranked between `local` and `flag`, and a trusted
     origin (no approval prompt). It still enters the gate iteration, so `policy` deny-lists and
-    the generic disable switch apply to it. **Known gap** (tracked separately): a pure embedded
-    host (`Computer(...)` + `boot_up`, no REPL) has no approval gate at all, so `policy`
-    deny-lists do not reach it.
+    the generic disable switch apply to it. **Known gaps** (tracked separately, both stem from
+    §5 item 10 putting plugin declarations outside the gate):
+    - a pure embedded host (`Computer(...)` + `boot_up`, no REPL) has no approval gate at all,
+      so `policy` deny-lists do not reach it;
+    - unmounting a policy-denied `embed` server frees its `bundle_id`, after which the governance
+      remount may mount a *plugin*-declared server with the same `bundle_id` — the deny-list is
+      still circumvented, just by a different config. (Before this change the denied embed server
+      simply kept running, so neither state is good; the gate cannot reach plugin declarations by
+      protocol design.)
   - **Reclaim criterion re-anchored** (closes a #153 gap): "X is not user-declared" is now
     evaluated on the **origin-carrying** declaration set, which covers *every* non-plugin mount
     path (durable scopes + `flag` + `embed`). Servers mounted via `--mcp-config` or via the host

--- a/a2c_smcp/computer/cli/commands/__init__.py
+++ b/a2c_smcp/computer/cli/commands/__init__.py
@@ -33,18 +33,19 @@ from a2c_smcp.utils.bundle_id import resolve_bundle_id
 if TYPE_CHECKING:  # 仅类型，避免运行时循环导入 / type-only to dodge runtime import cycle
     from a2c_smcp.computer.computer import Computer
     from a2c_smcp.computer.mcp_clients.model import MCPServerConfig
-    from a2c_smcp.computer.settings.installer import ExistingBundleIds, RegisterServer, RemoveServer
+    from a2c_smcp.computer.settings.installer import ExistingBundleIds, NonPluginBundleIds, RegisterServer, RemoveServer
     from a2c_smcp.computer.settings.schema import SettingsValidationError
     from a2c_smcp.computer.settings.scope import ResolvedSettings
 
 
 @dataclass(frozen=True, slots=True)
 class McpCallbacks:
-    """installer / 卸载级联所需的三个 MCP 注入回调 / The three MCP injection callbacks installer/cascade needs。"""
+    """installer / 卸载级联所需的 MCP 注入回调 / The MCP injection callbacks installer/cascade needs。"""
 
     existing_bundle_ids: ExistingBundleIds
     register_server: RegisterServer
     remove_server: RemoveServer
+    non_plugin_bundle_ids: NonPluginBundleIds
 
 
 def build_mcp_callbacks(comp: Computer) -> McpCallbacks:
@@ -53,7 +54,11 @@ def build_mcp_callbacks(comp: Computer) -> McpCallbacks:
 
     - ``existing_bundle_ids``：当前**运行期活跃** server 的 bundle_id 集（依赖预检用）；
     - ``register_server``：**运行期挂载**一个 ``MCPServerConfig``（enable / 治理重挂用）；
-    - ``remove_server``：按 **bundle_id** 运行期停摘 server（disable / uninstall 回收用）。
+    - ``remove_server``：按 **bundle_id** 运行期停摘 server（disable / uninstall 回收用）；
+    - ``non_plugin_bundle_ids``：**声明面**中 ``origin != plugin`` 的 bundle_id 集（§4.9.1-2 回收判据的
+      「X 非用户声明」项，#164）——与 ``existing_bundle_ids`` **判然不同**，勿混用：前者是「谁被声明了（且非 plugin
+      带入）」，后者是「谁挂起来了」。协议**明禁**用裸活跃集判回收（无 origin ⇒ flag/embed/plugin 三条挂载路径
+      可观测同形 ⇒ 连坐停摘用户 / 宿主自有 server）。
 
     设计 §12.2：marketplace remove 的级联卸载（→ :func:`installer.uninstall_plugin`）与 #69 的 plugin
     enable/disable/install/uninstall 共用此接缝，避免各处重复装配。
@@ -81,7 +86,30 @@ def build_mcp_callbacks(comp: Computer) -> McpCallbacks:
     async def _remove(bundle_id: str) -> None:
         await comp.aunmount_server_by_id(bundle_id)
 
-    return McpCallbacks(existing_bundle_ids=_existing, register_server=_register, remove_server=_remove)
+    def _non_plugin() -> set[str]:
+        # 声明面（含 flag/embed 层，携 origin）；每次重算、零持久态（§2.5-5 禁落盘为快照）。
+        return {resolve_bundle_id(srv.config) for srv in comp.resolve_mcp_declarations().servers.values()}
+
+    return McpCallbacks(
+        existing_bundle_ids=_existing,
+        register_server=_register,
+        remove_server=_remove,
+        non_plugin_bundle_ids=_non_plugin,
+    )
+
+
+def files_only_non_plugin_bundle_ids(env: Mapping[str, str] | None = None) -> NonPluginBundleIds:
+    """
+    **无 Computer** 的非交互进程的非-plugin 声明面 / The non-plugin declaration surface for Computer-less processes。
+
+    非交互 ``plugin uninstall|disable|gc`` / ``marketplace remove`` 是 **ledger-only**（无 MCP 回调、不挂载、
+    ``remove_server=None`` ⇒ 回收判据结果实际未被消费，见 :func:`~a2c_smcp.computer.settings.installer.uninstall_plugin`）。
+    该进程**既无宿主构造入参（embed）、也无 ``--mcp-config``（flag 仅存在于 ``run``）** ⇒ 声明面 = durable scopes，
+    这不是「漏传两层」而是「那两层在此进程确实不存在」。REPL / boot 路径请用 :func:`build_mcp_callbacks`。
+    """
+    from a2c_smcp.computer.settings.mcp_config import non_plugin_declared_bundle_ids
+
+    return lambda: non_plugin_declared_bundle_ids(env=env)
 
 
 # ── 跨命令解析 / 视图接缝（marketplace / skill / plugin / settings 共用）/ shared parse & view seams ──

--- a/a2c_smcp/computer/cli/commands/marketplace.py
+++ b/a2c_smcp/computer/cli/commands/marketplace.py
@@ -27,7 +27,7 @@ from typing import Any
 
 from rich.table import Table
 
-from a2c_smcp.computer.cli.commands import McpCallbacks, flag_value
+from a2c_smcp.computer.cli.commands import McpCallbacks, files_only_non_plugin_bundle_ids, flag_value
 from a2c_smcp.computer.cli.progress import clone_spinner, refresh_summary_table
 from a2c_smcp.computer.cli.utils import console
 from a2c_smcp.computer.settings.installer import uninstall_plugin
@@ -301,8 +301,13 @@ async def marketplace_remove(
         installed = load_installed_plugins(home, env).get("plugins") or {}
         victims = [pid for pid in installed if pid.endswith(f"@{name}")]
         remove_cb = mcp_cbs.remove_server if mcp_cbs is not None else None
+        # 回收判据数据源：有 Computer 走其声明面（含 flag/embed）；无 Computer（非交互 ledger-only、
+        # ``remove_cb is None`` ⇒ 判据结果实际未被消费）走 durable scopes。
+        non_plugin_cb = mcp_cbs.non_plugin_bundle_ids if mcp_cbs is not None else files_only_non_plugin_bundle_ids(env)
         for pid in victims:
-            if await uninstall_plugin(pid, registry, home, env=env, remove_server=remove_cb):
+            if await uninstall_plugin(
+                pid, registry, home, non_plugin_bundle_ids=non_plugin_cb, env=env, remove_server=remove_cb,
+            ):
                 uninstalled.append(pid)
 
     pruned = prune_marketplaces([name], registry, home, env=env)

--- a/a2c_smcp/computer/cli/commands/plugin.py
+++ b/a2c_smcp/computer/cli/commands/plugin.py
@@ -53,6 +53,7 @@ from a2c_smcp.computer.inputs.plugin_pool import load_plugin_inputs
 from a2c_smcp.computer.settings.installer import (
     ExistingBundleIds,
     InjectInputs,
+    NonPluginBundleIds,
     PluginInstallError,
     RegisterServer,
     RemoveServer,
@@ -68,7 +69,6 @@ from a2c_smcp.computer.settings.mcp_config import (
     approve_mcp_server,
     deny_mcp_server,
     gate_mcp_servers,
-    resolve_mcp_config,
 )
 from a2c_smcp.computer.settings.reconciler import (
     DANGLING_CATALOG_MISSING,
@@ -83,6 +83,7 @@ from a2c_smcp.computer.settings.reconciler import (
 )
 from a2c_smcp.computer.skills.manifest import MCP_INPUTS_FILENAME, MCP_SERVERS_SUBDIR
 from a2c_smcp.computer.skills.registry import SkillRegistry
+from a2c_smcp.utils.bundle_id import resolve_bundle_id
 from a2c_smcp.utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -152,7 +153,7 @@ def _plugin_inject_inputs_cb(comp: Any, plugin: str, marketplace: str) -> Inject
     return _inject
 
 
-async def run_governance_remount(comp: Any, *, flag_config: Path | None = None) -> None:
+async def run_governance_remount(comp: Any, *, settings_flag_path: Path | None = None) -> None:
     """
     启动期治理重挂（#117 设计 Y 的 client 接线参考实现）/ Boot-time governance remount (reference client wiring)。
 
@@ -170,7 +171,7 @@ async def run_governance_remount(comp: Any, *, flag_config: Path | None = None) 
       bundled **免批准**（§5.10 不走 project 信任门），单点失败不阻断。
     """
     env = os.environ
-    declared = resolved_settings(env, flag_path=flag_config)
+    declared = resolved_settings(env, flag_path=settings_flag_path)
 
     async def _register(cfg: Any, record: Any) -> None:
         # #137 ③：治理重挂 = 投影（ledger 是真相），走 transient amount_server，不回写 mcp.json。
@@ -260,12 +261,21 @@ async def plugin_uninstall(
     env: Mapping[str, str] | None,
     plugin_id: str,
     *,
+    non_plugin_bundle_ids: NonPluginBundleIds,
     keep_servers: bool = False,
     remove_server: RemoveServer | None = None,
     json_output: bool = False,
 ) -> int:
-    """卸载单个 plugin（删 installPath 树 + 注销 skills + 级联停摘 bundled server + 删账本）/ Uninstall a plugin。"""
-    ok = await uninstall_plugin(plugin_id, registry, home, env=env, keep_servers=keep_servers, remove_server=remove_server)
+    """卸载单个 plugin（删 installPath 树 + 注销 skills + **按判据**回收 bundled server + 删账本）/ Uninstall a plugin。"""
+    ok = await uninstall_plugin(
+        plugin_id,
+        registry,
+        home,
+        non_plugin_bundle_ids=non_plugin_bundle_ids,
+        env=env,
+        keep_servers=keep_servers,
+        remove_server=remove_server,
+    )
     if not ok:
         return _err(f"plugin {plugin_id!r} not installed (no-op)", json_output=json_output)
     if json_output:
@@ -324,6 +334,7 @@ async def plugin_disable(
     env: Mapping[str, str] | None,
     plugin_id: str,
     *,
+    non_plugin_bundle_ids: NonPluginBundleIds,
     remove_server: RemoveServer | None = None,
     json_output: bool = False,
 ) -> int:
@@ -337,6 +348,7 @@ async def plugin_disable(
     for rec in records:
         await disable_plugin(
             plugin_id, registry, home,
+            non_plugin_bundle_ids=non_plugin_bundle_ids,
             scope=str(rec.get("scope", "user")), project_path=rec.get("projectPath"), env=env, remove_server=remove_server,
         )
     if json_output:
@@ -466,6 +478,7 @@ async def plugin_gc(
     home: Path,
     env: Mapping[str, str] | None,
     *,
+    non_plugin_bundle_ids: NonPluginBundleIds,
     mcp_teardown: Callable[[list[str]], Awaitable[None]] | None = None,
     confirm: Callable[[list[str]], Awaitable[bool]] | None = None,
     prune_dangling: bool = False,
@@ -498,7 +511,13 @@ async def plugin_gc(
         if not await confirm(items):
             return _err("aborted by user", json_output=json_output)
 
-    removed = await gc_plugins(orphans, registry, home, env=env, mcp_teardown=mcp_teardown) if orphans else []
+    removed = (
+        await gc_plugins(
+            orphans, registry, home, non_plugin_bundle_ids=non_plugin_bundle_ids, env=env, mcp_teardown=mcp_teardown,
+        )
+        if orphans
+        else []
+    )
     pruned: list[str] = []
     residual: list[str] = []
     for pid, _reason in prunable:
@@ -554,25 +573,35 @@ async def run_mcp_approval(
     session: Any | None,
     *,
     approve_all: bool = False,
-    flag_config: Path | None = None,
+    settings_flag_path: Path | None = None,
 ) -> None:
-    """启动期解析 ``.tfrobot/mcp.json`` 定义层 + 批准门控 + 挂载 ENABLED server（§9.2）/ Boot-time MCP approval + mount。
+    """启动期解析 mcp.json 声明面 + 批准门控 + 收敛挂载态（§9.2）/ Boot-time MCP approval + mount reconciliation。
 
-    - user/flag/policy origin server（trusted）→ 门控判 ENABLED → 直挂（免批准框）；
-    - DISABLED（企业拒绝/不在白名单/显式 disabled）→ 跳过；
+    - user/embed/flag/policy origin server（trusted）→ 门控判 ENABLED → 直挂（免批准框）；
+    - DISABLED（企业拒绝/不在白名单/显式 disabled）→ **确保停摘**；
     - PENDING（工作区共享未决）→ TTY 弹 y/a/n 写 local scope；非 TTY → skip+WARN，``approve_all`` 全批（仅本次不落盘）。
 
     ``--approve-all-mcp`` 在**非交互**仅本次挂载、**不落盘**；TTY ``[a]`` 才写 enableAllProjectMcpServers（用户显式决定）。
 
-    **flag 层 schema 区分**（fix-review #1）：``flag_config`` 源自 ``--settings <file>``，是 **settings.json** flag 层
-    （喂 :func:`resolved_settings` 的 ``flag_path``——``{enabledPlugins/MCP 门控字段…}``）。它**不是 mcp.json**，故
-    **不**喂 ``resolve_mcp_config(flag_config_path=)``（后者期望 ``{servers,inputs}``、schema 不符）；flag-scope
-    **mcp.json 当前无 CLI 入口**（旧 ``--config`` 仅 ``_run_impl`` server 预加载、从不喂门控解析）。
+    **循环契约 = `ENABLED ⇒ 确保已挂 / DISABLED ⇒ 确保停摘 / PENDING ⇒ 问`**（#164）。「确保」而非「挂载」是
+    因为 embed 层（``Computer(mcp_servers=...)``）在 ``boot_up`` 已被**无门**挂起：
+    - ENABLED 时若 bundle_id 已活跃则跳过——重复 ``amount_server`` 会 restart 客户端，``auto_reconnect=False``
+      时更直接抛 ``RuntimeError``（见 ``manager._add_or_update_server_config``）。文件来源的 server 此刻恒未活跃，
+      故行为不变。
+    - DISABLED 时**必须真的摘掉**，否则 policy 拒绝名单对 embed 只是装饰品、协议「用户/管理员保留最终关停权」
+      落空。对从未挂过的文件来源 server，``aunmount_server_by_id`` 是幂等 no-op，行为不变。
+
+    **两个 flag 文件分工**（协议 §2.5-3 的 flag scope **文件对**）：``settings_flag_path`` = ``--settings <file>``，
+    是 **settings.json** flag 层（喂 :func:`resolved_settings` 的 ``flag_path``——``{enabledPlugins/MCP 门控字段…}``）；
+    flag 层 **mcp.json** = ``--mcp-config <file>``，经 :class:`Computer` 注入、由 ``comp.resolve_mcp_declarations()``
+    解析（含其 ``inputs`` 段）。二者 schema 不同、**不可互喂**。旧参数名 ``flag_config`` 已更名——它从来是
+    settings.json，旧名主动误导（#154）。
     """
     env = os.environ
-    # flag_config 是 settings.json（见 docstring）→ resolve_mcp_config 不收（避免 settings.json 当 mcp.json 误读）。
+    # 声明面 = durable scopes + flag（`--mcp-config`）+ embed（构造入参），均携 origin（§2.5-5）。两个 flag 文件
+    # 分工见 docstring：settings_flag_path 是 settings.json，**不**喂 resolve_mcp_config。
     # #116：project/local 层由 resolve_mcp_config 内部锚定进程 cwd。
-    resolved = resolve_mcp_config(env=env, flag_config_path=None)
+    resolved = comp.resolve_mcp_declarations(env=env)
 
     # 被 drop 的畸形 server/input 必须呈现（§5.6 / mcp_config 容错不静默，#69 Group B 风险 3）。
     for e in resolved.errors:
@@ -583,12 +612,13 @@ async def run_mcp_approval(
 
     # #157：scope 越权被过滤的字段必须有解释——否则用户只看到莫名的批准框（协议 §2.1「响亮失败」）。
     # 典型：仓库的 project settings.json 携 enableAllProjectMcpServers → 被过滤 → 此处告知该挪去 local/user。
-    resolved_st = resolved_settings_with_errors(env, flag_path=flag_config)
+    resolved_st = resolved_settings_with_errors(env, flag_path=settings_flag_path)
     for line in format_settings_errors(resolved_st.errors):
         console.print(f"[yellow]{line}[/yellow]")
     settings = resolved_st.settings
-    # #148/F8：审批门 MUST NOT 依赖账本 bundled 名集；plugin 声明本就不入 resolve_mcp_config（走 transient
-    # amount_server 挂载、不落 mcp.json），迭代永不遇 plugin origin，无需显式过滤（详见 mcp_server_status）。
+    # #148/F8：审批门 MUST NOT 依赖账本 bundled 名集；plugin 声明**结构性**不入 resolve（无 plugin 入参 +
+    # SettingsScope 无 PLUGIN 成员，见 schema.SCOPE_ORDER）⇒ 迭代物理上遇不到 plugin origin，无需过滤器
+    # ——写一个就是永假守卫（死代码），且是档④「进门后豁免」形状复活的诱因（详见 mcp_server_status）。
     statuses = gate_mcp_servers(resolved, settings)
 
     # mcp.json 定义的 input 入池（无前缀），供 server config 的裸 ${input:} 解析（#69 Group B 风险 3）。
@@ -597,23 +627,47 @@ async def run_mcp_approval(
 
     approved_all_session = approve_all  # 非交互 --approve-all-mcp，或 TTY 选过一次 [a]
 
-    async def _mount(name: str) -> None:
+    def _active_bundle_ids() -> set[str]:
+        """运行期活跃集的 bundle_id（embed 层已被 ``boot_up`` 无门挂起 ⇒ 挂载前须查）/ Active bundle_ids。"""
+        if getattr(comp, "mcp_manager", None) is None:
+            return set()
+        return {resolve_bundle_id(cfg) for cfg in comp.mcp_manager.server_configs()}
+
+    async def _ensure_mounted(name: str) -> None:
         try:
+            srv = resolved.servers[name]
+            # embed 层在 boot_up 已挂 ⇒ 重复 amount_server 会 restart 客户端（auto_reconnect=False 时抛
+            # RuntimeError）。文件来源此刻恒未活跃，故此分支对其不改变行为。
+            if resolve_bundle_id(srv.config) in _active_bundle_ids():
+                console.print(f"[dim]· MCP server {name!r} already active (embed/构造入参), left as is[/dim]")
+                return
             # #137 ③：boot 读**已声明** mcp.json 挂载 = 投影（盘上已是真相），走 transient amount_server，不回写
             # （否则每 boot 重复回写用户声明层 / scope 漂移，见 #138）。
-            await comp.amount_server(_mount_dict(resolved.servers[name]), session=session)
+            await comp.amount_server(_mount_dict(srv), session=session)
             console.print(f"[green]✓ mounted MCP server {name!r}[/green]")
         except Exception as exc:  # 单个 server 挂载失败不阻断其余 / one failure must not block the rest
             console.print(f"[red]✗ failed to mount MCP server {name!r}: {exc}[/red]")
 
+    async def _ensure_unmounted(name: str) -> None:
+        """DISABLED ⇒ 真的摘掉：embed 已被 boot_up 无门挂起，只打印不摘会让 policy 拒绝名单沦为装饰品。"""
+        try:
+            bid = resolve_bundle_id(resolved.servers[name].config)
+            if bid not in _active_bundle_ids():
+                return  # 从未挂过（文件来源恒走此分支）→ 幂等 no-op，行为不变
+            await comp.aunmount_server_by_id(bid)
+            console.print(f"[dim]· MCP server {name!r} disabled (policy/denied) → unmounted[/dim]")
+        except Exception as exc:
+            console.print(f"[red]✗ failed to unmount disabled MCP server {name!r}: {exc}[/red]")
+
     for name, status in statuses.items():
         if status == McpApprovalStatus.ENABLED:
-            await _mount(name)
+            await _ensure_mounted(name)
         elif status == McpApprovalStatus.DISABLED:
             console.print(f"[dim]· MCP server {name!r} disabled (policy/denied), skipped[/dim]")
+            await _ensure_unmounted(name)
         else:  # PENDING
             if approved_all_session:
-                await _mount(name)
+                await _ensure_mounted(name)
                 continue
             if session is None:  # 非 TTY 且未 --approve-all-mcp → skip + WARN
                 console.print(
@@ -629,10 +683,10 @@ async def run_mcp_approval(
             if ans in {"a", "all"}:
                 approve_all_project_mcp()
                 approved_all_session = True
-                await _mount(name)
+                await _ensure_mounted(name)
             elif ans in {"y", "yes"}:
                 approve_mcp_server(name)
-                await _mount(name)
+                await _ensure_mounted(name)
             else:
                 deny_mcp_server(name)
                 console.print(f"[dim]· denied MCP server {name!r} (written to local scope)[/dim]")
@@ -676,6 +730,7 @@ async def repl_dispatch(comp: Any, parts: list[str], *, session: Any) -> None:
             return
         code = await plugin_uninstall(
             registry, home, env, pos[0],
+            non_plugin_bundle_ids=cbs.non_plugin_bundle_ids,
             keep_servers="--keep-servers" in args, remove_server=cbs.remove_server, json_output=json_output,
         )
         if code == EXIT_OK:
@@ -703,7 +758,10 @@ async def repl_dispatch(comp: Any, parts: list[str], *, session: Any) -> None:
         if not pos:
             console.print("[yellow]usage: plugin disable <plugin>@<marketplace>[/yellow]")
             return
-        code = await plugin_disable(registry, home, env, pos[0], remove_server=cbs.remove_server, json_output=json_output)
+        code = await plugin_disable(
+            registry, home, env, pos[0],
+            non_plugin_bundle_ids=cbs.non_plugin_bundle_ids, remove_server=cbs.remove_server, json_output=json_output,
+        )
         if code == EXIT_OK:
             comp.mark_skills_dirty()
     elif sub == "list":
@@ -722,6 +780,7 @@ async def repl_dispatch(comp: Any, parts: list[str], *, session: Any) -> None:
         # REPL 有 confirm 门 → 悬挂意图 prune 一并纳入确认（#125 任务 2；Typer 非交互须显式 --prune-dangling）
         code = await plugin_gc(
             registry, home, env,
+            non_plugin_bundle_ids=cbs.non_plugin_bundle_ids,
             mcp_teardown=_batch_teardown(cbs.remove_server), confirm=_confirm, prune_dangling=True, json_output=json_output,
         )
         if code == EXIT_OK:

--- a/a2c_smcp/computer/cli/commands/plugin.py
+++ b/a2c_smcp/computer/cli/commands/plugin.py
@@ -81,6 +81,7 @@ from a2c_smcp.computer.settings.reconciler import (
     list_dangling_plugin_intents,
     list_orphan_plugins,
 )
+from a2c_smcp.computer.settings.schema import SettingsScope
 from a2c_smcp.computer.skills.manifest import MCP_INPUTS_FILENAME, MCP_SERVERS_SUBDIR
 from a2c_smcp.computer.skills.registry import SkillRegistry
 from a2c_smcp.utils.bundle_id import resolve_bundle_id
@@ -636,10 +637,21 @@ async def run_mcp_approval(
     async def _ensure_mounted(name: str) -> None:
         try:
             srv = resolved.servers[name]
-            # embed 层在 boot_up 已挂 ⇒ 重复 amount_server 会 restart 客户端（auto_reconnect=False 时抛
-            # RuntimeError）。文件来源此刻恒未活跃，故此分支对其不改变行为。
-            if resolve_bundle_id(srv.config) in _active_bundle_ids():
-                console.print(f"[dim]· MCP server {name!r} already active (embed/构造入参), left as is[/dim]")
+            # **只在「已挂的那份就是胜出者」时跳过**（隔离审查 🔴1）。``boot_up`` **只**预挂 embed 层
+            # （``_mcp_servers``），故该条件精确等价于「胜出者的 origin 是 embed」：
+            #   - 胜出者 = embed ∧ 已活跃 ⇒ boot_up 挂的正是它 ⇒ 无事可做（重挂只会 restart 客户端，
+            #     ``auto_reconnect=False`` 时更抛 RuntimeError）；
+            #   - 胜出者 = flag/policy/local/user ⇒ **必须挂**，否则 resolved 里那份更高层的胜出配置永不
+            #     生效 ⇒ 运行期层序相对 resolve 层被反转（``local < embed < flag < policy`` 名存实亡）。
+            # 文件来源此刻恒未活跃 ⇒ 走 mount 分支，行为不变。
+            #
+            # ⚠️ **勿改成比较 config**（两种都试过、都错）：``mcp_manager.server_configs()`` 存**渲染后**配置、
+            # 而声明面恒为 **raw**（D1）⇒ 任何带 ``${input:}`` 的 config 恒不相等 ⇒ 每 boot 重挂（restart /
+            # RuntimeError）；改用 raw-对-raw 又受 embed 层 ``model_dump`` 往返规整影响，同样脆。
+            # origin 判据直接表达意图，不受二者影响。守卫见
+            # ``test_higher_layer_beats_embed_at_mount_time`` + ``test_embed_with_placeholder_is_not_remounted...``。
+            if srv.origin is SettingsScope.EMBED and resolve_bundle_id(srv.config) in _active_bundle_ids():
+                console.print(f"[dim]· MCP server {name!r} already mounted from the embed layer (winner), left as is[/dim]")
                 return
             # #137 ③：boot 读**已声明** mcp.json 挂载 = 投影（盘上已是真相），走 transient amount_server，不回写
             # （否则每 boot 重复回写用户声明层 / scope 漂移，见 #138）。

--- a/a2c_smcp/computer/cli/interactive_impl.py
+++ b/a2c_smcp/computer/cli/interactive_impl.py
@@ -58,14 +58,16 @@ async def interactive_loop(
     init_client: Any | None = None,
     completer: Completer | None = None,
     approve_all_mcp: bool = False,
-    mcp_flag_config: Path | None = None,
+    settings_flag_path: Path | None = None,
 ) -> None:
     """
     中文: 交互循环的可注入实现；从 main.py 传入 PromptSession 工厂、patch_stdout 上下文与 SMCP 客户端类。
     English: DI-friendly interactive loop; main.py passes PromptSession factory, patch_stdout ctx and SMCP client class.
 
     completer: 可选 Tab 补全器（逐次传入 ``prompt_async``，trust y/N 等子提示不带补全）/ optional Tab completer.
-    approve_all_mcp / mcp_flag_config: 全局 flag ``--approve-all-mcp`` / ``--settings <file>``，透传给启动期 MCP 批准框（#69 Group B）。
+    approve_all_mcp / settings_flag_path: 全局 flag ``--approve-all-mcp`` / ``--settings <file>``，透传给启动期
+    MCP 批准框（#69 Group B）。``settings_flag_path`` 旧名 ``mcp_flag_config`` 已更名——它是 **settings.json**，
+    旧名主动误导（#154）；flag 层 **mcp.json**（``--mcp-config``）不走本参数，而是注入 :class:`Computer`。
     """
     session = session_factory()
     smcp_client = init_client
@@ -85,7 +87,7 @@ async def interactive_loop(
     # 非 TTY（管道/CI）→ 传 session=None 走 skip+WARN / --approve-all-mcp 分支（避免 prompt_async 在无终端下 EOF）。
     try:
         approval_session = session if sys.stdin.isatty() else None
-        await plugin_cmd.run_mcp_approval(comp, approval_session, approve_all=approve_all_mcp, flag_config=mcp_flag_config)
+        await plugin_cmd.run_mcp_approval(comp, approval_session, approve_all=approve_all_mcp, settings_flag_path=settings_flag_path)
     except Exception as e:  # pragma: no cover - 批准框失败不阻断进入 REPL
         console.print(f"[yellow]⚠ MCP 批准门控初始化失败 / MCP approval init failed: {e}[/yellow]")
 
@@ -93,7 +95,7 @@ async def interactive_loop(
     # reconcile_governance(hooks) 重挂 enabled bundled MCP server。时序刻意在批准框之后——mcp.json 的
     # 显式用户配置先挂先占名（同名 bundled 被 skip，用户配置胜）；bundled 免批准（§5.10）。
     try:
-        await plugin_cmd.run_governance_remount(comp, flag_config=mcp_flag_config)
+        await plugin_cmd.run_governance_remount(comp, settings_flag_path=settings_flag_path)
     except Exception as e:  # pragma: no cover - 重挂失败不阻断进入 REPL
         console.print(f"[yellow]⚠ 治理重挂失败 / governance remount failed: {e}[/yellow]")
 

--- a/a2c_smcp/computer/cli/main.py
+++ b/a2c_smcp/computer/cli/main.py
@@ -77,9 +77,15 @@ class _RootState:
     恒返回 ``{}``。统一收口到 ``ctx.obj``。#116：project/local scope 锚定进程 cwd，
     不再有 ``--add-dir`` / workdir 状态。
     Root-level context gathered by the callback and read by `settings` subcommands via inherited ``ctx.obj``.
+
+    **#154（隔离审查 🔴2）**：flag scope 的**文件对**（``--settings`` + ``--mcp-config``）在根回调与 ``run``
+    上各声明一份，但根那份此前**只在无子命令时**被消费 ⇒ ``a2c-computer --mcp-config x.json run``（flag 置于
+    子命令之前）会把文件**静默丢弃**（连 fail-fast 都碰不到，用户落进空 REPL）。二者现统一收口到本状态，
+    由 ``run`` 兜底回读（``run`` 自身的显式值优先）。
     """
 
-    flag_path: Path | None = None
+    flag_path: Path | None = None  # --settings <file>（flag 层 settings.json）
+    mcp_config: str | None = None  # --mcp-config <file>（flag 层 mcp.json；未剥 `@`、未校验）
 
 
 def _root_state(ctx: typer.Context) -> _RootState:
@@ -202,6 +208,7 @@ def _root(
     # Click 子上下文默认继承父 ctx.obj，故无论是否带子命令都先填充（无子命令时 run 路径仍走显式参数）。
     ctx.obj = _RootState(
         flag_path=Path(settings_file) if isinstance(settings_file, str) else None,
+        mcp_config=mcp_config if isinstance(mcp_config, str) else None,
     )
 
     if ctx.invoked_subcommand is None:
@@ -337,6 +344,7 @@ def _run_impl(
 
 @app.command()
 def run(
+    ctx: typer.Context,
     auto_connect: bool = typer.Option(True, help="是否自动连接 / Auto connect"),
     auto_reconnect: bool = typer.Option(True, help="是否自动重连 / Auto reconnect"),
     url: str | None = typer.Option(None, help="Socket.IO 服务器URL，例如 https://host:port"),
@@ -366,6 +374,11 @@ def run(
     中文: 启动计算机并进入持续运行模式。servers 与 inputs 经 mcp.json 各 scope（含 ``--mcp-config`` flag 层）声明。
     English: Boot the computer and enter the persistent loop. Servers/inputs come from mcp.json scopes.
     """
+    # flag 文件对兜底回读根级（隔离审查 🔴2）：``a2c-computer --mcp-config x.json run`` 里 flag 被 Click 归给
+    # 根回调，``run`` 自身收到 None ⇒ 不回读就**静默丢弃**（连 fail-fast 都碰不到）。``run`` 自身显式值优先。
+    st = _root_state(ctx)
+    mcp_config = mcp_config if isinstance(mcp_config, str) else st.mcp_config
+    settings_file = settings_file if isinstance(settings_file, str) else (str(st.flag_path) if st.flag_path else None)
     _run_impl(
         auto_connect=auto_connect,
         auto_reconnect=auto_reconnect,

--- a/a2c_smcp/computer/cli/main.py
+++ b/a2c_smcp/computer/cli/main.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import asyncio
 import json
 import os
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -23,8 +23,8 @@ from typing import Any
 import typer
 from prompt_toolkit import PromptSession
 from prompt_toolkit.patch_stdout import patch_stdout
-from pydantic import TypeAdapter
 
+from a2c_smcp.computer.cli.commands import files_only_non_plugin_bundle_ids
 from a2c_smcp.computer.cli.commands import marketplace as mp_cmd
 from a2c_smcp.computer.cli.commands import plugin as plugin_cmd
 from a2c_smcp.computer.cli.commands import settings as settings_cmd
@@ -45,12 +45,24 @@ from a2c_smcp.computer.skills.registry import SkillRegistry
 from a2c_smcp.computer.socketio.client import SMCPComputerClient
 from a2c_smcp.computer.utils import console as console_util
 from a2c_smcp.smcp import SMCP_NAMESPACE
-from a2c_smcp.smcp import MCPServerConfig as SMCPServerConfigDict
-from a2c_smcp.smcp import MCPServerInput as SMCPServerInputDict
 
 app = typer.Typer(add_completion=False, help="A2C Computer CLI")
 # 使用全局 Console（引用模块属性，便于后续动态切换）
 console = console_util.console
+
+# flag scope 的**文件对**（协议 §2.5-3）：`--mcp-config`（flag 层 mcp.json）+ `--settings`（flag 层 settings.json），
+# 与其余 scope 的双文件形态对称。二者均在根回调与 `run` 上各声明一份（根回调 `invoke_without_command=True` 时
+# **就是** run 路径，故 `a2c-computer --mcp-config x.json` 必须可用）⇒ help 文案抽常量，杜绝两份漂移。
+# The flag-scope **file pair**; declared on both the root callback and `run` (the root callback *is* the run path
+# when no subcommand is given) ⇒ help text is a shared constant so the two copies cannot drift.
+_MCP_CONFIG_HELP = (
+    "额外 mcp.json（flag scope，含 servers/inputs；优先级次高、仅低于 policy）。支持 @file 语法或直接文件路径 / "
+    "extra mcp.json (flag scope, with servers/inputs; second-highest precedence, below policy only)"
+)
+_SETTINGS_HELP = (
+    "额外 settings.json（flag scope，优先级次高、仅低于 policy）/ extra settings.json (flag scope, second-highest "
+    "precedence, below policy only)"
+)
 
 
 # ------------------------------
@@ -74,6 +86,49 @@ def _root_state(ctx: typer.Context) -> _RootState:
     """从 Typer 上下文取根状态；缺失（未经根回调，如单测直呼）时回退空状态。/ Read root state, empty fallback。"""
     obj = ctx.obj
     return obj if isinstance(obj, _RootState) else _RootState()
+
+
+def _mcp_flag_path(raw: str | None) -> Path | None:
+    """
+    ``--mcp-config`` → 校验过的 :class:`Path`；形状不符 **fail-fast** / Validate the flag file's shape, fail-fast。
+
+    **为何在此 fail-fast，而非交给** :func:`~a2c_smcp.computer.settings.mcp_config.load_mcp_config_file`：后者按 §5.6
+    对**全部五个 durable scope** 共用地容错（人编文件：损坏 → 空视图 + 诊断 + 保留原文件），在那里 fail-fast 会让一份
+    陈旧的 user-scope ``mcp.json`` 阻断启动。不对称是**刻意**的：durable 文件是**环境既有**的 ⇒ 容错；flag 文件是
+    **操作员此刻在命令行上点名**的 ⇒ 形状不符意味着他要的**每个 server 都没加载**，静默降级会把人丢进一个空的 REPL、
+    而那行红字早已滚出屏幕。
+
+    这也是对历史 ``--config`` 那两个裸 ``except Exception`` + ``# pragma: no cover`` 吞异常块的**刻意反转**——
+    拼错的路径本会静默降级启动。退出码 2 = Click 的 usage-error 惯例。
+
+    **v0.3.0 破坏性变更**：文件形状由旧 ``--config`` 的「裸 server 对象 / server 数组」硬切为 ``mcp.json`` 形状
+    ``{"servers": {...}, "inputs": [...]}``（协议 §2.5-3：flag scope 的文件对 = ``--mcp-config`` + ``--settings``）。
+    无存量用户，按通用口径不做兼容设计。
+    """
+    if not isinstance(raw, str):  # 直呼 _run_impl 时 OptionInfo 可能泄漏 → 守卫（同 settings_file 姿态）
+        return None
+    path = Path(raw[1:] if raw.startswith("@") else raw)  # ``@file`` 是可选糖，与裸路径等价
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except Exception as e:
+        console.print(f"[red]✗ 无法读取 --mcp-config 文件 / cannot read --mcp-config file: {path}: {e}[/red]")
+        raise typer.Exit(2) from e
+    if isinstance(data, Mapping) and ("servers" in data or "inputs" in data):
+        return path
+    # 形状不符：尽量说清「实际是什么」+ 给出可照抄的改写形状。
+    shape = "server 数组 / an array of servers" if isinstance(data, list) else f"{type(data).__name__}"
+    if isinstance(data, Mapping):
+        shape = "裸 server 对象（无 servers/inputs 键）/ a bare server object (no servers/inputs key)"
+    console.print(
+        f"[red]✗ --mcp-config 文件格式无效 / invalid --mcp-config file: {path}[/red]\n"
+        f"[red]  期望 mcp.json 形状 {{'servers': {{...}}, 'inputs': [...]}}，实际为 {shape}。[/red]\n"
+        f"[red]  Expected the mcp.json shape {{'servers': {{...}}, 'inputs': [...]}}.[/red]\n"
+        "[yellow]  提示：v0.3.0 起 --config 的裸 server 格式已废止，server 身份由 map key 承载"
+        "（**去掉 body 里的 name 字段**，否则会因 name≠key 被丢弃）：[/yellow]\n"
+        '[yellow]  Hint: the legacy bare-server format is removed; the map key is the identity (drop the "name" field):[/yellow]\n'
+        '[dim]  {"servers": {"<server-name>": {"type": "stdio", "server_parameters": {...}}}, "inputs": []}[/dim]',
+    )
+    raise typer.Exit(2)
 
 
 # ------------------------------
@@ -125,9 +180,8 @@ def _root(
         help="关闭彩色输出（PyCharm控制台不渲染ANSI时可使用） / Disable ANSI colors",
     ),
     json_output: bool = typer.Option(False, "--json", help="非交互默认 JSON 输出（子命令亦各带 --json）/ JSON output"),
-    settings_file: str | None = typer.Option(
-        None, "--settings", help="额外 settings.json（flag scope，最低优先级）/ extra settings.json (flag scope)",
-    ),
+    mcp_config: str | None = typer.Option(None, "--mcp-config", "-c", help=_MCP_CONFIG_HELP),
+    settings_file: str | None = typer.Option(None, "--settings", help=_SETTINGS_HELP),
     approve_all_mcp: bool = typer.Option(
         False, "--approve-all-mcp", help="启动期全批 pending MCP server（仅本次、不落盘）/ approve all pending MCP (this run)",
     ),
@@ -152,7 +206,7 @@ def _root(
 
     if ctx.invoked_subcommand is None:
         # 注意：不要直接调用被 @app.command 装饰的 run()，否则未传入的参数会保留 OptionInfo 默认值
-        # 这里改为调用纯实现函数 _run_impl，并显式传入 config=None 与 inputs=None。
+        # 这里改为调用纯实现函数 _run_impl。
         _run_impl(
             auto_connect=auto_connect,
             auto_reconnect=auto_reconnect,
@@ -161,8 +215,7 @@ def _root(
             auth=auth,
             headers=headers,
             computer_factory=computer_factory,
-            config=None,
-            inputs=None,
+            mcp_config=mcp_config,
             approve_all_mcp=approve_all_mcp,
             settings_file=settings_file,
         )
@@ -173,11 +226,15 @@ async def _interactive_loop(
     init_client: SMCPComputerClient | None = None,
     *,
     approve_all_mcp: bool = False,
-    mcp_flag_config: Path | None = None,
+    settings_flag_path: Path | None = None,
 ) -> None:
     """
     中文: 兼容外部引用的包装器，委托到 interactive_impl，并注入依赖。
     English: Backward-compatible wrapper that delegates to interactive_impl with dependencies injected.
+
+    ``settings_flag_path`` = ``--settings <file>``（flag 层 **settings.json**）。旧名 ``mcp_flag_config`` 已更名：
+    它从来不是 mcp.json，那个名字主动误导（#154）。flag 层 **mcp.json**（``--mcp-config``）走另一条路——注入
+    :class:`Computer`（boot 声明式输入），不经本参数。
     """
     await _interactive_loop_impl(
         comp,
@@ -187,7 +244,7 @@ async def _interactive_loop(
         init_client=init_client,
         completer=A2CCompleter(comp),
         approve_all_mcp=approve_all_mcp,
-        mcp_flag_config=mcp_flag_config,
+        settings_flag_path=settings_flag_path,
     )
 
 
@@ -200,8 +257,7 @@ def _run_impl(
     auth: str | None,
     headers: str | None,
     computer_factory: str | None,
-    config: str | None,
-    inputs: str | None,
+    mcp_config: str | None,
     approve_all_mcp: bool = False,
     settings_file: str | None = None,
 ) -> None:
@@ -209,9 +265,17 @@ def _run_impl(
     纯实现函数：不要在此处使用 Typer 的 Option 默认值，避免 OptionInfo 泄露到运行时。
     Both CLI (@app.command) 与回调 (@app.callback) 在需要时调用本函数。
 
-    approve_all_mcp / settings_file 来自全局 flag ``--approve-all-mcp`` / ``--settings``
-    （#69 Group B/D）：透传启动期 MCP 批准框 / flag scope 文件。
+    approve_all_mcp / settings_file / mcp_config 来自全局 flag ``--approve-all-mcp`` / ``--settings`` /
+    ``--mcp-config``：透传启动期 MCP 批准框 + flag scope 的**文件对**（settings.json + mcp.json，§2.5-3）。
+
+    ``--mcp-config`` **不在此急切挂载**（#154）：它是 flag 层 mcp.json，经 :class:`Computer` 注入、由
+    :func:`~a2c_smcp.computer.cli.commands.plugin.run_mcp_approval` 与其余 scope **同一条**解析/门控/挂载路径处理。
+    历史 ``--config`` 在此 ``json.loads`` → ``amount_server`` 直挂，**绕开 scope 合并、origin 记录与审批门**——
+    正是 origin 缺失（§2.5-5 MUST）与 §4.9.1-2 连坐停摘用户 server 的根源。
     """
+    # 形状 fail-fast **先于任何副作用**：历史解析在 ``connect`` 之后（旧 :255 vs :275），坏文件会留下一个已连接的
+    # socket 和一个已 boot 的 Computer。/ Validate before any side effect (the old parse ran post-connect).
+    flag_mcp_path = _mcp_flag_path(mcp_config)
 
     async def _amain() -> None:
         # 初始化空配置，后续通过交互动态维护 / init with empty config, then manage dynamically
@@ -229,12 +293,16 @@ def _run_impl(
             console.print("[red]计算机构造目标不可调用，将回退到默认 Computer[/red]")
             comp_factory_obj = Computer
 
+        # inputs / mcp_servers 恒空：CLI **不是**嵌入式宿主 —— 所有 server 经声明面（mcp.json 各 scope，含
+        # ``--mcp-config`` flag 层）解析后由审批门挂载，或经 REPL 运行期挂载。``mcp_servers`` 是 embed 层的
+        # 声明面（§2.5-3），CLI 下恒空是正确表现、非缺陷（见 ``Computer.__init__``）。
         comp = comp_factory_obj(
             name="friday_hands",
             inputs=set(),
             mcp_servers=set(),
             auto_connect=auto_connect,
             auto_reconnect=auto_reconnect,
+            mcp_flag_config=flag_mcp_path,
         )
         async with comp:
             init_client: SMCPComputerClient | None = None
@@ -254,51 +322,14 @@ def _run_impl(
                 await init_client.connect(url, auth=auth_dict, headers=headers_dict, namespaces=[effective_namespace])
                 console.print("[green]已通过启动参数连接到 Socket.IO / Connected via CLI options[/green]")
 
-            # 启动参数加载 inputs 与 servers 配置
-            # Load inputs first (so that servers config rendering can use them if needed later via interactive commands)
-            if inputs:
-                try:
-                    ipath = inputs[1:] if inputs.startswith("@") else inputs
-                    data = json.loads(Path(ipath).read_text(encoding="utf-8"))
-                    # 允许单个对象或数组
-                    if isinstance(data, list):
-                        raw_items = TypeAdapter(list[SMCPServerInputDict]).validate_python(data)
-                        models: set[MCPServerInputModel] = {TypeAdapter(MCPServerInputModel).validate_python(item) for item in raw_items}
-                        comp.update_inputs(models)
-                    else:
-                        item: SMCPServerInputDict = TypeAdapter(SMCPServerInputDict).validate_python(data)
-                        comp.add_or_update_input(TypeAdapter(MCPServerInputModel).validate_python(item))
-                    console.print("[green]已加载 Inputs 配置 / Inputs loaded[/green]")
-                except Exception as e:  # pragma: no cover
-                    console.print(f"[red]加载 Inputs 失败 / Failed to load inputs: {e}[/red]")
-
-            if config:
-                try:
-                    spath = config[1:] if config.startswith("@") else config
-                    data = json.loads(Path(spath).read_text(encoding="utf-8"))
-                    # 允许单个对象或数组
-
-                    async def _add_server(cfg_obj: dict[str, Any]) -> None:
-                        validated: dict[str, Any] = TypeAdapter(SMCPServerConfigDict).validate_python(cfg_obj)
-                        # #137 ③：`--config @file` 加载既有声明 = 投影（加载 ≠ 用户此刻新声明），走 transient
-                        # amount_server，不回写 mcp.json（对齐 rust boot approval 用 mount_server，见 #138）。
-                        await comp.amount_server(validated)
-
-                    if isinstance(data, list):
-                        for cfg in data:
-                            await _add_server(cfg)
-                    else:
-                        await _add_server(data)
-                    console.print("[green]已加载 Servers 配置 / Servers loaded[/green]")
-                except Exception as e:  # pragma: no cover
-                    console.print(f"[red]加载 Servers 失败 / Failed to load servers: {e}[/red]")
-
+            # `--mcp-config` 的 servers/inputs 不在此加载：它是 flag 层 mcp.json，已注入 Computer，由
+            # `run_mcp_approval` 与 user/project/local/policy 各层**同路**解析（含 inputs 入池）+ 过审批门 + 挂载。
             # settings_file 直接调用 run() 时可能泄漏 OptionInfo → isinstance 守卫（同 computer_factory 容错姿态）。
             await _interactive_loop(
                 comp,
                 init_client=init_client,
                 approve_all_mcp=approve_all_mcp is True,
-                mcp_flag_config=Path(settings_file) if isinstance(settings_file, str) else None,
+                settings_flag_path=Path(settings_file) if isinstance(settings_file, str) else None,
             )
 
     asyncio.run(_amain())
@@ -325,28 +356,15 @@ def run(
             "不支持以 '.' 开头的相对导入；模块解析相对于运行 a2c-computer 时的工作目录可导入包环境。"
         ),
     ),
-    config: str | None = typer.Option(
-        None,
-        "--config",
-        "-c",
-        help="在启动时从文件加载 MCP Servers 配置（支持 @file 语法或直接文件路径） / Load MCP Servers from file at startup",
-    ),
-    inputs: str | None = typer.Option(
-        None,
-        "--inputs",
-        "-i",
-        help="在启动时从文件加载 Inputs 定义（支持 @file 语法或直接文件路径） / Load Inputs from file at startup",
-    ),
-    settings_file: str | None = typer.Option(
-        None, "--settings", help="额外 settings.json（flag scope，最低优先级）/ extra settings.json (flag scope)",
-    ),
+    mcp_config: str | None = typer.Option(None, "--mcp-config", "-c", help=_MCP_CONFIG_HELP),
+    settings_file: str | None = typer.Option(None, "--settings", help=_SETTINGS_HELP),
     approve_all_mcp: bool = typer.Option(
         False, "--approve-all-mcp", help="启动期全批 pending MCP server（仅本次、不落盘）/ approve all pending MCP (this run)",
     ),
 ) -> None:
     """
-    中文: 启动计算机并进入持续运行模式。后续将支持从配置文件加载 servers 与 inputs。
-    English: Boot the computer and enter persistent loop. Config-file loading will be added later.
+    中文: 启动计算机并进入持续运行模式。servers 与 inputs 经 mcp.json 各 scope（含 ``--mcp-config`` flag 层）声明。
+    English: Boot the computer and enter the persistent loop. Servers/inputs come from mcp.json scopes.
     """
     _run_impl(
         auto_connect=auto_connect,
@@ -356,8 +374,7 @@ def run(
         auth=auth,
         headers=headers,
         computer_factory=computer_factory,
-        config=config,
-        inputs=inputs,
+        mcp_config=mcp_config,
         approve_all_mcp=approve_all_mcp,
         settings_file=settings_file,
     )
@@ -489,7 +506,9 @@ def _plugin_uninstall(
     """卸载 plugin / Uninstall a plugin."""
     code = asyncio.run(
         plugin_cmd.plugin_uninstall(
-            SkillRegistry(), ensure_skill_home(), os.environ, plugin_id, keep_servers=keep_servers, json_output=json_output,
+            SkillRegistry(), ensure_skill_home(), os.environ, plugin_id,
+            non_plugin_bundle_ids=files_only_non_plugin_bundle_ids(os.environ),
+            keep_servers=keep_servers, json_output=json_output,
         ),
     )
     raise typer.Exit(code)
@@ -508,7 +527,11 @@ def _plugin_enable(plugin_id: str = typer.Argument(...), json_output: bool = typ
 def _plugin_disable(plugin_id: str = typer.Argument(...), json_output: bool = typer.Option(False, "--json")) -> None:
     """禁用 plugin = 整 plugin 下线 / Disable a plugin (whole-plugin offline)."""
     code = asyncio.run(
-        plugin_cmd.plugin_disable(SkillRegistry(), ensure_skill_home(), os.environ, plugin_id, json_output=json_output),
+        plugin_cmd.plugin_disable(
+            SkillRegistry(), ensure_skill_home(), os.environ, plugin_id,
+            non_plugin_bundle_ids=files_only_non_plugin_bundle_ids(os.environ),
+            json_output=json_output,
+        ),
     )
     raise typer.Exit(code)
 
@@ -540,7 +563,9 @@ def _plugin_gc(
     """清理孤儿 plugin + 诊断悬挂意图（非交互删权威意图须显式 --prune-dangling）/ GC orphans + diagnose dangling."""
     code = asyncio.run(
         plugin_cmd.plugin_gc(
-            SkillRegistry(), ensure_skill_home(), os.environ, confirm=None, prune_dangling=prune_dangling, json_output=json_output,
+            SkillRegistry(), ensure_skill_home(), os.environ,
+            non_plugin_bundle_ids=files_only_non_plugin_bundle_ids(os.environ),
+            confirm=None, prune_dangling=prune_dangling, json_output=json_output,
         ),
     )
     raise typer.Exit(code)

--- a/a2c_smcp/computer/computer.py
+++ b/a2c_smcp/computer/computer.py
@@ -69,6 +69,8 @@ from a2c_smcp.computer.settings.installer import migrate_legacy_installs
 from a2c_smcp.computer.settings.mcp_config import (
     McpWriteScope,
     McpWriteTargetError,
+    ResolvedMcpConfig,
+    is_writable_origin,
     remove_mcp_server,
     resolve_mcp_config,
     upsert_mcp_server,
@@ -125,6 +127,7 @@ class Computer(BaseComputer[PromptSession]):
         blob_resolvers: dict[str, BlobResolver] | None = None,
         blob_thresholds: BlobThresholds | None = None,
         skill_home: Path | None = None,
+        mcp_flag_config: Path | None = None,
     ) -> None:
         """
         初始化 Computer 实例
@@ -158,11 +161,28 @@ class Computer(BaseComputer[PromptSession]):
                 ``A2C_SKILL_HOME`` → ``$XDG_DATA_HOME/a2c/skills`` → ``~/.a2c/skills`` 解析链。
                 mcp 源 ``skill://`` 物化落盘于 ``<home>/mcp/<server>/<skill>/``。
                 SKILL Home root override (test/deploy injection); defaults to the env resolution chain.
+            mcp_flag_config (Path | None): flag 层 ``mcp.json`` 路径（CLI ``--mcp-config <file>``，含
+                ``servers``/``inputs``；优先级**次高、仅低于 policy**，§2.5-3）。与 ``mcp_servers``（embed 层）
+                同属**当次 boot 的声明式输入** —— §2.5-5 要求 origin 集「可从当次 boot 的声明式输入重建」，
+                Computer 即该 boot 对象，故二者同住于此，经 :meth:`resolve_mcp_declarations` 一并投影。
+                The flag-layer mcp.json path (CLI ``--mcp-config``); a boot-declarative input alongside
+                ``mcp_servers`` (the embed layer). See :meth:`resolve_mcp_declarations`.
         """
         self.name = name
         self.mcp_manager: MCPServerManager | None = None
         self._inputs: set[MCPServerInput] = set(inputs or set())
+        # **embed scope 的声明面**（协议 §2.5-3 / §2.5-5，Discussion #32 裁决）：宿主构造入参 = 代码级显式意图。
+        # The **embed-scope declaration surface**: the embedded host's constructor args = explicit code-level intent.
+        #
+        # ⚠️ 勿被历史注释误导：本字段**仅在此处赋值一次、全仓无第二处写入**，CLI 下恒空（`cli/main.py` 传
+        # `mcp_servers=set()`，所有 server 走运行期挂载）。#149/#153 据此定性它为「构造期死快照」——那**依然成立**，
+        # 指的是「MUST NOT 把它当**运行期活跃集**读」（它对运行期挂载不可见，读它会把「依赖已满足」误判为「未满足」；
+        # 运行期权威见 `active_server_configs()` / `mcp_manager.server_configs()`，§2.5-4）。
+        # 但 §2.5-5 **新增**要求：把它当 **embed 声明层**参与 resolve（见 `resolve_mcp_declarations`）。二者不矛盾——
+        # 它在 CLI 下恒空不是缺陷，而是「CLI 不是嵌入式宿主」的正确表现。
         self._mcp_servers: set[MCPServerConfig] = set(mcp_servers or set())
+        # flag 层 mcp.json 路径（`--mcp-config`）：与 `_mcp_servers` 同为当次 boot 的声明式输入（§2.5-5）。
+        self._mcp_flag_config: Path | None = mcp_flag_config
         # #149：运行期活跃集的**声明面 raw 投影**缓存（bundle_id → raw-with-bundle 未渲染 config）。get_config wire
         # 从此取 body（占位符字面保留、绝不外泄已解析 secret）；SET 仍以 manager 运行期权威为准（见 active_server_configs）。
         # #149: raw (un-rendered) projection of the runtime-active set, keyed by bundle_id — the body source for the
@@ -969,6 +989,27 @@ class Computer(BaseComputer[PromptSession]):
         # 3. 复用 render 结果物化（capability 自动上报；config 上报由调用方驱动，见分账注释）。
         await self._amount_rendered(raw_cfg, validated)
 
+    def resolve_mcp_declarations(self, *, env: Mapping[str, str] | None = None) -> ResolvedMcpConfig:
+        """当次 boot 的**非-plugin 声明面**（协议 §2.5-5 权威集的非-plugin 部分）/ This boot's non-plugin declaration surface。
+
+        = :func:`resolve_mcp_config` 全量层 + 本 Computer 的两条 **boot 声明式输入**：
+        ``--mcp-config``（flag 层，:attr:`_mcp_flag_config`）与宿主构造入参（embed 层，:attr:`_mcp_servers`）。
+        产出条目**均携带正确 origin**，origin 恒 ∈ ``{user, project, local, embed, flag, policy}``（结构性非-plugin，
+        见 :data:`~a2c_smcp.computer.settings.schema.SCOPE_ORDER`）。
+
+        §2.5-5 要求该集合「MUST 可从当次 boot 的声明式输入重建、MUST NOT 落盘为快照」——本方法即**每次重算**、
+        零持久态，天然满足。
+
+        **与 `active_server_configs()` 的分工**（勿混）：本方法是**声明面**（谁被声明了、以何 origin）；
+        ``active_server_configs()`` / ``mcp_manager.server_configs()`` 是**运行期活跃集**（谁真的挂起来了）。
+        依赖预检与 wire 投影读后者（§2.5-4）；回收判据的「X 非用户声明」读前者（§4.9.1-2）。
+        """
+        return resolve_mcp_config(
+            env=env,
+            flag_config_path=self._mcp_flag_config,
+            embed_servers=self._mcp_servers,
+        )
+
     async def aremove_server(self, bundle_id: str, *, session: PromptSession | None = None) -> None:
         """**持久删除**一个 MCP server 声明（bundle_id → 声明名 → 删所有可写 scope）+ 运行期停摘 / Durably remove。
 
@@ -978,42 +1019,63 @@ class Computer(BaseComputer[PromptSession]):
         **守卫按 origin 判定，不按账本名集**（#148 / 指南 §5，取代历史 name-keyed bundled 拒删——那会误伤与某已装
         plugin bundled server 同名的用户 server）：
 
-        1. **声明优先**：经 :func:`resolve_mcp_config` 取**快照**，收集 ``bundle_id`` 匹配的**用户侧声明名**
-           （:func:`resolve_bundle_id` 逐条比对）。
-        2. **有用户侧声明 ⇒ 放行**：经 ① :func:`remove_mcp_server` 删**所有可写 scope** + :meth:`aunmount_server_by_id`
-           停摘。删的是用户自己那条声明——即便它与某 plugin bundled server 同 bundle_id，用户覆盖权优先（runtime-contract
-           §2.5「用户主权」），plugin 基线保留。
-        3. **无用户侧声明 ∧ 运行期仍有该 bundle_id 活跃投影 ⇒ 拒删**（抛 :class:`McpWriteTargetError`）：它是**纯运行期
-           投影**——「挂载却不落声明」的生产路径有 plugin/治理重挂（#137③）与 ``--config @file`` 预加载（``cli/main.py``），
-           均经 transient :meth:`amount_server` 挂载、不入 :func:`resolve_mcp_config`（层仅 FLAG/USER/PROJECT/LOCAL/POLICY，
-           **无 plugin origin**——boot 挂 mcp.json 声明的投影有盘上声明、落档 2）。durable rm 只操作声明面，对无声明的投影
-           拒删——若属 plugin 应经 ``plugin uninstall`` **整体**停用（单独打掉某 bundled server 产生 §2.4 禁止的半态），若
-           属纯 transient 应经 :meth:`aunmount_server_by_id` 停摘。**架构限制**：manager 不存 provenance，本 scope（#148 不依赖
-           #153/#154）下无法精确区分 ``origin == plugin``，故保守拒删——这即指南 §5「``origin == plugin`` ∧ 无用户侧声明」
-           在当前架构下的**可观测等价**（宁可拒删导向显式停用，也不越权停摘一个非用户声明的投影）。
-        4. **无用户侧声明 ∧ 未活跃 ⇒ no-op**（无声明可删、无投影可停；``aunmount_server_by_id`` 幂等 no-op）。
+        1. **声明优先**：经 :meth:`resolve_mcp_declarations` 取**快照**（含 flag/embed 层），收集 ``bundle_id``
+           匹配的声明名（:func:`resolve_bundle_id` 逐条比对）。
+        2. **有声明 ∧ origin 可写（user/project/local）⇒ 放行**：经 :func:`remove_mcp_server` 删**所有可写 scope**
+           + :meth:`aunmount_server_by_id` 停摘。删的是用户自己那条声明——即便它与某 plugin bundled server 同
+           bundle_id，用户覆盖权优先（runtime-contract §2.5「用户主权」），plugin 基线保留。
+
+           *为何 origin 可写 ⇒ 删干净*：只读 scope（embed/flag/policy）在 §2.5-3 序中**全部高于**三个可写 scope
+           ⇒ origin 若是可写 scope，该名在只读层**必然无声明**（否则 origin 就会是那个更高的只读 scope）⇒ 删尽可写
+           scope 即删尽该名的全部声明。
+        3. **有声明 ∧ origin 只读（embed/flag/policy）⇒ 拒删**（抛 :class:`McpWriteTargetError`）：胜出的那条声明
+           SDK **删不掉**（policy 企业托管 / flag 命令行文件 / embed 宿主构造入参根本不在盘上）。若仍走档 2 会
+           **静默假成功**——``remove_mcp_server`` 无声可删、``aunmount`` 停摘、返回成功，而下次 boot 该声明原样复活
+           （#143 正在根治的同类假成功）。故显式报错并指出真正的关停途径。
+        4. **无声明 ∧ 运行期仍有该 bundle_id 活跃投影 ⇒ 拒删**（抛 :class:`McpWriteTargetError`）：它是**纯运行期
+           投影**——「挂载却不落声明」的生产路径为 plugin/治理重挂（#137③）与临时 :meth:`amount_server`，均不入
+           :func:`resolve_mcp_config`。durable rm 只操作声明面，对无声明的投影拒删——若属 plugin 应经
+           ``plugin uninstall`` **整体**停用（单独打掉某 bundled server 产生 §2.4 禁止的半态），若属纯 transient
+           应经 :meth:`aunmount_server_by_id` 停摘。**架构限制**：``origin == plugin`` 不进 resolve（结构性缺席，见
+           :data:`~a2c_smcp.computer.settings.schema.SCOPE_ORDER`）故仍不可精确区分，保守拒删 = 指南 §5
+           「``origin == plugin`` ∧ 无用户侧声明」的**可观测等价**（宁可拒删导向显式停用，也不越权停摘）。
+        5. **无声明 ∧ 未活跃 ⇒ no-op**（无声明可删、无投影可停；``aunmount_server_by_id`` 幂等 no-op）。
 
         Args:
             bundle_id (str): MCP Server 唯一身份 bundle_id（协议 #18）。REPL ``server rm <name>`` 在缺省身份下
                 （bundle_id = normalize(name)）以 name 寻址即可。
+
+        Raises:
+            McpWriteTargetError: 档 3（声明只存在于只读 scope）或档 4（纯运行期投影）。
         """
         env = os.environ
-        # 1. 声明优先：快照解析用户侧声明名（未渲染 config，derive-on-raw 与注册边界同源）。
-        snapshot = resolve_mcp_config(env=env)
-        matched = {name for name, srv in snapshot.servers.items() if resolve_bundle_id(srv.config) == bundle_id}
+        # 1. 声明优先：快照解析声明名（未渲染 config，derive-on-raw 与注册边界同源）。含 flag/embed 层（§2.5-5）。
+        snapshot = self.resolve_mcp_declarations(env=env)
+        matched = {name: srv.origin for name, srv in snapshot.servers.items() if resolve_bundle_id(srv.config) == bundle_id}
         if matched:
-            # 2. 有用户侧声明 ⇒ 放行：删所有可写 scope + 停摘（用户覆盖权，即便与某 bundled 同 bundle_id 亦可删）。
+            # 3. 胜出声明落只读 scope ⇒ 删不掉，拒删而非静默假成功（见 docstring 档 3）。
+            readonly = {name: origin for name, origin in matched.items() if not is_writable_origin(origin)}
+            if readonly:
+                detail = ", ".join(f"{name!r} (origin={origin.value})" for name, origin in sorted(readonly.items()))
+                raise McpWriteTargetError(
+                    f"bundle_id={bundle_id!r} is declared in a read-only scope and cannot be durably removed: {detail}. "
+                    "A 'policy' declaration is enterprise-managed (edit managed-mcp.json); a 'flag' declaration comes "
+                    "from this run's '--mcp-config <file>' (drop it from that file or from the command line); an "
+                    "'embed' declaration comes from the embedding host's Computer(mcp_servers=...) constructor "
+                    "argument. To only stop it for this run, unmount the projection instead.",
+                )
+            # 2. origin 可写 ⇒ 放行：删所有可写 scope + 停摘（用户覆盖权，即便与某 bundled 同 bundle_id 亦可删）。
             for name in matched:
                 remove_mcp_server(name, env=env)
             await self.aunmount_server_by_id(bundle_id)
             return
-        # 3. 无用户侧声明 ∧ 运行期仍活跃 ⇒ plugin/治理投影，拒删、导向 plugin uninstall（origin==plugin 的可观测等价）。
+        # 4. 无声明 ∧ 运行期仍活跃 ⇒ plugin/治理投影，拒删、导向 plugin uninstall（origin==plugin 的可观测等价）。
         if self.mcp_manager is not None and any(
             resolve_bundle_id(cfg) == bundle_id for cfg in self.mcp_manager.server_configs()
         ):
             raise McpWriteTargetError(
-                f"bundle_id={bundle_id!r} has no user-side mcp.json declaration but is active at runtime; "
-                "it is a runtime-only projection (a plugin/governance mount, or a '--config @file' preload), "
+                f"bundle_id={bundle_id!r} has no mcp.json declaration but is active at runtime; "
+                "it is a runtime-only projection (a plugin/governance mount, or an ad-hoc amount_server), "
                 "not a durably-declared server—if it is plugin-provided use 'plugin uninstall' to disable the "
                 "whole plugin; otherwise unmount the transient projection directly instead of removing it via mcp.json",
             )

--- a/a2c_smcp/computer/computer.py
+++ b/a2c_smcp/computer/computer.py
@@ -898,9 +898,9 @@ class Computer(BaseComputer[PromptSession]):
         """**运行期挂载**一个 MCP server（渲染校验 → 物化，**不落盘**）/ Transient mount (no disk write)。
 
         对齐 rust ``mount_server``。语义 = 本 SDK 历史 ``aadd_or_aupdate_server`` 的**原状**（现已 flip 为 durable，
-        故抽此新名承接纯运行期投影）。用于「把别处已是真相的东西投影进 runtime」：boot 读已声明 mcp.json 挂载、
-        ``--config @file`` 加载、plugin/治理 bundled 重挂——这些**不应回写** mcp.json（否则双源 / 每 boot 重写 /
-        scope 漂移，见 #138）。只 bump **capability**（manager 物化自动上报），不碰持久 config。
+        故抽此新名承接纯运行期投影）。用于「把别处已是真相的东西投影进 runtime」：boot 读已声明 mcp.json 各 scope
+        （含 ``--mcp-config`` flag 层）挂载、plugin/治理 bundled 重挂——这些**不应回写** mcp.json（否则双源 /
+        每 boot 重写 / scope 漂移，见 #138）。只 bump **capability**（manager 物化自动上报），不碰持久 config。
 
         Args:
             server: 待挂载配置，可为模型或原始字典。

--- a/a2c_smcp/computer/settings/installer.py
+++ b/a2c_smcp/computer/settings/installer.py
@@ -745,8 +745,14 @@ async def enable_plugin(
     **依赖已满足 ⇒ 复用既有实例**（协议 §2.5-1，#153/D3）：声明的 ``bundle_id`` 若已在运行期活跃集里，
     **跳过 register**——既有实例（用户 mcp.json 声明的，或他 plugin 带入的）胜出，本 plugin 复用它而非覆盖。
     与 :meth:`Computer.reconcile_governance` 的「existing wins → skip」同姿态。
-    完整来源优先序（``plugin < user < project < local < flag < policy``）属 #154 范围；此处「existing wins」
-    是其**可观测等价**（``origin=plugin`` 恒最低 ⇒ 任何既有声明都胜过 plugin 带入的）。
+    完整来源优先序见 :data:`~a2c_smcp.computer.settings.schema.SCOPE_ORDER`（**唯一权威**，勿在此复述字面量
+    ——两处手写序漂移正是 #154 的根因）。此处「existing wins」是「``origin=plugin`` 恒最低」的**可观测等价**：
+    plugin 声明**不进任一 resolve**（结构性缺席，见 ``SCOPE_ORDER`` 的说明），其「输给用户侧」由本处 +
+    :meth:`Computer.reconcile_governance` 的 skip 保证。
+    ⚠️ **等价的边界**：保证的是「plugin 输给任何**已挂载**的 server」，而非「输给任何**声明**」——若某用户声明
+    被审批门拦下（DISABLED / PENDING 未批）而未挂，其 bundle_id 空出，plugin 那份仍会挂上。这与 rust
+    ``collect_enabled_bundled_servers``（plugin 集内 first-wins、不与用户声明比对）**同姿态**，parity 保持；
+    且协议 §5 item 10 明定 plugin 声明 MUST NOT 进审批门，故门控结果本就不该反向决定 plugin 基线。
 
     v0.3.0 §2.4「enable 原子性」：顺序 ① 从物化记录的 ``installPath`` 重解析 bundled servers →
     **依赖预检（先于 settings 写）**；② 快照该 scope ``enabledPlugins`` 原值 + 本 plugin 已活跃 skills →

--- a/a2c_smcp/computer/settings/installer.py
+++ b/a2c_smcp/computer/settings/installer.py
@@ -66,8 +66,8 @@ from pathlib import Path
 from typing import Any
 
 from a2c_smcp.computer.mcp_clients.model import MCPServerConfig
-from a2c_smcp.computer.settings.mcp_config import mcp_json_declared_bundle_ids
 from a2c_smcp.computer.settings.reconciler import (
+    NonPluginBundleIds,
     ledger_mcp_deps_of,
     other_plugin_mcp_deps,
     reclaimable_mcp_deps,
@@ -138,6 +138,9 @@ RegisterServer = Callable[[MCPServerConfig], Awaitable[None]]
 # 运行期停摘一个 server（异步，入参 **bundle_id**；CLI 包 transient ``Computer.aunmount_server_by_id``，
 # 停进程不删声明）。仅对经 §4.9.1-2 回收判据判定**可回收**者调用。
 RemoveServer = Callable[[str], Awaitable[None]]
+# ``NonPluginBundleIds``（§4.9.1-2 回收判据「X 非用户声明」项的数据源，#164）定义在 :mod:`.reconciler`
+# ——判据本体 ``reclaimable_mcp_deps`` 的所在地，且本模块**导入** reconciler（反向导入会成环）。此处仅转导出，
+# 使四个回调别名在 installer 的公开面齐整 / re-exported here so the callback aliases read together.
 # 注入 plugin-scoped inputs 入池（异步；入参 plugin_root；CLI 包 ``load_plugin_inputs`` → ``Computer.add_or_update_input``）。
 # 在 register（→render bundled server 的 ${input:}）之前调，使裸 id 可经 D2 前缀回退解析（#69 Group A，§9.3 D2）。
 InjectInputs = Callable[[Path], Awaitable[None]]
@@ -515,6 +518,7 @@ async def uninstall_plugin(
     registry: SkillRegistry,
     home: Path,
     *,
+    non_plugin_bundle_ids: NonPluginBundleIds,
     scope: str | None = None,
     keep_servers: bool = False,
     env: Mapping[str, str] | None = None,
@@ -569,7 +573,7 @@ async def uninstall_plugin(
     reclaim = reclaimable_mcp_deps(
         deps,
         other_deps=other_plugin_mcp_deps(ledger_plugins, exclude_pid=plugin_id, retained_records=retained),
-        user_declared=mcp_json_declared_bundle_ids(env=env),
+        user_declared=non_plugin_bundle_ids(),
     )
 
     # ② 删树 → ③ 注销 skills → ④ 回收依赖 → ⑤ 删账本记录（⑤ 恒在末位，勿前移，见 §4.9.1-3）
@@ -673,6 +677,7 @@ async def disable_plugin(
     registry: SkillRegistry,
     home: Path,
     *,
+    non_plugin_bundle_ids: NonPluginBundleIds,
     scope: str = "user",
     project_path: str | None = None,
     env: Mapping[str, str] | None = None,
@@ -712,7 +717,7 @@ async def disable_plugin(
         reclaim = reclaimable_mcp_deps(
             sorted(ledger_mcp_deps_of(ledger_plugins.get(plugin_id, []))),
             other_deps=other_plugin_mcp_deps(ledger_plugins, exclude_pid=plugin_id),
-            user_declared=mcp_json_declared_bundle_ids(env=env),
+            user_declared=non_plugin_bundle_ids(),
         )
         for bundle_id in reclaim:
             await remove_server(bundle_id)

--- a/a2c_smcp/computer/settings/mcp_config.py
+++ b/a2c_smcp/computer/settings/mcp_config.py
@@ -45,7 +45,7 @@ from __future__ import annotations
 import json
 import os
 import sys
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass, field
 from enum import StrEnum
 from pathlib import Path
@@ -62,6 +62,7 @@ from a2c_smcp.computer.settings.schema import (
     FIELD_DISABLED_MCPJSON_SERVERS,
     FIELD_ENABLE_ALL_PROJECT_MCP,
     FIELD_ENABLED_MCPJSON_SERVERS,
+    SCOPE_ORDER,
     SettingsScope,
     SettingsValidationError,
 )
@@ -89,9 +90,20 @@ MANAGED_MCP_FILENAME = "managed-mcp.json"  # policy scope（企业下发）
 # 剥离、原样保留交 #65 渲染消费 / VS Code-style extension keys, stripped before validation, kept for #65.
 _VSCODE_EXT_KEYS: frozenset[str] = frozenset({"envFile"})
 
-# 预信任 origin scope（用户/老 flag/企业自己加的 server，不弹批准框，§9.2）；project/local = 工作区共享、
-# 受门控 / Pre-trusted origin scopes (no approval prompt); project/local = workspace-shared, gated.
-_TRUSTED_ORIGINS: frozenset[SettingsScope] = frozenset({SettingsScope.USER, SettingsScope.FLAG, SettingsScope.POLICY})
+# 预信任 origin scope（用户 / CLI 显式传入 / 宿主构造 / 企业自己加的 server，不弹批准框，§9.2 + 审批门档④）；
+# project/local = 工作区共享（入 git、随仓库分发）⇒ 受门控。
+# Pre-trusted origin scopes (no approval prompt); project/local = workspace-shared (git-tracked) ⇒ gated.
+#
+# ``EMBED`` 受信依据（Discussion #32 裁决 / §2.5-3）：宿主构造入参 ``Computer(mcp_servers=...)`` 是**代码级
+# 显式意图**，与 ``flag`` 同属「调用方显式受信层」。注意受信**不等于**豁免——embed 条目仍**进门迭代**，故
+# 档①②③（policy 拒绝名单 / 白名单 / 通用禁用开关）对其适用（用户/管理员保留最终关停权）；只有 project 信任门
+# （``enabledMcpjsonServers`` / ``enableAllProjectMcpServers``，档⑤⑥）因档④已放行而不可达。
+_TRUSTED_ORIGINS: frozenset[SettingsScope] = frozenset(
+    {SettingsScope.USER, SettingsScope.EMBED, SettingsScope.FLAG, SettingsScope.POLICY},
+)
+
+# embed 层的 ``source`` 标签：非文件来源，故不是路径 / Source label for the embed layer (not a file path).
+_EMBED_SOURCE = "<embed:Computer(mcp_servers=...)>"
 
 # 单点构造校验入口（照 manifest.py 范式）/ Single dict→model adapters.
 _MCP_SERVER_ADAPTER: TypeAdapter[MCPServerConfig] = TypeAdapter(MCPServerConfig)
@@ -261,42 +273,67 @@ def _validate_input(idef: Any, scope: SettingsScope, source: str | None) -> tupl
 # ---------------------------------------------------------------------------
 # 多 scope 解析 / Multi-scope resolution
 # ---------------------------------------------------------------------------
+def _embed_layer(embed_servers: Iterable[MCPServerConfig]) -> dict[str, Any]:
+    """
+    宿主构造入参 → mcp.json 形状的 embed 层 / Embedded-constructor args → an mcp.json-shaped embed layer。
+
+    ``Computer(mcp_servers={...})`` 收的是**已校验的模型**，而合并管线吃 raw dict（各层同构、复用
+    :func:`_validate_server`）⇒ 此处 ``model_dump(mode="json")`` 回落 raw。往返无损：``model_config``
+    的 ``populate_by_name`` 令 by-alias 输出（如 ``envFile``）可被重新吸收。
+
+    identity 由 map key 承载（与文件层一致）：key = ``cfg.name``。embed 层**无 inputs**——构造入参
+    ``Computer(inputs=...)`` 是另一条通路（直接入 ``_inputs`` 池），不经本层。
+    """
+    return {"servers": {cfg.name: cfg.model_dump(mode="json") for cfg in embed_servers}, "inputs": []}
+
+
 def resolve_mcp_config(
     *,
     env: Mapping[str, str] | None = None,
     flag_config_path: Path | None = None,
+    embed_servers: Iterable[MCPServerConfig] | None = None,
     managed_mcp_path: Path | None = None,
     platform: str | None = None,
 ) -> ResolvedMcpConfig:
     """
     多 scope 加载合并 ``.tfrobot/mcp.json`` + 字段级校验 / Multi-scope load + merge + validate mcp.json。
 
-    合并顺序 low → high = ``[flag, user, project, local, policy]``（即优先级
-    ``policy > local > project > user > flag``，§9.1/§5.5）；**无能力层并集**（敏感面隔离，区别于
-    settings.json）。#116：project/local 无条件锚定进程 ``os.getcwd()`` 的 ``.tfrobot/mcp[.local].json``
-    （cwd 恒存在；文件缺失 → 层不贡献）。
+    合并顺序**派生自** :data:`~a2c_smcp.computer.settings.schema.SCOPE_ORDER`（协议 §2.5-3 唯一权威，
+    低 → 高 ``user < project < local < embed < flag < policy``），与 settings.json 的
+    :func:`~a2c_smcp.computer.settings.scope.resolve_settings` **同序**——协议明令两套来源 MUST 一致。
+    **无能力层并集**（敏感面隔离，区别于 settings.json）。#116：project/local 无条件锚定进程
+    ``os.getcwd()`` 的 ``.tfrobot/mcp[.local].json``（cwd 恒存在；文件缺失 → 层不贡献）。
+
+    **本函数的 origin 恒 ∈ 非-plugin**（无 plugin 入参、``SettingsScope`` 无 ``PLUGIN`` 成员，见
+    :data:`~a2c_smcp.computer.settings.schema.SCOPE_ORDER` 的「为何无 PLUGIN 成员」）。这是**结构性**保证，
+    不是约定——故本函数产出即协议 §2.5-5 的「带 origin 的运行期权威配置集」中的非-plugin 部分，
+    :func:`non_plugin_declared_bundle_ids` 据此无需过滤。
 
     - **servers**：按 name **整体替换**（高 scope 同名整体覆盖；server config 是原子单元、**非**深合并），
-      ``origin`` = 最高定义 scope，``trusted_origin`` = origin ∈ {user, flag, policy}。
+      ``origin`` = 最高定义 scope，``trusted_origin`` = origin ∈ :data:`_TRUSTED_ORIGINS`。
     - **inputs**：按 ``id`` 去重、高 scope 胜（缺 ``id`` 的条目各自保留以便逐条报错）。
     - 单 server / input 畸形 → drop + :class:`SettingsValidationError`，**不 abort**（§5.6 人编文件容错）。
 
     :param env: 环境映射（解析 user config dir），默认 ``os.environ``。
-    :param flag_config_path: ``--config @file`` 老接口文件（最低优先级，§5.5）。
+    :param flag_config_path: ``--mcp-config <file>``（flag 层 mcp.json，含 ``servers``/``inputs``；
+        **次高优先级、仅低于 policy**，§2.5-3）。历史 ``--config`` 老接口曾把本层排**最低**，协议已废止该形态。
+    :param embed_servers: 宿主构造入参 ``Computer(mcp_servers=...)``（embed 层，§2.5-3）。
     :param managed_mcp_path: policy scope ``managed-mcp.json`` 覆盖路径（缺省按平台推导；便于测试）。
     :param platform: 平台标识（缺省 ``sys.platform``）；仅在 ``managed_mcp_path`` 未给时用于推导 managed 目录。
     """
     managed_path = managed_mcp_path if managed_mcp_path is not None else managed_mcp_config_path(platform)
 
-    # (scope, path) 层，低优先级在前；project/local 锚 cwd（#116）/ layers, lowest first; cwd-anchored.
+    # 各 scope 的数据源（未排序；顺序由 SCOPE_ORDER 唯一决定）；project/local 锚 cwd（#116）。
+    # Per-scope sources (unordered here — SCOPE_ORDER alone decides precedence); cwd-anchored.
     cwd = Path(os.getcwd())
-    layers: list[tuple[SettingsScope, Path]] = []
+    file_sources: dict[SettingsScope, Path] = {
+        SettingsScope.USER: user_mcp_config_path(env),
+        SettingsScope.PROJECT: workdir_mcp_config_path(cwd),
+        SettingsScope.LOCAL: workdir_mcp_local_config_path(cwd),
+        SettingsScope.POLICY: managed_path,
+    }
     if flag_config_path is not None:
-        layers.append((SettingsScope.FLAG, Path(flag_config_path)))
-    layers.append((SettingsScope.USER, user_mcp_config_path(env)))
-    layers.append((SettingsScope.PROJECT, workdir_mcp_config_path(cwd)))
-    layers.append((SettingsScope.LOCAL, workdir_mcp_local_config_path(cwd)))
-    layers.append((SettingsScope.POLICY, managed_path))
+        file_sources[SettingsScope.FLAG] = Path(flag_config_path)
 
     errors: list[SettingsValidationError] = []
     # 累积原始定义（低→高，后者覆盖前者）；server 整体替换 + 记 origin / source / Raw accumulation.
@@ -304,10 +341,18 @@ def resolve_mcp_config(
     raw_inputs: dict[str, tuple[Any, SettingsScope, str]] = {}
     noid = 0
 
-    for scope, path in layers:
-        data, errs = load_mcp_config_file(path, scope)
-        errors.extend(errs)
-        src = str(path)
+    for scope in SCOPE_ORDER:
+        if scope is SettingsScope.EMBED:
+            if not embed_servers:
+                continue
+            data, src = _embed_layer(embed_servers), _EMBED_SOURCE
+        else:
+            path = file_sources.get(scope)
+            if path is None:
+                continue
+            data, errs = load_mcp_config_file(path, scope)
+            errors.extend(errs)
+            src = str(path)
         for srv_name, sdef in data["servers"].items():
             raw_servers[srv_name] = (sdef, scope, src)  # 高 scope 整体覆盖 → origin = 最高 / high wins.
         for idef in data["inputs"]:
@@ -334,27 +379,37 @@ def resolve_mcp_config(
     return ResolvedMcpConfig(servers=servers, inputs=inputs, errors=errors)
 
 
-def mcp_json_declared_bundle_ids(*, env: Mapping[str, str] | None = None) -> set[str]:
+def non_plugin_declared_bundle_ids(
+    *,
+    env: Mapping[str, str] | None = None,
+    flag_config_path: Path | None = None,
+    embed_servers: Iterable[MCPServerConfig] | None = None,
+) -> set[str]:
     """
-    **mcp.json 声明面**（各 scope）全部 server 的 bundle_id 集 / bundle_ids declared in mcp.json。
+    §4.9.1-2 回收判据「X 非用户声明」项的**完整**数据源 / The complete source for the criterion's 2nd term。
 
-    这是回收判据「X 非用户声明」的**其中一个**来源，**不是全部**——完整判定集见
-    :func:`~a2c_smcp.computer.settings.reconciler.user_owned_bundle_ids`（协议 §4.9.1-2 的数据源是
-    **运行期权威配置集** + ``origin != plugin``，而 mcp.json 只覆盖其中「落了声明」的那部分）。
+    = 运行期权威配置集中 ``origin != plugin`` 的 bundle_id 集（协议 §2.5-5 + Discussion #32 裁决）。
+    即 :func:`resolve_mcp_config` 的全部产出——**每条非-plugin 挂载路径都在其中留下携带正确 origin 的条目**：
+    durable scopes（user/project/local/policy）、flag（``--mcp-config``）、embed（``Computer(mcp_servers=...)``）。
 
-    **⚠️ 勿单独用它当「用户声明」判据**（#153 隔离审查 🔴）：「出现在 mcp.json ⇒ 用户声明」成立，但
-    **反向不成立**——用户经 ``a2c-computer run --config @file`` 预加载、或 SDK 内嵌
-    ``Computer(mcp_servers={...})`` 构造的 server 均走 transient ``amount_server`` 挂载，**进运行期活跃集
-    但不进 mcp.json**（``cli/main.py`` `_add_server` / ``computer.py`` boot_up）。只读本视图会把它们误判为
-    「非用户声明」而在 plugin 卸载时**连坐停摘**，正是 §4.9.1-2 与 Epic #147 北极星要根治的 P0。
-    根治需运行期 origin（#134 轴）或 ``--config`` 归一进 mcp.json flag 层（#154）——**方案求裁于
-    protocol Discussion #32**（https://github.com/A2C-SMCP/a2c-smcp-protocol/discussions/32）；在此之前本函数是回收判据「非用户声明」项的**唯一**数据源，
-    该缺口由 ``test_runtime_only_user_server_is_never_collateral``（xfail）钉住。
+    **``origin != plugin`` 无需过滤——由构造保证**：本函数与 :func:`resolve_mcp_config` 均**无 plugin 入参**，
+    且 ``SettingsScope`` **无 ``PLUGIN`` 成员**（见 :data:`~a2c_smcp.computer.settings.schema.SCOPE_ORDER`），
+    故 plugin origin 在此**物理上不可能出现**。plugin 声明基线层不经本 resolve（经 transient ``amount_server``
+    从 manifest 挂载）。
 
-    ``origin`` 无需过滤：本视图的 origin 恒为 ``user/project/local/flag/policy``（plugin 声明依赖的 server
-    从不回写 mcp.json），故 ``origin != plugin`` 在此恒真。同款推理见 :func:`mcp_server_status` 的 #148 注释。
+    ⚠️ **两条被协议钉死为 MUST NOT 的歧路**（§4.9.1-2，本仓实测证伪，勿再尝试）：
+
+    1. **MUST NOT 用裸 manager 活跃集**（无 origin ⇒ flag / embed / plugin 三条挂载路径在其中**可观测同形**
+       ⇒ 连坐停摘用户 / 宿主自有 server）；
+    2. **MUST NOT 用「活跃集 ∖ 全 plugin 声明集」差集**（回收候选**必然**落在 plugin 声明集内，该差集对其
+       **恒空**，判定退化为死代码——#153 期间已实现并实测：守卫仍红）。
+
+    :param env: 环境映射（解析 user config dir），默认 ``os.environ``。
+    :param flag_config_path: ``--mcp-config <file>``（flag 层 mcp.json）。**MUST 传**——漏传会让经 flag
+        挂载的用户 server 退回「非用户声明」而被连坐（正是 #153 遗留缺口的形状）。
+    :param embed_servers: 宿主构造入参 ``Computer(mcp_servers=...)``（embed 层）。同上，**MUST 传**。
     """
-    snapshot = resolve_mcp_config(env=env)
+    snapshot = resolve_mcp_config(env=env, flag_config_path=flag_config_path, embed_servers=embed_servers)
     return {resolve_bundle_id(srv.config) for srv in snapshot.servers.values()}
 
 
@@ -375,20 +430,29 @@ def mcp_server_status(name: str, *, settings: Mapping[str, Any], trusted_origin:
     1. ``deniedMcpServers``（企业拒绝名单，policy）→ ``DISABLED``。
     2. ``allowedMcpServers`` 非空（企业白名单，policy）且不在其中 → ``DISABLED``。
     3. ``disabledMcpjsonServers`` → ``DISABLED``（**disabled 优先** over enabled）。
-    4. ``trusted_origin``（user/flag/policy scope 自定义 server）→ ``ENABLED``（用户自己加的，不弹框）。
+    4. ``trusted_origin``（user/embed/flag/policy origin）→ ``ENABLED``（用户/宿主/CLI/企业自己加的，不弹框）。
     5. ``enabledMcpjsonServers`` → ``ENABLED``。
     6. ``enableAllProjectMcpServers is True`` → ``ENABLED``。
     7. 否则（工作区共享且未决）→ ``PENDING``。
 
-    **#148（P0 安全）**：历史「plugin-bundled 名集免批准」档位（`if name in bundled → ENABLED`）**已删除**。
-    真正的 plugin bundled server **从不进入** :func:`resolve_mcp_config`（走 transient ``amount_server`` 挂载、
-    不落 mcp.json），故该档**唯一可达路径** = project/local 声明的 server 借用了某已装 plugin 的 server 名 =
-    100% 借名跳过审批门。审批门 **MUST NOT 依赖物化账本的名集**，plugin 声明 **MUST NOT 进入迭代**（其可信性由
-    install ∧ enable 门保证，不走 settings 信任面）——见协议 ``runtime-contract.md §5 item 10`` 与
-    ``guides/mcp-approval-gate-alignment.md``。本函数只判 :func:`resolve_mcp_config` 产出的 mcp.json origin，
-    当前架构下这些 origin 恒非 plugin，无需在此额外过滤。
+    **档④ 与 embed**（Discussion #32 裁决）：``embed`` 已入 :data:`_TRUSTED_ORIGINS` ⇒ 命中档④。注意它**进门
+    迭代**、只是在档④ 被放行——故档①②③（policy 拒绝名单 / 白名单 / 通用禁用开关）**对 embed 适用**
+    （用户/管理员保留最终关停权；embed 无 plugin 那样的整体 enable/disable 兜底，不可豁免）；档⑤⑥ 的 project
+    信任门对 embed 不可达。
 
-    :param settings: 六层合并后的 resolved settings（含 #56 落地的 MCP 门控字段）。
+    **#148（P0 安全）**：历史「plugin-bundled 名集免批准」档位（`if name in bundled → ENABLED`）**已删除**。
+    其唯一可达路径 = project/local 声明的 server 借用某已装 plugin 的 server 名 = 100% 借名跳过审批门。
+    审批门 **MUST NOT 依赖物化账本的名集**，plugin 声明 **MUST NOT 进入迭代**（其可信性由 install ∧ enable 门
+    保证，不走 settings 信任面）——见协议 ``runtime-contract.md §5 item 10`` 与
+    ``guides/mcp-approval-gate-alignment.md``。
+
+    **F8 由结构保证、无需过滤器**（#154 裁决）：本函数只判 :func:`resolve_mcp_config` 的产出，而该 resolve
+    **无 plugin 入参**、``SettingsScope`` **无 ``PLUGIN`` 成员**（见
+    :data:`~a2c_smcp.computer.settings.schema.SCOPE_ORDER`）⇒ plugin origin **物理上不可能进入迭代**。
+    在此写 ``if origin is PLUGIN: continue`` 会是**永假守卫**（死代码），且新增一个无生产者的 ``PLUGIN``
+    成员正是档④ 那个「进门后豁免」形状复活的诱因。**验收信号取缺席**（「成员不存在」比「文档说别用」可靠）。
+
+    :param settings: 多层合并后的 resolved settings（含 #56 落地的 MCP 门控字段）。
     :param trusted_origin: 该 server 是否来自预信任 scope（见 :attr:`ResolvedMcpServer.trusted_origin`）。
     """
     if name in _str_list(settings, FIELD_DENIED_MCP_SERVERS):
@@ -537,6 +601,21 @@ _SETTINGS_TO_WRITE_SCOPE: dict[SettingsScope, McpWriteScope] = {v: k for k, v in
 _WRITABLE_SCOPES: tuple[McpWriteScope, ...] = (McpWriteScope.USER, McpWriteScope.PROJECT, McpWriteScope.LOCAL)
 
 
+def is_writable_origin(scope: SettingsScope) -> bool:
+    """
+    该 origin scope 的声明是否**可被 SDK 删改** / Whether declarations of this origin scope are writable by the SDK。
+
+    可写 = ``user`` / ``project`` / ``local``（有 ``mcp.json`` 落点）；只读 = ``policy``（企业托管）、``flag``
+    （``--mcp-config`` 命令行文件）、``embed``（宿主构造入参——根本不在盘上）。
+
+    **纯委托** :data:`_SETTINGS_TO_WRITE_SCOPE`（可写性的单一权威），**勿写 DRY 副本**：判据分叉会让写层与
+    「能不能删」的判定不一致（#142 ``is_valid_bundle_id`` 同款教训）。
+
+    **注意「只读」≠「优先级低」**：``flag``/``embed`` 优先级**次高**（§2.5-3）却不可写——二者正交。
+    """
+    return scope in _SETTINGS_TO_WRITE_SCOPE
+
+
 def mcp_write_path(scope: McpWriteScope, *, env: Mapping[str, str] | None = None) -> Path:
     """
     某写 scope 的 ``mcp.json`` 落点路径 / The ``mcp.json`` write path for a given scope。
@@ -584,8 +663,14 @@ def upsert_mcp_server(
       新声明**生效，杜绝跨 scope 漂移。origin 判定基于**锁外快照**（轻微 TOCTOU：并发进程可在快照与取锁间改动
       声明；实际写在锁内原子）。**注意**：若 origin 为只读 **policy**（``managed-mcp.json``，读优先级最高）则回落
       写请求 scope——但该写会被 policy 定义在 :func:`resolve_mcp_config` 中**遮蔽**（``changed`` 为 ``True`` 而有效
-      配置不变，属 rust parity 行为：policy 非可写目标、等同新声明）；``flag`` origin 优先级最低、user-写胜出、
-      不被遮蔽。
+      配置不变，属 rust parity 行为：policy 非可写目标、等同新声明）。
+
+      ⚠️ **本处的 origin 快照 MUST NOT 串入 ``flag_config_path`` / ``embed_servers``**（#154）：``:608`` 刻意只
+      解析 durable 层（user/project/local/policy）。理由——flag/embed 均**非可写目标**
+      （``_SETTINGS_TO_WRITE_SCOPE`` 无其条目），把它们喂进来只会让 ``target`` 回落到请求 scope 并**额外**造出
+      一条被 flag/embed 遮蔽的重复声明（写成功、有效配置不变），比现状更坏。**已知代价**（follow-up）：REPL
+      ``server add`` 因此看不见 flag 层，写 user scope 报成功、却被 flag 层静默遮蔽——与 policy 同形，但 policy
+      至少已在上文写明「遮蔽」。
     - **不因「同 bundle_id 已由 plugin 提供」而拒写**（#148 / 指南 §5）：用户在 mcp.json 声明同 bundle_id 的 server
       正是优先序赋予的**覆盖权**（用户侧 scope > plugin 声明基线），历史「bundled 名拒写」短路**已删除**。SDK MAY
       在别处提示「该 bundle_id 已由 plugin 提供、你的声明将覆盖它」，但**写层不阻止**。

--- a/a2c_smcp/computer/settings/reconciler.py
+++ b/a2c_smcp/computer/settings/reconciler.py
@@ -44,7 +44,6 @@ from collections.abc import Awaitable, Callable, Iterable, Mapping, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from a2c_smcp.computer.settings.mcp_config import mcp_json_declared_bundle_ids
 from a2c_smcp.computer.settings.schema import is_valid_enabled_plugin_key, is_valid_marketplace_name
 from a2c_smcp.computer.settings.store import (
     InstalledPluginsFile,
@@ -467,6 +466,19 @@ def other_plugin_mcp_deps(
     return out
 
 
+# §4.9.1-2 回收判据「X 非用户声明」项的数据源接缝（同步）/ The criterion's "not user-declared" data-source seam。
+# = **声明面**中 ``origin != plugin`` 的 bundle_id 集；CLI 包 ``Computer.resolve_mcp_declarations()``
+# （durable scopes + flag ``--mcp-config`` + embed 构造入参，每次重算、零持久态，§2.5-5 禁落盘为快照）。
+#
+# 定义在此（而非 :mod:`.installer` 那组回调别名旁）有二：① 判据本体 :func:`reclaimable_mcp_deps` 在本模块，
+# 数据源与判据同源易改不易漂；② installer **导入**本模块，反向导入会成环。installer 转导出本名。
+#
+# ⚠️ **与 :data:`~a2c_smcp.computer.settings.installer.ExistingBundleIds` 判然不同，勿混用**：本接缝是
+# 「谁被声明了（且非 plugin 带入）」，那个是「谁挂起来了」。协议 §4.9.1-2 **明禁**以裸活跃集判回收——无 origin
+# ⇒ flag / embed / plugin 三条挂载路径可观测同形 ⇒ 连坐停摘用户 / 宿主自有 server。
+NonPluginBundleIds = Callable[[], set[str]]
+
+
 def reclaimable_mcp_deps(
     deps: Iterable[str],
     *,
@@ -486,14 +498,12 @@ def reclaimable_mcp_deps(
 
     :param deps: 本次 disable/uninstall 的 plugin 所声明的依赖（``ledger_mcp_deps_of`` 产出）。
     :param other_deps: :func:`other_plugin_mcp_deps` 产出。
-    :param user_declared: :func:`~a2c_smcp.computer.settings.mcp_config.mcp_json_declared_bundle_ids` 产出。
-        ⚠️ **已知未覆盖面**（#153 隔离审查 🔴，方案待三仓 Discussion 定案）：协议把本项的数据源写作「**运行期
-        权威配置集**中 ``origin != plugin`` 的条目」，而本 SDK 的 manager **不存 origin**——用户经
-        ``--config @file`` / SDK 内嵌 ``Computer(mcp_servers={...})`` 挂载的 server 走 transient
-        ``amount_server``、**不落 mcp.json**，与「plugin 自己挂的 server」在可观测信息上**完全同形**。
-        故若该 server 同时被某 plugin 声明依赖，卸载该 plugin 时仍会回收它。详见
-        :func:`~a2c_smcp.computer.settings.mcp_config.mcp_json_declared_bundle_ids`；
-        方案求裁于 protocol Discussion #32（https://github.com/A2C-SMCP/a2c-smcp-protocol/discussions/32）。
+    :param user_declared: :func:`~a2c_smcp.computer.settings.mcp_config.non_plugin_declared_bundle_ids` 产出
+        ——**带 origin 的运行期权威配置集中 ``origin != plugin`` 的 bundle_id 集**（协议 §2.5-5 + §4.9.1-2，
+        Discussion #32 裁决落地于 #164）。它覆盖**全部**非-plugin 挂载路径：durable scopes、flag
+        （``--mcp-config``）、embed（``Computer(mcp_servers=...)``）⇒ 用户 / 宿主自有 server **永不连坐**。
+        MUST NOT 退回只读 mcp.json 声明面（那正是 #153 遗留缺口的形状：经 flag/embed 挂载者会被误判为
+        「非用户声明」而连坐停摘）。
     :return: 可回收的 bundle_id（保 ``deps`` 迭代序）。
     """
     return [d for d in deps if d not in other_deps and d not in user_declared]
@@ -559,6 +569,7 @@ async def gc_plugins(
     registry: SkillRegistry,
     home: Path,
     *,
+    non_plugin_bundle_ids: NonPluginBundleIds,
     env: Mapping[str, str] | None = None,
     mcp_teardown: Callable[[list[str]], Awaitable[None]] | None = None,
 ) -> list[str]:
@@ -588,7 +599,7 @@ async def gc_plugins(
         reclaim = reclaimable_mcp_deps(
             sorted(deps),
             other_deps=other_plugin_mcp_deps(plugins, exclude_pid=pid),
-            user_declared=mcp_json_declared_bundle_ids(env=env),
+            user_declared=non_plugin_bundle_ids(),
         )
         for rec in records:
             install_path = rec.get("installPath")

--- a/a2c_smcp/computer/settings/schema.py
+++ b/a2c_smcp/computer/settings/schema.py
@@ -78,9 +78,21 @@ class SettingsScope(StrEnum):
 # transient ``amount_server`` 从 plugin manifest 挂载；plugin-lowest 由 boot 序保证（``run_mcp_approval``
 # 先于 ``run_governance_remount``，后者跳过 ``bundle_id`` 已活跃者，见 ``installer.py`` 的「existing wins」）。
 # 无任一消费者需要 plugin 层：审批门 MUST 滤掉它（F8）、回收判据要 ``origin != plugin``、``upsert_mcp_server``
-# 只认可写 scope ⇒「合并进来再处处滤掉」与「从不合并」**可证等价**。加一个无生产者的 ``PLUGIN`` 成员会让
-# 「迭代层过滤」沦为永假守卫（死代码），且正是 #148 那个 P0「进门后豁免」档位复活的诱因。F8 的可验收信号
-# 取**缺席**（「成员不存在」比「文档说别用」可靠）。
+# 只认可写 scope ⇒ 对上述三个消费者而言，「合并进来再处处滤掉」与「从不合并」**输出同集**。加一个无生产者的
+# ``PLUGIN`` 成员会让「迭代层过滤」沦为永假守卫（死代码），且正是 #148 那个 P0「进门后豁免」档位复活的诱因。
+# F8 的可验收信号取**缺席**（「成员不存在」比「文档说别用」可靠）。
+#
+# ⚠️ **等价的边界**（隔离审查订正，勿把「等价」读成无限定）：现设计保证「plugin 输给任何**已挂载**的 server」，
+# **非**「输给任何**声明**」——若某用户声明被审批门拦下（DISABLED / PENDING 未批 / 挂载抛异常）而未挂，其
+# bundle_id 空出，governance remount 会挂上 plugin 那份；真有 PLUGIN 层时用户声明会在 merge 层遮蔽它、
+# 什么都不挂。二者行为不同。但协议 §5 item 10 明定 plugin 声明 MUST NOT 进审批门（门控结果本就不该反向决定
+# plugin 基线），且 rust ``collect_enabled_bundled_servers`` 同为「plugin 集内 first-wins、不与用户声明比对」
+# ⇒ **parity 保持**，结论仍成立。
+#
+# ⚠️ 与 rust-sdk#137（显式 ``ProvenanceScope::Plugin`` 变体 + 迭代层过滤）**代码形态分叉、行为等价**：
+# rust 无本 SDK 这套 approval→remount boot 序。协议 §2.5-5 明许「scope 纯推导与挂载时标记**行为等价即合规**」。
+# **须盯的唯一差异**：rust 的权威集**能观测到** ``origin==plugin`` 条目、python 的不能——若将来 conformance
+# 出现「权威集须含 origin==plugin 条目」这类向量，python 会失败（双端跟踪 Issue 已记）。
 #
 # ⚠️ 与 rust-sdk#137（显式 ``ProvenanceScope::Plugin`` 变体 + 迭代层过滤）**代码形态分叉、行为等价**：
 # rust 无本 SDK 这套 approval→remount boot 序，其 ``collect_enabled_bundled_servers`` 是 plugin 集内

--- a/a2c_smcp/computer/settings/schema.py
+++ b/a2c_smcp/computer/settings/schema.py
@@ -48,17 +48,51 @@ logger = get_logger(__name__)
 
 class SettingsScope(StrEnum):
     """
-    settings 来源 scope（低 → 高，high 覆盖 low）/ Settings source scope (low → high)。
+    配置来源 scope（低 → 高，high 覆盖 low）/ Config source scope (low → high)。
 
-    五级与 Claude Code 完整对齐（user/project/local/flag/policy）；project/local 锚定进程 cwd（#116）。
-    Five levels aligned with Claude Code; project/local anchored at process cwd (#116).
+    与 Claude Code 对齐（user/project/local/flag/policy）；project/local 锚定进程 cwd（#116）。
+    ``embed`` 为 A2C 特有的**宿主构造挂载层**，仅存在于 mcp.json 轴（settings.json 无此来源，见 :data:`SCOPE_ORDER`）。
+    Aligned with Claude Code, plus A2C's ``embed`` (mcp.json axis only).
+
+    **顺序权威在 :data:`SCOPE_ORDER`，不在本枚举的成员声明序**——成员序只是巧合一致，勿依赖。
     """
 
     USER = "user"
     PROJECT = "project"
     LOCAL = "local"
+    EMBED = "embed"  # 宿主构造入参 Computer(mcp_servers=...)；仅 mcp.json 轴 / embedded-constructor, mcp.json axis only
     FLAG = "flag"
     POLICY = "policy"  # 最高 / highest
+
+
+# 协议 ``runtime-contract.md`` §2.5-3 来源优先序（低 → 高）的**唯一**权威 / The single authority for §2.5-3。
+#
+#     plugin 声明 < user < project < local < embed < flag < policy
+#
+# **settings.json 与 mcp.json 两套 resolve MUST 由本元组派生顺序，MUST NOT 各写列表字面量**——两份字面量
+# 漂移（mcp.json 曾把 flag 排最低、settings.json 排次高，差四格）正是 #154 的根因。改序只需改本元组，
+# 两边同时翻转；任何一边改回字面量都会被 ``test_scope_order_matches_protocol_and_has_no_plugin_member``
+# 与两套 resolve 的层位守卫抓住。
+#
+# **为何无 ``PLUGIN`` 成员**（#154 裁决，刻意的结构性缺席）：plugin 声明基线层**不经任一 resolve**——它经
+# transient ``amount_server`` 从 plugin manifest 挂载；plugin-lowest 由 boot 序保证（``run_mcp_approval``
+# 先于 ``run_governance_remount``，后者跳过 ``bundle_id`` 已活跃者，见 ``installer.py`` 的「existing wins」）。
+# 无任一消费者需要 plugin 层：审批门 MUST 滤掉它（F8）、回收判据要 ``origin != plugin``、``upsert_mcp_server``
+# 只认可写 scope ⇒「合并进来再处处滤掉」与「从不合并」**可证等价**。加一个无生产者的 ``PLUGIN`` 成员会让
+# 「迭代层过滤」沦为永假守卫（死代码），且正是 #148 那个 P0「进门后豁免」档位复活的诱因。F8 的可验收信号
+# 取**缺席**（「成员不存在」比「文档说别用」可靠）。
+#
+# ⚠️ 与 rust-sdk#137（显式 ``ProvenanceScope::Plugin`` 变体 + 迭代层过滤）**代码形态分叉、行为等价**：
+# rust 无本 SDK 这套 approval→remount boot 序，其 ``collect_enabled_bundled_servers`` 是 plugin 集内
+# first-wins、不与用户声明比对。协议 §2.5-5 明许「scope 纯推导与挂载时标记**行为等价即合规**」。
+SCOPE_ORDER: tuple[SettingsScope, ...] = (
+    SettingsScope.USER,
+    SettingsScope.PROJECT,
+    SettingsScope.LOCAL,
+    SettingsScope.EMBED,
+    SettingsScope.FLAG,
+    SettingsScope.POLICY,
+)
 
 
 # ---------------------------------------------------------------------------

--- a/a2c_smcp/computer/settings/scope.py
+++ b/a2c_smcp/computer/settings/scope.py
@@ -39,6 +39,7 @@ from pathlib import Path
 from typing import Any
 
 from a2c_smcp.computer.settings.schema import (
+    SCOPE_ORDER,
     SettingsScope,
     SettingsValidationError,
     validate_settings,
@@ -158,7 +159,9 @@ def merge_layers(layers: Sequence[Mapping[str, Any]], *, on_conflict: ConflictHo
     """
     按 low → high 顺序折叠多层 settings（读合并）/ Fold multiple layers low → high (read merge)。
 
-    :param layers: 已校验的各 scope dict，**低优先级在前**（如 ``[capability, user, project, local, flag, policy]``）。
+    :param layers: 已校验的各 scope dict，**低优先级在前**。调用方 MUST 按
+        :data:`~a2c_smcp.computer.settings.schema.SCOPE_ORDER` 派生顺序（协议 §2.5-3 的唯一权威），
+        MUST NOT 手写列表字面量——两处字面量漂移正是 #154 的根因。
     """
     result: dict[str, Any] = {}
     for layer in layers:
@@ -220,7 +223,7 @@ class ResolvedSettings:
     """
     解析结果 / The resolved settings result。
 
-    ``settings`` 为六层合并后的最终视图；``errors`` 汇总各层字段级校验错误（不阻断启动，供
+    ``settings`` 为多层合并后的最终视图；``errors`` 汇总各层字段级校验错误（不阻断启动，供
     ``settings show`` / 诊断命令呈现，§5.6），已按出现顺序去重。
     ``settings`` is the merged view; ``errors`` aggregates field-level validation errors
     (non-fatal, deduped, surfaced via diagnostics).
@@ -246,7 +249,13 @@ def resolve_settings(
     policy_settings: Mapping[str, Any] | None = None,
 ) -> ResolvedSettings:
     """
-    解析五层 settings 视图（user / project / local / flag / policy）/ Resolve the five-layer view。
+    解析 settings 视图（user / project / local / flag / policy）/ Resolve the settings view。
+
+    合并序由 :data:`~a2c_smcp.computer.settings.schema.SCOPE_ORDER` 派生（协议 §2.5-3，与 ``mcp.json``
+    的 :func:`~a2c_smcp.computer.settings.mcp_config.resolve_mcp_config` **同序**——两套来源 MUST 一致）。
+    ``embed`` 在本轴**无数据源**（宿主经 ``Computer(mcp_servers=...)`` 只供 server 配置，无 settings 入参；
+    plugin 亦然——manifest 只带 server 与 skill，不带 settings），故 ``SCOPE_ORDER`` 里的 ``EMBED`` 在此
+    被 ``if s in by_scope`` 过滤掉。这是**轴不对称**、非缺陷。
 
     #116：project/local 无条件锚定进程 ``os.getcwd()`` 的 ``.tfrobot/settings[.local].json``
     （cwd 恒存在；文件缺失 → 层为空）。原「能力发现层 + active-workdir 单根」两层模型随
@@ -281,5 +290,13 @@ def resolve_settings(
     policy_layer, policy_errors = validate_settings(dict(policy_settings or {}), SettingsScope.POLICY)
     errors.extend(policy_errors)
 
-    merged = merge_layers([user_layer, project_layer, local_layer, flag_layer, policy_layer])
+    # 顺序**派生**自 SCOPE_ORDER（协议 §2.5-3 唯一权威），不手写字面量 / order derived, never hand-written.
+    by_scope: dict[SettingsScope, Mapping[str, Any]] = {
+        SettingsScope.USER: user_layer,
+        SettingsScope.PROJECT: project_layer,
+        SettingsScope.LOCAL: local_layer,
+        SettingsScope.FLAG: flag_layer,
+        SettingsScope.POLICY: policy_layer,
+    }
+    merged = merge_layers([by_scope[s] for s in SCOPE_ORDER if s in by_scope])
     return ResolvedSettings(settings=merged, errors=_dedup_errors(errors))

--- a/docs/design-0.2.1-cli-marketplace-ux.md
+++ b/docs/design-0.2.1-cli-marketplace-ux.md
@@ -40,7 +40,7 @@
 | 19 | Uninstall 级联 | 默认 stop+remove plugin 携带的 MCP server；`--keep-servers` 跳过 | |
 | 20 | settings.json 职责 | **只**放 `enabledPlugins` + `extraKnownMarketplaces` + MCP 门控字段 + trust policy 字段；**不放** MCP server 定义/inputs | 校正：MCP defs 移出 settings.json（见 #25） |
 | 21 | Reconciler | **additive-only 只增不删**（true-CC）；孤儿靠显式 `plugin uninstall` / `plugin gc` 清 | 校正：CC 不自动清理「声明没、物化有」 |
-| 22 | 老 flag 迁移 | settings.json 与 `--config/--inputs` **并存**；启动合并，settings 优先 | 不破坏老脚本 |
+| 22 | ~~老 flag 迁移~~ | **#154 已 supersede**：`--config`→`--mcp-config`（flag 层 mcp.json，次高）；`--inputs` 删除（inputs 段并入该文件）。无存量用户，不做兼容 | 见 §5.5 |
 | 23 | JSON 输出 | 启动时**全局** `--json` flag | REPL 内也默认 JSON |
 | 24 | 非交互形态 | Typer 子命令 + REPL 同名同义 | `a2c-computer marketplace add ...` 与 REPL `marketplace add ...` 走同一逻辑 |
 | 25 | MCP server 定义文件 | A2C **原生 schema**（`{servers,inputs}`）→ workspace/project `.tfrobot/mcp.json` + user `$XDG_CONFIG_HOME/a2c/mcp.json` | `server_parameters` 嵌套 + 治理字段与标准 `.mcp.json` 不兼容，**不同名混用**（§9.1） |
@@ -56,7 +56,7 @@
 
 1. **CLI 命令表面**：marketplace / plugin / skill 三组命名空间命令（add/install/list/info/enable/disable/refresh/remove）+ 现有命令保持。
 2. **REPL UX**：tab 补全、help 重组、Rich 进度反馈、Banner、zero-state 引导。
-3. **意图层文件**：`settings.json` 格式 + 五级 scope 合并；与现有 `--config/--inputs` 共存。
+3. **意图层文件**：`settings.json` 格式 + 多级 scope 合并（#154：与 `mcp.json` **同序**，flag 次高）；flag scope 的文件对 = `--settings` + `--mcp-config`。
 4. **Reconciler**：启动时声明 vs 物化对账；自动 clone 缺失、自动清理废弃。
 5. **事件触发链**：CLI 动作 → 缓存失效 → debounce 300ms → emit_update_skills；与文件 watcher 同节奏。
 6. **Trust 流程**：首次 add 弹 y/N；持久化进 `known_marketplaces.json`。
@@ -486,18 +486,30 @@ $XDG_CONFIG_HOME/a2c/                     # → ~/.config/a2c
 - **删字段**：写 `undefined`（= 删 key）。
 - 写后 `markInternalWrite(<path>)` 给 file-watcher 打标，**避免把自己的写回当用户手编触发重载循环**（CC `settings.ts:~500` 同款机制）。
 
-### 5.5 与现有 `--config @file` / `--inputs @file` 共存
+### 5.5 flag scope 的**文件对**：`--mcp-config @file` + `--settings @file`
 
-老 flag 现在喂的是 **MCP 定义层**（§9.1），不是 settings.json：
+> **#154 起（breaking）**：旧 `--config`（收「裸 server 对象/数组」、排最低优先级、绕开审批门直挂）→ 更名
+> **`--mcp-config`**（保留 `-c`）、形状硬切为 mcp.json 的 `{servers, inputs}`、**排次高**、与其余 scope 同路
+> 过审批门；旧 `--inputs` **已删除**（其职责由 `--mcp-config` 文件的 `inputs` 段承载）。旧格式文件 **fail-fast**
+> （exit 2）并提示改写。无存量用户，按通用口径不做兼容设计。
+
+`--mcp-config`（flag 层 mcp.json）与 `--settings`（flag 层 settings.json）构成 flag scope 的**文件对**，
+与其余 scope 的双文件形态对称（协议 runtime-contract §2.5-3）。它喂的是 **MCP 定义层**（§9.1），不是 settings.json：
 
 ```
 MCP 定义合并顺序（高 → 低，§9.1 scope；同 §5.1 active-workdir 单根模型）：
   1. policy（managed-mcp.json）            ← 最高
-  2. active workdir local (.tfrobot/mcp.local.json)
-  3. active workdir project (.tfrobot/mcp.json)
-  4. user ($XDG_CONFIG_HOME/a2c/mcp.json)
-  5. --config / --inputs flag             ← 老接口，最低优先级
-  6. 默认值
+  2. --mcp-config <file> flag             ← 次高，仅低于 policy（#154）
+  3. embed（Computer(mcp_servers=...) 构造入参）  ← 宿主代码级显式意图（#164）
+  4. active workdir local (.tfrobot/mcp.local.json)
+  5. active workdir project (.tfrobot/mcp.json)
+  6. user ($XDG_CONFIG_HOME/a2c/mcp.json)
+  7. plugin 声明（基线，**不经 resolve**——由 boot 序「existing wins」保证，见 §12）
+  8. 默认值
+
+  ⚠️ **本序自 #154/#164 起翻转**：历史把 `--config` flag 排**最低**（老接口遗留），协议
+  runtime-contract §2.5-3 已**废止**该形态——settings 与 mcp.json MUST 同序、flag 统一次高。
+  **顺序的唯一权威 = `settings/schema.py` 的 `SCOPE_ORDER`**，两个 resolve 均由它派生，勿再手写字面量。
 
   注：MCP 定义层同构 settings 的 (B) 层——**只取 active workdir** 的 mcp.json/mcp.local.json，
   **不**跨登记目录并集（无 active 时仅 user + flag + 默认）；批准门控随之一致。
@@ -506,8 +518,8 @@ MCP 定义合并顺序（高 → 低，§9.1 scope；同 §5.1 active-workdir �
 settings.json（意图/治理层）独立按 §5.1/§5.4 合并。
 ```
 
-- `--config @servers.json` / `--inputs @inputs.json` 等价于在 MCP 定义层最低优先级注入；
-- 老脚本零迁移即可继续工作；新场景推荐 `.tfrobot/mcp.json` + settings.json + GitOps。
+- `--mcp-config @flag-mcp.json` 等价于在 MCP 定义层**次高**优先级注入（仅低于 policy）；其 `inputs` 段与 servers 同路消费；
+- **旧 `--config`/`--inputs` 脚本需迁移**（形状硬切 + 更名，旧文件 fail-fast 并给出改写提示）；新场景推荐 `.tfrobot/mcp.json` + settings.json + GitOps。
 
 ### 5.6 校验与前向兼容（复刻 CC：passthrough + 全可选，无版本字段）
 
@@ -723,7 +735,7 @@ class SkillEventDebouncer:
 | project | **active workdir** `<workdir>/.tfrobot/mcp.json` | 入 git、团队共享；**单根、不跨目录并集**；无 active 时空 |
 | local | **active workdir** `<workdir>/.tfrobot/mcp.local.json` | 不入 git；同上 |
 | policy | managed 路径下 `managed-mcp.json` | 企业下发 |
-| flag | `--config @file`（老接口，最低优先级） | 兼容 |
+| flag | `--mcp-config @file`（flag 层 mcp.json，**次高**、仅低于 policy；#154 由 `--config` 更名 + 形状硬切） | 与 `--settings` 构成 flag scope 文件对 |
 
 查找优先级 policy > active-local > active-project > user > flag（对齐 CC enterprise > local > project > user，A2C 主根随任务动态切换）。**无 active workdir** 时只取 user + flag + 默认；MCP server 定义**不**像能力层那样跨登记目录并集（敏感面隔离，与 §5.1 (B) 一致）。
 
@@ -1087,7 +1099,7 @@ a2c_smcp/computer/
 - **inputs 解析链**：env `A2C_INPUT_<ID>` 命中 → 不落盘；password prompt → keyring 存 → 重启不再问；非密钥 → 明文 state；keyring 不可用 + 无 env + 无 TTY → 硬错误。
 - File watcher：user/project 目录 SKILL.md 增删改 → debounce → emit；CLI 写回 settings 经 `markInternalWrite` 不触发重载循环。
 - Reconciler additive-only：物化多于声明的条目重启后**仍在**；`plugin gc` 才清。
-- `--config @file` + `.tfrobot/mcp.json` 同时存在 → settings/mcp 定义层优先合并。
+- `--mcp-config @file` + `.tfrobot/mcp.json` 同时存在 → 按 `SCOPE_ORDER` 合并，**flag 胜出**（#154）。
 
 ### 13.3 E2E（pexpect）
 
@@ -1162,7 +1174,7 @@ A ⫫ B（并行）；C 依赖 A+B；D 依赖 A；E 依赖 A/B/C/D；F 依赖 A/
 - [ ] `skill list/info` 跨三源扁平视图。
 - [ ] `settings show/edit/get/set` 四命令；非编辑器场景纯 CLI 可改；写回经 `markInternalWrite` 不触发 watcher 重载循环。
 - [ ] `--json` 全局 flag：所有命令机器可读输出；JSON line-delimited 进度。
-- [ ] `--config/--inputs` 老 flag 与 `.tfrobot/mcp.json` 共存，启动合并。
+- [x] `--mcp-config` 与 `.tfrobot/mcp.json` 各 scope 按统一序合并（flag 次高）；旧 `--config`/`--inputs` 已移除（#154）。
 - [ ] Tab 补全：动词/子命令/flag/动态名称/文件路径全覆盖。
 - [ ] Help 分组：默认列 namespace、`help <ns>` 详情。
 - [ ] Banner 仅 `plugins=0 AND servers=0` 触发。

--- a/tests/e2e/computer/configs/mcp_flag_direct_execution.json
+++ b/tests/e2e/computer/configs/mcp_flag_direct_execution.json
@@ -1,0 +1,21 @@
+{
+  "servers": {
+    "e2e.direct": {
+      "type": "stdio",
+      "disabled": false,
+      "forbidden_tools": [],
+      "tool_meta": {},
+      "server_parameters": {
+        "command": "python",
+        "args": [
+          "tests/integration_tests/computer/mcp_servers/direct_execution.py"
+        ],
+        "env": null,
+        "cwd": null,
+        "encoding": "utf-8",
+        "encoding_error_handler": "strict"
+      }
+    }
+  },
+  "inputs": []
+}

--- a/tests/e2e/computer/test_cli_run_with_mcp_config.py
+++ b/tests/e2e/computer/test_cli_run_with_mcp_config.py
@@ -1,12 +1,19 @@
 """
-文件名: test_cli_run_with_config.py
+文件名: test_cli_run_with_mcp_config.py
 作者: JQQ
 创建日期: 2025/9/22
 版权: 2023 JQQ. All rights reserved.
 依赖: pytest, pexpect
 描述:
-  中文: 启动 CLI 时通过 --config/-c 传入配置文件，验证服务加载与工具可见。
-  English: Pass --config at startup to load servers config and verify tools.
+  中文: 启动 CLI 时通过 --mcp-config/-c 传入 flag 层 mcp.json，验证服务加载与工具可见。
+  English: Pass --mcp-config (the flag-layer mcp.json) at startup and verify servers load and tools are visible.
+
+  #154：旧 `--config`（收「裸 server 对象/数组」、绕开 scope 合并与审批门直挂）已更名为 `--mcp-config`
+  且形状硬切为 mcp.json 的 `{servers, inputs}` —— 它现在是 flag scope 的 mcp.json（优先级次高、仅低于
+  policy），与 `--settings`（flag 层 settings.json）构成 flag scope 的**文件对**（协议 §2.5-3）。
+
+  注：REPL 面的 `server add @<file>` 仍吃**裸 server** 形状（另一条通路、另一套夹具），见
+  `test_cli_mcp_config_start.py` / `test_cli_inputs_resolve.py` —— 本次不动它们。
 """
 
 from __future__ import annotations
@@ -109,14 +116,25 @@ def _assert_status(child: pexpect.spawn, server: str, retries: int = 8, delay: f
 
 
 @pytest.mark.e2e
-def test_run_with_config_param_loads_server() -> None:
+def test_run_with_mcp_config_param_loads_server() -> None:
     """
-    启动参数包含 --config @tests/e2e/computer/configs/server_direct_execution.json，应能加载并启动服务：
-    - 进入 a2c> 后检查 status 含 e2e-test
+    启动参数含 --mcp-config @tests/e2e/computer/configs/mcp_flag_direct_execution.json，应能加载并启动服务：
+    - 进入 a2c> 后检查 status 含 e2e.direct
     - tools 中包含 hello
     若自动启动存在延迟，调用一次 start all 作为补偿
+
+    夹具键 `e2e.direct`（**非** `e2e-direct`）：`normalize_name` 折叠 `.`→`_` 但**不折叠 `-`** ⇒ `e2e-direct`
+    的 bundle_id 恰等于自身、两概念不分叉（conformance §2.0 违规）。`e2e.direct` → bundle_id `e2e_direct`。
+
+    保留 `--mcp-config=@...` 的**等号形**：这是全仓唯一钉住等号形解析的地方。
+
+    ⚠️ **status 断言的是 bundle_id `e2e_direct`，不是 display name** —— `MCPServerManager.get_server_status()`
+    刻意以 **bundle_id 为身份**返回（#129/#130/#131 BundleID 模型），而 `cli/utils.py` 把它渲染在标着 "Name"
+    的列下。**旧夹具 `e2e-test` 看不见这个分叉**（`-` 不折叠 ⇒ name ≡ bundle_id ⇒ 同值致盲，正是 Epic #147
+    「stub 同值陷阱」那一族）；换成分叉夹具后才暴露出来。「人机面该显示 display name」属 REPL 寻址/展示轴
+    （#143 / #144），**不在本 Issue 范围**——此处如实断言**今日行为**，勿改成 `e2e.direct` 掩盖它。
     """
-    cfg_arg = "--config=@tests/e2e/computer/configs/server_direct_execution.json"
+    cfg_arg = "--mcp-config=@tests/e2e/computer/configs/mcp_flag_direct_execution.json"
     with _spawn_cli_with_args(cfg_arg) as child:
         # 等横幅/提示符
         try:
@@ -137,5 +155,6 @@ def test_run_with_config_param_loads_server() -> None:
         child.sendline("start all")
         _wait_prompt(child)
 
-        _assert_status(child, "e2e-test", retries=10, delay=0.8)
+        # 身份 = bundle_id（见 docstring：status 渲染 get_server_status() 的 bundle_id，非 display name）
+        _assert_status(child, "e2e_direct", retries=10, delay=0.8)
         _assert_tools(child, "hello", retries=12, delay=1.0)

--- a/tests/integration_tests/computer/cli/test_main.py
+++ b/tests/integration_tests/computer/cli/test_main.py
@@ -150,7 +150,8 @@ class _FakeComputer:
         confirm_callback: Callable[[str, str, str, dict], bool] | None = None,
         input_resolver: Any | None = None,
         registered_workdirs: Any | None = None,  # #69/S16：CLI --add-dir → registered_workdirs，替身需接受
-    ) -> None:
+
+        mcp_flag_config: Any | None = None) -> None:
         self.init_args = {
             "name": name,
             "inputs": inputs,

--- a/tests/integration_tests/computer/cli/test_mcp_flag_config.py
+++ b/tests/integration_tests/computer/cli/test_mcp_flag_config.py
@@ -1,0 +1,258 @@
+# -*- coding: utf-8 -*-
+# filename: test_mcp_flag_config.py
+# @Time    : 2026/07/17
+# @Author  : JQQ
+# @Email   : jqq1716@gmail.com
+# @Software: PyCharm
+"""
+flag 层 mcp.json（``--mcp-config``）+ embed 层（构造入参）的**真实构造路径**契约测试（#154 / #164）。
+Contract tests for the flag-layer mcp.json (``--mcp-config``) and the embed layer, on the REAL construction path.
+
+协议 / Protocol: ``computer-management/runtime-contract.md`` §2.5-3（唯一优先序：
+``plugin < user < project < local < embed < flag < policy``）、§2.5-5（运行期权威配置集 MUST 携带 origin）；
+``conformance-tests.md`` §2.0（夹具 name/bundle_id 分叉）+ **F7**（涉及 Computer 状态的契约测试 MUST 至少
+一条走**真实构造路径**，不得全部依赖桩）。
+
+**本文件即 F7 的落点**：走**真** :class:`Computer`（CLI 同款空集构造 ``inputs=set(), mcp_servers=set()``）+
+**真** :func:`run_mcp_approval`，**不用** ``_FakeComp``。Epic #147 记载：``_FakeComputer`` 桩曾把「``Computer.mcp_servers``
+有内容」这个生产中恒假的前提固化为真，**逃过 F7 之前的所有条款**——故此处刻意不桩 Computer。
+
+测试意图 / Test intentions:
+- flag 文件的 **``inputs`` 段**被消费（``--inputs`` 删除后的替代通路）+ server 的 ``${input:}`` 得以渲染；
+- flag origin ⇒ trusted ⇒ 门控判 ENABLED ⇒ 挂载（净效果同旧 ``--config``，但**现在带 origin**）；
+- flag server **可被 policy 拒绝名单拦下**（新行为：旧 ``--config`` 完全绕开门控直挂）；
+- embed server（宿主构造入参）⇒ trusted ⇒ ENABLED；被 policy 拒绝时 ⇒ **确保停摘**（否则拒绝名单形同虚设）。
+
+隔离：``monkeypatch.chdir(tmp)`` 锚 project/local（#116）+ ``XDG_CONFIG_HOME`` → tmp 锚 user。
+**chdir 是必须的**：#137 flip 后 durable 路径落 ``cwd/.tfrobot/``，不 chdir 即污染真实仓库。
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+import pytest
+from pydantic import TypeAdapter
+
+from a2c_smcp.computer.cli.commands.plugin import run_mcp_approval
+from a2c_smcp.computer.computer import Computer
+from a2c_smcp.computer.mcp_clients.model import MCPServerConfig
+from a2c_smcp.computer.settings.mcp_config import MANAGED_MCP_FILENAME
+from a2c_smcp.utils.bundle_id import resolve_bundle_id
+
+# 夹具身份对：display name 含 `.` → normalize_name 折成 `_` ⇒ name ≠ bundle_id（conformance §2.0）。
+# ⚠️ **勿用 `-`**：`normalize_name` **不折叠** `-`，`e2e-direct` 的 bundle_id 恰等于自身 ⇒ 两概念不分叉 ⇒
+# 「误用 name 当身份」的实现能蒙混过关（本仓已因此出过四次假绿）。
+SRV_NAME, SRV_BID = "e2e.direct", "e2e_direct"
+
+
+@pytest.fixture(autouse=True)
+def _no_policy(monkeypatch: pytest.MonkeyPatch) -> None:
+    """policy 读 OS 源不确定 → 缺省固定为空（个别用例自行覆盖）/ pin policy empty for determinism。"""
+    import a2c_smcp.computer.settings.policy as policy_mod
+
+    monkeypatch.setattr(policy_mod, "resolve_policy_settings", lambda **_: {})
+
+
+def _isolate(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> dict[str, str]:
+    monkeypatch.chdir(tmp_path)  # #137：durable 落 cwd/.tfrobot/ ⇒ 不 chdir 即写进真实仓库
+    env = {**os.environ, "XDG_CONFIG_HOME": str(tmp_path / "cfg")}
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "cfg"))
+    return env
+
+
+def _server_body(command_placeholder: str) -> dict[str, Any]:
+    """一条 stdio server；``args[0]`` 走 ``${input:}`` 占位符，用以验证 inputs 段真的被消费并参与渲染。"""
+    return {
+        "type": "stdio",
+        "disabled": True,  # 免真拉进程：本测试验证配置态/门控/渲染，不验证 spawn
+        "forbidden_tools": [],
+        "tool_meta": {},
+        "server_parameters": {
+            "command": "python",
+            "args": [command_placeholder],
+            "env": None,
+            "cwd": None,
+            "encoding": "utf-8",
+            "encoding_error_handler": "strict",
+        },
+    }
+
+
+def _write_flag_file(tmp_path: Path, *, servers: dict[str, Any], inputs: list[dict[str, Any]]) -> Path:
+    p = tmp_path / "flag-mcp.json"
+    p.write_text(json.dumps({"servers": servers, "inputs": inputs}), encoding="utf-8")
+    return p
+
+
+def _real_computer(tmp_path: Path, **kw: Any) -> Computer:
+    """**CLI 同款真实构造**（空集 inputs/mcp_servers）——F7 要求，勿换成桩。"""
+    return Computer(
+        name="flag-config-test",
+        inputs=set(),
+        mcp_servers=set(),
+        auto_connect=False,
+        auto_reconnect=False,
+        skill_home=tmp_path / "home",
+        **kw,
+    )
+
+
+@pytest.mark.asyncio
+async def test_mcp_flag_config_inputs_segment_consumed_and_server_rendered(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    **F7 主用例**：``--mcp-config`` 文件的 ``inputs`` 段入池，且 server 的 ``${input:}`` 据此渲染后挂载。
+
+    这是 ``--inputs`` 被删除后的**替代通路**——旧 ``--config`` 的 schema（裸 server 对象）**没有 inputs 字段**，
+    故当年必须另立 ``--inputs``；现 flag 层就是 mcp.json，``{servers, inputs}` 一体，通路归一。
+
+    **变异验证**：把 ``plugin.py`` 的 ``comp.resolve_mcp_declarations(env=env)`` 换回
+    ``resolve_mcp_config(env=env, flag_config_path=None)`` → resolved.servers 空 → 早 return → ``SCRIPT``
+    不入池、server 不挂 → 本例转红（这是 `test_run_impl_hands_mcp_flag_path_to_computer` 的搭档守卫：
+    那条只钉「交接」，本条钉「真的被消费」）。
+    """
+    env = _isolate(tmp_path, monkeypatch)
+    script = "tests/integration_tests/computer/mcp_servers/direct_execution.py"
+    flag = _write_flag_file(
+        tmp_path,
+        servers={SRV_NAME: _server_body("${input:SCRIPT}")},
+        inputs=[{"id": "SCRIPT", "type": "promptString", "description": "server script", "default": script}],
+    )
+
+    comp = _real_computer(tmp_path, mcp_flag_config=flag)
+    async with comp:
+        await run_mcp_approval(comp, None, approve_all=False, settings_flag_path=None)
+
+        # ① inputs 段真的入池（旧 --config schema 根本没有 inputs 字段 ⇒ 此断言在旧通路上无从谈起）
+        assert "SCRIPT" in {i.id for i in comp.inputs}, "--mcp-config 的 inputs 段未被消费"
+
+        # ② server 已挂 且 ${input:SCRIPT} 已渲染（证明 inputs 段确实参与了渲染，而不只是入池）
+        assert comp.mcp_manager is not None
+        active = {resolve_bundle_id(c): c for c in comp.mcp_manager.server_configs()}
+        assert SRV_BID in active, "flag 层声明的 server 未挂载"
+        assert active[SRV_BID].server_parameters.args == [script], "${input:SCRIPT} 未渲染"
+
+        # ③ 该 server 的 origin 可观测为 flag（§2.5-5：权威集 MUST 携带 origin）
+        declared = comp.resolve_mcp_declarations(env=env)
+        assert declared.servers[SRV_NAME].origin.value == "flag"
+        assert declared.servers[SRV_NAME].trusted_origin is True  # flag ∈ _TRUSTED_ORIGINS ⇒ 免批准框
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("denied", [False, True], ids=["control_mounts", "denied_blocked"])
+async def test_flag_server_can_be_denied_by_policy(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, denied: bool,
+) -> None:
+    """
+    **新行为守卫**（用户已拍板接受）：flag server 现在**过审批门** ⇒ 可被 policy 拒绝名单拦下、**不挂载**。
+
+    旧 ``--config`` 在 ``_run_impl`` 里 ``json.loads`` → ``amount_server`` 直挂，**完全绕开门控** ⇒ 企业
+    policy 对它形同虚设。协议 §2.5-3 明定 ``policy > flag``，此为其落地。
+
+    ⚠️ **必须带 ``denied=False`` 的正对照**：只断言「被拒时不在活跃集」是**弱断言**——任何让 flag 层压根没被
+    解析的回归（如 ``plugin.py`` 退回 ``flag_config_path=None``）都会让它**因错误的理由变绿**（server 从未被
+    考虑过 ⇒ 自然不在活跃集）。正对照钉住「不拒时它确实会挂」，两者合起来才真正测到「是**拒绝名单**拦下了它」。
+    实测：无正对照时本例在该变异下保持绿（本次自查抓到的假绿）。
+    """
+    _isolate(tmp_path, monkeypatch)
+    import a2c_smcp.computer.settings.policy as policy_mod
+
+    policy = {"deniedMcpServers": [SRV_NAME]} if denied else {}
+    monkeypatch.setattr(policy_mod, "resolve_policy_settings", lambda **_: policy)
+    flag = _write_flag_file(tmp_path, servers={SRV_NAME: _server_body("x.py")}, inputs=[])
+
+    comp = _real_computer(tmp_path, mcp_flag_config=flag)
+    async with comp:
+        await run_mcp_approval(comp, None, approve_all=False, settings_flag_path=None)
+        assert comp.mcp_manager is not None
+        active = {resolve_bundle_id(c) for c in comp.mcp_manager.server_configs()}
+        if denied:
+            assert SRV_BID not in active, "policy 拒绝名单未能拦下 flag server（协议 §2.5-3：policy > flag）"
+        else:
+            assert SRV_BID in active, "正对照：未被拒绝时 flag server 必须挂上（否则上一分支是假绿）"
+
+
+@pytest.mark.asyncio
+async def test_embed_server_is_trusted_and_enabled(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """
+    **embed 层**（宿主构造入参 ``Computer(mcp_servers=...)``）：origin=embed ⇒ trusted ⇒ ENABLED（档④）。
+
+    宿主构造入参是**代码级显式意图**，与 flag 同属「调用方显式受信层」（Discussion #32 裁决 / §2.5-3）。
+    ``boot_up`` 已无门挂起它 ⇒ 门控循环**不得重复挂**（会 restart 客户端 / ``auto_reconnect=False`` 时抛）。
+    """
+    env = _isolate(tmp_path, monkeypatch)
+    embed_cfg = TypeAdapter(MCPServerConfig).validate_python({"name": SRV_NAME, **_server_body("x.py")})
+
+    comp = _real_computer(tmp_path)
+    comp._mcp_servers = {embed_cfg}  # 模拟宿主构造入参（构造后注入，避免与 _real_computer 的空集签名打架）
+    async with comp:
+        declared = comp.resolve_mcp_declarations(env=env)
+        assert declared.servers[SRV_NAME].origin.value == "embed"
+        assert declared.servers[SRV_NAME].trusted_origin is True
+
+        await run_mcp_approval(comp, None, approve_all=False, settings_flag_path=None)
+        assert comp.mcp_manager is not None
+        active = {resolve_bundle_id(c) for c in comp.mcp_manager.server_configs()}
+        assert SRV_BID in active, "embed server 应保持活跃（boot_up 已挂，门控判 ENABLED 不得摘）"
+
+
+@pytest.mark.asyncio
+async def test_embed_server_denied_by_policy_is_unmounted(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """
+    **档①②③ 对 embed 适用**（协议 §2.5 裁决：「用户/管理员保留最终关停权」）。
+
+    ``boot_up`` **已无门挂起** embed server ⇒ 门控判 DISABLED 时若只打印不摘，policy 拒绝名单对 embed 就是
+    **装饰品**。故循环契约是「DISABLED ⇒ **确保停摘**」而非「跳过」。
+
+    **变异验证**：把 ``run_mcp_approval`` 的 DISABLED 分支改回只 ``console.print`` 不 ``_ensure_unmounted``
+    → 本例转红。
+    """
+    _isolate(tmp_path, monkeypatch)
+    import a2c_smcp.computer.settings.policy as policy_mod
+
+    monkeypatch.setattr(policy_mod, "resolve_policy_settings", lambda **_: {"deniedMcpServers": [SRV_NAME]})
+    embed_cfg = TypeAdapter(MCPServerConfig).validate_python({"name": SRV_NAME, **_server_body("x.py")})
+
+    comp = _real_computer(tmp_path)
+    comp._mcp_servers = {embed_cfg}
+    async with comp:
+        assert comp.mcp_manager is not None
+        pre = {resolve_bundle_id(c) for c in comp.mcp_manager.server_configs()}
+        assert SRV_BID in pre, "前置：boot_up 无门挂起 embed server（正是本守卫存在的理由）"
+
+        await run_mcp_approval(comp, None, approve_all=False, settings_flag_path=None)
+
+        post = {resolve_bundle_id(c) for c in comp.mcp_manager.server_configs()}
+        assert SRV_BID not in post, "policy 拒绝的 embed server 未被停摘 ⇒ 拒绝名单形同虚设"
+
+
+@pytest.mark.asyncio
+async def test_flag_beats_local_on_real_construction_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """
+    **层序在真实构造路径上的端到端体现**：同名 server 上 flag 覆盖 local（§2.5-3 flag 次高）。
+
+    Group A 的单元守卫钉的是 ``resolve_mcp_config`` 纯函数；本例钉「经 Computer 注入后，挂起来的确实是 flag 那份」。
+    """
+    _isolate(tmp_path, monkeypatch)
+    (tmp_path / ".tfrobot").mkdir(parents=True, exist_ok=True)
+    (tmp_path / ".tfrobot" / "mcp.local.json").write_text(
+        json.dumps({"servers": {SRV_NAME: _server_body("local.py")}, "inputs": []}), encoding="utf-8",
+    )
+    flag = _write_flag_file(tmp_path, servers={SRV_NAME: _server_body("flag.py")}, inputs=[])
+
+    comp = _real_computer(tmp_path, mcp_flag_config=flag)
+    async with comp:
+        await run_mcp_approval(comp, None, approve_all=False, settings_flag_path=None)
+        assert comp.mcp_manager is not None
+        active = {resolve_bundle_id(c): c for c in comp.mcp_manager.server_configs()}
+        assert active[SRV_BID].server_parameters.args == ["flag.py"], "flag 未覆盖 local（改前 local 胜）"
+
+
+def test_managed_mcp_filename_is_stable() -> None:
+    """``MANAGED_MCP_FILENAME`` 被本模块的 policy 用例间接依赖；此处仅做导入面存在性守卫。"""
+    assert MANAGED_MCP_FILENAME.endswith(".json")

--- a/tests/integration_tests/computer/cli/test_mcp_flag_config.py
+++ b/tests/integration_tests/computer/cli/test_mcp_flag_config.py
@@ -37,9 +37,10 @@ from typing import Any
 import pytest
 from pydantic import TypeAdapter
 
+from a2c_smcp.computer.cli.commands import build_mcp_callbacks
 from a2c_smcp.computer.cli.commands.plugin import run_mcp_approval
 from a2c_smcp.computer.computer import Computer
-from a2c_smcp.computer.mcp_clients.model import MCPServerConfig
+from a2c_smcp.computer.mcp_clients.model import MCPServerConfig, MCPServerInput
 from a2c_smcp.computer.settings.mcp_config import MANAGED_MCP_FILENAME
 from a2c_smcp.utils.bundle_id import resolve_bundle_id
 
@@ -58,10 +59,21 @@ def _no_policy(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def _isolate(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> dict[str, str]:
-    monkeypatch.chdir(tmp_path)  # #137：durable 落 cwd/.tfrobot/ ⇒ 不 chdir 即写进真实仓库
-    env = {**os.environ, "XDG_CONFIG_HOME": str(tmp_path / "cfg")}
+    """
+    隔离**三条**落盘面 / Isolate all three on-disk surfaces。
+
+    - ``chdir``：#137 flip 后 durable 落 ``cwd/.tfrobot/`` ⇒ 不 chdir 即写进真实仓库；
+    - ``XDG_CONFIG_HOME``：user scope 的 ``mcp.json`` / ``settings.json``；
+    - ``XDG_STATE_HOME``：**明文 input value store**（``<state>/a2c/input-values.json``，
+      :func:`~a2c_smcp.computer.inputs.value_store.resolve_value_store_path`）——**极易漏**：它走
+      ``XDG_STATE_HOME``（非 CONFIG_HOME），不隔离则 ``${input:}`` 解析会读到**开发机真实存量值**、并把本次
+      解析结果**写进开发机**。实测本仓真实 state 里已积下 ``VAR1: "exit"`` / ``CHOICE: "x"`` 等历史测试残留
+      ⇒ 带 ``${input:}`` 的用例结果取决于**跑过什么**，非确定性。追踪 Issue 见 #168。
+    """
+    monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "cfg"))
-    return env
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "state"))
+    return {**os.environ, "XDG_CONFIG_HOME": str(tmp_path / "cfg"), "XDG_STATE_HOME": str(tmp_path / "state")}
 
 
 def _server_body(command_placeholder: str) -> dict[str, Any]:
@@ -251,6 +263,130 @@ async def test_flag_beats_local_on_real_construction_path(tmp_path: Path, monkey
         assert comp.mcp_manager is not None
         active = {resolve_bundle_id(c): c for c in comp.mcp_manager.server_configs()}
         assert active[SRV_BID].server_parameters.args == ["flag.py"], "flag 未覆盖 local（改前 local 胜）"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("winner", ["flag", "policy"], ids=["flag_beats_embed", "policy_beats_embed"])
+async def test_higher_layer_beats_embed_at_mount_time(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, winner: str,
+) -> None:
+    """
+    **层序在挂载层也 MUST 成立**：同 bundle_id 上 flag / policy 的胜出配置必须真的**跑起来**，不能被
+    「embed 已挂 ⇒ 跳过」静默丢弃（§2.5-3 `local < embed < flag < policy`）。
+
+    隔离审查 🔴1：``_ensure_mounted`` 若只比 bundle_id 是否活跃就 skip，则 ``resolved.servers[name]`` 里那份
+    更高层的胜出配置**永不生效** ⇒ 运行期层序相对 resolve 层被反转。
+
+    **为何 skip 过宽**：``manager._add_or_update_server_config`` 对**未激活**客户端是安全的原地更新
+    （``manager.py:164-169``）；即便客户端已激活，用更高层配置 restart **正是**「优先级」的定义。
+
+    **为何此前没被抓到**：`test_flag_beats_local_on_real_construction_path` 挑的是 ``local``（永不预挂），
+    而唯一会被 ``boot_up`` 预挂的 ``embed`` 恰恰没有对应用例；纯函数用例
+    `test_resolve_embed_beats_local_but_loses_to_flag` 给出了「端到端也成立」的错觉。
+
+    **可达性**：CLI 下 ``mcp_servers=set()`` 不可达；纯嵌入式宿主不调 ``run_mcp_approval`` 不可达；
+    **混合宿主**（嵌入式宿主调 ``run_mcp_approval``，或 ``--computer-factory`` 自注入 ``mcp_servers``）可达
+    —— 而那正是 ``_ensure_mounted``/``_ensure_unmounted`` 两分支存在的唯一理由。
+    """
+    _isolate(tmp_path, monkeypatch)
+    embed_cfg = TypeAdapter(MCPServerConfig).validate_python({"name": SRV_NAME, **_server_body("embed.py")})
+
+    kw: dict[str, Any] = {}
+    if winner == "flag":
+        kw["mcp_flag_config"] = _write_flag_file(tmp_path, servers={SRV_NAME: _server_body("flag.py")}, inputs=[])
+    else:
+        managed = tmp_path / "managed-mcp.json"
+        managed.write_text(json.dumps({"servers": {SRV_NAME: _server_body("policy.py")}, "inputs": []}), encoding="utf-8")
+        monkeypatch.setattr(
+            "a2c_smcp.computer.settings.mcp_config.managed_mcp_config_path", lambda *_a, **_k: managed,
+        )
+
+    comp = _real_computer(tmp_path, **kw)
+    comp._mcp_servers = {embed_cfg}
+    async with comp:
+        assert comp.mcp_manager is not None
+        pre = {resolve_bundle_id(c): c for c in comp.mcp_manager.server_configs()}
+        assert pre[SRV_BID].server_parameters.args == ["embed.py"], "前置：boot_up 已无门挂起 embed 那份"
+
+        await run_mcp_approval(comp, None, approve_all=False, settings_flag_path=None)
+
+        active = {resolve_bundle_id(c): c for c in comp.mcp_manager.server_configs()}
+        assert active[SRV_BID].server_parameters.args == [f"{winner}.py"], (
+            f"{winner} 的胜出配置未生效——被「embed 已挂 ⇒ 跳过」丢弃 ⇒ 运行期层序相对 resolve 层反转"
+        )
+
+
+@pytest.mark.asyncio
+async def test_embed_with_placeholder_is_not_remounted_when_config_unchanged(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    **`_ensure_mounted` 的比较必须 raw-对-raw**：含 ``${input:}`` 的 embed server 在配置未变时**不得**被重挂。
+
+    陷阱：``mcp_manager.server_configs()`` 存的是**渲染后**配置（供 spawn），而 ``resolved.servers[*].config``
+    是**未渲染 raw**（D1：盘上/声明面恒 raw）。若直接拿两者比较，**任何带占位符的 config 都恒不相等** ⇒ 每次
+    ``run_mcp_approval`` 都重挂 ⇒ 客户端 restart，``auto_reconnect=False`` 时更直接抛 ``RuntimeError``。
+    正确基准 = :meth:`Computer.active_server_configs`（#149 的 **raw 投影**，按 bundle_id join 回 ``_active_raw``）。
+
+    无占位符的 config 恰好 rendered == raw ⇒ **同值致盲**：不带占位符的夹具测不出此 bug（本仓「同值陷阱」同族）。
+    故本例夹具**必须**带占位符。
+    """
+    _isolate(tmp_path, monkeypatch)
+    embed_cfg = TypeAdapter(MCPServerConfig).validate_python({"name": SRV_NAME, **_server_body("${input:SCRIPT}")})
+
+    comp = _real_computer(tmp_path)
+    comp._mcp_servers = {embed_cfg}
+    comp.add_or_update_input(
+        TypeAdapter(MCPServerInput).validate_python(
+            {"id": "SCRIPT", "type": "promptString", "description": "d", "default": "real.py"},
+        ),
+    )
+    async with comp:
+        assert comp.mcp_manager is not None
+        # 前置：boot_up 已挂**渲染后**那份（占位符已解析）——正是 rendered≠raw 的来源
+        pre = {resolve_bundle_id(c): c for c in comp.mcp_manager.server_configs()}
+        assert pre[SRV_BID].server_parameters.args == ["real.py"], "前置：boot_up 挂的是渲染后配置"
+
+        mounts: list[Any] = []
+        orig = comp.amount_server
+
+        async def _spy(cfg: Any, **kw: Any) -> None:
+            mounts.append(cfg)
+            await orig(cfg, **kw)
+
+        monkeypatch.setattr(comp, "amount_server", _spy)
+        await run_mcp_approval(comp, None, approve_all=False, settings_flag_path=None)
+
+        assert mounts == [], "配置未变却重挂了 embed server（rendered 与 raw 直接比较 ⇒ 带占位符者恒不等）"
+
+
+@pytest.mark.asyncio
+async def test_build_mcp_callbacks_non_plugin_bundle_ids_covers_flag_and_embed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    **生产接线守卫**（隔离审查 🟡3）：``build_mcp_callbacks(comp).non_plugin_bundle_ids()`` 必须真的含
+    flag + embed 两个 bundle_id。
+
+    四景（``test_mcp_dependency_model.py``）走的是 ``_declared`` 直呼 ``non_plugin_declared_bundle_ids``，
+    **绕过**了 ``build_mcp_callbacks`` → ``Computer.resolve_mcp_declarations`` 这条生产接线 ⇒ 若 ``_non_plugin``
+    退化成 ``lambda: set()``、或被误接成 ``existing_bundle_ids``（同签名 ``() -> set[str]``、语义判然不同，
+    故极易混），**四景仍全绿**。本例即那条接线的守卫。
+    """
+    _isolate(tmp_path, monkeypatch)
+    flag_name, flag_bid = "flag.srv", "flag_srv"
+    embed_name, embed_bid = "embed.srv", "embed_srv"
+    flag = _write_flag_file(tmp_path, servers={flag_name: _server_body("f.py")}, inputs=[])
+    embed_cfg = TypeAdapter(MCPServerConfig).validate_python({"name": embed_name, **_server_body("e.py")})
+
+    comp = _real_computer(tmp_path, mcp_flag_config=flag)
+    comp._mcp_servers = {embed_cfg}
+    async with comp:
+        cbs = build_mcp_callbacks(comp)
+        assert cbs.non_plugin_bundle_ids() >= {flag_bid, embed_bid}, "生产接线漏了 flag/embed 层"
+        # 与 existing_bundle_ids 语义判然不同：后者是「谁挂起来了」，前者是「谁被声明了（且非 plugin）」。
+        # flag 声明的 server 此刻**未挂**（未过门），故两集合必然不等 —— 这钉住「误把两者接反」。
+        assert cbs.non_plugin_bundle_ids() != cbs.existing_bundle_ids(), "non_plugin 与 existing 被接反/混用"
 
 
 def test_managed_mcp_filename_is_stable() -> None:

--- a/tests/integration_tests/computer/settings/test_installer.py
+++ b/tests/integration_tests/computer/settings/test_installer.py
@@ -161,7 +161,7 @@ async def test_uninstall_end_to_end(tmp_path: Path) -> None:
     install_path = Path(load_installed_plugins(home=home)["plugins"]["audit@acme-skills"][0]["installPath"])
     assert install_path.exists() and reg.resolve("audit:lint") is not None
 
-    ok = await uninstall_plugin("audit@acme-skills", reg, home, env=env, remove_server=_remove)
+    ok = await uninstall_plugin("audit@acme-skills", reg, home, non_plugin_bundle_ids=lambda: set(), env=env, remove_server=_remove)
 
     assert ok is True
     assert removed == ["figma"]  # 级联 stop+remove
@@ -198,7 +198,7 @@ async def test_install_enable_disable_enable_no_reclone(tmp_path: Path) -> None:
     sentinel.write_text("x", encoding="utf-8")
 
     # disable：摘 server + orphan skill
-    await disable_plugin("audit@acme-skills", reg, home, env=env, remove_server=_remove)
+    await disable_plugin("audit@acme-skills", reg, home, non_plugin_bundle_ids=lambda: set(), env=env, remove_server=_remove)
     assert reg.is_orphan("audit:lint") and removed == ["figma"]
 
     # enable：复活 skill + 重挂 server，且不重 clone

--- a/tests/unit_tests/computer/cli/test_main.py
+++ b/tests/unit_tests/computer/cli/test_main.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+import typer
 
 import a2c_smcp.computer.cli.main as cli_main
 from a2c_smcp.computer.cli.main import _interactive_loop
@@ -42,6 +43,7 @@ class FakeComputer:
         confirm_callback: Callable[[str, str, str, dict], bool] | None = None,
         input_resolver: Any | None = None,
         registered_workdirs: Any | None = None,
+        mcp_flag_config: Any | None = None,
     ) -> None:
         self.init_args = {
             "inputs": inputs,
@@ -51,6 +53,7 @@ class FakeComputer:
             "confirm_callback": confirm_callback,
             "input_resolver": input_resolver,
             "registered_workdirs": registered_workdirs,
+            "mcp_flag_config": mcp_flag_config,
         }
 
     async def __aenter__(self) -> FakeComputer:
@@ -74,8 +77,7 @@ def test_run_impl_uses_default_computer_when_no_factory(monkeypatch: pytest.Monk
         auth=None,
         headers=None,
         computer_factory=None,
-        config=None,
-        inputs=None,
+        mcp_config=None,
     )
 
     assert DummyInteractive.called is True
@@ -104,8 +106,7 @@ def test_run_impl_uses_resolved_factory(monkeypatch: pytest.MonkeyPatch) -> None
         auth=None,
         headers=None,
         computer_factory="some.module:factory",
-        config=None,
-        inputs=None,
+        mcp_config=None,
     )
 
     assert calls["count"] == 1
@@ -129,8 +130,7 @@ def test_run_impl_factory_not_callable_fallback(monkeypatch: pytest.MonkeyPatch)
         auth=None,
         headers=None,
         computer_factory="x.y:bad",
-        config=None,
-        inputs=None,
+        mcp_config=None,
     )
 
     assert isinstance(DummyInteractive.last_comp, FakeComputer)
@@ -152,8 +152,7 @@ def test_run_impl_resolve_error_fallback(monkeypatch: pytest.MonkeyPatch) -> Non
         auth=None,
         headers=None,
         computer_factory="x.y:z",
-        config=None,
-        inputs=None,
+        mcp_config=None,
     )
 
     assert isinstance(DummyInteractive.last_comp, FakeComputer)
@@ -308,40 +307,12 @@ async def test_inputs_value_print_json_fallback(monkeypatch: pytest.MonkeyPatch)
     await _interactive_loop(comp)
 
 
-def test_run_impl_inputs_and_servers_single_object(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """覆盖 _run_impl 的 inputs/config 单对象路径。"""
-    # 立即退出的交互
-    monkeypatch.setattr(cli_main, "PromptSession", lambda: FakePromptSession(["exit"]))
-    monkeypatch.setattr(cli_main, "patch_stdout", lambda raw: no_patch_stdout())
-
-    inputs_file = tmp_path / "i.json"
-    inputs_file.write_text(
-        json.dumps({"id": "SO", "type": "promptString", "description": "d", "default": "a"}),
-        encoding="utf-8",
-    )
-
-    server_file = tmp_path / "s.json"
-    server_file.write_text(
-        json.dumps(
-            {
-                "name": "solo",
-                "type": "stdio",
-                "disabled": True,
-                "forbidden_tools": [],
-                "tool_meta": {},
-                "server_parameters": {
-                    "command": "echo",
-                    "args": [],
-                    "env": None,
-                    "cwd": None,
-                    "encoding": "utf-8",
-                    "encoding_error_handler": "strict",
-                },
-            },
-        ),
-        encoding="utf-8",
-    )
-
+# ── `--mcp-config` 形状硬切 + fail-fast（#154）/ shape hard-cut + fail-fast ──────
+#
+# 历史 `test_run_impl_inputs_and_servers_single_object` / `..._loads_inputs_and_servers_from_files` **已删除**：
+# 它们钉的正是本次要切掉的契约（`--config` 收「裸 server 对象 / 数组」+ 独立 `--inputs`）。替代守卫 = 下列
+# fail-fast 用例 + `tests/integration_tests/computer/cli/test_mcp_flag_config.py`（真实构造路径消费 inputs 段，F7）。
+def _run_with_mcp_config(raw: str) -> None:
     cli_main._run_impl(
         auto_connect=False,
         auto_reconnect=False,
@@ -350,9 +321,133 @@ def test_run_impl_inputs_and_servers_single_object(tmp_path: Path, monkeypatch: 
         auth=None,
         headers=None,
         computer_factory=None,
-        config=str(server_file),  # 单对象
-        inputs=str(inputs_file),  # 单对象
+        mcp_config=raw,
     )
+
+
+def test_run_impl_rejects_legacy_bare_server_mcp_config(tmp_path: Path) -> None:
+    """旧「裸 server 对象」格式 → fail-fast(2)，且提示含新形状与「去掉 name 字段」指引。"""
+    p = tmp_path / "old.json"
+    p.write_text(json.dumps({"name": "solo", "type": "stdio", "server_parameters": {"command": "echo"}}), encoding="utf-8")
+    with pytest.raises(typer.Exit) as ei:
+        _run_with_mcp_config(str(p))
+    assert ei.value.exit_code == 2
+
+
+def test_run_impl_rejects_legacy_server_array_mcp_config(tmp_path: Path) -> None:
+    """旧「server 数组」格式 → fail-fast(2)。"""
+    p = tmp_path / "old-arr.json"
+    p.write_text(json.dumps([{"name": "a", "type": "stdio", "server_parameters": {"command": "echo"}}]), encoding="utf-8")
+    with pytest.raises(typer.Exit) as ei:
+        _run_with_mcp_config(str(p))
+    assert ei.value.exit_code == 2
+
+
+def test_run_impl_rejects_unreadable_mcp_config(tmp_path: Path) -> None:
+    """路径不存在 / JSON 损坏 → fail-fast(2)（旧 `--config` 在此静默降级启动）。"""
+    with pytest.raises(typer.Exit) as ei:
+        _run_with_mcp_config(str(tmp_path / "nope.json"))
+    assert ei.value.exit_code == 2
+
+
+def test_run_impl_mcp_config_invalid_fails_before_connect(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """
+    **置于 connect 之前**的守卫：坏 flag 文件 MUST NOT 留下已连接 socket / 已 boot 的 Computer。
+
+    历史 `--config` 解析在 `await init_client.connect(...)` **之后**且吞异常 ⇒ 坏文件会连上再静默降级。
+    变异验证：把 `_mcp_flag_path(...)` 移回 `_amain` 的 connect 之后 → 本例转红（唯一钉住「校验位置」的守卫）。
+    """
+    connected: list[str] = []
+
+    class _Client:
+        def __init__(self, **_: Any) -> None: ...
+        async def connect(self, *a: Any, **kw: Any) -> None:
+            connected.append("yes")
+
+    constructed: list[str] = []
+
+    class _Comp(FakeComputer):
+        def __init__(self, **kw: Any) -> None:
+            constructed.append("yes")
+            super().__init__(**kw)
+
+    monkeypatch.setattr(cli_main, "SMCPComputerClient", _Client, raising=True)
+    monkeypatch.setattr(cli_main, "Computer", _Comp, raising=True)
+    monkeypatch.setattr(cli_main, "_interactive_loop", DummyInteractive.coro, raising=True)
+
+    bad = tmp_path / "bad.json"
+    bad.write_text("{not json", encoding="utf-8")
+    with pytest.raises(typer.Exit) as ei:
+        cli_main._run_impl(
+            auto_connect=False,
+            auto_reconnect=False,
+            url="http://example.invalid",  # 有 url ⇒ 若校验在 connect 之后，必已连接
+            namespace=cli_main.SMCP_NAMESPACE,
+            auth=None,
+            headers=None,
+            computer_factory=None,
+            mcp_config=str(bad),
+        )
+    assert ei.value.exit_code == 2
+    assert connected == [], "坏 --mcp-config 不得留下已连接的 socket（校验须先于 connect）"
+    assert constructed == [], "坏 --mcp-config 不得留下已 boot 的 Computer"
+
+
+def test_run_impl_hands_mcp_flag_path_to_computer(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """
+    `--mcp-config` 经 `Computer(mcp_flag_config=)` 注入（boot 声明式输入），且 `_run_impl` **不**自行急切挂载。
+
+    `@file` 前缀被剥离。搭档守卫 = 集成测试 C1（真正验证 flag 层被 resolve 消费）——本例只钉「交接」。
+    """
+    monkeypatch.setattr(cli_main, "Computer", FakeComputer, raising=True)
+    monkeypatch.setattr(cli_main, "_interactive_loop", DummyInteractive.coro, raising=True)
+
+    good = tmp_path / "flag-mcp.json"
+    good.write_text(
+        json.dumps({"servers": {"figma.mcp": {"type": "stdio", "server_parameters": {"command": "node"}}}, "inputs": []}), encoding="utf-8",
+    )
+
+    _run_with_mcp_config("@" + str(good))  # `@file` 语法
+    comp = DummyInteractive.last_comp
+    assert comp.init_args["mcp_flag_config"] == good  # `@` 已剥离
+    assert comp.init_args["mcp_servers"] == set()  # CLI 非嵌入式宿主 ⇒ embed 层恒空
+
+
+def test_run_cli_options_renamed_and_inputs_removed() -> None:
+    """
+    参数面契约：`--mcp-config`/`-c` 在，`--config` / `--inputs` / `-i` **不在**——root 与 run **双查**。
+
+    **程序化查参**而非查渲染 help：rich/typer 按终端宽度换行，help 文本断行会让子串断言 flaky。
+    """
+    import typer.main as typer_main
+
+    cmd = typer_main.get_command(cli_main.app)
+    run_cmd = cmd.commands["run"]  # type: ignore[attr-defined]
+    for name, target in (("run", run_cmd), ("root", cmd)):
+        opts = {o for p in target.params for o in p.opts}
+        assert "--mcp-config" in opts, f"{name}: --mcp-config 缺失"
+        assert "-c" in opts, f"{name}: -c 短参缺失"
+        assert "--config" not in opts, f"{name}: 旧 --config 未删"
+        assert "--inputs" not in opts, f"{name}: --inputs 未删"
+        assert "-i" not in opts, f"{name}: -i 未删"
+
+
+def test_settings_help_no_longer_claims_lowest_priority() -> None:
+    """
+    `--settings` 帮助文案订正：flag 是**次高**、不是「最低优先级」（该文案一直是错的，实现从来是次高）。
+
+    root 与 run **两份都查**——只查一份会让另一份烂掉（本仓 `--settings` 确有两份声明）。
+    """
+    import typer.main as typer_main
+
+    cmd = typer_main.get_command(cli_main.app)
+    run_cmd = cmd.commands["run"]  # type: ignore[attr-defined]
+    for name, target in (("run", run_cmd), ("root", cmd)):
+        helps = {p.name: (p.help or "") for p in target.params}
+        for flag in ("settings_file", "mcp_config"):
+            assert "最低优先级" not in helps.get(flag, ""), f"{name}.{flag}: 仍写「最低优先级」"
+        assert "次高" in helps.get("settings_file", ""), f"{name}: --settings 未写明次高"
+        assert "次高" in helps.get("mcp_config", ""), f"{name}: --mcp-config 未写明次高"
 
 
 @pytest.mark.asyncio
@@ -542,48 +637,50 @@ def test_root_no_color_triggers_console_switch(monkeypatch: pytest.MonkeyPatch) 
     assert called["ok"] is True
 
 
-def test_run_impl_loads_inputs_and_servers_from_files(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """覆盖 _run_impl 的 inputs/config 文件加载成功路径。"""
-    # 提供立即退出的交互
+def test_run_impl_accepts_valid_mcp_flag_config_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """
+    `--mcp-config` 合法 mcp.json 形状 → 正常 boot 进 REPL（本例只走通路径；层序/消费见 Group A + 集成 C1）。
+
+    取代已删除的 `test_run_impl_loads_inputs_and_servers_from_files`（它钉的是被切掉的「server 数组 + 独立
+    --inputs」契约）。`inputs` 段现由 flag 层 mcp.json 承载、经 `run_mcp_approval` 与其余 scope 同路消费。
+    """
+    # #137 ②：REPL 路径可能 durable 落盘 → 隔离 cwd/XDG 到 tmp，防写真实仓库 .tfrobot/。
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "cfg"))
+    monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(cli_main, "PromptSession", lambda: FakePromptSession(["exit"]))
     monkeypatch.setattr(cli_main, "patch_stdout", lambda raw: no_patch_stdout())
 
-    inputs_file = tmp_path / "inputs.json"
-    inputs_file.write_text(
+    flag_file = tmp_path / "flag-mcp.json"
+    flag_file.write_text(
         json.dumps(
-            [
-                {"id": "VA", "type": "promptString", "description": "d", "default": "1"},
-                {"id": "VB", "type": "pickString", "description": "d", "options": ["x", "y"], "default": "x"},
-            ],
-        ),
-        encoding="utf-8",
-    )
-
-    server_file = tmp_path / "servers.json"
-    server_file.write_text(
-        json.dumps(
-            [
-                {
-                    "name": "s1",
-                    "type": "stdio",
-                    "disabled": True,
-                    "forbidden_tools": [],
-                    "tool_meta": {},
-                    "server_parameters": {
-                        "command": "echo",
-                        "args": [],
-                        "env": None,
-                        "cwd": None,
-                        "encoding": "utf-8",
-                        "encoding_error_handler": "strict",
+            {
+                "servers": {
+                    # 键含 `.` ⇒ bundle_id `s1_srv` ≠ name（conformance §2.0 分叉；`-` 不会被折叠，故不用 `-`）
+                    "s1.srv": {
+                        "type": "stdio",
+                        "disabled": True,
+                        "forbidden_tools": [],
+                        "tool_meta": {},
+                        "server_parameters": {
+                            "command": "echo",
+                            "args": [],
+                            "env": None,
+                            "cwd": None,
+                            "encoding": "utf-8",
+                            "encoding_error_handler": "strict",
+                        },
                     },
                 },
-            ],
+                "inputs": [
+                    {"id": "VA", "type": "promptString", "description": "d", "default": "1"},
+                    {"id": "VB", "type": "pickString", "description": "d", "options": ["x", "y"], "default": "x"},
+                ],
+            },
         ),
         encoding="utf-8",
     )
 
-    # 运行：不提供 url，避免网络；仅加载文件
+    # 不提供 url，避免网络
     cli_main._run_impl(
         auto_connect=False,
         auto_reconnect=False,
@@ -592,8 +689,7 @@ def test_run_impl_loads_inputs_and_servers_from_files(tmp_path: Path, monkeypatc
         auth=None,
         headers=None,
         computer_factory=None,
-        config=str(server_file),
-        inputs=str(inputs_file),
+        mcp_config=str(flag_file),
     )
 
 
@@ -614,8 +710,7 @@ def test_run_impl_cli_params_parse_error(monkeypatch: pytest.MonkeyPatch) -> Non
         auth="invalid",  # 无效
         headers="also_invalid",  # 无效
         computer_factory=None,
-        config=None,
-        inputs=None,
+        mcp_config=None,
     )
 
 

--- a/tests/unit_tests/computer/cli/test_main.py
+++ b/tests/unit_tests/computer/cli/test_main.py
@@ -12,6 +12,7 @@ from typing import Any
 
 import pytest
 import typer
+from typer.testing import CliRunner
 
 import a2c_smcp.computer.cli.main as cli_main
 from a2c_smcp.computer.cli.main import _interactive_loop
@@ -432,6 +433,44 @@ def test_run_cli_options_renamed_and_inputs_removed() -> None:
         assert "-i" not in opts, f"{name}: -i 未删"
 
 
+def test_root_level_mcp_config_reaches_run(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """
+    ``a2c-computer --mcp-config <file> run``（flag 置于**子命令之前**）MUST 被消费 —— 不得静默丢弃。
+
+    隔离审查 🔴2：``--mcp-config`` 在根回调与 ``run`` 上各声明一份，但根回调**只在无子命令时**消费它；
+    显式带 ``run`` 时根的值既不入 ``_RootState``、``run`` 也不回读 ⇒ **静默丢弃**（连 fail-fast 都碰不到）。
+    实测 develop 上 ``a2c-computer --config bad.json run`` 会响亮报 "No such option"（exit 2），本 PR
+    若不修则退化为 exit 1 + 一个与 ``--mcp-config`` 毫无关系的 OSError ⇒ **本 PR 自引入的失败模式回归**。
+
+    ``--settings`` 同形（既有缺陷，一并修）：它同样 root+run 双声明，root 那份对 ``run`` 从来无效。
+    """
+    seen: dict[str, Any] = {}
+
+    def _capture(**kw: Any) -> None:
+        seen.update(kw)
+
+    monkeypatch.setattr(cli_main, "_run_impl", _capture, raising=True)
+
+    good = tmp_path / "flag-mcp.json"
+    good.write_text(json.dumps({"servers": {}, "inputs": []}), encoding="utf-8")
+    st = tmp_path / "flag-settings.json"
+    st.write_text(json.dumps({}), encoding="utf-8")
+
+    runner = CliRunner()
+    result = runner.invoke(cli_main.app, ["--mcp-config", str(good), "--settings", str(st), "run"])
+    assert result.exit_code == 0, result.output
+    assert seen.get("mcp_config") == str(good), "根级 --mcp-config 未透传到 run（静默丢弃）"
+    assert seen.get("settings_file") == str(st), "根级 --settings 未透传到 run（静默丢弃）"
+
+
+def test_root_level_mcp_config_still_fails_fast_on_bad_file(tmp_path: Path) -> None:
+    """根级 ``--mcp-config`` 的坏文件同样 fail-fast(2)——静默丢弃会让 fail-fast 形同虚设（🔴2 的后果面）。"""
+    bad = tmp_path / "bad.json"
+    bad.write_text("{not json", encoding="utf-8")
+    result = CliRunner().invoke(cli_main.app, ["--mcp-config", str(bad), "run"])
+    assert result.exit_code == 2, f"根级坏 --mcp-config 未 fail-fast；output={result.output!r}"
+
+
 def test_settings_help_no_longer_claims_lowest_priority() -> None:
     """
     `--settings` 帮助文案订正：flag 是**次高**、不是「最低优先级」（该文案一直是错的，实现从来是次高）。
@@ -792,14 +831,18 @@ def test_run_with_cli_url_auth_headers(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(cli_main, "PromptSession", lambda: FakePromptSession(commands))
     monkeypatch.setattr(cli_main, "patch_stdout", lambda raw: no_patch_stdout())
 
-    # 调用同步的 run()，其内部使用 asyncio.run() 执行
-    cli_main.run(
+    # 走 `_run_impl`（纯实现函数）而非被 @app.command 装饰的 `run`：后者的形参由 Typer 解析（#154 起还需
+    # `ctx` 兜底回读根级 flag），直呼会让未传的形参保留 OptionInfo —— 这正是 `_run_impl` 存在的理由，
+    # 本文件其余用例亦皆走它。
+    cli_main._run_impl(
         auto_connect=False,
         auto_reconnect=False,
         url="http://service:1234",
         namespace=cli_main.SMCP_NAMESPACE,
         auth="token:abc",
         headers="h1:v1,h2:v2",
+        computer_factory=None,
+        mcp_config=None,
     )
 
     last: FakeSMCPClient = FakeSMCPClient.last  # type: ignore[assignment]
@@ -1050,13 +1093,16 @@ def test_cli_namespace_flag_propagates_to_client_handler_registration(
     monkeypatch.setattr(cli_main, "PromptSession", lambda: FakePromptSession(["exit"]))
     monkeypatch.setattr(cli_main, "patch_stdout", lambda raw: no_patch_stdout())
 
-    cli_main.run(
+    # 同上：走纯实现函数 `_run_impl`，不直呼被 @app.command 装饰的 `run`（其形参由 Typer 解析）。
+    cli_main._run_impl(
         auto_connect=False,
         auto_reconnect=False,
         url="http://localhost:1",
         namespace=custom_ns,
         auth=None,
         headers=None,
+        computer_factory=None,
+        mcp_config=None,
     )
 
     # 至少应创建过一个客户端 / at least one client must have been created

--- a/tests/unit_tests/computer/cli/test_mcp_approval.py
+++ b/tests/unit_tests/computer/cli/test_mcp_approval.py
@@ -25,6 +25,7 @@ import pytest
 
 import a2c_smcp.computer.cli.commands.plugin as plugin_cmd
 from a2c_smcp.computer.cli.commands.plugin import run_mcp_approval
+from a2c_smcp.computer.settings.mcp_config import resolve_mcp_config
 from a2c_smcp.computer.settings.scope import user_settings_path, workdir_local_settings_path
 
 
@@ -70,10 +71,31 @@ class _Session:
 
 
 class _FakeComp:
-    def __init__(self, home: Path) -> None:
+    """Computer 桩：**声明面解析逐字复用生产实现**，只桩掉挂载副作用 / Stub that reuses the real declaration resolve。
+
+    ``resolve_mcp_declarations`` **刻意不自己实现**，而是照 :meth:`Computer.resolve_mcp_declarations` 同款委托
+    :func:`resolve_mcp_config`（同样透传 flag/embed 两条 boot 声明式输入）——否则桩会把「flag/embed 层不存在」
+    这个前提固化进测试，令 #154/#164 的层序与 origin 条款**在此文件内永远测不到**（Epic #147 记载的 ``_FakeComputer``
+    假绿正是此形状）。真实构造路径的契约测试见 ``tests/integration_tests/computer/cli/test_mcp_flag_config.py``（F7）。
+    """
+
+    def __init__(
+        self,
+        home: Path,
+        *,
+        mcp_flag_config: Path | None = None,
+        mcp_servers: list[Any] | None = None,
+    ) -> None:
         self.skill_home = home
         self.injected: list[Any] = []
         self.mounted: list[dict[str, Any]] = []
+        self.unmounted: list[str] = []
+        self.mcp_manager: Any = None  # pre-boot：无活跃集（与 CLI 首次 boot 同形）
+        self._mcp_flag_config = mcp_flag_config
+        self._mcp_servers = list(mcp_servers or [])
+
+    def resolve_mcp_declarations(self, *, env: Any = None) -> Any:
+        return resolve_mcp_config(env=env, flag_config_path=self._mcp_flag_config, embed_servers=self._mcp_servers)
 
     def add_or_update_input(self, inp: Any) -> None:
         self.injected.append(inp)
@@ -83,6 +105,9 @@ class _FakeComp:
     ) -> None:
         # #137 ③：run_mcp_approval 走 transient amount_server（boot 读已声明 mcp.json = 投影，不回写）。
         self.mounted.append(cfg)
+
+    async def aunmount_server_by_id(self, bundle_id: str) -> None:
+        self.unmounted.append(bundle_id)
 
 
 def _mounted_names(comp: _FakeComp) -> set[str]:
@@ -108,7 +133,7 @@ async def test_pending_approve_yes_writes_local_and_mounts_then_idempotent(tmp_p
     import unittest.mock as _m
 
     with _m.patch.dict(os.environ, env, clear=False):
-        await run_mcp_approval(comp, sess, approve_all=False, flag_config=None)
+        await run_mcp_approval(comp, sess, approve_all=False, settings_flag_path=None)
     assert "shared" in _mounted_names(comp)  # [y] → 挂载
     local = json.loads(workdir_local_settings_path(wd).read_text(encoding="utf-8"))
     assert local["enabledMcpjsonServers"] == ["shared"]  # 写 local scope（cwd 单根）
@@ -117,7 +142,7 @@ async def test_pending_approve_yes_writes_local_and_mounts_then_idempotent(tmp_p
     comp2 = _FakeComp(home)
     sess2 = _Session([])
     with _m.patch.dict(os.environ, env, clear=False):
-        await run_mcp_approval(comp2, sess2, approve_all=False, flag_config=None)
+        await run_mcp_approval(comp2, sess2, approve_all=False, settings_flag_path=None)
     assert "shared" in _mounted_names(comp2)
     assert sess2.prompts == []  # 不再弹批准框
 
@@ -134,7 +159,7 @@ async def test_pending_non_tty_skips_and_does_not_write(tmp_path: Path, monkeypa
     import unittest.mock as _m
 
     with _m.patch.dict(os.environ, env, clear=False):
-        await run_mcp_approval(comp, None, approve_all=False, flag_config=None)  # session=None = 非 TTY
+        await run_mcp_approval(comp, None, approve_all=False, settings_flag_path=None)  # session=None = 非 TTY
     assert _mounted_names(comp) == set()  # 未挂
     assert not workdir_local_settings_path(wd).exists()  # 未写
 
@@ -150,7 +175,7 @@ async def test_pending_non_tty_approve_all_mounts_without_persist(tmp_path: Path
     import unittest.mock as _m
 
     with _m.patch.dict(os.environ, env, clear=False):
-        await run_mcp_approval(comp, None, approve_all=True, flag_config=None)
+        await run_mcp_approval(comp, None, approve_all=True, settings_flag_path=None)
     assert "shared" in _mounted_names(comp)  # --approve-all-mcp → 挂载
     assert not workdir_local_settings_path(wd).exists()  # 仅本次、不落盘
 
@@ -168,7 +193,7 @@ async def test_user_origin_mounts_without_box(tmp_path: Path, monkeypatch: pytes
     import unittest.mock as _m
 
     with _m.patch.dict(os.environ, env, clear=False):
-        await run_mcp_approval(comp, sess, approve_all=False, flag_config=None)
+        await run_mcp_approval(comp, sess, approve_all=False, settings_flag_path=None)
     assert "mine" in _mounted_names(comp)
     assert sess.prompts == []
 
@@ -186,7 +211,7 @@ async def test_envfile_ext_merged_into_mount_dict(tmp_path: Path, monkeypatch: p
     import unittest.mock as _m
 
     with _m.patch.dict(os.environ, env, clear=False):
-        await run_mcp_approval(comp, _Session([]), approve_all=False, flag_config=None)
+        await run_mcp_approval(comp, _Session([]), approve_all=False, settings_flag_path=None)
     mine = next(m for m in comp.mounted if m.get("name") == "mine")
     assert mine.get("envFile") == envfile  # ext 合回，否则 spawn 丢 envFile
 
@@ -206,7 +231,7 @@ async def test_malformed_server_surfaces_warning(
     import unittest.mock as _m
 
     with _m.patch.dict(os.environ, env, clear=False):
-        await run_mcp_approval(comp, None, approve_all=True, flag_config=None)
+        await run_mcp_approval(comp, None, approve_all=True, settings_flag_path=None)
     out = capsys.readouterr().out
     assert "mcp.json" in out  # resolved.errors 呈现（被 drop 的 bad 不静默）
 
@@ -233,7 +258,7 @@ async def test_project_self_approval_filtered_and_surfaced_at_boot(
 
     with _m.patch.dict(os.environ, env, clear=False):
         # session=None（非 TTY）且未 --approve-all-mcp → 若自我批准生效会直挂；被过滤后应 skip+WARN。
-        await run_mcp_approval(comp, None, approve_all=False, flag_config=None)
+        await run_mcp_approval(comp, None, approve_all=False, settings_flag_path=None)
 
     assert _mounted_names(comp) == set(), "project 自我批准 MUST NOT 让恶意 server 直挂"
     out = capsys.readouterr().out

--- a/tests/unit_tests/computer/cli/test_plugin.py
+++ b/tests/unit_tests/computer/cli/test_plugin.py
@@ -227,7 +227,7 @@ async def test_disable_reads_scope_from_ledger(tmp_path: Path) -> None:
         home=home,
     )
     mcp = _FakeMCP()
-    code = await plugin_cmd.plugin_disable(reg, home, env, "audit@acme", remove_server=mcp.remove)
+    code = await plugin_cmd.plugin_disable(reg, home, env, "audit@acme", non_plugin_bundle_ids=lambda: set(), remove_server=mcp.remove)
     assert code == 0
     assert mcp.removed == [FIGMA_NAME]  # 整 plugin 下线：摘 bundled server
     user = json.loads(user_settings_path(env).read_text(encoding="utf-8"))
@@ -238,7 +238,7 @@ async def test_disable_reads_scope_from_ledger(tmp_path: Path) -> None:
 @pytest.mark.asyncio
 async def test_uninstall_not_installed_exit1(tmp_path: Path) -> None:
     home, env, reg = _home(tmp_path), _env(tmp_path), SkillRegistry()
-    assert await plugin_cmd.plugin_uninstall(reg, home, env, "ghost@acme") == 1
+    assert await plugin_cmd.plugin_uninstall(reg, home, env, "ghost@acme", non_plugin_bundle_ids=lambda: set()) == 1
 
 
 def test_list_and_info(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
@@ -291,7 +291,7 @@ async def test_gc_no_orphans(tmp_path: Path, capsys: pytest.CaptureFixture[str])
 
     atomic_write_json(_usp(env), apply_write({}, {"installedPlugins": ["audit@acme"]}))
     save_installed_plugins({"version": 1, "plugins": {"audit@acme": [{"scope": "user", "installPath": "/x"}]}}, home=home)
-    assert await plugin_cmd.plugin_gc(reg, home, env, json_output=True) == 0
+    assert await plugin_cmd.plugin_gc(reg, home, env, non_plugin_bundle_ids=lambda: set(), json_output=True) == 0
     assert json.loads(capsys.readouterr().out)["removed"] == []
 
 
@@ -471,7 +471,7 @@ async def test_run_governance_remount_flag_declared_disables(tmp_path: Path, mon
             recorded.append(server.name)
 
         monkeypatch.setattr(comp, "amount_server", fake_register)  # #137 ③：治理重挂经 transient amount_server
-        await plugin_cmd.run_governance_remount(comp, flag_config=flag_file)
+        await plugin_cmd.run_governance_remount(comp, settings_flag_path=flag_file)
 
         assert recorded == []
 
@@ -536,7 +536,7 @@ async def test_disable_effective_across_boot_after_rematerialization(
     assert report.rematerialized == ["audit@acme"]
 
     mcp = _FakeMCP()
-    code = await plugin_cmd.plugin_disable(reg, home, env, "audit@acme", remove_server=mcp.remove)
+    code = await plugin_cmd.plugin_disable(reg, home, env, "audit@acme", non_plugin_bundle_ids=lambda: set(), remove_server=mcp.remove)
 
     assert code == 0
     proj = json.loads(workdir_project_settings_path(workdir).read_text(encoding="utf-8"))
@@ -566,7 +566,7 @@ async def test_gc_prunes_dangling_json_contract(
     home, env, reg = _home(tmp_path), dict(os.environ), SkillRegistry()
     orphan_path = _seed_orphan_and_dangling(home, env)
 
-    code = await plugin_cmd.plugin_gc(reg, home, env, json_output=True, prune_dangling=True)
+    code = await plugin_cmd.plugin_gc(reg, home, env, non_plugin_bundle_ids=lambda: set(), json_output=True, prune_dangling=True)
 
     assert code == 0
     out = json.loads(capsys.readouterr().out)
@@ -594,7 +594,7 @@ async def test_gc_confirm_combined_and_abort_keeps_everything(
         got.extend(items)
         return False
 
-    code = await plugin_cmd.plugin_gc(reg, home, env, confirm=_confirm, prune_dangling=True)
+    code = await plugin_cmd.plugin_gc(reg, home, env, non_plugin_bundle_ids=lambda: set(), confirm=_confirm, prune_dangling=True)
 
     assert code == 1
     assert any("orphan@acme" in s for s in got)
@@ -614,7 +614,7 @@ async def test_gc_prune_dangling_off_by_default_diagnose_only(
     home, env, reg = _home(tmp_path), dict(os.environ), SkillRegistry()
     _write_json(user_settings_path(env), {"installedPlugins": ["ghost@nowhere"]})
 
-    code = await plugin_cmd.plugin_gc(reg, home, env, json_output=True)  # prune_dangling 缺省 False
+    code = await plugin_cmd.plugin_gc(reg, home, env, non_plugin_bundle_ids=lambda: set(), json_output=True)  # prune_dangling 缺省 False
 
     assert code == 0
     out = json.loads(capsys.readouterr().out)
@@ -649,7 +649,7 @@ async def test_gc_prune_residual_committable_declaration_not_counted(
     _write_json(proj_path, {"installedPlugins": ["ghost@nowhere"]})
     before = proj_path.read_text(encoding="utf-8")
 
-    code = await plugin_cmd.plugin_gc(reg, home, env, json_output=True, prune_dangling=True)
+    code = await plugin_cmd.plugin_gc(reg, home, env, non_plugin_bundle_ids=lambda: set(), json_output=True, prune_dangling=True)
 
     assert code == 0
     out = json.loads(capsys.readouterr().out)
@@ -671,7 +671,7 @@ async def test_gc_confirm_accept_removes_orphans_and_prunes_dangling(
     async def _confirm(items: list[str]) -> bool:
         return True
 
-    code = await plugin_cmd.plugin_gc(reg, home, env, confirm=_confirm, prune_dangling=True)
+    code = await plugin_cmd.plugin_gc(reg, home, env, non_plugin_bundle_ids=lambda: set(), confirm=_confirm, prune_dangling=True)
 
     assert code == 0
     assert not orphan_path.exists()  # 孤儿已删

--- a/tests/unit_tests/computer/settings/test_install_enable_separation.py
+++ b/tests/unit_tests/computer/settings/test_install_enable_separation.py
@@ -316,7 +316,7 @@ async def test_uninstall_clears_intent_and_enabled_entries(tmp_path: Path, monke
     monkeypatch.setattr(_STAGE, _fake_stage([]))
     mcp = _FakeMCP()
 
-    ok = await uninstall_plugin(_PID, SkillRegistry(), home, env=env, remove_server=mcp.remove)
+    ok = await uninstall_plugin(_PID, SkillRegistry(), home, non_plugin_bundle_ids=lambda: set(), env=env, remove_server=mcp.remove)
 
     assert ok is True
     settings = _read_user_settings(env)
@@ -545,7 +545,9 @@ async def test_uninstall_scoped_keeps_intent_for_remaining_scopes(tmp_path: Path
     _write_json(user_settings_path(env), {"installedPlugins": [_PID], "enabledPlugins": {_PID: True}})
     monkeypatch.setattr(_STAGE, _fake_stage([]))
 
-    ok = await uninstall_plugin(_PID, SkillRegistry(), home, env=env, scope="project", keep_servers=True)
+    ok = await uninstall_plugin(
+        _PID, SkillRegistry(), home, non_plugin_bundle_ids=lambda: set(), env=env, scope="project", keep_servers=True,
+    )
 
     assert ok is True
     remaining = load_installed_plugins(home=home)["plugins"][_PID]
@@ -700,7 +702,7 @@ async def test_uninstall_clears_cwd_visible_enabled_entries_without_ledger_proje
     _write_json(workdir_project_settings_path(workdir), {"enabledPlugins": {_PID: True}})
     monkeypatch.setattr(_STAGE, _fake_stage([]))
 
-    ok = await uninstall_plugin(_PID, SkillRegistry(), home, env=env)
+    ok = await uninstall_plugin(_PID, SkillRegistry(), home, non_plugin_bundle_ids=lambda: set(), env=env)
 
     assert ok is True
     proj = json.loads(workdir_project_settings_path(workdir).read_text(encoding="utf-8"))
@@ -720,7 +722,7 @@ async def test_uninstall_does_not_create_tfrobot_dir_in_cwd(tmp_path: Path, monk
     _write_json(user_settings_path(env), {"installedPlugins": [_PID], "enabledPlugins": {_PID: True}})
     monkeypatch.setattr(_STAGE, _fake_stage([]))
 
-    ok = await uninstall_plugin(_PID, SkillRegistry(), home, env=env)
+    ok = await uninstall_plugin(_PID, SkillRegistry(), home, non_plugin_bundle_ids=lambda: set(), env=env)
 
     assert ok is True
     assert not (workdir / ".tfrobot").exists()  # 不制造垃圾目录/锁文件

--- a/tests/unit_tests/computer/settings/test_installer.py
+++ b/tests/unit_tests/computer/settings/test_installer.py
@@ -301,7 +301,7 @@ async def test_uninstall_default_cascades(tmp_path: Path, monkeypatch) -> None:
     assert install_path.exists()
     mcp.removed.clear()
 
-    ok = await uninstall_plugin("audit@acme", reg, home, env=env, remove_server=mcp.remove)
+    ok = await uninstall_plugin("audit@acme", reg, home, non_plugin_bundle_ids=lambda: set(), env=env, remove_server=mcp.remove)
 
     assert ok is True
     assert mcp.removed == [FIGMA_BID]  # 级联 stop+remove
@@ -321,7 +321,9 @@ async def test_uninstall_keep_servers_skips_teardown(tmp_path: Path, monkeypatch
     await _install(home, tmp_path, monkeypatch, mcp, reg, servers=[FIGMA_NAME])
     mcp.removed.clear()
 
-    ok = await uninstall_plugin("audit@acme", reg, home, env=env, keep_servers=True, remove_server=mcp.remove)
+    ok = await uninstall_plugin(
+        "audit@acme", reg, home, non_plugin_bundle_ids=lambda: set(), env=env, keep_servers=True, remove_server=mcp.remove,
+    )
 
     assert ok is True
     assert mcp.removed == []  # 保留 server
@@ -331,7 +333,7 @@ async def test_uninstall_keep_servers_skips_teardown(tmp_path: Path, monkeypatch
 
 async def test_uninstall_not_installed_is_noop(tmp_path: Path) -> None:
     env = _env(tmp_path)
-    assert await uninstall_plugin("ghost@acme", SkillRegistry(), _home(tmp_path), env=env) is False
+    assert await uninstall_plugin("ghost@acme", SkillRegistry(), _home(tmp_path), non_plugin_bundle_ids=lambda: set(), env=env) is False
     assert not user_settings_path(env).exists()  # 真 no-op：零写盘（迁移不被 no-op 路径触发，审查 N1）
 
 
@@ -344,7 +346,7 @@ async def test_disable_writes_flag_detaches_servers_orphans_skills(tmp_path: Pat
     await _install(home, tmp_path, monkeypatch, mcp, reg, servers=[FIGMA_NAME])
     mcp.removed.clear()
 
-    await disable_plugin("audit@acme", reg, home, env=env, remove_server=mcp.remove)
+    await disable_plugin("audit@acme", reg, home, non_plugin_bundle_ids=lambda: set(), env=env, remove_server=mcp.remove)
 
     settings = json.loads(user_settings_path(env).read_text(encoding="utf-8"))
     assert settings["enabledPlugins"]["audit@acme"] is False
@@ -364,7 +366,9 @@ async def test_disable_project_scope_writes_workdir_settings(tmp_path: Path, mon
     _seed_installed(home, {"audit@acme": [{"scope": "project", "installPath": audit_path}]})
     monkeypatch.setattr(_STAGE, _fake_stage([]))
 
-    await disable_plugin("audit@acme", SkillRegistry(), home, scope="project", project_path=str(workdir), env=env)
+    await disable_plugin(
+        "audit@acme", SkillRegistry(), home, scope="project", project_path=str(workdir), non_plugin_bundle_ids=lambda: set(), env=env,
+    )
 
     settings = json.loads(workdir_project_settings_path(workdir).read_text(encoding="utf-8"))
     assert settings["enabledPlugins"]["audit@acme"] is False
@@ -372,12 +376,16 @@ async def test_disable_project_scope_writes_workdir_settings(tmp_path: Path, mon
 
 async def test_disable_project_scope_requires_project_path(tmp_path: Path) -> None:
     with pytest.raises(PluginInstallError, match="project_path"):
-        await disable_plugin("audit@acme", SkillRegistry(), _home(tmp_path), scope="project", env=_env(tmp_path))
+        await disable_plugin(
+            "audit@acme", SkillRegistry(), _home(tmp_path), non_plugin_bundle_ids=lambda: set(), scope="project", env=_env(tmp_path),
+        )
 
 
 async def test_disable_managed_scope_rejected(tmp_path: Path) -> None:
     with pytest.raises(PluginInstallError, match="writable"):
-        await disable_plugin("audit@acme", SkillRegistry(), _home(tmp_path), scope="managed", env=_env(tmp_path))
+        await disable_plugin(
+            "audit@acme", SkillRegistry(), _home(tmp_path), non_plugin_bundle_ids=lambda: set(), scope="managed", env=_env(tmp_path),
+        )
 
 
 # ── enable ────────────────────────────────────────────────────────────────────
@@ -387,7 +395,7 @@ async def test_enable_recovers_skills_and_remounts_servers(tmp_path: Path, monke
     mcp = _FakeMCP()
     reg = SkillRegistry()
     await _install(home, tmp_path, monkeypatch, mcp, reg, servers=[FIGMA_NAME])
-    await disable_plugin("audit@acme", reg, home, env=env, remove_server=mcp.remove)
+    await disable_plugin("audit@acme", reg, home, non_plugin_bundle_ids=lambda: set(), env=env, remove_server=mcp.remove)
     assert reg.is_orphan("audit:lint")
     mcp.registered.clear()
 

--- a/tests/unit_tests/computer/settings/test_mcp_config.py
+++ b/tests/unit_tests/computer/settings/test_mcp_config.py
@@ -168,6 +168,126 @@ def test_resolve_inputs_dedup_by_id_high_wins(tmp_path: Path, monkeypatch: pytes
     assert by_id["tok"].description == "local"  # 高 scope 胜
 
 
+# ── 协议 §2.5-3 统一优先序（#154/#164）/ The unified source-priority order ─────
+# 夹具键一律用 ``figma.mcp``（**非** ``figma-mcp``）：``normalize_name`` 折叠 ``.``→``_`` 但**不折叠 ``-``**，
+# 故 ``figma-mcp`` 的 bundle_id 恰等于自身、令 name/bundle_id 两概念不分叉（conformance §2.0 违规，本仓已因此
+# 出过四次假绿）。``figma.mcp`` → bundle_id ``figma_mcp``，两者分叉。
+def test_scope_order_matches_protocol_and_has_no_plugin_member() -> None:
+    """
+    ``SCOPE_ORDER`` 是协议 §2.5-3 优先序的**唯一**权威（两套 resolve 都迭代它，不各写字面量）。
+
+    协议序（低→高）：``plugin 声明 < user < project < local < embed < flag < policy``。
+
+    **无 ``PLUGIN`` 成员是刻意的结构性缺席**（#154 裁决）：plugin 声明基线层**不经任一 resolve**——
+    它经 transient ``amount_server`` 从 plugin manifest 挂载，plugin-lowest 由 boot 序保证
+    （``run_mcp_approval`` 先于 ``run_governance_remount``，后者跳过 ``bundle_id in existing`` 者）。
+    加一个无生产者的 ``PLUGIN`` 成员会让「迭代层过滤」沦为永假守卫（死代码），并正是 #148 那个 P0
+    「进门后豁免」档位复活的诱因。F8 的可验收信号 = **缺席**（「成员不存在」比「文档说别用」可靠）。
+    """
+    from a2c_smcp.computer.settings.schema import SCOPE_ORDER
+
+    assert SCOPE_ORDER == (
+        SettingsScope.USER,
+        SettingsScope.PROJECT,
+        SettingsScope.LOCAL,
+        SettingsScope.EMBED,
+        SettingsScope.FLAG,
+        SettingsScope.POLICY,
+    )
+    assert "plugin" not in {s.value for s in SettingsScope}
+    assert not hasattr(SettingsScope, "PLUGIN")
+
+
+def test_resolve_flag_beats_user_and_local_same_name(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """
+    **flag 次高**（协议 §2.5-3）：同名 server 上 flag 覆盖 user/project/local，仅低于 policy。
+
+    历史实现把 mcp.json 的 flag 层排**最低**（``--config`` 老接口遗留），协议明写该形态**废止**——
+    CLI 显式传入的配置被用户默认配置覆盖违反直觉，且与 ``_TRUSTED_ORIGINS`` 已把 flag 当受信来源自相矛盾。
+
+    本用例是本次改动的**红灯守卫**：改前 `test_resolve_origins_partition_trust` 用四个**不同** server 名、
+    永不发生遮蔽 ⇒ 无一条现存测试钉住 flag 层位 ⇒ 把 flag 挪到次高会**全绿通过**。
+    """
+    env = _env(tmp_path)
+    flag = tmp_path / "flag-mcp.json"
+    _write_json(flag, _mcp_doc(servers={"figma.mcp": _stdio("flag-cmd")}))
+    _write_json(_user_mcp(tmp_path), _mcp_doc(servers={"figma.mcp": _stdio("user-cmd")}))
+    _write_json(tmp_path / ".tfrobot" / "mcp.json", _mcp_doc(servers={"figma.mcp": _stdio("proj-cmd")}))
+    _write_json(tmp_path / ".tfrobot" / "mcp.local.json", _mcp_doc(servers={"figma.mcp": _stdio("local-cmd")}))
+    monkeypatch.chdir(tmp_path)
+    out = resolve_mcp_config(env=env, flag_config_path=flag, managed_mcp_path=tmp_path / "absent.json")
+    srv = out.servers["figma.mcp"]
+    assert srv.origin == SettingsScope.FLAG
+    assert isinstance(srv.config, StdioServerConfig)
+    assert srv.config.server_parameters.command == "flag-cmd"  # 整体覆盖（flag 次高）
+    assert srv.trusted_origin is True
+
+
+def test_resolve_policy_still_beats_flag(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """
+    天花板栅栏：policy 仍高于 flag（§2.5-3 「flag 仅低于 policy」）。
+
+    **注**：本例改前即绿（flag 曾最低、policy 曾最高，policy 本就胜出），是**回归栅栏**而非红灯守卫——
+    它钉住的是 `test_resolve_flag_beats_user_and_local_same_name` 够不到的那个边界（防「flag 一路提到顶」）。
+    """
+    env = _env(tmp_path)
+    flag = tmp_path / "flag-mcp.json"
+    managed = tmp_path / "managed-mcp.json"
+    _write_json(flag, _mcp_doc(servers={"figma.mcp": _stdio("flag-cmd")}))
+    _write_json(managed, _mcp_doc(servers={"figma.mcp": _stdio("policy-cmd")}))
+    monkeypatch.chdir(tmp_path)
+    out = resolve_mcp_config(env=env, flag_config_path=flag, managed_mcp_path=managed)
+    srv = out.servers["figma.mcp"]
+    assert srv.origin == SettingsScope.POLICY
+    assert isinstance(srv.config, StdioServerConfig)
+    assert srv.config.server_parameters.command == "policy-cmd"
+
+
+def test_resolve_inputs_flag_beats_local_by_id(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """inputs 同 ``id`` 亦按统一序去重：flag 胜 local（改前 flag 最低 ⇒ local 胜）。"""
+    env = _env(tmp_path)
+    flag = tmp_path / "flag-mcp.json"
+    _write_json(flag, _mcp_doc(inputs=[{"id": "tok", "type": "promptString", "description": "flag"}]))
+    _write_json(tmp_path / ".tfrobot" / "mcp.local.json", _mcp_doc(inputs=[{"id": "tok", "type": "promptString", "description": "local"}]))
+    monkeypatch.chdir(tmp_path)
+    out = resolve_mcp_config(env=env, flag_config_path=flag, managed_mcp_path=tmp_path / "absent.json")
+    by_id = {i.id: i for i in out.inputs}
+    assert by_id["tok"].description == "flag"
+
+
+def test_resolve_embed_layer_origin_and_trust(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """
+    ``embed`` = 宿主构造挂载层（``Computer(mcp_servers=...)`` 构造入参，§2.5-3）：代码级显式受信意图。
+
+    与 flag 同属「调用方显式受信层」⇒ ``trusted_origin`` 为真（审批门档④，§2.5 裁决 Discussion #32）。
+    """
+    env = _env(tmp_path)
+    embed = StdioServerConfig(name="figma.mcp", server_parameters={"command": "embed-cmd"})
+    monkeypatch.chdir(tmp_path)
+    out = resolve_mcp_config(env=env, embed_servers=[embed], managed_mcp_path=tmp_path / "absent.json")
+    srv = out.servers["figma.mcp"]
+    assert srv.origin == SettingsScope.EMBED
+    assert srv.trusted_origin is True
+    assert isinstance(srv.config, StdioServerConfig)
+    assert srv.config.server_parameters.command == "embed-cmd"
+
+
+def test_resolve_embed_beats_local_but_loses_to_flag(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """层位 ``local < embed < flag``（§2.5-3）：宿主构造入参覆盖工作区声明，但宿主自身 flag 仍可覆盖代码默认。"""
+    env = _env(tmp_path)
+    embed = StdioServerConfig(name="figma.mcp", server_parameters={"command": "embed-cmd"})
+    _write_json(tmp_path / ".tfrobot" / "mcp.local.json", _mcp_doc(servers={"figma.mcp": _stdio("local-cmd")}))
+    monkeypatch.chdir(tmp_path)
+
+    out = resolve_mcp_config(env=env, embed_servers=[embed], managed_mcp_path=tmp_path / "absent.json")
+    assert out.servers["figma.mcp"].origin == SettingsScope.EMBED  # embed > local
+
+    flag = tmp_path / "flag-mcp.json"
+    _write_json(flag, _mcp_doc(servers={"figma.mcp": _stdio("flag-cmd")}))
+    out = resolve_mcp_config(env=env, embed_servers=[embed], flag_config_path=flag, managed_mcp_path=tmp_path / "absent.json")
+    assert out.servers["figma.mcp"].origin == SettingsScope.FLAG  # flag > embed
+
+
 # ── ext 剥离 + 字段级容错 ──────────────────────────────────────────────────────
 def test_resolve_envfile_stripped_to_ext(tmp_path: Path) -> None:
     """envFile 是 VS Code 扩展（非 MCPServerConfig 字段）→ 剥离入 ext，配置仍校验通过。"""

--- a/tests/unit_tests/computer/settings/test_mcp_dependency_model.py
+++ b/tests/unit_tests/computer/settings/test_mcp_dependency_model.py
@@ -32,13 +32,15 @@ from pathlib import Path
 
 import pytest
 
+from a2c_smcp.computer.mcp_clients.model import MCPServerConfig
 from a2c_smcp.computer.settings.installer import (
     disable_plugin,
     enable_plugin,
     install_plugin,
     uninstall_plugin,
 )
-from a2c_smcp.computer.settings.reconciler import gc_plugins
+from a2c_smcp.computer.settings.mcp_config import non_plugin_declared_bundle_ids
+from a2c_smcp.computer.settings.reconciler import NonPluginBundleIds, gc_plugins
 from a2c_smcp.computer.settings.store import (
     load_installed_plugins,
     load_known_marketplaces,
@@ -75,6 +77,25 @@ def _write_json(path: Path, obj: object) -> None:
 
 def _stdio(name: str, command: str = "node") -> dict:
     return {"name": name, "type": "stdio", "server_parameters": {"command": command}}
+
+
+def _declared(
+    env: dict[str, str],
+    *,
+    flag: Path | None = None,
+    embed: list[MCPServerConfig] | None = None,
+) -> NonPluginBundleIds:
+    """
+    回收判据「X 非用户声明」项的数据源，**与生产同构** / The criterion's data source, mirroring production。
+
+    生产侧 = :func:`~a2c_smcp.computer.cli.commands.build_mcp_callbacks` 的 ``non_plugin_bundle_ids``
+    （包 ``Computer.resolve_mcp_declarations()``）。此处直呼同一底层函数，故测试与生产读**同一判据面**——
+    传桩（如 ``lambda: set()``）会让「用户/宿主自有 server 永不连坐」这条守卫**永真**，正是本仓踩过四次的假绿。
+
+    :param flag: ``--mcp-config`` flag 层 mcp.json（四景 ①④）。
+    :param embed: 宿主构造入参 ``Computer(mcp_servers=...)``（四景 ②）。
+    """
+    return lambda: non_plugin_declared_bundle_ids(env=env, flag_config_path=flag, embed_servers=embed)
 
 
 def _setup_catalog(home: Path, mp: str, plugin: str, *, servers: list[str], commit: str = "abc123") -> Path:
@@ -185,7 +206,7 @@ async def test_scenario1_sole_dependent_uninstall_reclaims(tmp_path: Path, monke
     mcp = _FakeMCP()
     await _install(home, env, "audit@acme", mcp)
 
-    await uninstall_plugin("audit@acme", SkillRegistry(), home, env=env, remove_server=mcp.remove)
+    await uninstall_plugin("audit@acme", SkillRegistry(), home, non_plugin_bundle_ids=_declared(env), env=env, remove_server=mcp.remove)
 
     assert mcp.removed == [FIGMA_BID]  # 停摘身份 = bundle_id
 
@@ -200,7 +221,7 @@ async def test_scenario2_user_declared_server_is_never_collateral(tmp_path: Path
     mcp = _FakeMCP(existing={FIGMA_BID})
     await _install(home, env, "audit@acme", mcp)
 
-    await uninstall_plugin("audit@acme", SkillRegistry(), home, env=env, remove_server=mcp.remove)
+    await uninstall_plugin("audit@acme", SkillRegistry(), home, non_plugin_bundle_ids=_declared(env), env=env, remove_server=mcp.remove)
 
     assert mcp.removed == []  # 用户声明 → 非本 plugin 可回收之物
 
@@ -217,11 +238,11 @@ async def test_scenario3_and_4_shared_dependency_no_leak(tmp_path: Path, monkeyp
     await _install(home, env, "review@beta", mcp)
 
     # ③ 卸 A —— B 仍声明依赖 X → 保留
-    await uninstall_plugin("audit@acme", SkillRegistry(), home, env=env, remove_server=mcp.remove)
+    await uninstall_plugin("audit@acme", SkillRegistry(), home, non_plugin_bundle_ids=_declared(env), env=env, remove_server=mcp.remove)
     assert mcp.removed == []
 
     # ④ 续卸 B —— 最后一个依赖者 → 回收，X 不泄漏
-    await uninstall_plugin("review@beta", SkillRegistry(), home, env=env, remove_server=mcp.remove)
+    await uninstall_plugin("review@beta", SkillRegistry(), home, non_plugin_bundle_ids=_declared(env), env=env, remove_server=mcp.remove)
     assert mcp.removed == [FIGMA_BID]
 
 
@@ -236,7 +257,7 @@ async def test_scenario5_user_declares_after_install_blocks_reclaim(tmp_path: Pa
 
     _user_mcp_json(tmp_path, {FIGMA_NAME: _stdio(FIGMA_NAME)})  # 事后声明
 
-    await uninstall_plugin("audit@acme", SkillRegistry(), home, env=env, remove_server=mcp.remove)
+    await uninstall_plugin("audit@acme", SkillRegistry(), home, non_plugin_bundle_ids=_declared(env), env=env, remove_server=mcp.remove)
 
     assert mcp.removed == []
 
@@ -275,7 +296,7 @@ async def test_runtime_only_user_server_is_never_collateral(tmp_path: Path, monk
     mcp = _FakeMCP(existing={FIGMA_BID})
     await _install(home, env, "audit@acme", mcp)
 
-    await uninstall_plugin("audit@acme", SkillRegistry(), home, env=env, remove_server=mcp.remove)
+    await uninstall_plugin("audit@acme", SkillRegistry(), home, non_plugin_bundle_ids=_declared(env), env=env, remove_server=mcp.remove)
 
     assert mcp.removed == [], "用户经 --config @file / 内嵌构造挂载的 server 被连坐停摘（协议 §4.9.1-2）"
 
@@ -297,8 +318,8 @@ async def test_disable_both_dependents_keeps_dep_resident(tmp_path: Path, monkey
     await _install(home, env, "audit@acme", mcp)
     await _install(home, env, "review@beta", mcp)
 
-    await disable_plugin("audit@acme", SkillRegistry(), home, env=env, remove_server=mcp.remove)
-    await disable_plugin("review@beta", SkillRegistry(), home, env=env, remove_server=mcp.remove)
+    await disable_plugin("audit@acme", SkillRegistry(), home, non_plugin_bundle_ids=_declared(env), env=env, remove_server=mcp.remove)
+    await disable_plugin("review@beta", SkillRegistry(), home, non_plugin_bundle_ids=_declared(env), env=env, remove_server=mcp.remove)
 
     assert mcp.removed == []  # 两者账本记录仍在 → 互相替对方挡住回收（驻留，非泄漏）
 
@@ -323,7 +344,9 @@ async def test_scoped_uninstall_keeps_dep_for_remaining_scope(tmp_path: Path, mo
     monkeypatch.setattr(_STAGE, _fake_stage())
     mcp = _FakeMCP()
 
-    await uninstall_plugin("audit@acme", SkillRegistry(), home, env=env, scope="user", remove_server=mcp.remove)
+    await uninstall_plugin(
+        "audit@acme", SkillRegistry(), home, non_plugin_bundle_ids=_declared(env), env=env, scope="user", remove_server=mcp.remove,
+    )
 
     assert mcp.removed == []  # project scope 记录仍依赖 X
 
@@ -338,7 +361,7 @@ async def test_disable_applies_reclaim_criterion(tmp_path: Path, monkeypatch) ->
     mcp = _FakeMCP(existing={FIGMA_BID})
     await _install(home, env, "audit@acme", mcp)
 
-    await disable_plugin("audit@acme", SkillRegistry(), home, env=env, remove_server=mcp.remove)
+    await disable_plugin("audit@acme", SkillRegistry(), home, non_plugin_bundle_ids=_declared(env), env=env, remove_server=mcp.remove)
 
     assert mcp.removed == []
 
@@ -461,7 +484,7 @@ async def test_gc_does_not_reclaim_user_declared_server(tmp_path: Path, monkeypa
     async def _teardown(ids: list[str]) -> None:
         torn.append(ids)
 
-    await gc_plugins(["audit@acme"], SkillRegistry(), home, env=env, mcp_teardown=_teardown)
+    await gc_plugins(["audit@acme"], SkillRegistry(), home, non_plugin_bundle_ids=_declared(env), env=env, mcp_teardown=_teardown)
 
     assert torn == []  # 用户声明 → 不回收
 
@@ -480,6 +503,6 @@ async def test_gc_reclaims_unreferenced_server(tmp_path: Path, monkeypatch) -> N
     async def _teardown(ids: list[str]) -> None:
         torn.append(ids)
 
-    await gc_plugins(["audit@acme"], SkillRegistry(), home, env=env, mcp_teardown=_teardown)
+    await gc_plugins(["audit@acme"], SkillRegistry(), home, non_plugin_bundle_ids=_declared(env), env=env, mcp_teardown=_teardown)
 
     assert torn == [[FIGMA_BID]]

--- a/tests/unit_tests/computer/settings/test_mcp_dependency_model.py
+++ b/tests/unit_tests/computer/settings/test_mcp_dependency_model.py
@@ -31,6 +31,7 @@ import os
 from pathlib import Path
 
 import pytest
+from pydantic import TypeAdapter
 
 from a2c_smcp.computer.mcp_clients.model import MCPServerConfig
 from a2c_smcp.computer.settings.installer import (
@@ -262,43 +263,112 @@ async def test_scenario5_user_declares_after_install_blocks_reclaim(tmp_path: Pa
     assert mcp.removed == []
 
 
-@pytest.mark.xfail(
-    reason="已知未覆盖面（#153 隔离审查 🔴）：协议 §4.9.1-2 的数据源是**运行期权威配置集** + origin != plugin，"
-    "而本 SDK 的 manager 不存 origin —— 用户经 `--config @file` / SDK 内嵌 Computer(mcp_servers=) 挂载的 "
-    "server 与 plugin 自己挂的在可观测信息上完全同形，无法区分。根治需运行期 origin（#134 轴）或 --config "
-    "归一进 mcp.json flag 层（#154）。**方案求裁中：protocol Discussion #32** "
-    "（https://github.com/A2C-SMCP/a2c-smcp-protocol/discussions/32）。本用例钉住缺口：修好后 XPASS 提醒。",
-    strict=False,
-)
-async def test_runtime_only_user_server_is_never_collateral(tmp_path: Path, monkeypatch) -> None:
+# ── conformance §5：回收判据 origin 四景对拍（#164 / Discussion #32 裁决）─────────
+#
+# **#153 遗留缺口的转正**：原 `test_runtime_only_user_server_is_never_collateral`（xfail）钉的是
+# 「用户经 `--config @file` / 内嵌构造挂的 server 不落 mcp.json ⇒ 被判『非用户声明』⇒ plugin 卸载连坐停摘」。
+# 该 xfail 现**转正为下列四景**：`--config` 已归一为 `--mcp-config`（flag 层 mcp.json）、构造入参已成 embed 层，
+# 二者均在 resolve 输出中携带正确 origin ⇒ 判据可分辨。
+#
+# ⚠️ **注意四景**不再**用 `_FakeMCP(existing=...)` 模拟「用户挂了 X」**——那是**裸运行期活跃集**，正是协议
+# §4.9.1-2 钉死的歧路①（无 origin ⇒ flag/embed/plugin 三条挂载路径可观测同形）。用它做夹具会让守卫测的是
+# 一个协议禁止的判据面。四景改注入**真实的 flag 文件 / embed 构造入参**。
+def _flag_mcp(tmp_path: Path, servers: dict) -> Path:
+    """写一份 flag 层 mcp.json（模拟 ``a2c-computer run --mcp-config <file>``）。"""
+    p = tmp_path / "flag-mcp.json"
+    _write_json(p, {"servers": servers, "inputs": []})
+    return p
+
+
+async def test_vector1_flag_mounted_server_is_never_collateral(tmp_path: Path, monkeypatch) -> None:
     """
-    ⚠️ **已知缺口守卫**（xfail）：用户经 ``--config @file`` 挂的 server 在运行期活跃集、**不在 mcp.json**。
+    **四景①**：X 经 flag（``--mcp-config``）挂载 → 卸载声明依赖 X 的 plugin **不回收** X。
 
-    协议 §4.9.1-2 把「X 非用户声明」的数据源定为**运行期权威配置集**（``origin != plugin``），**不是** mcp.json。
-    ``a2c-computer run --config @servers.json``（``cli/main.py`` `_add_server`）与 SDK 内嵌
-    ``Computer(mcp_servers={...})`` 都走 transient ``amount_server``、**从不回写 mcp.json** ⇒ 本 SDK 只读
-    mcp.json 声明面就会把它们判成「非用户声明」⇒ 若该 server 同时被某 plugin 声明依赖，卸载该 plugin 时**连坐停摘**。
-
-    **为何不在 #153 内根治**：「用户 --config 挂的 X」与「plugin enable 挂的 X」在 manager 层信息完全相同
-    （无 origin / 无归属），不新增运行期归属就无法同时满足场景①（A 引入 X 无人依赖 → 回收）与本例。
-    补运行期归属 = #134「ownership 归属混源」轴（Epic #147 明载「共识未覆盖该轴」）；
-    ``--config`` 归一进 mcp.json flag 层 = #154。二者择一，求裁于 protocol Discussion #32：
-    https://github.com/A2C-SMCP/a2c-smcp-protocol/discussions/32
-
-    **注**：本 PR 相对 develop 仍是净改善——develop 是「卸载**无条件**摘」（连 mcp.json 声明的用户 server 都摘），
-    本 PR 已保护住 mcp.json 各 scope 声明面，仅剩本例这条路径。
+    origin=flag ⇒ 落 `non_plugin_declared_bundle_ids` ⇒ 「X 非用户声明」为假 ⇒ 不回收。
+    **变异验证**：把判据数据源退回「只读 mcp.json 声明面」（即 `_declared(env)` 去掉 `flag=`）→ 本例必红。
     """
     monkeypatch.chdir(tmp_path)
     home, env = _home(tmp_path), _env(tmp_path)
     _setup_catalog(home, "acme", "audit", servers=[FIGMA_NAME])
     monkeypatch.setattr(_STAGE, _fake_stage())
-    # 用户自己挂的 figma.mcp：进运行期活跃集，但**没有** _user_mcp_json（不落 mcp.json 声明）
-    mcp = _FakeMCP(existing={FIGMA_BID})
+    flag = _flag_mcp(tmp_path, {FIGMA_NAME: _stdio(FIGMA_NAME)})  # 用户经命令行点名声明 figma.mcp
+    mcp = _FakeMCP()
     await _install(home, env, "audit@acme", mcp)
 
-    await uninstall_plugin("audit@acme", SkillRegistry(), home, non_plugin_bundle_ids=_declared(env), env=env, remove_server=mcp.remove)
+    await uninstall_plugin(
+        "audit@acme", SkillRegistry(), home,
+        non_plugin_bundle_ids=_declared(env, flag=flag), env=env, remove_server=mcp.remove,
+    )
 
-    assert mcp.removed == [], "用户经 --config @file / 内嵌构造挂载的 server 被连坐停摘（协议 §4.9.1-2）"
+    assert mcp.removed == [], "经 --mcp-config 挂载的用户 server 被连坐停摘（协议 §4.9.1-2 四景①）"
+
+
+async def test_vector2_embed_mounted_server_is_never_collateral(tmp_path: Path, monkeypatch) -> None:
+    """
+    **四景②**：X 经宿主构造入参挂载（``Computer(mcp_servers=...)``，origin=embed）→ **不回收**。
+
+    宿主自有 server 不因 plugin 卸载连坐（§2.5-3：embed 是非-plugin origin）。
+    **变异验证**：`_declared(env, embed=...)` 去掉 `embed=` → 本例必红。
+    """
+    monkeypatch.chdir(tmp_path)
+    home, env = _home(tmp_path), _env(tmp_path)
+    _setup_catalog(home, "acme", "audit", servers=[FIGMA_NAME])
+    monkeypatch.setattr(_STAGE, _fake_stage())
+    embed = [TypeAdapter(MCPServerConfig).validate_python(_stdio(FIGMA_NAME))]  # 宿主构造挂载
+    mcp = _FakeMCP()
+    await _install(home, env, "audit@acme", mcp)
+
+    await uninstall_plugin(
+        "audit@acme", SkillRegistry(), home,
+        non_plugin_bundle_ids=_declared(env, embed=embed), env=env, remove_server=mcp.remove,
+    )
+
+    assert mcp.removed == [], "宿主构造入参挂载的 server 被连坐停摘（协议 §4.9.1-2 四景②）"
+
+
+async def test_vector3_plugin_only_server_is_reclaimed(tmp_path: Path, monkeypatch) -> None:
+    """
+    **四景③**：X 仅由 plugin 声明（无其他 plugin 依赖、无任何非-plugin 声明）→ **回收**。
+
+    这一景是四景里唯一「该回收」的——它守住判据**不会因为①②的修法而全面失灵**（否则 server 永久泄漏）。
+    plugin 声明**不进 resolve**（结构性缺席，见 schema.SCOPE_ORDER）⇒ X ∉ 非-plugin 集 ⇒ 回收。
+    """
+    monkeypatch.chdir(tmp_path)
+    home, env = _home(tmp_path), _env(tmp_path)
+    _setup_catalog(home, "acme", "audit", servers=[FIGMA_NAME])
+    monkeypatch.setattr(_STAGE, _fake_stage())
+    mcp = _FakeMCP()
+    await _install(home, env, "audit@acme", mcp)
+
+    await uninstall_plugin(
+        "audit@acme", SkillRegistry(), home,
+        non_plugin_bundle_ids=_declared(env), env=env, remove_server=mcp.remove,
+    )
+
+    assert mcp.removed == [FIGMA_BID], "无人依赖 ∧ 无非-plugin 声明的 server 未被回收 ⇒ 泄漏（四景③）"
+
+
+async def test_vector4_mixed_origin_same_bundle_id_is_never_collateral(tmp_path: Path, monkeypatch) -> None:
+    """
+    **四景④**：同 ``bundle_id`` 混源碰撞（plugin 声明依赖 X ∧ 用户经 flag 也声明 X，flag > plugin）→ **不回收**。
+
+    用户覆盖权（§2.5-3「用户主权」）：即便某 plugin 也声明依赖同一 bundle_id，用户那条声明令 X 永不连坐。
+    与①的区别：①的 X 只有 flag 一个来源；④ 的 X **两个来源并存**，考的是「plugin 也声明」不会盖过「非 plugin 声明」。
+    """
+    monkeypatch.chdir(tmp_path)
+    home, env = _home(tmp_path), _env(tmp_path)
+    _setup_catalog(home, "acme", "audit", servers=[FIGMA_NAME])  # plugin 声明依赖 figma.mcp
+    monkeypatch.setattr(_STAGE, _fake_stage())
+    flag = _flag_mcp(tmp_path, {FIGMA_NAME: _stdio(FIGMA_NAME, command="user-cmd")})  # 用户也声明同 bundle_id
+    mcp = _FakeMCP()
+    await _install(home, env, "audit@acme", mcp)
+
+    await uninstall_plugin(
+        "audit@acme", SkillRegistry(), home,
+        non_plugin_bundle_ids=_declared(env, flag=flag), env=env, remove_server=mcp.remove,
+    )
+
+    assert mcp.removed == [], "混源（plugin + flag）同 bundle_id 被连坐停摘（协议 §4.9.1-2 四景④）"
 
 
 async def test_disable_both_dependents_keeps_dep_resident(tmp_path: Path, monkeypatch) -> None:

--- a/tests/unit_tests/computer/settings/test_reconciler.py
+++ b/tests/unit_tests/computer/settings/test_reconciler.py
@@ -357,7 +357,7 @@ async def test_list_and_gc_plugins(tmp_path: Path) -> None:
     async def _cb(servers: list[str]) -> None:
         teardown.append(servers)
 
-    removed = await gc_plugins(["audit@acme"], reg, home, mcp_teardown=_cb)
+    removed = await gc_plugins(["audit@acme"], reg, home, non_plugin_bundle_ids=lambda: set(), mcp_teardown=_cb)
 
     assert removed == ["audit@acme"]
     assert not audit_path.exists()  # installPath 树清除
@@ -376,7 +376,7 @@ async def test_gc_guards_installpath_outside_home(tmp_path: Path) -> None:
     (outside / "keepme").write_text("x", encoding="utf-8")
     _seed_installed(home, {"evil@acme": [{"scope": "user", "installPath": str(outside)}]})
 
-    removed = await gc_plugins(["evil@acme"], SkillRegistry(), home)
+    removed = await gc_plugins(["evil@acme"], SkillRegistry(), home, non_plugin_bundle_ids=lambda: set())
 
     assert removed == ["evil@acme"]
     assert outside.exists() and (outside / "keepme").exists()  # 越界守卫：拒删盘外目录
@@ -390,7 +390,7 @@ async def test_gc_without_teardown_callback(tmp_path: Path) -> None:
     p.mkdir(parents=True)
     _seed_installed(home, {"audit@acme": [{"scope": "user", "installPath": str(p), "mcpServers": ["x"]}]})
 
-    removed = await gc_plugins(["audit@acme"], SkillRegistry(), home, mcp_teardown=None)
+    removed = await gc_plugins(["audit@acme"], SkillRegistry(), home, non_plugin_bundle_ids=lambda: set(), mcp_teardown=None)
 
     assert removed == ["audit@acme"]
     assert not p.exists()
@@ -422,7 +422,7 @@ async def test_gc_skips_unknown_plugin_id(tmp_path: Path) -> None:
     home = _home(tmp_path)
     _seed_installed(home, {"real@acme": [{"scope": "user", "installPath": str(marketplace_skill_dir(home, "acme"))}]})
 
-    removed = await gc_plugins(["ghost@acme"], SkillRegistry(), home)
+    removed = await gc_plugins(["ghost@acme"], SkillRegistry(), home, non_plugin_bundle_ids=lambda: set())
 
     assert removed == []
     assert "real@acme" in load_installed_plugins(home=home)["plugins"]  # 已存在项不受影响
@@ -435,7 +435,7 @@ async def test_gc_plugin_id_without_at_sign(tmp_path: Path) -> None:
     p.mkdir(parents=True)
     _seed_installed(home, {"noatsign": [{"scope": "user", "installPath": str(p)}]})
 
-    removed = await gc_plugins(["noatsign"], SkillRegistry(), home)
+    removed = await gc_plugins(["noatsign"], SkillRegistry(), home, non_plugin_bundle_ids=lambda: set())
 
     assert removed == ["noatsign"]
     assert not p.exists()

--- a/tests/unit_tests/computer/test_computer_dual_path_crud.py
+++ b/tests/unit_tests/computer/test_computer_dual_path_crud.py
@@ -29,15 +29,18 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+from pydantic import TypeAdapter
 
 from a2c_smcp.computer.computer import Computer
 from a2c_smcp.computer.inputs.resolver import InputResolver
+from a2c_smcp.computer.mcp_clients.model import MCPServerConfig
 from a2c_smcp.computer.settings.mcp_config import (
     McpWriteScope,
     McpWriteTargetError,
     mcp_write_path,
     resolve_mcp_config,
 )
+from a2c_smcp.utils.bundle_id import resolve_bundle_id
 
 
 class _MapResolver(InputResolver):
@@ -91,13 +94,21 @@ def _read_servers(path: Path) -> dict[str, Any]:
     return json.loads(path.read_text(encoding="utf-8")).get("servers", {})
 
 
-def _comp(tmp_path: Path, resolver: InputResolver | None = None) -> Computer:
+def _comp(
+    tmp_path: Path,
+    resolver: InputResolver | None = None,
+    *,
+    mcp_flag_config: Path | None = None,
+    mcp_servers: set[Any] | None = None,
+) -> Computer:
     return Computer(
         name="dual-path-test",
         auto_connect=False,
         auto_reconnect=False,
         skill_home=tmp_path / "home",
         input_resolver=resolver,
+        mcp_flag_config=mcp_flag_config,
+        mcp_servers=mcp_servers,
     )
 
 
@@ -217,6 +228,56 @@ async def test_aremove_server_rejects_undeclared_runtime_projection(tmp_path: Pa
     # 拒删后运行期投影仍在（未被误停摘）；且未产生任何落盘写。
     assert comp.mcp_manager is not None
     assert any(c.name == "figma" for c in comp.mcp_manager.server_configs())
+    for scope in (McpWriteScope.LOCAL, McpWriteScope.PROJECT, McpWriteScope.USER):
+        assert not mcp_write_path(scope, env=os.environ).exists()
+
+
+# ── durable: aremove_server 声明只存在于**只读 scope** → 拒删（不静默假成功，#154）───────────────────
+@pytest.mark.asyncio
+@pytest.mark.parametrize("origin", ["flag", "embed", "policy"])
+async def test_aremove_server_rejects_readonly_scope_declaration(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, origin: str,
+) -> None:
+    """
+    胜出声明落**只读 scope**（flag / embed / policy）⇒ 抛 :class:`McpWriteTargetError`，**不**静默假成功。
+
+    若走档②「有声明 ⇒ 放行」：``remove_mcp_server`` 只扫 user/project/local ⇒ **一条也删不掉**，却 unmount +
+    返回成功，下次 boot 该声明原样复活 = 假成功（#143 正在根治的同类）。
+
+    - ``policy``：**本次之前即已存在**的缺陷（policy 从来不在 ``_WRITABLE_SCOPES``），随本判据一并根治；
+    - ``flag`` / ``embed``：#154/#164 让它们进 resolve 后**本会新引入**该缺陷 —— 本守卫即其修法。
+
+    夹具 name(``figma.mcp``) ≠ bundle_id(``figma_mcp``)：`-` 不被 normalize_name 折叠，故用 `.`（conformance §2.0）。
+    """
+    _isolate(tmp_path, monkeypatch)
+    name, bid = "figma.mcp", "figma_mcp"
+
+    flag_path: Path | None = None
+    embed: set[Any] | None = None
+    if origin == "flag":
+        flag_path = tmp_path / "flag-mcp.json"
+        _write_mcp_file(flag_path, {name: _stdio_dict(name, "/bin/figma")})
+    elif origin == "embed":
+        embed = {TypeAdapter(MCPServerConfig).validate_python(_stdio_dict(name, "/bin/figma"))}
+    else:  # policy：managed-mcp.json 只读、读优先级最高
+        managed = tmp_path / "managed-mcp.json"
+        _write_mcp_file(managed, {name: _stdio_dict(name, "/bin/figma")})
+        monkeypatch.setattr(
+            "a2c_smcp.computer.settings.mcp_config.managed_mcp_config_path", lambda *_a, **_k: managed,
+        )
+
+    comp = _comp(tmp_path, mcp_flag_config=flag_path, mcp_servers=embed)
+    assert bid in {
+        resolve_bundle_id(s.config) for s in comp.resolve_mcp_declarations(env=os.environ).servers.values()
+    }, "前置：该 bundle_id 确已被只读 scope 声明"
+
+    with pytest.raises(McpWriteTargetError, match=origin):
+        await comp.aremove_server(bid)
+
+    # 拒删后声明仍在（未被静默"删"掉）；且未在任一可写 scope 留下写痕。
+    assert bid in {
+        resolve_bundle_id(s.config) for s in comp.resolve_mcp_declarations(env=os.environ).servers.values()
+    }
     for scope in (McpWriteScope.LOCAL, McpWriteScope.PROJECT, McpWriteScope.USER):
         assert not mcp_write_path(scope, env=os.environ).exists()
 

--- a/tests/unit_tests/computer/test_python_rust_alignment.py
+++ b/tests/unit_tests/computer/test_python_rust_alignment.py
@@ -118,7 +118,7 @@ async def _boot_mount(comp: Computer) -> None:
     ``session=None``（非 TTY）+ ``approve_all=True`` → PENDING（工作区 local/project origin）**仅本次挂载、不落盘**，
     忠实复现「新进程启动读盘挂载已声明 server」。
     """
-    await run_mcp_approval(comp, None, approve_all=True, flag_config=None)
+    await run_mcp_approval(comp, None, approve_all=True, settings_flag_path=None)
 
 
 def _write_mcp_file(path: Path, servers: dict[str, Any]) -> None:


### PR DESCRIPTION
Closes #154, Closes #164 ｜ 母单 #147 ｜ 协议 `runtime-contract.md` §2.5-3 / §2.5-5（已落 protocol develop [`859fc87`](https://github.com/A2C-SMCP/a2c-smcp-protocol/commit/859fc87)）｜ rust 镜像 rust-sdk#137 / #147

> **⚠️ Breaking**（无存量用户，按通用口径「正式上线前一律不做向后兼容设计」）。详见 CHANGELOG。

## 根因

来源优先序此前**只以两处手写列表字面量存在**，无单一权威 ⇒ 必然漂移：

| 来源 | 改前层序（低→高） | Flag |
|---|---|---|
| `settings.json`（`scope.py:284`） | `user, project, local, flag, policy` | 次高 ✅ |
| `mcp.json`（`mcp_config.py:294`） | `flag, user, project, local, policy` | **最低** ❌ |

差**四格**。协议明写「历史实现把 mcp.json 的 flag 层排最低（`--config` 老接口遗留），该形态**废止**」。

## 修法

新增 `settings/schema.py::SCOPE_ORDER` 为协议 §2.5-3 的**唯一权威**，两个 resolve 都**迭代**它、不再各写字面量：

```
plugin 声明 < user < project < local < embed < flag < policy
```

**反漂移属性可验证**：变异 `SCOPE_ORDER` 会让 settings 轴（`test_scope.py`）与 mcp.json 轴（`test_mcp_config.py`）的守卫**同时**变红。

## 主要变更

- **层序统一**：flag 最低 → **次高**；新增 `embed` scope（宿主构造挂载，`local < embed < flag`）+ `_TRUSTED_ORIGINS` 增列
- **`--config` → `--mcp-config`**（保留 `-c`）：文件形状硬切为 `{servers, inputs}`；旧格式 **fail-fast(exit 2)** 并提示改写（含「去掉 body 里的 `name` 字段」——否则 name≠key 会被丢弃）；校验**先于任何副作用**（历史解析在 `connect` **之后**且吞异常 ⇒ 坏文件会留下已连接 socket + 已 boot 的 Computer）
- **删 `--inputs`/`-i`**：inputs 段由 `--mcp-config` 文件承载，与其余 scope 同路消费
- **`--mcp-config` 现在过审批门**（此前完全绕开直挂）⇒ 可被 policy 拒绝名单拦下（协议正确：`policy > flag`）
- **判据锚定 origin**：`mcp_json_declared_bundle_ids` → `non_plugin_declared_bundle_ids`（覆盖 durable + flag + embed 全部非-plugin 路径）⇒ **#153 遗留 xfail 转正**为 conformance §5 四景
- **接缝**：`Computer(mcp_flag_config=)` + `resolve_mcp_declarations()`（boot 声明式输入，每次重算、不落盘）；`McpCallbacks` += `non_plugin_bundle_ids`（**required kwarg**，不给默认值——默认回落 files-only 正是重新引入 #153 连坐的静默漏斗）

## 连带根治（非本次引入）

`aremove_server` 遇**只读 scope**（`policy`/`flag`/`embed`）的胜出声明 ⇒ 抛 `McpWriteTargetError`。此前 **policy-origin server 即已**「删不掉任何东西却停摘并报成功、下次 boot 复活」= 静默假成功（#143 同类）。

## 刻意偏离 #154 验收字面（架构决策人已拍板）

**不新增 `SettingsScope.PLUGIN` —— 结构性缺席**。无任一消费者需要 plugin 层（审批门 MUST 滤掉、判据要 `origin != plugin`、`upsert` 只认可写 scope）⇒ 对三消费者**输出同集**；四景无 PLUGIN 全绿；plugin-lowest 已由 boot 序保证（approval 先于 governance remount + "existing wins"）。加无生产者的成员会让「迭代层过滤」沦为**永假守卫（死代码）**，且是 #148 档④「进门后豁免」复活的诱因。F8 验收信号取**缺席**。

**等价的边界**（已写进 `SCOPE_ORDER` 注释）：只保证「plugin 输给**已挂载**者」，非「输给**声明**」。与 rust-sdk#137 **代码形态分叉、行为等价**（协议 §2.5-5 明许），说明已留 rust-sdk#137。⇒ **建议订正 #154 验收第 2 条**。

## 测试

| 门 | 结果 |
|---|---|
| 单元 + 集成 | **2024 passed**, 2 skipped, **4 xfailed**（较 develop 少一条 = #153 缺口已闭） |
| e2e | **65 passed** |
| `poe lint` | mypy 103 files + ruff clean |

**红灯守卫**：`test_resolve_flag_beats_user_and_local_same_name`（改前 `origin == LOCAL`）——**现存无一条测试钉住「flag 是 mcp.json 最低层」**（既有 `test_resolve_origins_partition_trust` 用四个**不同** server 名、永不遮蔽）⇒ 层序翻转本会**全绿通过**，这是本 PR 最大的假绿风险。

**变异验证**（结论已写进各 commit message）：
1. 判据丢 flag/embed（#153 缺口形状）→ 四景 ①②④ 红、③ 绿（③ 无 flag/embed，正确不受影响）
2. `SCOPE_ORDER` 把 flag 排回最低 → 5 条红，**含 settings 轴用例** ⇒ 反漂移属性成立
3. 删 `aremove_server` 只读判据 → 3 条红
4. `plugin.py` 退回 `flag_config_path=None` → 4 条红
5. `build_mcp_callbacks._non_plugin` 退化成 `lambda: set()` → 生产接线守卫红

**夹具纪律**：`figma.mcp`/`figma_mcp`、`e2e.direct`/`e2e_direct` 全程 name≠bundle_id 分叉（**`-` 不被 `normalize_name` 折叠**，故不用 `-`）。**F7**：`tests/integration_tests/computer/cli/test_mcp_flag_config.py` 走**真** Computer + **真** `run_mcp_approval`，不用桩。

## 隔离审查（`a2c-smcp-toolkit:code-reviewer`）：2 🔴 + 5 🟡 已全清

1. 🔴 **层序只落在 resolve 层、没落到挂载层**：`_ensure_mounted` 只比 bundle_id 就 skip ⇒ boot_up 预挂的 embed 把 flag/policy 的胜出配置**静默丢弃**。修法：skip 判据改 `origin is EMBED`（boot_up 只预挂 embed ⇒ 精确等价于「已挂的就是胜出者」）。
2. 🔴 **`a2c-computer --mcp-config x.json run`（flag 置于子命令前）静默丢弃** —— **本 PR 自引入的失败模式回归**：实测 develop 上旧 `--config` 会响亮报 exit 2 "No such option"，本 PR 未修前退化为 exit 1 + 无关 OSError。修法：`_RootState` 携 flag 文件对 + `run` 兜底回读（`--settings` 同形既有缺陷一并修）。

**自查另抓到一处自己的假绿**：`test_flag_server_can_be_denied_by_policy` 原只断言「被拒时不在活跃集」= 弱断言（flag 层压根没被解析的回归也会让它**因错误理由变绿**，实测 mutation 下保持绿）⇒ 已加 `denied=False` 正对照。

## 已知缺口（如实记 CHANGELOG，已开 follow-up）

- #165 纯嵌入式宿主**无审批门** ⇒ policy 拒绝名单对 embed 不生效；停摘让出的 bundle_id 可能被 plugin 基线补位（同源：协议 §5 item 10 让 plugin 不进门）
- #166 REPL `status` 的 "Name" 列显示 **bundle_id** —— 换分叉夹具后暴露的既有问题（旧夹具 `e2e-test` 因 `-` 不折叠 ⇒ name≡bundle_id ⇒ 同值致盲），属 #143/#144 展示轴
- #167 `server add` 被 flag 层静默遮蔽 / `python -m` 入口静默 exit 0（CLAUDE.md 却列为入口）/ `_resolve_declared_settings` 丢 `flag_path`
- #168 **测试写入开发机真实 state**（`~/.local/state/a2c/input-values.json`，走 `XDG_STATE_HOME` 而隔离只覆盖 `XDG_CONFIG_HOME`）⇒ 带 `${input:}` 的用例**跨 run** 非确定性

🤖 Generated with [Claude Code](https://claude.com/claude-code)
