### PR TITLE
fix(0.3.0-release): protocol version 断言鲁棒化 + CHANGELOG 切段 [0.3.0]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [PEP 440](https://peps.python.org/pep-0440/) versioning.
 
-## [Unreleased]
+## [0.3.0] - 2026-07-22
 
-> A2C-SMCP protocol **v0.2.0 GA** implementation. SDK package version bump to
-> `0.2.0` is performed separately at release cut. Tracking issue:
-> [#8](https://github.com/A2C-SMCP/python-sdk/issues/8).
+> **A2C-SMCP 协议 v0.3.0 GA** 实现。SDK 包版本 `0.3.0`。
+> 主线：server-name-as-identity 历史残留彻底清除——`bundle_id` 成为 MCP Server
+> 唯一身份/主键/路由键，`name` 降为纯展示（允许同名合法共存）。三方共识见
+> a2c-smcp-protocol Discussion #23（F1–F8 终审，无遗留裁决）。
+>
+> 注：v0.2.0 / v0.2.1 发版时 CHANGELOG 未单独切段，本段累积 [0.1.5a1] 以来的全部
+> 变更。其中 v0.2 协议面（连接握手 `a2c_version` / `client:get_resources` /
+> `window://` URI 纯标识符化 / DPE 移除）已随 v0.2.x 发布；本版本（v0.3）新增为
+> BundleID 身份模型、两套 scope 层序统一、env 命名全迁、审批门档④根治、上游授权
+> 错误 4006/4007 surfacing、plugin install/enable 分离。
 
 ### Breaking Changes
 - **MCP inventory projection re-keyed to `bundle_id`; `managedBy` is now pure-derived** (#144, mirrors

--- a/tests/unit_tests/test_smcp.py
+++ b/tests/unit_tests/test_smcp.py
@@ -55,8 +55,20 @@ class TestProtocolVersion:
         assert a2c_smcp.PROTOCOL_VERSION == PROTOCOL_VERSION
 
     def test_protocol_version_independent_from_package_version(self) -> None:
-        """协议版本与包版本独立 / protocol version is independent from package version."""
-        assert a2c_smcp.__version__ != PROTOCOL_VERSION
+        """协议版本与包版本独立 / protocol version is independent from package version.
+
+        PROTOCOL_VERSION 锁定协议兼容性契约（干净 ``X.Y.Z``），不随包版本
+        ``__version__`` 的 PEP 440 预发布/开发后缀变化——包处于 a/b/rc 阶段时
+        协议版本仍保持稳定 ``X.Y.Z``。故断言 PROTOCOL_VERSION 为干净三段版本，
+        而非与 ``__version__`` 比值：SDK 正式发布协议同号版本时两者数值相同是
+        合理且预期的（如 SDK 0.3.0 实现协议 0.3.0）。
+        """
+        import re
+
+        assert re.fullmatch(r"\d+\.\d+\.\d+", PROTOCOL_VERSION), (
+            f"PROTOCOL_VERSION={PROTOCOL_VERSION!r} 必须是干净的 X.Y.Z 协议契约版本，"
+            "独立于 PEP 440 包发布标识（不含预发布/开发后缀）"
+        )
 
 
 class TestErrorCode:


### PR DESCRIPTION
## 0.3.0 发版收尾

验收 v0.3.0（921f6e0）发现 CI 阻塞 + CHANGELOG 未切段，本 PR 收尾。

### 🔴 CI 阻塞修复
`test_smcp.py::TestProtocolVersion::test_protocol_version_independent_from_package_version` 原断言 `__version__ != PROTOCOL_VERSION`，在 SDK 0.3.0（包版本 == 协议版本 == "0.3.0"）时必败——这是 v0.3.0 commit Tests 失败的**唯一**原因（1 failed, 2125 passed）。

改为验证 PROTOCOL_VERSION 为干净 `X.Y.Z` 协议契约版本，独立于 PEP 440 包发布标识——包在 a/b/rc 阶段时协议版本仍稳定 X.Y.Z（符合 `__init__.py` 注释"MAJOR.MINOR 锁定协议，PATCH 自由"）。

### CHANGELOG 切段
`[Unreleased]` → `[0.3.0] - 2026-07-22`，订正段头（原停留 v0.2.0 GA 引导文本）。注明 v0.2.0/v0.2.1 发版未单独切段的历史累积与 v0.3 新增范围。

### 验证
- `poe lint` 绿（ruff + mypy）
- TestProtocolVersion 3 测试本地通过

### ⚠️ 合并后注意
v0.3.0 tag 当前在 921f6e0（**CI 失败**的 commit）。本 PR 合并后 develop HEAD 为含修复的 commit，v0.3.0 tag 需移到含修复的 commit（或 promote develop→main 后 tag on main），否则发布指向 CI 失败的点。

Co-Authored-By: Claude <noreply@anthropic.com>