### PR TITLE
fix(#143)!: R4 库层收 bundle_id + resolve_target 上移 CLI —— 根治 REPL rm/stop 静默假成功

### DIFF
--- a/a2c_smcp/computer/cli/help.py
+++ b/a2c_smcp/computer/cli/help.py
@@ -35,9 +35,11 @@ NAMESPACES: dict[str, str] = {
 NAMESPACE_COMMANDS: dict[str, list[tuple[str, str]]] = {
     "server": [
         ("server add <json|@file>", "添加或更新 MCP 配置 / add or update config"),
-        ("server rm <name>", "移除 MCP 配置 / remove config"),
-        ("start <name>|all", "启动客户端 / start client(s)"),
-        ("stop <name>|all", "停止客户端 / stop client(s)"),
+        # #143：三个动词收 <name|bundle_id>——CLI 经 resolve.py 解析（name 唯一命中 → 其 bundle_id；同名多条
+        # 则列候选要求改用 bundle_id）。bundle_id 可经 `status` 查看。
+        ("server rm <name|bundle_id>", "移除 MCP 配置 / remove config"),
+        ("start <name|bundle_id>|all", "启动客户端 / start client(s)"),
+        ("stop <name|bundle_id>|all", "停止客户端 / stop client(s)"),
     ],
     "inputs": [
         ("inputs load <@file>", "从文件加载 inputs 定义 / load inputs"),

--- a/a2c_smcp/computer/cli/interactive_impl.py
+++ b/a2c_smcp/computer/cli/interactive_impl.py
@@ -41,6 +41,7 @@ from a2c_smcp.computer.mcp_clients.model import MCPServerInput as MCPServerInput
 from a2c_smcp.smcp import MCPServerConfig as SMCPServerConfigDict
 from a2c_smcp.smcp import MCPServerInput as SMCPServerInputDict
 from a2c_smcp.smcp import ToolCallReq as SMCPToolCallReq
+from a2c_smcp.utils.bundle_id import resolve_bundle_id
 
 # 定义上下文管理器类型
 ContextManager = AbstractContextManager[None]
@@ -76,6 +77,39 @@ def _resolve_or_report(comp: Computer, token: str, *, settings_flag_path: Path |
         console.print("[yellow]请用 bundle_id 重试 / Retry with a bundle_id[/yellow]")
     except TargetNotFoundError:
         console.print(f"[red]❌ 未找到服务器 '{token}' / Server '{token}' not found[/red]")
+    return None
+
+
+def _resolve_lifecycle_target(comp: Computer, token: str, *, verb: str, settings_flag_path: Path | None) -> str | None:
+    """为 ``start`` / ``stop`` 解析 token，且**额外要求命中的 bundle_id 当前真的挂载着**（#143 决策 1 补丁）。
+
+    决策 1 的查找空间是「运行期 ∪ 声明面」（为让 ``server rm`` 的档 1-4 可达）。副作用：仅**声明**而尚未挂载
+    的 server（如本次启动未过审批门的 project 声明）也会解析成功。但 ``start``/``stop`` 操作的是**运行期进程**，
+    对未挂载目标：``astop_client`` 会静默 no-op → 打印「✅ 停止完成」（本 Issue 要根治的假回执）；``astart_client``
+    会抛内部 ``Unknown server bundle_id=...``（把内部 id 概念漏给用户）。故解析后再判「是否已挂载」，未挂载则
+    诚实陈述而非假成功/漏内部错。
+
+    .. note::
+       这两条路径是决策 1 引入的、协议 §5.1-1「在**活跃配置集**反查」未覆盖的态（协议此处 MUST 双端逐字一致）。
+       已开 **#171** 求协议把查找空间改为「活跃集 ∪ 声明面」并明确本态行为，裁决后双端同步。
+
+    :returns: 已挂载 → 其 bundle_id；未命中 / 多命中 / 已声明未挂载 → ``None``（打印诊断，调用方不得执行）。
+    """
+    bundle_id = _resolve_or_report(comp, token, settings_flag_path=settings_flag_path)
+    if bundle_id is None:
+        return None
+    mounted = comp.mcp_manager is not None and any(
+        resolve_bundle_id(cfg) == bundle_id for cfg in comp.mcp_manager.server_configs()
+    )
+    if mounted:
+        return bundle_id
+    if verb == "stop":
+        console.print(f"[yellow]⚠ 服务器 '{token}' 尚未挂载，无需停止 / Server '{token}' not mounted; nothing to stop[/yellow]")
+    else:
+        console.print(
+            f"[yellow]⚠ 服务器 '{token}' 已声明但未挂载 / Server '{token}' declared but not mounted[/yellow]",
+        )
+        console.print("[yellow]  提示：它可能在 mcp.json 里但本次启动未过批准门 / it may be pending the approval gate[/yellow]")
     return None
 
 
@@ -231,7 +265,7 @@ async def interactive_loop(
                             await comp.mcp_manager.astart_all()
                             console.print("[green]✅ 所有服务器启动完成 / All servers started[/green]")
                         else:
-                            bundle_id = _resolve_or_report(comp, target, settings_flag_path=settings_flag_path)
+                            bundle_id = _resolve_lifecycle_target(comp, target, verb="start", settings_flag_path=settings_flag_path)
                             if bundle_id is not None:
                                 await comp.mcp_manager.astart_client(bundle_id)
                                 console.print(f"[green]✅ 服务器 '{target}' 启动完成 / Server '{target}' started[/green]")
@@ -250,8 +284,8 @@ async def interactive_loop(
                             console.print("[green]✅ 所有服务器停止完成 / All servers stopped[/green]")
                         else:
                             # #143：``_astop_client`` 用 ``pop(bundle_id, None)`` 静默吞 miss（与 rust 逐行同构，
-                            # 刻意不动，见 R4）——假成功必须在此拦住：未命中不下传、不打印成功。
-                            bundle_id = _resolve_or_report(comp, target, settings_flag_path=settings_flag_path)
+                            # 刻意不动，见 R4）——假成功必须在此拦住：未命中/已声明未挂载不下传、不打印成功。
+                            bundle_id = _resolve_lifecycle_target(comp, target, verb="stop", settings_flag_path=settings_flag_path)
                             if bundle_id is not None:
                                 await comp.mcp_manager.astop_client(bundle_id)
                                 console.print(f"[green]✅ 服务器 '{target}' 停止完成 / Server '{target}' stopped[/green]")

--- a/a2c_smcp/computer/cli/interactive_impl.py
+++ b/a2c_smcp/computer/cli/interactive_impl.py
@@ -29,6 +29,12 @@ from a2c_smcp.computer.cli.commands import plugin as plugin_cmd
 from a2c_smcp.computer.cli.commands import settings as settings_cmd
 from a2c_smcp.computer.cli.commands import skill as skill_cmd
 from a2c_smcp.computer.cli.help import render_help
+from a2c_smcp.computer.cli.resolve import (
+    AmbiguousTargetError,
+    TargetNotFoundError,
+    collect_candidates,
+    resolve_target,
+)
 from a2c_smcp.computer.cli.utils import console, parse_kv_pairs, print_mcp_config, print_status, print_tools
 from a2c_smcp.computer.computer import Computer
 from a2c_smcp.computer.mcp_clients.model import MCPServerInput as MCPServerInputModel
@@ -47,6 +53,30 @@ class PatchStdoutCtx(Protocol):
 
 class _Session(Protocol):
     async def prompt_async(self, *_: str, **__: Any) -> str: ...
+
+
+def _resolve_or_report(comp: Computer, token: str, *, settings_flag_path: Path | None) -> str | None:
+    """人机面寻址：token → **bundle_id**，未命中 / 多命中打印诊断并返回 ``None``（#143 / R4）。
+
+    库层公开 API 一律收 bundle_id、无 name 启发式（协议 ``sdk-api-guidance.md §5.1``），故 REPL 收到的
+    ``<name|bundle_id>`` **必须**在此解析后再下传。返回 ``None`` = 调用方不得继续执行该动词——**绝不**静默成功。
+
+    Resolve a REPL token to a bundle_id; on miss/ambiguity print diagnostics and return None (never fake success).
+    """
+    try:
+        return resolve_target(token, collect_candidates(comp, settings_flag_path=settings_flag_path))
+    except AmbiguousTargetError as e:
+        # §5.1-3：列出每个候选的 bundle_id + display name + 归属（只列 bundle_id 用户分不清哪个是自己的）。
+        console.print(
+            f"[yellow]⚠ 有 {len(e.candidates)} 个 server 叫 '{token}' / {len(e.candidates)} servers named '{token}':[/yellow]",
+        )
+        width = max(len(c.bundle_id) for c in e.candidates)
+        for cand in sorted(e.candidates, key=lambda c: c.bundle_id):
+            console.print(f"[yellow]   {cand.bundle_id:<{width}}  {cand.name}  ({cand.attribution})[/yellow]")
+        console.print("[yellow]请用 bundle_id 重试 / Retry with a bundle_id[/yellow]")
+    except TargetNotFoundError:
+        console.print(f"[red]❌ 未找到服务器 '{token}' / Server '{token}' not found[/red]")
+    return None
 
 
 async def interactive_loop(
@@ -177,12 +207,16 @@ async def interactive_loop(
                         console.print(f"[red]❌ 添加/更新服务器失败 / Failed to add/update server: {e}[/red]")
                 elif sub in {"rm", "remove"}:
                     if len(parts) < 3:
-                        console.print("[yellow]用法: server rm <name>[/yellow]")
+                        console.print("[yellow]用法: server rm <name|bundle_id>[/yellow]")
                     else:
-                        await comp.aremove_server(parts[2])
-                        console.print("[green]已移除配置 / Removed[/green]")
-                        if smcp_client:
-                            await smcp_client.emit_update_config()
+                        # #143：先解析再下传——历史直接把 token 当 bundle_id 交 aremove_server，name≠bundle_id
+                        # 时落档⑤ no-op 却照打「已移除配置」= 静默假成功。
+                        bundle_id = _resolve_or_report(comp, parts[2], settings_flag_path=settings_flag_path)
+                        if bundle_id is not None:
+                            await comp.aremove_server(bundle_id)
+                            console.print("[green]已移除配置 / Removed[/green]")
+                            if smcp_client:
+                                await smcp_client.emit_update_config()
                 else:
                     console.print("[yellow]未知的 server 子命令 / Unknown subcommand[/yellow]")
 
@@ -193,11 +227,14 @@ async def interactive_loop(
                 else:
                     try:
                         if target == "all":
+                            # `all` 是关键字而非 server 标识 → 先短路，不进解析。
                             await comp.mcp_manager.astart_all()
                             console.print("[green]✅ 所有服务器启动完成 / All servers started[/green]")
                         else:
-                            await comp.mcp_manager.astart_client(target)
-                            console.print(f"[green]✅ 服务器 '{target}' 启动完成 / Server '{target}' started[/green]")
+                            bundle_id = _resolve_or_report(comp, target, settings_flag_path=settings_flag_path)
+                            if bundle_id is not None:
+                                await comp.mcp_manager.astart_client(bundle_id)
+                                console.print(f"[green]✅ 服务器 '{target}' 启动完成 / Server '{target}' started[/green]")
                     except Exception as e:
                         console.print(f"[red]❌ 启动服务器失败 / Failed to start server: {e}[/red]")
 
@@ -208,11 +245,16 @@ async def interactive_loop(
                 else:
                     try:
                         if target == "all":
+                            # `all` 是关键字而非 server 标识 → 先短路，不进解析。
                             await comp.mcp_manager.astop_all()
                             console.print("[green]✅ 所有服务器停止完成 / All servers stopped[/green]")
                         else:
-                            await comp.mcp_manager.astop_client(target)
-                            console.print(f"[green]✅ 服务器 '{target}' 停止完成 / Server '{target}' stopped[/green]")
+                            # #143：``_astop_client`` 用 ``pop(bundle_id, None)`` 静默吞 miss（与 rust 逐行同构，
+                            # 刻意不动，见 R4）——假成功必须在此拦住：未命中不下传、不打印成功。
+                            bundle_id = _resolve_or_report(comp, target, settings_flag_path=settings_flag_path)
+                            if bundle_id is not None:
+                                await comp.mcp_manager.astop_client(bundle_id)
+                                console.print(f"[green]✅ 服务器 '{target}' 停止完成 / Server '{target}' stopped[/green]")
                     except Exception as e:
                         console.print(f"[red]❌ 停止服务器失败 / Failed to stop server: {e}[/red]")
 

--- a/a2c_smcp/computer/cli/resolve.py
+++ b/a2c_smcp/computer/cli/resolve.py
@@ -1,0 +1,173 @@
+# -*- coding: utf-8 -*-
+"""
+文件名: resolve.py
+作者: JQQ
+创建日期: 2026/7/17
+最后修改日期: 2026/7/17
+版权: 2023 JQQ. All rights reserved.
+依赖: 无第三方
+描述:
+  中文: 人机面（CLI / REPL）的 MCP server 寻址解析——**全仓唯一** name→bundle_id 解析处（#143 / R4）。
+  English: The human-facing (CLI/REPL) MCP-server target resolver — the one and only name→bundle_id site.
+
+分层契约（协议 ``computer-management/sdk-api-guidance.md §5.1``，Discussion #23 终审 R4）:
+
+- **库层公开 API**（``aremove_server`` / ``astart_client`` / ``astop_client`` / ``aunmount_server_by_id`` …）
+  **一律收 bundle_id，无 name 启发式**——「入参即身份」。name→id 启发式若放库层，每个外部集成方都会各继承一次
+  不可靠推断：name 空间与 id 空间在缺省派生下（``bundle_id = normalize_name(name)``）大面积重叠，重叠处
+  「先按 name 再回退按 id」不可靠（``A(name=foo, id=foo_1)`` 与 ``B(name=bar, id=foo)`` 共存时，按 name 先命中
+  A ⇒ **永远拿不到 B**）。故启发式只应存在于**可交互报错**的人机面。
+- **人机面**：本模块。未命中 / 多命中 **MUST 报错，MUST NOT 静默成功**——假成功回执（打印「已停止」而 server
+  仍在跑）用户无从察觉，正是 #143 要根治的 P0。
+
+该用户可见语义 **MUST 双端（python / rust）逐字一致**（rust 镜像 rust-sdk#141）。
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from a2c_smcp.computer.settings.recovery import collect_enabled_bundled_servers
+from a2c_smcp.types import BUNDLE_ID
+from a2c_smcp.utils.bundle_id import is_valid_bundle_id, resolve_bundle_id
+from a2c_smcp.utils.logger import get_logger
+
+if TYPE_CHECKING:  # pragma: no cover - 仅类型，避免与 computer.py 循环导入
+    from a2c_smcp.computer.computer import Computer
+
+logger = get_logger(__name__)
+
+# 纯运行期投影（无声明、非 ledger bundled）的归属显示值：ad-hoc ``amount_server`` 挂进来的东西。
+_RUNTIME_ATTRIBUTION = "runtime"
+
+
+@dataclass(frozen=True)
+class ServerCandidate:
+    """一个可寻址的 MCP server 候选（寻址三元组）/ An addressable MCP server candidate。
+
+    ``attribution`` 是**给人看的归属**：声明面 origin（``user`` / ``project`` / ``local`` / ``embed`` /
+    ``flag`` / ``policy``）、``plugin:<plugin>``、或 ``runtime``（纯运行期投影）。协议 §5.1-3 要求多命中报错时
+    **同时**打印 bundle_id + display name + 归属——只列 bundle_id 用户分不清哪个是自己的。
+    """
+
+    bundle_id: BUNDLE_ID
+    name: str
+    attribution: str
+
+
+class TargetNotFoundError(Exception):
+    """token 既非已知 display name，也非已注册的合法 bundle_id（协议 §5.1-2 后半 / §5.1-5）。"""
+
+    def __init__(self, token: str) -> None:
+        self.token = token
+        super().__init__(f"No MCP server matches {token!r}")
+
+
+class AmbiguousTargetError(Exception):
+    """token 作为 display name 命中多条（同名合法共存，协议 §5.6）——列候选要求用户改用 bundle_id 重试。
+
+    **MUST NOT** 以字典序最小等任意规则「确定性地选一个」（§5.1-4）：那是把不确定的错变成确定的错。
+    """
+
+    def __init__(self, token: str, candidates: tuple[ServerCandidate, ...]) -> None:
+        self.token = token
+        self.candidates = candidates
+        super().__init__(f"{len(candidates)} MCP servers are named {token!r}")
+
+
+def collect_candidates(comp: Computer, *, settings_flag_path: Path | None = None) -> tuple[ServerCandidate, ...]:
+    """汇集当前一切可寻址的 server 候选，**按 bundle_id 为键**合并三源 / Collect addressable candidates。
+
+    查找空间 = **运行期活跃集 ∪ 声明面**（#143 决策 1）。取并集而非单取运行期，是为了让
+    :meth:`~a2c_smcp.computer.computer.Computer.aremove_server` 的档 1-4 全部可达——它本身就是双空间语义
+    （声明优先、无声明则看运行期投影）。若只取运行期，「手改 mcp.json 但未重载」的声明会被本解析器判为
+    「未找到」，而 ``aremove_server`` 本可删掉它 ⇒ 回归。
+
+    归属推导（三源，优先序自上而下）:
+
+    1. **声明面** :meth:`~a2c_smcp.computer.computer.Computer.resolve_mcp_declarations` —— 自带 ``origin``，
+       恒 ∈ ``{user, project, local, embed, flag, policy}``（结构性非-plugin）。
+    2. **ledger** :func:`~a2c_smcp.computer.settings.recovery.collect_enabled_bundled_servers` —— 恰好补上
+       声明面的结构性缺口：``origin == plugin`` **不进 resolve**，plugin bundled server 走 transient
+       ``amount_server`` 挂载。命中 ⇒ ``plugin:<plugin>``。
+    3. **运行期** ``mcp_manager.server_configs()`` —— 兜底补前两者都没有的纯 transient 投影（ad-hoc
+       ``amount_server``），归属 ``runtime``。
+
+    .. note::
+       **DRY 接缝声明**：:meth:`Computer.ainventory` 做同类 join，但其 join key 是 **display name**（已知缺陷，
+       同名会退化误标 plugin，迁 bundle_id 挂 **#144**）。本函数从一开始就 **bundle_id join**，不复制该缺陷；
+       两处收敛属 #144 范围，不在 #143 内。
+
+    :param settings_flag_path: 全局 ``--settings <file>`` flag 层路径（flag-aware 账本视图）。
+    """
+    from a2c_smcp.computer.cli.commands import resolved_settings
+
+    by_id: dict[BUNDLE_ID, ServerCandidate] = {}
+
+    # 1. 声明面（携 origin）——最权威的「谁被声明了、以何 origin」。
+    declarations = comp.resolve_mcp_declarations(env=os.environ)
+    for name, srv in declarations.servers.items():
+        bundle_id = resolve_bundle_id(srv.config)
+        by_id[bundle_id] = ServerCandidate(bundle_id=bundle_id, name=name, attribution=srv.origin.value)
+
+    # 2. ledger 派生的 enabled plugin bundled server（补声明面的 origin==plugin 结构性缺席；已按 bundle_id 去重）。
+    try:
+        declared = resolved_settings(os.environ, flag_path=settings_flag_path)
+        for record in collect_enabled_bundled_servers(comp.skill_home, declared):
+            bundle_id = resolve_bundle_id(record.config)
+            if bundle_id not in by_id:  # 用户自己的声明胜出（§2.5 用户主权）——显示它能操作的那条真相。
+                by_id[bundle_id] = ServerCandidate(
+                    bundle_id=bundle_id, name=record.config.name, attribution=f"plugin:{record.plugin}",
+                )
+    except Exception as e:  # noqa: BLE001 - 读层容错去连坐（#155）：账本不可读只丢 plugin 归属标注，不该让
+        # 寻址整体瘫痪（用户的 user-scope server 与 plugin 账本无关，不连坐）。降级**必须留痕**——静默降级
+        # 会让「归属显示 runtime 而非 plugin:x」变成查无实据的怪事。
+        logger.warning("resolve: plugin 归属推导降级（账本不可读）/ ownership derivation degraded: %s", e)
+
+    # 3. 运行期活跃集兜底：补纯 transient 投影（无声明、非 bundled）。
+    if comp.mcp_manager is not None:
+        for cfg in comp.mcp_manager.server_configs():
+            bundle_id = resolve_bundle_id(cfg)
+            if bundle_id not in by_id:
+                by_id[bundle_id] = ServerCandidate(bundle_id=bundle_id, name=cfg.name, attribution=_RUNTIME_ATTRIBUTION)
+
+    return tuple(by_id.values())
+
+
+def resolve_target(token: str, candidates: tuple[ServerCandidate, ...]) -> BUNDLE_ID:
+    """把用户敲的 token 解析为 **bundle_id**，严格按协议 §5.1 / Resolve a user token to a bundle_id。
+
+    步骤序（**顺序有意义**，勿重排）:
+
+    1. token 按 **display name** 反查，**唯一命中** → 其 bundle_id；
+    2. **0 命中** ∧ token 是**合法且已注册**的 bundle_id → token 本身（语法合法 ≠ 存在：未注册须报「未找到」，
+       否则 ``stop <合法但不存在的 id>`` 会一路走到底层的静默 no-op ⇒ 假成功复活）；
+    3. **多命中** → :class:`AmbiguousTargetError`（列候选，要求改用 bundle_id 重试）；
+    4. 其余 → :class:`TargetNotFoundError`。
+
+    .. warning::
+       **步骤 4（协议）：MUST NOT 以字典序最小等任意规则「确定性地选一个」**——那是把不确定的错变成确定的错。
+
+    .. note::
+       **已知缺口（协议 §5.1 步骤序，#143 决策 4，待协议裁决后双端同步修）**：步骤 2 的门是**「0 命中」**，
+       故多命中时够不到步骤 2。⇒ ``A(name='foo', 缺省派生 id='foo')`` 与 ``B(name='foo', 显式 id='bundle_x')``
+       合法共存（§5.6）时，A 的 bundle_id 恰等于那个冲突的名字，用户照「请用 bundle_id 重试」再敲 ``foo``
+       仍是 name 多命中 ⇒ **A 永远不可寻址**。修它属改协议明文，且该语义 MUST 双端逐字一致 ⇒ 不单端发明。
+       缺口由 ``tests/unit_tests/computer/cli/test_resolve.py`` 的 xfail 用例钉住。
+
+    :raises AmbiguousTargetError: token 作为 display name 命中多条。
+    :raises TargetNotFoundError: token 既非已知 name 也非已注册的合法 bundle_id。
+    """
+    name_hits = tuple(c for c in candidates if c.name == token)
+    if len(name_hits) == 1:
+        return name_hits[0].bundle_id
+    if len(name_hits) > 1:
+        raise AmbiguousTargetError(token, name_hits)
+    if is_valid_bundle_id(token):
+        for cand in candidates:
+            if cand.bundle_id == token:
+                return token
+    raise TargetNotFoundError(token)

--- a/a2c_smcp/computer/cli/resolve.py
+++ b/a2c_smcp/computer/cli/resolve.py
@@ -97,9 +97,12 @@ def collect_candidates(comp: Computer, *, settings_flag_path: Path | None = None
        ``amount_server``），归属 ``runtime``。
 
     .. note::
-       **DRY 接缝声明**：:meth:`Computer.ainventory` 做同类 join，但其 join key 是 **display name**（已知缺陷，
-       同名会退化误标 plugin，迁 bundle_id 挂 **#144**）。本函数从一开始就 **bundle_id join**，不复制该缺陷；
-       两处收敛属 #144 范围，不在 #143 内。
+       **DRY 接缝声明**：:meth:`~a2c_smcp.computer.computer.Computer.list_mcp_servers_with_metadata` 做同类
+       join，但其 join key 是 **display name**（已知缺陷，同名会退化误标 plugin，见该方法 docstring 的 ⚠️ 注；
+       迁 bundle_id 挂 **#144**）。本函数从一开始就 **bundle_id join**，不复制该缺陷；两处收敛属 #144 范围。
+       另：该方法取 ``_resolve_declared_settings()``（**无 flag 层**），本函数取 flag-aware 的
+       :func:`~a2c_smcp.computer.cli.commands.resolved_settings` ⇒ 「谁是 enabled plugin」两处答案在 flag scope
+       上可分叉，一并挂 #144 收敛。
 
     :param settings_flag_path: 全局 ``--settings <file>`` flag 层路径（flag-aware 账本视图）。
     """
@@ -111,21 +114,34 @@ def collect_candidates(comp: Computer, *, settings_flag_path: Path | None = None
     declarations = comp.resolve_mcp_declarations(env=os.environ)
     for name, srv in declarations.servers.items():
         bundle_id = resolve_bundle_id(srv.config)
+        if bundle_id in by_id:
+            # 声明面是 name-keyed，两个不同 name 可折叠到同一 bundle_id（``my.server`` 与 ``my server`` 都 →
+            # ``my_server``；或两条显式同 id）。此处后写胜出 ⇒ 先者从候选里消失、其 name 将报「未找到」。
+            # 声明面不受注册期 no-double-open 门约束，该态可达 ⇒ 至少留痕，别让它成为查无实据的怪事。
+            logger.warning(
+                "resolve: 声明 %r 与 %r 折叠到同一 bundle_id=%r，候选表只保留后者 / declarations collapse",
+                by_id[bundle_id].name, name, bundle_id,
+            )
         by_id[bundle_id] = ServerCandidate(bundle_id=bundle_id, name=name, attribution=srv.origin.value)
 
     # 2. ledger 派生的 enabled plugin bundled server（补声明面的 origin==plugin 结构性缺席；已按 bundle_id 去重）。
-    try:
-        declared = resolved_settings(os.environ, flag_path=settings_flag_path)
-        for record in collect_enabled_bundled_servers(comp.skill_home, declared):
-            bundle_id = resolve_bundle_id(record.config)
-            if bundle_id not in by_id:  # 用户自己的声明胜出（§2.5 用户主权）——显示它能操作的那条真相。
-                by_id[bundle_id] = ServerCandidate(
-                    bundle_id=bundle_id, name=record.config.name, attribution=f"plugin:{record.plugin}",
-                )
-    except Exception as e:  # noqa: BLE001 - 读层容错去连坐（#155）：账本不可读只丢 plugin 归属标注，不该让
-        # 寻址整体瘫痪（用户的 user-scope server 与 plugin 账本无关，不连坐）。降级**必须留痕**——静默降级
-        # 会让「归属显示 runtime 而非 plugin:x」变成查无实据的怪事。
-        logger.warning("resolve: plugin 归属推导降级（账本不可读）/ ownership derivation degraded: %s", e)
+    #    读裸 ``_skill_home``（可能 None）而非公开 ``skill_home`` property：后者会 ``ensure_skill_home()`` 建目录，
+    #    本函数当前只在 REPL boot 后调（已解析）故无害，但读裸属性 + None 短路可防将来 pre-boot 复用踩副作用
+    #    （同 ``interactive_impl`` banner 的既有约定）。home 为 None ⇒ 跳过 ledger 源，仅丢 plugin 归属标注。
+    home = comp._skill_home
+    if home is not None:
+        try:
+            declared = resolved_settings(os.environ, flag_path=settings_flag_path)
+            for record in collect_enabled_bundled_servers(home, declared):
+                bundle_id = resolve_bundle_id(record.config)
+                if bundle_id not in by_id:  # 用户自己的声明胜出（§2.5 用户主权）——显示它能操作的那条真相。
+                    by_id[bundle_id] = ServerCandidate(
+                        bundle_id=bundle_id, name=record.config.name, attribution=f"plugin:{record.plugin}",
+                    )
+        except Exception as e:  # noqa: BLE001 - 读层容错去连坐（#155）：账本不可读只丢 plugin 归属标注，不该让
+            # 寻址整体瘫痪（用户的 user-scope server 与 plugin 账本无关，不连坐）。降级**必须留痕**——静默降级
+            # 会让「归属显示 runtime 而非 plugin:x」变成查无实据的怪事。
+            logger.warning("resolve: plugin 归属推导降级（账本不可读）/ ownership derivation degraded: %s", e)
 
     # 3. 运行期活跃集兜底：补纯 transient 投影（无声明、非 bundled）。
     if comp.mcp_manager is not None:
@@ -156,7 +172,7 @@ def resolve_target(token: str, candidates: tuple[ServerCandidate, ...]) -> BUNDL
        故多命中时够不到步骤 2。⇒ ``A(name='foo', 缺省派生 id='foo')`` 与 ``B(name='foo', 显式 id='bundle_x')``
        合法共存（§5.6）时，A 的 bundle_id 恰等于那个冲突的名字，用户照「请用 bundle_id 重试」再敲 ``foo``
        仍是 name 多命中 ⇒ **A 永远不可寻址**。修它属改协议明文，且该语义 MUST 双端逐字一致 ⇒ 不单端发明。
-       缺口由 ``tests/unit_tests/computer/cli/test_resolve.py`` 的 xfail 用例钉住。
+       缺口由 ``tests/unit_tests/computer/cli/test_resolve.py`` 的 xfail 用例钉住，求裁于 **#170**。
 
     :raises AmbiguousTargetError: token 作为 display name 命中多条。
     :raises TargetNotFoundError: token 既非已知 name 也非已注册的合法 bundle_id。

--- a/a2c_smcp/computer/cli/utils.py
+++ b/a2c_smcp/computer/cli/utils.py
@@ -193,7 +193,10 @@ def print_status(comp: Computer) -> None:
 
     rows = comp.mcp_manager.get_server_status()
     table = Table(title="MCP 服务器状态 / MCP Servers Status")
-    table.add_column("Name", style="cyan")
+    # #143：``get_server_status`` 返回的是 **bundle_id**（manager 以 bundle_id 为键），历史表头写 "Name" 主动
+    # 误导——与 `mcp` 命令（显示真 display name）打架，用户照本表抄的其实是 bundle_id。本表是 bundle_id 的
+    # 发现入口（寻址多命中时提示「请用 bundle_id 重试」即指这里）。
+    table.add_column("Bundle ID", style="cyan")
     table.add_column("Active", style="magenta")
     table.add_column("State", style="yellow")
     for name, active, state in rows:

--- a/a2c_smcp/computer/cli/utils.py
+++ b/a2c_smcp/computer/cli/utils.py
@@ -194,8 +194,10 @@ def print_status(comp: Computer) -> None:
     rows = comp.mcp_manager.get_server_status()
     table = Table(title="MCP 服务器状态 / MCP Servers Status")
     # #143：``get_server_status`` 返回的是 **bundle_id**（manager 以 bundle_id 为键），历史表头写 "Name" 主动
-    # 误导——与 `mcp` 命令（显示真 display name）打架，用户照本表抄的其实是 bundle_id。本表是 bundle_id 的
-    # 发现入口（寻址多命中时提示「请用 bundle_id 重试」即指这里）。
+    # 误导——用户照本表抄下来的其实是 bundle_id。本表是 bundle_id 的发现入口（寻址多命中时提示「请用
+    # bundle_id 重试」即指这里）。
+    # 注：本表**不显示 display name**，故「我的 server 叫 X，它的 bundle_id 是哪个」需借多命中列表或 `mcp`。
+    # 是否补 Name 列属 #166 未决项（本轮刻意只做表头订正，不抢先裁定）。
     table.add_column("Bundle ID", style="cyan")
     table.add_column("Active", style="magenta")
     table.add_column("State", style="yellow")

--- a/a2c_smcp/computer/computer.py
+++ b/a2c_smcp/computer/computer.py
@@ -843,9 +843,15 @@ class Computer(BaseComputer[PromptSession]):
     # 「把别处已是真相的东西投影进 runtime」→ transient（纯运行期、不落盘）。**
     #   - durable  ：:meth:`aadd_or_aupdate_server` / :meth:`aadd_or_aupdate_server_in_scope` / :meth:`aremove_server`
     #                （REPL ``server add``/``rm``、外部 API 用户显式增删）。对齐 rust ``add_or_update_server*`` / ``remove_server``。
-    #   - transient：:meth:`amount_server` / :meth:`aunmount_server` / :meth:`aunmount_server_by_id`
+    #   - transient：:meth:`amount_server` / :meth:`aunmount_server_by_id`
     #                （boot 读已声明 mcp.json 挂载、``--config @file`` 加载、plugin/治理 D2 挂载/重挂）。对齐 rust
-    #                ``mount_server`` / ``unmount_server`` / ``unmount_server_by_id``。
+    #                ``mount_server`` / ``unmount_server_by_id``。
+    #
+    # 寻址（#143 / R4，协议 sdk-api-guidance §5.1）：本类**公开 API 一律收 bundle_id，无 name 启发式**。历史的
+    #   ``aunmount_server(name)`` 便捷入口已**删除**（它是库层最后一个 name 入口；零生产调用方——plugin
+    #   disable/uninstall/marketplace 级联走 ``aunmount_server_by_id``）。name→bundle_id 解析只存在于人机面
+    #   :mod:`a2c_smcp.computer.cli.resolve`，那里未命中/多命中可交互报错；库层做启发式回退会让每个外部集成方
+    #   各继承一次不可靠推断（name 空间与 id 空间在缺省派生下大面积重叠）。
     #
     # §12 R2 revision 分账（对齐 rust）：durable 落盘属 **config** 轴变化、transient 属纯 **capability** 轴。python 侧
     #   **capability** 上报由 manager 物化经 ``_on_manager_change`` → ``emit_update_tool_list`` **自动**触发（两路径皆有）；
@@ -916,20 +922,6 @@ class Computer(BaseComputer[PromptSession]):
         """
         raw_cfg, validated = await self._arender_and_validate_server(server, session=session, plugin=plugin, marketplace=marketplace)
         await self._amount_rendered(raw_cfg, validated)
-
-    async def aunmount_server(self, name: str) -> None:
-        """按 **name** 纯运行期**停摘**一个 server（不删声明、不落盘）/ Transient unmount by name。
-
-        对齐 rust ``unmount_server``。manager 以 bundle_id 为键，故按 name 在运行期活跃集里解析出对应 bundle_id 再停摘
-        （同名多条则全摘，正常运行集内 name 唯一）。用于 plugin disable / uninstall / marketplace 级联的 bundled 停摘
-        （bundled 真相在 ledger，停进程而**不删** mcp.json 声明）。manager 未建 / 无匹配 → no-op。
-        """
-        if self.mcp_manager is None:
-            return
-        targets = {resolve_bundle_id(cfg) for cfg in self.mcp_manager.server_configs() if cfg.name == name}
-        for bundle_id in targets:
-            await self.mcp_manager.aremove_server(bundle_id)
-            self._active_raw.pop(bundle_id, None)  # #149 hygiene：raw 投影随停摘回收（读时以 manager 集为准，非正确性关键）
 
     async def aunmount_server_by_id(self, bundle_id: str) -> None:
         """按 **bundle_id** 纯运行期**停摘**一个 server（不删声明、不落盘）/ Transient unmount by bundle_id。
@@ -1048,8 +1040,10 @@ class Computer(BaseComputer[PromptSession]):
         5. **无声明 ∧ 未活跃 ⇒ no-op**（无声明可删、无投影可停；``aunmount_server_by_id`` 幂等 no-op）。
 
         Args:
-            bundle_id (str): MCP Server 唯一身份 bundle_id（协议 #18）。REPL ``server rm <name>`` 在缺省身份下
-                （bundle_id = normalize(name)）以 name 寻址即可。
+            bundle_id (str): MCP Server 唯一身份 bundle_id（协议 #18）。**入参即身份，无 name 启发式**（R4）——
+                历史此处曾注「REPL ``server rm <name>`` 在缺省身份下（bundle_id = normalize(name)）以 name 寻址
+                即可」，该前提**只在 name 本身已属 ``[A-Za-z0-9_-]`` 时成立**，正是 #143 静默假成功的病根，已作废。
+                人机面的 ``<name|bundle_id>`` 解析见 :mod:`a2c_smcp.computer.cli.resolve`。
 
         Raises:
             McpWriteTargetError: 档 3（声明只存在于只读 scope）或档 4（纯运行期投影）。

--- a/a2c_smcp/computer/mcp_clients/manager.py
+++ b/a2c_smcp/computer/mcp_clients/manager.py
@@ -241,6 +241,11 @@ class MCPServerManager:
             await self._astop_client(bundle_id)
 
     async def _astop_client(self, bundle_id: BUNDLE_ID) -> None:
+        # ⚠️ 未命中 = **静默 no-op**，与同类三兄弟刻意不同（``aremove_server`` 抛 KeyError、``_astart_client``
+        #    抛 ValueError）：停止是幂等语义，且与 rust ``stop_client`` 逐行同构（#143 决策 2 保留现状）。
+        #    代价：**报错义务落在人机面** :mod:`a2c_smcp.computer.cli.resolve` —— REPL 先 ``resolve_target``
+        #    解析并校验「已注册」，未命中不下传。**绕过 CLI 直调本方法的调用方拿不到任何未命中信号**
+        #    （历史 P0「stop <未知 token> 却打印 ✅ 停止完成」即由此而来，见 #143）。新增调用方请自行判存。
         """停止单个服务器客户端（按 bundle_id）。"""
         client = self._active_clients.pop(bundle_id, None)
         if client:

--- a/docs/guides/cli-guide.md
+++ b/docs/guides/cli-guide.md
@@ -43,9 +43,29 @@ a2c-computer run --auto-connect true --auto-reconnect true
 | 命令 | 说明 |
 |------|------|
 | `server add <json\|@file>` | 添加/更新 MCP Server 配置 |
-| `server rm <name>` | 移除 MCP Server 配置 |
-| `start <name>\|all` | 启动 MCP Server |
-| `stop <name>\|all` | 停止 MCP Server |
+| `server rm <name\|bundle_id>` | 移除 MCP Server 配置 |
+| `start <name\|bundle_id>\|all` | 启动 MCP Server |
+| `stop <name\|bundle_id>\|all` | 停止 MCP Server |
+
+#### 寻址：`<name>` 还是 `<bundle_id>`？
+
+`name` 是**给人看的显示名**（允许重名），`bundle_id` 是 **server 的唯一身份**。上述三个命令两者都收：
+
+1. 按 `name` 唯一命中 → 直接执行；
+2. 没有 server 叫这个名，但它是个已注册的 `bundle_id` → 按 `bundle_id` 执行；
+3. **有多个 server 同名**（合法共存）→ 列出候选并要求改用 `bundle_id` 重试，**不会**替你猜一个：
+
+```
+a2c> stop filesystem
+⚠ 有 2 个 server 叫 'filesystem' / 2 servers named 'filesystem':
+   bundle_a3f9c2e1  filesystem  (plugin:fs-tools)
+   filesystem       filesystem  (user)
+请用 bundle_id 重试 / Retry with a bundle_id
+```
+
+4. 都不匹配 → 报「未找到」。**绝不会**出现「打印已停止/已移除，实际什么都没做」的假回执。
+
+各 server 的 `bundle_id` 用 `status` 命令查看。
 
 ### Inputs 管理
 

--- a/tests/unit_tests/computer/cli/test_collect_candidates.py
+++ b/tests/unit_tests/computer/cli/test_collect_candidates.py
@@ -1,0 +1,202 @@
+# -*- coding: utf-8 -*-
+# filename: test_collect_candidates.py
+# @Time    : 2026/07/17
+# @Author  : JQQ
+# @Email   : jqq1716@gmail.com
+# @Software: PyCharm
+"""
+#143 / R4: ``cli/resolve.py::collect_candidates`` 的三源合并与**归属推导**。
+
+归属（``attribution``）不是装饰——协议 §5.1-3 / PROTO-10 扩条把它定为 **MUST**：多命中报错时必须同时打印
+bundle_id + display name + 归属，「只列 bundle_id 用户分不清哪个是自己的」。故三源各自的归属值都需守卫：
+
+1. **声明面**（``resolve_mcp_declarations``）→ origin 字面（``user`` / ``project`` / ``local`` / ``embed`` /
+   ``flag`` / ``policy``）；
+2. **ledger**（``collect_enabled_bundled_servers``）→ ``plugin:<plugin>``——它恰好补上声明面的结构性缺口
+   （``origin == plugin`` **不进** resolve）；
+3. **运行期**兜底 → ``runtime``（ad-hoc ``amount_server`` 的纯 transient 投影）。
+
+隔离同 ``test_repl_addressing.py``：chdir + XDG + A2C_SKILL_HOME + ``Computer(skill_home=)`` 四面锚 tmp。
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+import pytest
+from pydantic import TypeAdapter
+
+from a2c_smcp.computer.cli import resolve as resolve_mod
+from a2c_smcp.computer.cli.resolve import collect_candidates
+from a2c_smcp.computer.computer import Computer
+from a2c_smcp.computer.mcp_clients.model import MCPServerConfig
+from a2c_smcp.computer.settings.mcp_config import McpWriteScope
+from a2c_smcp.computer.settings.recovery import BundledServerRecord
+
+
+def _isolate(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "cfg"))
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "data"))
+    monkeypatch.setenv("A2C_SKILL_HOME", str(tmp_path / "skills"))
+    monkeypatch.chdir(tmp_path)
+
+
+def _stdio_dict(name: str, *, bundle_id: str | None = None) -> dict[str, Any]:
+    cfg: dict[str, Any] = {
+        "type": "stdio",
+        "name": name,
+        "disabled": True,
+        "server_parameters": {"command": "echo", "args": [], "env": None, "cwd": None, "encoding": "utf-8"},
+    }
+    if bundle_id is not None:
+        cfg["bundle_id"] = bundle_id
+    return cfg
+
+
+async def _fresh_computer(tmp_path: Path) -> Computer:
+    comp = Computer(
+        name="cands", inputs=set(), mcp_servers=set(), auto_connect=False, auto_reconnect=False,
+        skill_home=tmp_path / "skills",
+    )
+    await comp.boot_up()
+    return comp
+
+
+def _attribution_of(comp: Computer, bundle_id: str) -> str:
+    return next(c.attribution for c in collect_candidates(comp) if c.bundle_id == bundle_id)
+
+
+def _bundled_record(name: str, *, bundle_id: str, plugin: str, tmp_path: Path) -> BundledServerRecord:
+    """构造一条 ledger bundled 记录（ledger 源的归属输入）。"""
+    cfg = TypeAdapter(MCPServerConfig).validate_python(_stdio_dict(name, bundle_id=bundle_id))
+    return BundledServerRecord(
+        plugin_id=f"{plugin}@mkt", plugin=plugin, marketplace="mkt", install_path=tmp_path / "p", config=cfg,
+    )
+
+
+# ── 源 1：声明面 origin ────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("scope", "expected"),
+    [(McpWriteScope.LOCAL, "local"), (McpWriteScope.PROJECT, "project"), (McpWriteScope.USER, "user")],
+)
+async def test_declaration_origin_becomes_attribution(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, scope: McpWriteScope, expected: str,
+) -> None:
+    """声明面条目的归属 = 其 origin 字面（三个可写 scope 各自可分辨，非同值）。"""
+    _isolate(tmp_path, monkeypatch)
+    comp = await _fresh_computer(tmp_path)
+    await comp.aadd_or_aupdate_server_in_scope(_stdio_dict("decl.srv"), scope)
+
+    assert _attribution_of(comp, "decl_srv") == expected
+
+
+# ── 源 2：ledger plugin 归属 ───────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_ledger_bundled_server_attributed_to_its_plugin(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """ledger 派生的 enabled bundled server → ``plugin:<plugin>``。
+
+    这是**声明面结构性缺口的唯一补法**：``origin == plugin`` 不进 resolve（SettingsScope 无 PLUGIN 成员），
+    plugin bundled server 走 transient ``amount_server`` 挂载 ⇒ 不查 ledger 就只能标成 ``runtime``，
+    用户在多命中列表里就分不出「哪条是插件带来的」。
+    """
+    _isolate(tmp_path, monkeypatch)
+    comp = await _fresh_computer(tmp_path)
+    record = _bundled_record("fs.srv", bundle_id="bundle_fs", plugin="fs-tools", tmp_path=tmp_path)
+    monkeypatch.setattr(resolve_mod, "collect_enabled_bundled_servers", lambda home, declared: [record])
+
+    assert _attribution_of(comp, "bundle_fs") == "plugin:fs-tools"
+
+
+@pytest.mark.asyncio
+async def test_user_declaration_wins_over_same_bundle_id_ledger_record(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """同 bundle_id 时**用户自己的声明胜出**（§2.5 用户主权）——显示用户能操作的那条真相。
+
+    正对照：把用户声明拿掉，同一条就该回落 ``plugin:fs-tools`` ⇒ 证明本断言不是永真。
+    """
+    _isolate(tmp_path, monkeypatch)
+    comp = await _fresh_computer(tmp_path)
+    record = _bundled_record("fs.srv", bundle_id="bundle_fs", plugin="fs-tools", tmp_path=tmp_path)
+    monkeypatch.setattr(resolve_mod, "collect_enabled_bundled_servers", lambda home, declared: [record])
+    await comp.aadd_or_aupdate_server_in_scope(_stdio_dict("fs.srv", bundle_id="bundle_fs"), McpWriteScope.LOCAL)
+
+    assert _attribution_of(comp, "bundle_fs") == "local", "用户声明胜出"
+
+    # 正对照：撤掉用户声明 → 归属回落 plugin（否则上面的断言可能只是碰巧）。
+    await comp.aremove_server("bundle_fs")
+    assert _attribution_of(comp, "bundle_fs") == "plugin:fs-tools"
+
+
+# ── 源 3：运行期兜底 ───────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_adhoc_transient_projection_attributed_runtime(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """无声明、非 ledger bundled 的 ad-hoc ``amount_server`` 投影 → ``runtime``。"""
+    _isolate(tmp_path, monkeypatch)
+    comp = await _fresh_computer(tmp_path)
+    await comp.amount_server(_stdio_dict("adhoc.srv"))
+
+    assert _attribution_of(comp, "adhoc_srv") == "runtime"
+
+
+# ── 查找空间：运行期 ∪ 声明面（#143 决策 1）────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_candidate_space_unions_runtime_and_declarations(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """候选 = 运行期 ∪ 声明面：两侧各有独占条目时都必须在，且按 bundle_id 去重不重复计。"""
+    _isolate(tmp_path, monkeypatch)
+    comp = await _fresh_computer(tmp_path)
+    await comp.aadd_or_aupdate_server_in_scope(_stdio_dict("both.srv"), McpWriteScope.LOCAL)  # 声明 + 运行期
+    await comp.amount_server(_stdio_dict("only.rt"))  # 仅运行期
+
+    cands = collect_candidates(comp)
+    by_id = {c.bundle_id: c for c in cands}
+
+    assert by_id["both_srv"].attribution == "local"
+    assert by_id["only_rt"].attribution == "runtime"
+    assert len(cands) == len(by_id), "同一 bundle_id 不得产生重复候选"
+
+
+# ── 降级：账本不可读不连坐（#155 读层容错）────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_unreadable_ledger_degrades_without_collateral_and_leaves_a_trace(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture,
+) -> None:
+    """账本读失败 ⇒ 只丢 plugin 归属标注，**不该**让整个寻址瘫痪（用户的 server 与 plugin 账本无关）。
+
+    且降级 **MUST 留痕**：静默降级会让「归属显示 runtime 而非 plugin:x」变成查无实据的怪事。
+    """
+    _isolate(tmp_path, monkeypatch)
+    comp = await _fresh_computer(tmp_path)
+    await comp.aadd_or_aupdate_server_in_scope(_stdio_dict("mine.srv"), McpWriteScope.LOCAL)
+
+    def _boom(*_a: Any, **_k: Any) -> Any:
+        raise RuntimeError("ledger unreadable")
+
+    monkeypatch.setattr(resolve_mod, "collect_enabled_bundled_servers", _boom)
+
+    # a2c_smcp 根 logger 设了 propagate=False（utils/logger.py:29）⇒ caplog 默认挂 root 抓不到，
+    # 须把 caplog.handler 直接挂到本模块 logger 上（同 tests/unit_tests/computer/settings/test_store.py:161 约定）。
+    resolve_mod.logger.addHandler(caplog.handler)
+    caplog.set_level(logging.WARNING)
+    try:
+        cands = collect_candidates(comp)
+    finally:
+        resolve_mod.logger.removeHandler(caplog.handler)
+
+    assert any(c.bundle_id == "mine_srv" for c in cands), "账本坏了不该连坐用户自己的 server（去连坐）"
+    assert any("ledger unreadable" in r.getMessage() for r in caplog.records), "降级必须留痕"

--- a/tests/unit_tests/computer/cli/test_repl_addressing.py
+++ b/tests/unit_tests/computer/cli/test_repl_addressing.py
@@ -14,8 +14,15 @@
 
 修法（协议 sdk-api-guidance §5.1 / PROTO-10）: 解析上移 CLI ``resolve_target``；未命中/多命中 MUST 报错。
 
-隔离: ``_isolate`` chdir tmp + XDG → tmp（``aremove_server`` 是 durable，会写 ``cwd/.tfrobot/``，
-不 chdir 即污染真仓库，#137 已踩）。``disabled=True`` + ``auto_connect=False`` 免拉起真实进程。
+隔离（三面都要锚，缺一即污染开发者真实环境）:
+
+- ``chdir(tmp)``——``aremove_server`` 是 durable，会写 ``cwd/.tfrobot/``（#137 已踩）；
+- ``XDG_CONFIG_HOME``→tmp——user scope ``mcp.json``；
+- ``A2C_SKILL_HOME`` + ``XDG_DATA_HOME``→tmp **且** ``Computer(skill_home=)``——``boot_up`` 会 ``mkdir`` +
+  迁移账本，``collect_candidates`` 会读 ``installed_plugins.json``；XDG_CONFIG_HOME **管不到**它
+  （SKILL Home 解析链是 ``A2C_SKILL_HOME → $XDG_DATA_HOME/a2c/skills → ~/.a2c/skills``）。
+
+``disabled=True`` + ``auto_connect=False`` 免拉起真实进程。
 
 ⚠️ 夹具铁律（Epic #147 陷阱其一）: name 与 bundle_id **必须分叉** —— 全文件用 ``my.server`` → ``my_server``。
 """
@@ -61,8 +68,16 @@ class _NoClient:
 
 
 def _isolate(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """隔离落盘面：project/local 锚 cwd（#116），user 锚 XDG → tmp。"""
+    """隔离落盘面：project/local 锚 cwd（#116），user 锚 XDG → tmp，SKILL Home 锚 tmp。
+
+    ``A2C_SKILL_HOME`` **必须**设——``XDG_CONFIG_HOME`` 管不到 SKILL Home：其解析链是
+    ``A2C_SKILL_HOME → $XDG_DATA_HOME/a2c/skills → ~/.a2c/skills``。不设则 ``boot_up`` 会在**开发者真实
+    home** 建目录、``collect_candidates`` 会读**真实 installed_plugins.json**（本机装了同名 plugin 即翻车）。
+    ``_fresh_computer`` 另传 ``skill_home=`` 双保险（同 ``test_computer_dual_path_crud.py:108`` 约定）。
+    """
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "cfg"))
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "data"))
+    monkeypatch.setenv("A2C_SKILL_HOME", str(tmp_path / "skills"))
     monkeypatch.chdir(tmp_path)
 
 
@@ -78,9 +93,20 @@ def _stdio_dict(name: str, *, bundle_id: str | None = None) -> dict[str, Any]:
     return cfg
 
 
-async def _fresh_computer() -> Computer:
-    """F7: 走**真实构造路径**（CLI 空集构造 + boot_up），不依赖 `_FakeComputer` 桩。"""
-    comp = Computer(name="repl_addr", inputs=set(), mcp_servers=set(), auto_connect=False, auto_reconnect=False)
+async def _fresh_computer(tmp_path: Path) -> Computer:
+    """F7: 走**真实构造路径**（CLI 空集构造 + boot_up），不依赖 `_FakeComputer` 桩。
+
+    ``skill_home`` 显式锚 tmp：``boot_up`` 会 ``ensure_skill_home()`` 建目录 + ``migrate_legacy_installs`` 写账本，
+    绝不能落到开发者真实 home（见 :func:`_isolate`）。
+    """
+    comp = Computer(
+        name="repl_addr",
+        inputs=set(),
+        mcp_servers=set(),
+        auto_connect=False,
+        auto_reconnect=False,
+        skill_home=tmp_path / "skills",
+    )
     await comp.boot_up()
     return comp
 
@@ -114,7 +140,7 @@ async def test_stop_unknown_token_must_error_not_fake_success(
     协议 §5.1-5: 未命中 MUST 报错，MUST NOT 静默成功（假成功回执：打印「已停止」而 server 仍在跑）。
     """
     _isolate(tmp_path, monkeypatch)
-    comp = await _fresh_computer()
+    comp = await _fresh_computer(tmp_path)
 
     out = await _run_repl(comp, ["stop nonexistent"], monkeypatch, capsys)
 
@@ -148,7 +174,7 @@ async def test_stop_by_display_name_passes_resolved_bundle_id_to_library(
     改后: name 唯一命中 → 解析为 ``my_server`` 再交库层。库层收到的**必须**是 bundle_id（R4）。
     """
     _isolate(tmp_path, monkeypatch)
-    comp = await _fresh_computer()
+    comp = await _fresh_computer(tmp_path)
     await comp.amount_server(_stdio_dict(_DISPLAY_NAME))
     assert any(resolve_bundle_id(c) == _BUNDLE_ID for c in comp.mcp_manager.server_configs())
     seen = _spy_stop(comp, monkeypatch)
@@ -168,7 +194,7 @@ async def test_server_rm_unknown_token_must_error_not_fake_success(
 ) -> None:
     """🔴 现状: 声明面无匹配 + 运行期无该 id ⇒ 落 ``aremove_server`` 档⑤ no-op ⇒ 仍打印「已移除配置」。"""
     _isolate(tmp_path, monkeypatch)
-    comp = await _fresh_computer()
+    comp = await _fresh_computer(tmp_path)
 
     out = await _run_repl(comp, ["server rm nonexistent"], monkeypatch, capsys)
 
@@ -182,7 +208,7 @@ async def test_server_rm_by_display_name_actually_removes_declaration(
 ) -> None:
     """🔴 现状: ``server rm my.server`` 拿 name 当 bundle_id 比对声明 → 匹配不上 → 无声不删 + 假成功。"""
     _isolate(tmp_path, monkeypatch)
-    comp = await _fresh_computer()
+    comp = await _fresh_computer(tmp_path)
     await comp.aadd_or_aupdate_server_in_scope(_stdio_dict(_DISPLAY_NAME), McpWriteScope.LOCAL)
     assert _DISPLAY_NAME in comp.resolve_mcp_declarations(env={}).servers
 
@@ -204,9 +230,11 @@ async def test_name_collision_lists_candidates_with_id_name_and_attribution(
     只列 bundle_id 用户分不清哪个是自己的。
     """
     _isolate(tmp_path, monkeypatch)
-    comp = await _fresh_computer()
+    comp = await _fresh_computer(tmp_path)
     # 同名合法共存（协议 §5.6）：显式异 bundle_id 是两个不同身份。
-    await comp.amount_server(_stdio_dict("dup.srv", bundle_id="bundle_left"))
+    # ⚠️ 归属**刻意分叉**（local 声明 vs runtime 投影）：若两条归属同值，「候选须列归属」的断言会同值致盲
+    #    ——Epic #147 陷阱第一条。归属存在的唯一理由就是让用户分清哪个是自己的，夹具必须体现该差异。
+    await comp.aadd_or_aupdate_server_in_scope(_stdio_dict("dup.srv", bundle_id="bundle_left"), McpWriteScope.LOCAL)
     await comp.amount_server(_stdio_dict("dup.srv", bundle_id="bundle_right"))
 
     out = await _run_repl(comp, ["stop dup.srv"], monkeypatch, capsys)
@@ -214,6 +242,9 @@ async def test_name_collision_lists_candidates_with_id_name_and_attribution(
     assert "停止完成" not in out, "多命中 MUST 报错，MUST NOT 任选一个执行"
     assert "bundle_left" in out and "bundle_right" in out, "候选须列 bundle_id"
     assert "dup.srv" in out, "候选须列 display name（只列 bundle_id 用户分不清哪个是自己的）"
+    # PROTO-10 扩条：归属**也**是 MUST。两条归属分叉 ⇒ 本断言可证伪（删掉输出里的归属即转红）。
+    assert "(local)" in out, "候选须列归属：用户自己声明的那条"
+    assert "(runtime)" in out, "候选须列归属：纯运行期投影那条"
 
 
 @pytest.mark.asyncio
@@ -222,7 +253,7 @@ async def test_stop_by_explicit_bundle_id_hits_exactly(
 ) -> None:
     """协议 §5.1-2: 0 个 name 命中 ∧ token 是合法已注册 bundle_id → 精确命中执行（消歧后的正解路径）。"""
     _isolate(tmp_path, monkeypatch)
-    comp = await _fresh_computer()
+    comp = await _fresh_computer(tmp_path)
     await comp.amount_server(_stdio_dict("dup.srv", bundle_id="bundle_left"))
     await comp.amount_server(_stdio_dict("dup.srv", bundle_id="bundle_right"))
     seen = _spy_stop(comp, monkeypatch)
@@ -233,21 +264,132 @@ async def test_stop_by_explicit_bundle_id_hits_exactly(
     assert "停止完成" in out
 
 
+# ── start：与 stop 同构（三个动词共用 _resolve_or_report，勿只守两个）───────────────────────────
+
+
+def _spy_start(comp: Computer, monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    """探针：记录 REPL 实际交给 ``astart_client`` 的 token（同 :func:`_spy_stop` 理由）。"""
+    seen: list[str] = []
+    original = comp.mcp_manager.astart_client
+
+    async def _recording(bundle_id: str) -> None:
+        seen.append(bundle_id)
+        await original(bundle_id)
+
+    monkeypatch.setattr(comp.mcp_manager, "astart_client", _recording)
+    return seen
+
+
+@pytest.mark.asyncio
+async def test_start_unknown_token_reports_not_found(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: Any,
+) -> None:
+    """``start`` 未命中不假成功（本就不假），但报错**内容**已变更：从库层内部错误 → 人机面「未找到」。
+
+    旧: ❌ 启动服务器失败: Unknown server bundle_id='nonexistent'（把内部 id 概念漏给用户）
+    新: ❌ 未找到服务器 'nonexistent'
+    """
+    _isolate(tmp_path, monkeypatch)
+    comp = await _fresh_computer(tmp_path)
+
+    out = await _run_repl(comp, ["start nonexistent"], monkeypatch, capsys)
+
+    assert "启动完成" not in out
+    assert "未找到" in out or "not found" in out
+
+
+@pytest.mark.asyncio
+async def test_start_by_display_name_passes_resolved_bundle_id_to_library(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: Any,
+) -> None:
+    """``start my.server`` 同样须解析后再下传——历史原样传 name → 库层抛 Unknown server（不假成功但够不着）。"""
+    _isolate(tmp_path, monkeypatch)
+    comp = await _fresh_computer(tmp_path)
+    await comp.amount_server(_stdio_dict(_DISPLAY_NAME))
+    seen = _spy_start(comp, monkeypatch)
+
+    await _run_repl(comp, [f"start {_DISPLAY_NAME}"], monkeypatch, capsys)
+
+    assert seen == [_BUNDLE_ID], f"库层应收到解析后的 bundle_id，实收 {seen}"
+
+
+@pytest.mark.asyncio
+async def test_start_name_collision_lists_candidates(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: Any,
+) -> None:
+    """``start`` 的多命中同样列候选（三动词语义一致，不能只有 stop/rm 守住）。"""
+    _isolate(tmp_path, monkeypatch)
+    comp = await _fresh_computer(tmp_path)
+    await comp.aadd_or_aupdate_server_in_scope(_stdio_dict("dup.srv", bundle_id="bundle_left"), McpWriteScope.LOCAL)
+    await comp.amount_server(_stdio_dict("dup.srv", bundle_id="bundle_right"))
+
+    out = await _run_repl(comp, ["start dup.srv"], monkeypatch, capsys)
+
+    assert "启动完成" not in out, "多命中 MUST 报错，MUST NOT 任选一个执行"
+    assert "bundle_left" in out and "bundle_right" in out
+    assert "(local)" in out and "(runtime)" in out
+
+
+# ── 决策 1 补丁：已声明未挂载不假成功、不漏内部错（#143 隔离审查 🔴3）─────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_stop_declared_but_unmounted_is_not_fake_success(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: Any,
+) -> None:
+    """决策 1（∪声明面）让「已声明未挂载」解析成功；``stop`` 对它须诚实陈述，MUST NOT 打「✅ 停止完成」。
+
+    构造：durable 声明落盘、但用一个全新 Computer boot（不过审批门）⇒ 声明在、运行期无。
+    """
+    _isolate(tmp_path, monkeypatch)
+    seed = await _fresh_computer(tmp_path)
+    await seed.aadd_or_aupdate_server_in_scope(_stdio_dict(_DISPLAY_NAME), McpWriteScope.PROJECT)
+
+    comp = await _fresh_computer(tmp_path)  # 全新实例：声明可读、但未挂载
+    assert not any(resolve_bundle_id(c) == _BUNDLE_ID for c in comp.mcp_manager.server_configs())
+
+    out = await _run_repl(comp, [f"stop {_DISPLAY_NAME}"], monkeypatch, capsys)
+
+    assert "停止完成" not in out, "已声明未挂载却打印停止成功 = 决策 1 引入的新假回执"
+    assert "尚未挂载" in out or "not mounted" in out
+
+
+@pytest.mark.asyncio
+async def test_start_declared_but_unmounted_does_not_leak_internal_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: Any,
+) -> None:
+    """``start`` 对「已声明未挂载」须诚实陈述，MUST NOT 漏库层内部 ``Unknown server bundle_id=...``。"""
+    _isolate(tmp_path, monkeypatch)
+    seed = await _fresh_computer(tmp_path)
+    await seed.aadd_or_aupdate_server_in_scope(_stdio_dict(_DISPLAY_NAME), McpWriteScope.PROJECT)
+
+    comp = await _fresh_computer(tmp_path)
+    out = await _run_repl(comp, [f"start {_DISPLAY_NAME}"], monkeypatch, capsys)
+
+    assert "启动完成" not in out
+    assert "Unknown server" not in out, "内部 bundle_id 概念不得漏给用户"
+    assert "已声明但未挂载" in out or "declared but not mounted" in out
+
+
 # ── 守卫：`all` 不进解析 ────────────────────────────────────────────────────────────────────────
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(("cmd", "expected"), [("stop all", "所有服务器停止完成"), ("start all", "所有服务器启动完成")])
 async def test_all_keyword_bypasses_resolution(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: Any,
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: Any, cmd: str, expected: str,
 ) -> None:
-    """``start|stop all`` 是关键字而非 server 标识 ⇒ 先短路，不进 resolve_target（否则会报「未找到 all」）。"""
+    """``start|stop all`` 是关键字而非 server 标识 ⇒ 先短路，不进 resolve_target（否则会报「未找到 all」）。
+
+    两个动词各有一份短路代码 ⇒ 各守一次（只守 stop 则 start 那份失守）。
+    """
     _isolate(tmp_path, monkeypatch)
-    comp = await _fresh_computer()
+    comp = await _fresh_computer(tmp_path)
     await comp.amount_server(_stdio_dict(_DISPLAY_NAME))
 
-    out = await _run_repl(comp, ["stop all"], monkeypatch, capsys)
+    out = await _run_repl(comp, [cmd], monkeypatch, capsys)
 
-    assert "所有服务器停止完成" in out
+    assert expected in out
     assert "未找到" not in out
 
 

--- a/tests/unit_tests/computer/cli/test_repl_addressing.py
+++ b/tests/unit_tests/computer/cli/test_repl_addressing.py
@@ -1,0 +1,264 @@
+# -*- coding: utf-8 -*-
+# filename: test_repl_addressing.py
+# @Time    : 2026/07/17
+# @Author  : JQQ
+# @Email   : jqq1716@gmail.com
+# @Software: PyCharm
+"""
+#143 / R4: REPL `server rm` / `start` / `stop` 的 name 寻址与**静默假成功**回归。
+
+病理（本文件复现的即是它）: 三个动词把用户敲的 token **原样**传给以 **bundle_id** 为键的库层 API，
+两者只在 ``bundle_id == normalize_name(name)`` 时碰巧相等。name 含 ``.`` / 空格 / CJK 或配了显式
+``bundle_id`` 时查不到 → 底层静默 no-op → REPL 照样打印成功 ⇒ 用户以为删了/停了，server 还在跑、
+工具还暴露给 Agent，**无从察觉**。
+
+修法（协议 sdk-api-guidance §5.1 / PROTO-10）: 解析上移 CLI ``resolve_target``；未命中/多命中 MUST 报错。
+
+隔离: ``_isolate`` chdir tmp + XDG → tmp（``aremove_server`` 是 durable，会写 ``cwd/.tfrobot/``，
+不 chdir 即污染真仓库，#137 已踩）。``disabled=True`` + ``auto_connect=False`` 免拉起真实进程。
+
+⚠️ 夹具铁律（Epic #147 陷阱其一）: name 与 bundle_id **必须分叉** —— 全文件用 ``my.server`` → ``my_server``。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import a2c_smcp.computer.cli.main as cli_main
+from a2c_smcp.computer.cli.main import _interactive_loop
+from a2c_smcp.computer.computer import Computer
+from a2c_smcp.computer.settings.mcp_config import McpWriteScope
+from a2c_smcp.utils.bundle_id import resolve_bundle_id
+
+# 分叉夹具：`.` 被 normalize_name 折成 `_` ⇒ display name ≠ bundle_id，断言才有鉴别力。
+_DISPLAY_NAME = "my.server"
+_BUNDLE_ID = "my_server"
+
+
+class FakePromptSession:
+    """中文: 将脚本化命令注入交互循环。English: Feed scripted inputs to interactive loop."""
+
+    def __init__(self, commands: list[str]) -> None:
+        self._commands = list(commands)
+
+    async def prompt_async(self, *_: str, **__: Any) -> str:
+        if not self._commands:
+            raise EOFError
+        return self._commands.pop(0)
+
+
+class _NoClient:
+    """不触网的最小 SMCP 客户端桩（本文件只验证寻址，不验证 emit）。"""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        self.connected = False
+
+    async def emit_update_config(self) -> None:  # pragma: no cover - 未连接时 CLI 不调
+        pass
+
+
+def _isolate(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """隔离落盘面：project/local 锚 cwd（#116），user 锚 XDG → tmp。"""
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "cfg"))
+    monkeypatch.chdir(tmp_path)
+
+
+def _stdio_dict(name: str, *, bundle_id: str | None = None) -> dict[str, Any]:
+    cfg: dict[str, Any] = {
+        "type": "stdio",
+        "name": name,
+        "disabled": True,  # 免 boot/auto_connect 拉起真实进程
+        "server_parameters": {"command": "echo", "args": [], "env": None, "cwd": None, "encoding": "utf-8"},
+    }
+    if bundle_id is not None:
+        cfg["bundle_id"] = bundle_id
+    return cfg
+
+
+async def _fresh_computer() -> Computer:
+    """F7: 走**真实构造路径**（CLI 空集构造 + boot_up），不依赖 `_FakeComputer` 桩。"""
+    comp = Computer(name="repl_addr", inputs=set(), mcp_servers=set(), auto_connect=False, auto_reconnect=False)
+    await comp.boot_up()
+    return comp
+
+
+async def _run_repl(comp: Computer, commands: list[str], monkeypatch: pytest.MonkeyPatch, capsys: Any) -> str:
+    """驱动真实交互循环并返回其打印输出。"""
+    monkeypatch.setattr(cli_main, "SMCPComputerClient", _NoClient)
+    monkeypatch.setattr(cli_main, "PromptSession", lambda: FakePromptSession([*commands, "exit"]))
+    monkeypatch.setattr(cli_main, "patch_stdout", lambda raw: _no_patch_stdout())
+    await _interactive_loop(comp)
+    return capsys.readouterr().out
+
+
+class _no_patch_stdout:
+    def __enter__(self) -> None:
+        return None
+
+    def __exit__(self, *exc: Any) -> None:
+        return None
+
+
+# ── 假成功：stop ────────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_stop_unknown_token_must_error_not_fake_success(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: Any,
+) -> None:
+    """🔴 现状: ``_astop_client`` 的 ``pop(bundle_id, None)`` 吞掉 miss ⇒ REPL 打印「✅ 停止完成」。
+
+    协议 §5.1-5: 未命中 MUST 报错，MUST NOT 静默成功（假成功回执：打印「已停止」而 server 仍在跑）。
+    """
+    _isolate(tmp_path, monkeypatch)
+    comp = await _fresh_computer()
+
+    out = await _run_repl(comp, ["stop nonexistent"], monkeypatch, capsys)
+
+    assert "停止完成" not in out, "未注册 token 却打印停止成功 = 静默假成功（#143 P0）"
+    assert "未找到" in out or "not found" in out
+
+
+def _spy_stop(comp: Computer, monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    """探针：记录 REPL **实际交给库层**的 token。
+
+    这是 #143 唯一有鉴别力的观测点。反例（勿重蹈）：断言「停完后不在 ``_active_clients``」——本文件夹具
+    ``disabled=True`` + ``auto_connect=False`` 下 client 从未启动，该集合恒空 ⇒ **没停也成立**，零鉴别力。
+    """
+    seen: list[str] = []
+    original = comp.mcp_manager.astop_client
+
+    async def _recording(bundle_id: str) -> None:
+        seen.append(bundle_id)
+        await original(bundle_id)
+
+    monkeypatch.setattr(comp.mcp_manager, "astop_client", _recording)
+    return seen
+
+
+@pytest.mark.asyncio
+async def test_stop_by_display_name_passes_resolved_bundle_id_to_library(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: Any,
+) -> None:
+    """🔴 现状: ``stop my.server`` 把 **display name** 原样当 bundle_id 传下去 → 查不到 → 静默 no-op + 假 ✅。
+
+    改后: name 唯一命中 → 解析为 ``my_server`` 再交库层。库层收到的**必须**是 bundle_id（R4）。
+    """
+    _isolate(tmp_path, monkeypatch)
+    comp = await _fresh_computer()
+    await comp.amount_server(_stdio_dict(_DISPLAY_NAME))
+    assert any(resolve_bundle_id(c) == _BUNDLE_ID for c in comp.mcp_manager.server_configs())
+    seen = _spy_stop(comp, monkeypatch)
+
+    out = await _run_repl(comp, [f"stop {_DISPLAY_NAME}"], monkeypatch, capsys)
+
+    assert seen == [_BUNDLE_ID], f"库层应收到解析后的 bundle_id，实收 {seen}（原样传 display name = #143 病根）"
+    assert "停止完成" in out
+
+
+# ── 假成功：server rm ───────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_server_rm_unknown_token_must_error_not_fake_success(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: Any,
+) -> None:
+    """🔴 现状: 声明面无匹配 + 运行期无该 id ⇒ 落 ``aremove_server`` 档⑤ no-op ⇒ 仍打印「已移除配置」。"""
+    _isolate(tmp_path, monkeypatch)
+    comp = await _fresh_computer()
+
+    out = await _run_repl(comp, ["server rm nonexistent"], monkeypatch, capsys)
+
+    assert "已移除配置" not in out, "未找到目标却打印已移除 = 静默假成功（#143 P0）"
+    assert "未找到" in out or "not found" in out
+
+
+@pytest.mark.asyncio
+async def test_server_rm_by_display_name_actually_removes_declaration(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: Any,
+) -> None:
+    """🔴 现状: ``server rm my.server`` 拿 name 当 bundle_id 比对声明 → 匹配不上 → 无声不删 + 假成功。"""
+    _isolate(tmp_path, monkeypatch)
+    comp = await _fresh_computer()
+    await comp.aadd_or_aupdate_server_in_scope(_stdio_dict(_DISPLAY_NAME), McpWriteScope.LOCAL)
+    assert _DISPLAY_NAME in comp.resolve_mcp_declarations(env={}).servers
+
+    out = await _run_repl(comp, [f"server rm {_DISPLAY_NAME}"], monkeypatch, capsys)
+
+    assert "已移除配置" in out
+    assert _DISPLAY_NAME not in comp.resolve_mcp_declarations(env={}).servers, "声明未被真正删除"
+
+
+# ── 多命中：列候选（bundle_id + name + 归属三者）────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_name_collision_lists_candidates_with_id_name_and_attribution(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: Any,
+) -> None:
+    """协议 §5.1-3 + PROTO-10 扩条: 多命中 → 报错并列出各候选的 **bundle_id + display name + 归属**。
+
+    只列 bundle_id 用户分不清哪个是自己的。
+    """
+    _isolate(tmp_path, monkeypatch)
+    comp = await _fresh_computer()
+    # 同名合法共存（协议 §5.6）：显式异 bundle_id 是两个不同身份。
+    await comp.amount_server(_stdio_dict("dup.srv", bundle_id="bundle_left"))
+    await comp.amount_server(_stdio_dict("dup.srv", bundle_id="bundle_right"))
+
+    out = await _run_repl(comp, ["stop dup.srv"], monkeypatch, capsys)
+
+    assert "停止完成" not in out, "多命中 MUST 报错，MUST NOT 任选一个执行"
+    assert "bundle_left" in out and "bundle_right" in out, "候选须列 bundle_id"
+    assert "dup.srv" in out, "候选须列 display name（只列 bundle_id 用户分不清哪个是自己的）"
+
+
+@pytest.mark.asyncio
+async def test_stop_by_explicit_bundle_id_hits_exactly(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: Any,
+) -> None:
+    """协议 §5.1-2: 0 个 name 命中 ∧ token 是合法已注册 bundle_id → 精确命中执行（消歧后的正解路径）。"""
+    _isolate(tmp_path, monkeypatch)
+    comp = await _fresh_computer()
+    await comp.amount_server(_stdio_dict("dup.srv", bundle_id="bundle_left"))
+    await comp.amount_server(_stdio_dict("dup.srv", bundle_id="bundle_right"))
+    seen = _spy_stop(comp, monkeypatch)
+
+    out = await _run_repl(comp, ["stop bundle_left"], monkeypatch, capsys)
+
+    assert seen == ["bundle_left"], f"应精确命中显式 bundle_id，实收 {seen}"
+    assert "停止完成" in out
+
+
+# ── 守卫：`all` 不进解析 ────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_all_keyword_bypasses_resolution(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: Any,
+) -> None:
+    """``start|stop all`` 是关键字而非 server 标识 ⇒ 先短路，不进 resolve_target（否则会报「未找到 all」）。"""
+    _isolate(tmp_path, monkeypatch)
+    comp = await _fresh_computer()
+    await comp.amount_server(_stdio_dict(_DISPLAY_NAME))
+
+    out = await _run_repl(comp, ["stop all"], monkeypatch, capsys)
+
+    assert "所有服务器停止完成" in out
+    assert "未找到" not in out
+
+
+# ── 库层 name 入口移除（验收信号取「函数不存在」，非文档降级）──────────────────────────────────
+
+
+def test_library_has_no_name_addressed_unmount_entry() -> None:
+    """R4: 库层公开 API 一律收 bundle_id，无 name 启发式 ⇒ ``aunmount_server(name)`` 必须**不存在**。
+
+    验收信号取「函数不存在」而非「文档说别用」——Epic #147 教训：字段/函数降级为诊断 = 产出 P0 的模式，
+    删掉才拦得住下一个实现者。零生产调用方（级联走 ``aunmount_server_by_id``）⇒ 纯删除。
+    """
+    assert not hasattr(Computer, "aunmount_server"), "库层 name 寻址入口应已删除（R4）"
+    assert hasattr(Computer, "aunmount_server_by_id"), "bundle_id 停摘入口应保留"

--- a/tests/unit_tests/computer/cli/test_resolve.py
+++ b/tests/unit_tests/computer/cli/test_resolve.py
@@ -69,10 +69,11 @@ def test_name_collision_raises_ambiguous_with_full_candidates() -> None:
     with pytest.raises(AmbiguousTargetError) as exc:
         resolve_target("filesystem", (user_fs, plugin_fs))
 
+    # 候选原样带出三元组，供 CLI 渲染 bundle_id + name + 归属。
+    # （勿加 ``assert c.bundle_id and c.name and c.attribution`` 之流：resolve_target 对候选是纯透传，
+    #   那只是在断言本测试自己构造的字面量非空 = 永真，与被测实现无关。归属**是否真被打印**的守卫在
+    #   test_repl_addressing.py 的多命中用例——那里才是渲染发生的地方。）
     assert set(exc.value.candidates) == {user_fs, plugin_fs}
-    # 三个维度都必须能被 CLI 渲染出来，缺一不可。
-    for cand in exc.value.candidates:
-        assert cand.bundle_id and cand.name and cand.attribution
 
 
 def test_ambiguous_never_silently_picks_lexicographically_smallest() -> None:
@@ -105,7 +106,7 @@ def test_name_hit_takes_precedence_over_bundle_id_hit() -> None:
         "报错、步骤 4 禁任意规则选一。⇒ A(name='foo', 缺省派生 id='foo') 与 B(name='foo', 显式 "
         "id='bundle_x') 合法共存（§5.6）时，A 的 bundle_id 恰等于那个冲突的名字，用户照「请用 bundle_id "
         "重试」再敲 'foo' 仍是 name 多命中 ⇒ **A 永远不可寻址**。修它属改协议明文，且该语义 MUST 双端逐字"
-        "一致 ⇒ 不单端发明。本轮严格实现协议并以本例钉住缺口（不靠文档降级）。"
+        "一致 ⇒ 不单端发明。本轮严格实现协议并以本例钉住缺口（不靠文档降级）。求裁于 #170。"
     ),
     strict=True,
 )

--- a/tests/unit_tests/computer/cli/test_resolve.py
+++ b/tests/unit_tests/computer/cli/test_resolve.py
@@ -1,0 +1,117 @@
+# -*- coding: utf-8 -*-
+"""
+文件名: test_resolve.py
+作者: JQQ
+创建日期: 2026/7/17
+最后修改日期: 2026/7/17
+版权: 2023 JQQ. All rights reserved.
+依赖: pytest
+描述:
+  中文: `cli/resolve.py` 的 `resolve_target` 纯函数契约（#143 / R4 / 协议 sdk-api-guidance §5.1）。
+    人机面唯一的 name→bundle_id 解析处；四分支 + 禁字典序 + 未命中必报错（杜绝静默假成功）。
+  English: Pure-function contract of `resolve_target` (#143 / R4 / protocol sdk-api-guidance §5.1) —
+    the only name→bundle_id resolution site, which lives on the human-facing surface.
+
+⚠️ 夹具铁律（Epic #147 陷阱其一，已四例致盲）: name 与 bundle_id **必须分叉**。
+   ``name="my.server"`` → ``bundle_id="my_server"``（``.`` 被 normalize 成 ``_``）。
+   **禁**用 ``stdio-srv`` 这类规范化后恰等于自身的名——``-`` 不被折叠，两概念同值 ⇒ 断言零鉴别力。
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from a2c_smcp.computer.cli.resolve import (
+    AmbiguousTargetError,
+    ServerCandidate,
+    TargetNotFoundError,
+    resolve_target,
+)
+
+# 分叉夹具：display name 含 `.` / 空格，规范化后与 bundle_id 不等 ⇒ 断言有鉴别力。
+_MY_SERVER = ServerCandidate(bundle_id="my_server", name="my.server", attribution="user")
+_CAP_SERVER = ServerCandidate(bundle_id="My_Server", name="My Server", attribution="project")
+
+
+def test_unique_name_hit_resolves_to_bundle_id() -> None:
+    """步骤 1: token 按 display name 反查唯一命中 → 解析为其 bundle_id。"""
+    assert resolve_target("my.server", (_MY_SERVER, _CAP_SERVER)) == "my_server"
+
+
+def test_zero_name_hit_but_valid_registered_bundle_id_resolves_as_id() -> None:
+    """步骤 2: 0 个 name 命中 ∧ token 是合法且**已注册**的 bundle_id → 按 bundle_id 执行。"""
+    assert resolve_target("my_server", (_MY_SERVER, _CAP_SERVER)) == "my_server"
+
+
+def test_valid_but_unregistered_bundle_id_raises_not_found() -> None:
+    """步骤 2 后半 + 步骤 5: token 形如合法 bundle_id 但**不在候选集** → 必须报「未找到」。
+
+    这是杀死 ``stop <未注册 token>`` 静默假成功的关键断言：语法合法 ≠ 存在。
+    """
+    with pytest.raises(TargetNotFoundError):
+        resolve_target("bundle_deadbeef", (_MY_SERVER,))
+
+
+def test_unknown_token_raises_not_found() -> None:
+    """步骤 4/5: 既非 name 又非合法已注册 bundle_id → 报「未找到」，MUST NOT 静默成功。"""
+    with pytest.raises(TargetNotFoundError):
+        resolve_target("nonexistent", (_MY_SERVER, _CAP_SERVER))
+
+
+def test_name_collision_raises_ambiguous_with_full_candidates() -> None:
+    """步骤 3 + PROTO-10 扩条: 多命中 → 报错并列出**每个候选的 bundle_id + name + 归属三者**。
+
+    只列 bundle_id 用户分不清哪个是自己的（协议 §5.1-3）。
+    """
+    user_fs = ServerCandidate(bundle_id="filesystem", name="filesystem", attribution="user")
+    plugin_fs = ServerCandidate(bundle_id="bundle_a3f9c2e1", name="filesystem", attribution="plugin:fs-tools")
+
+    with pytest.raises(AmbiguousTargetError) as exc:
+        resolve_target("filesystem", (user_fs, plugin_fs))
+
+    assert set(exc.value.candidates) == {user_fs, plugin_fs}
+    # 三个维度都必须能被 CLI 渲染出来，缺一不可。
+    for cand in exc.value.candidates:
+        assert cand.bundle_id and cand.name and cand.attribution
+
+
+def test_ambiguous_never_silently_picks_lexicographically_smallest() -> None:
+    """步骤 4: MUST NOT 以字典序最小等任意规则「确定性地选一个」——那是把不确定的错变成确定的错。
+
+    变异守卫: 若实现退化为 ``return min(hits)``，本例会拿到 ``"bundle_a"`` 而非抛错 ⇒ 转红。
+    """
+    a = ServerCandidate(bundle_id="bundle_a", name="dup", attribution="user")
+    z = ServerCandidate(bundle_id="bundle_z", name="dup", attribution="plugin:p")
+
+    with pytest.raises(AmbiguousTargetError):
+        resolve_target("dup", (a, z))
+
+
+def test_name_hit_takes_precedence_over_bundle_id_hit() -> None:
+    """步骤序: name 反查（步骤 1）先于 bundle_id 反查（步骤 2）——步骤 2 的门是「0 个 name 命中」。
+
+    A(name='foo', id='foo_1') 与 B(name='bar', id='foo') 共存时，``foo`` 命中 A 的 **name** ⇒ 解析为 foo_1。
+    """
+    a = ServerCandidate(bundle_id="foo_1", name="foo", attribution="user")
+    b = ServerCandidate(bundle_id="foo", name="bar", attribution="user")
+
+    assert resolve_target("foo", (a, b)) == "foo_1"
+
+
+@pytest.mark.xfail(
+    reason=(
+        "协议 sdk-api-guidance §5.1 步骤序缺口（#143 决策 4，待协议裁决）: 步骤 2「0 命中且是合法 "
+        "bundle_id → 当 id」的门是**「0 命中」**，故同名多命中时够不到步骤 2；而步骤 3 要求多命中 MUST "
+        "报错、步骤 4 禁任意规则选一。⇒ A(name='foo', 缺省派生 id='foo') 与 B(name='foo', 显式 "
+        "id='bundle_x') 合法共存（§5.6）时，A 的 bundle_id 恰等于那个冲突的名字，用户照「请用 bundle_id "
+        "重试」再敲 'foo' 仍是 name 多命中 ⇒ **A 永远不可寻址**。修它属改协议明文，且该语义 MUST 双端逐字"
+        "一致 ⇒ 不单端发明。本轮严格实现协议并以本例钉住缺口（不靠文档降级）。"
+    ),
+    strict=True,
+)
+def test_deadlock_corner_bundle_id_equal_to_colliding_name_should_be_addressable() -> None:
+    """死锁角落: 同名冲突 ∧ 其中一条的 bundle_id 恰等于那个名字 → 该条应仍可用 bundle_id 寻址。"""
+    a = ServerCandidate(bundle_id="foo", name="foo", attribution="user")
+    b = ServerCandidate(bundle_id="bundle_x", name="foo", attribution="plugin:fs-tools")
+
+    assert resolve_target("foo", (a, b)) == "foo"

--- a/tests/unit_tests/computer/test_computer_dual_path_crud.py
+++ b/tests/unit_tests/computer/test_computer_dual_path_crud.py
@@ -322,24 +322,31 @@ async def test_aadd_or_aupdate_server_existing_lands_origin_scope(
     assert project_servers["origin-svc"]["server_parameters"]["command"] == "/bin/v2", "内容已更新（整体替换）"
 
 
-# ── transient: aunmount_server(name) 只摘目标 + 守护 no-op ───────────────────────────────────────────
+# ── transient: aunmount_server_by_id(bundle_id) 只摘目标 + 守护 no-op ───────────────────────────────
 @pytest.mark.asyncio
-async def test_aunmount_server_by_name_unmounts_only_target(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_aunmount_server_by_id_unmounts_only_target(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """#143 / R4：库层停摘**一律收 bundle_id**（历史 ``aunmount_server(name)`` 便捷入口已删）。
+
+    夹具 name/bundle_id **刻意分叉**（``keep.me`` → ``keep_me``）：若实现回退成按 name 寻址，本例转红。
+    """
     _isolate(tmp_path, monkeypatch)
     comp = _comp(tmp_path)
-    await comp.amount_server(_stdio_dict("keep", "/bin/keep"))
-    await comp.amount_server(_stdio_dict("drop", "/bin/drop"))
+    await comp.amount_server(_stdio_dict("keep.me", "/bin/keep"))
+    await comp.amount_server(_stdio_dict("drop.me", "/bin/drop"))
     assert comp.mcp_manager is not None
-    assert {c.name for c in comp.mcp_manager.server_configs()} == {"keep", "drop"}
+    assert {resolve_bundle_id(c) for c in comp.mcp_manager.server_configs()} == {"keep_me", "drop_me"}
 
-    await comp.aunmount_server("drop")
-    assert {c.name for c in comp.mcp_manager.server_configs()} == {"keep"}, "按 name 只摘目标，不误伤同侪"
+    await comp.aunmount_server_by_id("drop_me")
+    assert {resolve_bundle_id(c) for c in comp.mcp_manager.server_configs()} == {"keep_me"}, "按 bundle_id 只摘目标，不误伤同侪"
     # 纯运行期：不落任一 scope。
     for scope in (McpWriteScope.LOCAL, McpWriteScope.PROJECT, McpWriteScope.USER):
         assert not mcp_write_path(scope, env=os.environ).exists()
-    # 不存在的 name → no-op（不抛、不误摘）。
-    await comp.aunmount_server("ghost")
-    assert {c.name for c in comp.mcp_manager.server_configs()} == {"keep"}
+    # display name 不是身份：拿 name 来摘**摘不掉**（R4 无 name 启发式；解析是人机面的事）。
+    await comp.aunmount_server_by_id("drop.me")
+    assert {resolve_bundle_id(c) for c in comp.mcp_manager.server_configs()} == {"keep_me"}
+    # 不存在的 bundle_id → no-op（不抛、不误摘）。
+    await comp.aunmount_server_by_id("ghost")
+    assert {resolve_bundle_id(c) for c in comp.mcp_manager.server_configs()} == {"keep_me"}
 
 
 @pytest.mark.asyncio
@@ -347,7 +354,6 @@ async def test_aunmount_server_manager_none_is_noop(tmp_path: Path, monkeypatch:
     _isolate(tmp_path, monkeypatch)
     comp = _comp(tmp_path)
     # manager 未建（无任何挂载）→ no-op，不抛、不建 manager。
-    await comp.aunmount_server("anything")
     await comp.aunmount_server_by_id("anything")
     assert comp.mcp_manager is None
 

--- a/tests/unit_tests/computer/test_python_rust_alignment.py
+++ b/tests/unit_tests/computer/test_python_rust_alignment.py
@@ -285,13 +285,16 @@ async def test_alignment_transient_mount_does_not_persist(tmp_path: Path, monkey
 
 @pytest.mark.asyncio
 async def test_alignment_transient_unmount_does_not_persist(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """``aunmount_server(name)`` 只摘运行期投影，不动任一 mcp 文件。"""
+    """``aunmount_server_by_id(bundle_id)`` 只摘运行期投影，不动任一 mcp 文件。
+
+    #143 / R4：库层停摘一律收 **bundle_id**（历史 name 便捷入口已删，rust 侧 ``unmount_server`` 收 id 后同构）。
+    """
     _isolate(tmp_path, monkeypatch)
     comp = _comp(tmp_path)
     await comp.amount_server(_stdio_dict("tmp.srv.disp", "/bin/t"))  # name "tmp.srv.disp" → bundle_id "tmp_srv_disp"
     before = _snapshot_mcp_files()  # 均不存在（transient 未落盘）
 
-    await comp.aunmount_server("tmp.srv.disp")  # aunmount_server 以 **name**（display）寻址
+    await comp.aunmount_server_by_id("tmp_srv_disp")  # 以 **bundle_id**（身份）寻址，非 display name
 
     assert _snapshot_mcp_files() == before, "transient 停摘不产生任何落盘"
     assert "tmp_srv_disp" not in _runtime_bundle_ids(comp), "运行期投影已摘除（身份键 = bundle_id）"


### PR DESCRIPTION
## 问题

REPL `server rm <name>` / `stop <name>` 把用户敲的 token **原样**传给以 **bundle_id** 为键的库层 API，中间无任何 name→bundle_id 解析。两者只在 `bundle_id == normalize_name(name)` 时碰巧相等。name 含 `.` / 空格 / CJK 或配了显式 `bundle_id` 时查不到 → 底层静默 no-op → REPL 照样打印「✅ 停止完成」/「已移除配置」，而 server 仍在跑、工具仍暴露给 Agent，用户**无从察觉**。

## 根因

`Computer.aremove_server` docstring 自认的前提「REPL `server rm <name>` 以 name 寻址即可」**只在 name 本身已属 `[A-Za-z0-9_-]` 时成立**。post-BundleID（#129/#130/#131）display name 允许碰撞、永不做键，该隐含前提本就不该继续依赖。

## 方案（Discussion #23 终审 R4 + 协议 `sdk-api-guidance.md §5.1` / PROTO-10，协议 develop `9cde57c` 已落 ⇒ 阻塞解除）

- **新增 `cli/resolve.py`**：全仓唯一 name→bundle_id 解析处。库层公开 API 一律收 bundle_id、无 name 启发式；解析只在人机面，未命中/多命中 **MUST 报错，MUST NOT 静默成功**。查找空间 = 运行期 ∪ 声明面（保住 `aremove_server` 档1-4 可达）；归属三源按 **bundle_id** join（声明面 origin ⊕ ledger `plugin:x` ⊕ runtime 兜底）。
- **接线 `server rm` / `start` / `stop`**（`all` 先短路）：未命中 `❌ 未找到`；多命中 `⚠ 列候选`（bundle_id + name + 归属三者，PROTO-10 扩条）要求改用 bundle_id，**禁字典序最小**；已声明未挂载则诚实陈述（不假 ✅、不漏内部错）。
- **删 `Computer.aunmount_server(name)`**（库层最后一个 name 入口，零生产调用方）+ 订正 `aremove_server` docstring 的错误前提。
- `status` 表头 `Name` → `Bundle ID`；help / docs 同步 `<name|bundle_id>`。

## 用户可见 before/after

```
── 现状（假成功）──
a2c> stop my.server          ✅ 停止完成                ← 骗人，什么都没停
a2c> server rm my.server     已移除配置                 ← 骗人，什么都没删

── 改后 ──
a2c> stop my.server          ✅ 停止完成               （name 唯一命中 → bundle_id=my_server → 真停）
a2c> stop nonexistent        ❌ 未找到服务器 'nonexistent'
a2c> stop filesystem         ⚠ 有 2 个 server 叫 'filesystem':
                                bundle_a3f9c2e1  filesystem  (plugin:fs-tools)
                                filesystem       filesystem  (user)
                             请用 bundle_id 重试
```

## 测试

- 新增 `test_resolve.py`（四分支 + 禁字典序 + 死锁角落 xfail）、`test_collect_candidates.py`（三源归属 + 降级去连坐）、`test_repl_addressing.py`（假成功回归 + 三动词 + 已声明未挂载）。
- 夹具 name/bundle_id 全部分叉（`my.server` → `my_server`）；两处变异验证守卫非永真。
- 单元 2082 passed / e2e 65 passed / lint clean（mypy 105 files + ruff）。

## 隔离审查

隔离上下文 `code-reviewer` 复审抓出 🔴×3（归属零守卫 / 测试写真实 HOME / 决策1 新假成功路径），全部自证并根治（见 `fix-review(#143)` commit）。审查者复现的两处变异现均转红。

## Follow-up

- **#170**：`resolve_target` 步骤序死锁角落（协议 §5.1 缺口，xfail 钉住求裁）
- **#171**：查找空间 §5.1-1「活跃配置集」vs 决策 1「∪ 声明面」+ start/stop 对已声明未挂载的规范行为
- **rust-sdk#141**：镜像，python 语义定稿后按「逐字一致」跟

Closes #143
Refs #147 (Epic), Discussion #23 R4 / PROTO-10

🤖 Generated with [Claude Code](https://claude.com/claude-code)